### PR TITLE
Scaffold Dockerfile and devcontainer for vade-core

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+  "name": "vade-runtime",
+  "build": {
+    "context": "..",
+    "dockerfile": "../Dockerfile"
+  },
+  "remoteUser": "node",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "forwardPorts": [5173, 7600],
+  "portsAttributes": {
+    "5173": {
+      "label": "Vite dev server",
+      "onAutoForward": "notify"
+    },
+    "7600": {
+      "label": "VADE MCP WebSocket bridge",
+      "onAutoForward": "silent"
+    }
+  },
+  "postCreateCommand": "bash scripts/bootstrap.sh || true",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "ms-vscode.vscode-typescript-next",
+        "anthropic.claude-code"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "typescript.tsdk": "node_modules/typescript/lib"
+      }
+    }
+  },
+  "mounts": [
+    "source=vade-library,target=/home/node/.vade,type=volume"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,13 @@ is the exact class of bug this repository exists to prevent.
 
 ## Current state
 
-Stub repository. No Dockerfile yet. The first concrete task is to
-write a minimal `Dockerfile` based on `node:20-bookworm-slim` with
-the `claude` CLI pre-installed, plus a `devcontainer.json` that
-opens the image inside VS Code.
+Alpha. Minimal Dockerfile in place (based on `node:20.19.1-bookworm-slim`)
+with Claude Code CLI and `tsx` pre-installed. `.devcontainer/devcontainer.json`
+forwards ports 5173 (Vite) and 7600 (MCP WebSocket bridge), and mounts
+a named volume for the `~/.vade/library/` canvas library. `scripts/bootstrap.sh`
+and `scripts/healthcheck.sh` handle first-run setup and smoke testing.
+See `versions.lock` for pinned tools.
+
+Next planned additions (deferred until needed): Rust toolchain via
+`rustup` when the first performance module lands, Python 3.12 when a
+canvas artifact needs scientific helpers.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# VADE development container
+# Base: Node 20 LTS on Debian Bookworm (slim variant)
+# See versions.lock for pinned versions with rationale.
+FROM node:20.19.1-bookworm-slim
+
+# Non-root user for VS Code devcontainer convention. The 'node' user
+# already exists in the base image (uid 1000); reuse it.
+ARG USERNAME=node
+
+# System packages: git for repo work, ca-certificates for npm/TLS,
+# build tools for any native npm deps, curl for debugging, procps for
+# tools like `ps` used by dev servers.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      ca-certificates \
+      build-essential \
+      curl \
+      procps \
+      openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI (global install). Pinned in versions.lock.
+# Install as root into /usr/local so all users can use it.
+RUN npm install -g @anthropic-ai/claude-code@1.0.120 \
+    && npm cache clean --force
+
+# tsx globally so the MCP server can run without `npx` overhead in
+# environments where npm cache isn't warm. vade-core still lists it
+# as a devDependency.
+RUN npm install -g tsx@4.21.0 \
+    && npm cache clean --force
+
+# Pre-create the library mount point with 'node' ownership so the
+# named volume inherits correct permissions on first attach.
+RUN mkdir -p /home/${USERNAME}/.vade/library/canvases \
+             /home/${USERNAME}/.vade/library/entities \
+    && chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.vade
+
+# Standard devcontainer workspace mount point.
+WORKDIR /workspace
+
+# Drop to the 'node' user for runtime. VS Code will take over from here.
+USER ${USERNAME}
+
+# Expose documented ports so `docker run -p` works without surprise.
+# Vite dev server = 5173, VADE MCP WebSocket bridge = 7600.
+EXPOSE 5173 7600
+
+# Default command: interactive bash. Devcontainer / docker run -it
+# will give the operator a prompt inside /workspace.
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -7,20 +7,23 @@ task-agent workspaces) run inside during development.
 
 ## Status
 
-**Stub.** Bootstrap phase — no Dockerfile yet. Scaffolding begins
-when `vade-core` has enough structure to need a pinned environment.
+**Alpha.** Minimal Dockerfile and devcontainer are in place. Node 20
+LTS + Claude Code CLI + tsx pre-installed. Targets the vade-core
+Vite/tldraw/MCP stack.
 
-## Goals
+## What's in the image
 
-- **Reproducible dev env** — one `devcontainer.json` that works on
-  macOS, Linux, and (eventually) Windows.
-- **Pinned toolchain** — Node.js 20 LTS, TypeScript, pnpm or npm
-  (TBD), Rust stable, Python 3.12 for scientific helpers.
-- **Cached layers** for fast iteration.
-- **Claude Code friendly** — the container ships with `claude`
-  CLI pre-installed and configured to read `/workspace/CLAUDE.md`.
+| Tool | Version | Why |
+|------|---------|-----|
+| Node.js | 20.19.1 LTS | Runtime for vade-core app and MCP server |
+| @anthropic-ai/claude-code | 1.0.120 | Agent CLI inside the container |
+| tsx | 4.21.0 | Run the vade-canvas MCP server |
+| git, build-essential, ca-certificates, curl | bookworm | Dev essentials |
 
-## Planned layout
+See [`versions.lock`](./versions.lock) for the full pinned list and
+rationale.
+
+## Layout
 
 ```
 vade-runtime/
@@ -28,29 +31,53 @@ vade-runtime/
 ├── .devcontainer/
 │   └── devcontainer.json     ← VS Code / Codespaces entry point
 ├── scripts/
-│   ├── bootstrap.sh          ← first-run setup
-│   └── healthcheck.sh        ← container smoke test
-└── versions.lock             ← pinned tool versions
+│   ├── bootstrap.sh          ← first-run setup (npm install, dirs)
+│   └── healthcheck.sh        ← smoke test: versions + PATH
+└── versions.lock             ← pinned tool versions + rationale
 ```
 
-## How to use (once built)
+## How to use
+
+### With VS Code (recommended)
+
+Copy (or symlink) the `.devcontainer/` folder into the vade-core
+checkout, then:
 
 ```bash
-# Clone vade-core next to this repo
-git clone git@github.com:vade-app/vade-core.git ~/repos/vade-core
-cd ~/repos/vade-core
-
-# Open in VS Code with devcontainer
+cd ~/GitHub/VADE/repos/vade-core
 code .
 # → "Reopen in Container" when prompted
 ```
 
-Or via Docker directly:
+The container forwards port **5173** (Vite dev server) and **7600**
+(VADE MCP WebSocket bridge). A named volume `vade-library` persists
+`~/.vade/library/` across rebuilds.
+
+### With Docker directly
 
 ```bash
-docker pull ghcr.io/vade-app/vade-runtime:latest
-docker run -it --rm -v "$PWD:/workspace" ghcr.io/vade-app/vade-runtime
+docker build -t vade-runtime .
+docker run -it --rm \
+  -v "$PWD:/workspace" \
+  -p 5173:5173 -p 7600:7600 \
+  -v vade-library:/home/node/.vade \
+  vade-runtime
 ```
+
+### Verify the image
+
+```bash
+docker run --rm vade-runtime bash /workspace/scripts/healthcheck.sh
+```
+
+## Deferred
+
+- **Rust** — planned for Phase 3+ performance modules. Add via
+  `rustup` when the first Rust crate lands in vade-core.
+- **Python 3.12** — planned for scientific helpers (numpy/scipy).
+  Add when a canvas artifact needs it for agent-side computation.
+- **pnpm** — TBD; sticking with npm until there's a concrete reason
+  to switch.
 
 ## Governance
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# First-run setup for the VADE devcontainer.
+# Idempotent: safe to run multiple times.
+set -euo pipefail
+
+echo "[bootstrap] VADE devcontainer first-run setup"
+
+# Ensure the library directory structure exists. The volume mount
+# creates the root as a mount point; we create subdirs on first run.
+mkdir -p "$HOME/.vade/library/canvases" "$HOME/.vade/library/entities" 2>/dev/null || \
+  echo "[bootstrap] Warning: could not create $HOME/.vade subdirs. Check volume permissions."
+
+# If we're inside a vade-core checkout, install npm deps so the
+# dev loop is ready immediately.
+if [ -f "/workspace/package.json" ]; then
+  echo "[bootstrap] Installing npm dependencies..."
+  cd /workspace
+  npm install --no-audit --no-fund
+fi
+
+# Verify the tools we expect are on PATH.
+echo "[bootstrap] Tool versions:"
+node --version
+npm --version
+claude --version 2>/dev/null || echo "  claude CLI: not logged in (run 'claude login' after first start)"
+tsx --version 2>/dev/null || npx tsx --version
+
+echo "[bootstrap] Done. Library at $HOME/.vade/library/"

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Container smoke test. Exits 0 if all expected tools are available
+# and at their pinned major versions.
+set -euo pipefail
+
+fail=0
+
+check() {
+  local name="$1"
+  local cmd="$2"
+  local expected="$3"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "FAIL: $name not on PATH"
+    fail=1
+    return
+  fi
+  local actual
+  actual=$(eval "$cmd" 2>&1 | head -1)
+  if [[ "$actual" == *"$expected"* ]]; then
+    echo "OK:   $name -> $actual"
+  else
+    echo "WARN: $name -> $actual (expected contains '$expected')"
+  fi
+}
+
+check node  'node --version'  'v20.'
+check npm   'npm --version'   '10.'
+check git   'git --version'   'git version'
+check tsx   'tsx --version'   '4.'
+check claude 'claude --version' '1.'
+
+# Network / build-essential sanity
+check curl 'curl --version'   'curl '
+check cc   'cc --version'     'gcc'
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "healthcheck: FAIL"
+  exit 1
+fi
+
+echo
+echo "healthcheck: OK"

--- a/versions.lock
+++ b/versions.lock
@@ -1,0 +1,49 @@
+# VADE runtime — pinned tool versions
+#
+# Every tool installed in the Dockerfile must be listed here with
+# its exact version and a short rationale. Unpinned dependencies
+# cause silent dev-env drift across contributors; this file exists
+# to prevent that class of bug.
+#
+# Format: <tool> <version> # <rationale>
+# Last updated: 2026-04-19
+
+# Base image
+node                20.19.1   # Active LTS as of April 2026. vade-core
+                              # tech stack targets Node 20 LTS per
+                              # vade-core/CLAUDE.md.
+debian              bookworm  # Stable, recent glibc, slim variant
+                              # keeps image small (~150 MB base).
+
+# Globally installed via npm
+@anthropic-ai/claude-code 1.0.120  # Claude Code CLI. Pinned to the
+                                   # minor available at container
+                                   # bake time; rev forward when a
+                                   # new feature is needed or a
+                                   # security advisory lands.
+tsx                 4.21.0    # TypeScript execution (esbuild-based)
+                              # for running the vade-canvas MCP
+                              # server. Matches vade-core devDep.
+
+# System packages (tracked loosely; the bookworm repo pin is the
+# ultimate source of truth for these). Listed for observability.
+git                 debian-bookworm   # Whatever bookworm ships.
+build-essential     debian-bookworm   # gcc, make, etc. for native
+                                      # npm modules like `ws`.
+ca-certificates     debian-bookworm   # TLS trust roots for npm.
+curl                debian-bookworm   # Debugging + MCP endpoint
+                                      # reachability checks.
+procps              debian-bookworm   # `ps`, `top` — helpful when
+                                      # dev-servers hang.
+openssh-client      debian-bookworm   # `git push` over SSH for
+                                      # operators who prefer it to
+                                      # HTTPS+PAT.
+
+# Deferred (not in image yet, listed so the absence is explicit):
+# rust       — planned for Phase 3+ performance modules per vade-core
+#              CLAUDE.md. Add via `rustup` when the first Rust crate
+#              lands in vade-core.
+# python3.12 — planned for scientific helpers. Add when a canvas
+#              artifact needs numpy/scipy for agent-side computation.
+# pnpm       — still TBD per vade-runtime/README.md. Stick with npm
+#              until a concrete reason to switch (workspace speed?).


### PR DESCRIPTION
## Summary

- **Dockerfile** — `node:20.19.1-bookworm-slim` base with Claude Code CLI (`@anthropic-ai/claude-code@1.0.120`) and `tsx@4.21.0` globally installed. Includes git, build-essential, ca-certificates, curl, procps, openssh-client. Runs as non-root `node` user. Exposes ports 5173 (Vite) and 7600 (MCP WebSocket bridge). Pre-creates `~/.vade/library/` with correct ownership for the named volume mount.
- **`.devcontainer/devcontainer.json`** — VS Code / Codespaces entry point. Forwards ports, installs ESLint + Prettier + Claude Code extensions, runs `bootstrap.sh` on create, mounts `vade-library` named volume for canvas library persistence.
- **`scripts/bootstrap.sh`** — Idempotent first-run setup: creates library directories, runs `npm install` if `package.json` exists, prints tool versions.
- **`scripts/healthcheck.sh`** — Smoke test verifying node, npm, git, tsx, claude, curl, cc are on PATH at expected major versions.
- **`versions.lock`** — Every pinned tool version with rationale. Explicitly documents what is deferred (Rust, Python, pnpm) and why.

## Test plan

- [ ] `docker build -t vade-runtime .` — builds without errors
- [ ] `docker run --rm vade-runtime node --version` → `v20.19.1`
- [ ] `docker run --rm vade-runtime claude --version` → `1.0.120`
- [ ] `docker run --rm vade-runtime tsx --version` → `4.21.0`
- [ ] Mount vade-core and run `npm install && npm run dev` inside container
- [ ] VS Code "Reopen in Container" works with the devcontainer config
- [ ] `scripts/healthcheck.sh` exits 0 inside the container

https://claude.ai/code/session_01QDuqCNHTxxVsXYdBhUJsUq