### PR TITLE
Factor bootstrap into shared lib; add cloud-setup.sh for web sessions

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,26 +3,15 @@
 # Idempotent: safe to run multiple times.
 set -euo pipefail
 
-echo "[bootstrap] VADE devcontainer first-run setup"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
 
-# Ensure the library directory structure exists. The volume mount
-# creates the root as a mount point; we create subdirs on first run.
-mkdir -p "$HOME/.vade/library/canvases" "$HOME/.vade/library/entities" 2>/dev/null || \
-  echo "[bootstrap] Warning: could not create $HOME/.vade subdirs. Check volume permissions."
+log "VADE devcontainer first-run setup"
 
-# If we're inside a vade-core checkout, install npm deps so the
-# dev loop is ready immediately.
-if [ -f "/workspace/package.json" ]; then
-  echo "[bootstrap] Installing npm dependencies..."
-  cd /workspace
-  npm install --no-audit --no-fund
-fi
+ensure_dirs
 
-# Verify the tools we expect are on PATH.
-echo "[bootstrap] Tool versions:"
-node --version
-npm --version
-claude --version 2>/dev/null || echo "  claude CLI: not logged in (run 'claude login' after first start)"
-tsx --version 2>/dev/null || npx tsx --version
+install_deps /workspace
 
-echo "[bootstrap] Done. Library at $HOME/.vade/library/"
+print_versions
+
+log "Done. Library at $HOME/.vade/library/"

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Claude Code web cloud environment setup.
+# Runs once per session, before Claude Code launches.
+#
+# Entry point: paste this into the cloud env "Setup script" field:
+#   #!/bin/bash
+#   git clone --depth 1 https://github.com/vade-app/vade-runtime /tmp/vade-runtime
+#   bash /tmp/vade-runtime/scripts/cloud-setup.sh
+#
+# Or run directly if vade-runtime is already cloned.
+#
+# Tracks main — acceptable for personal prototype phase.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
+
+log "Cloud environment setup starting"
+
+log "Baseline: node=$(node --version 2>/dev/null || echo 'missing') npm=$(npm --version 2>/dev/null || echo 'missing')"
+
+ensure_dirs
+ensure_tsx
+
+REPOS_ROOT="${VADE_REPOS_ROOT:-$HOME/repos}"
+mkdir -p "$REPOS_ROOT"
+
+if [ ! -d "$REPOS_ROOT/vade-core" ]; then
+  log "Cloning vade-core..."
+  git clone https://github.com/vade-app/vade-core.git "$REPOS_ROOT/vade-core"
+fi
+
+install_deps "$REPOS_ROOT/vade-core"
+
+print_versions
+
+log "Done. vade-core at $REPOS_ROOT/vade-core, library at $HOME/.vade/library/"

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -27,7 +27,7 @@ mkdir -p "$REPOS_ROOT"
 
 if [ ! -d "$REPOS_ROOT/vade-core" ]; then
   log "Cloning vade-core..."
-  git clone https://github.com/vade-app/vade-core.git "$REPOS_ROOT/vade-core"
+  git clone --depth 1 https://github.com/vade-app/vade-core.git "$REPOS_ROOT/vade-core"
 fi
 
 install_deps "$REPOS_ROOT/vade-core"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -43,7 +43,11 @@ print_versions() {
 
   if check_cmd claude; then
     claude_version="$(claude --version 2>/dev/null || true)"
-    [ -n "$claude_version" ] || claude_version="installed but not logged in (run: claude login)"
+    if [ -n "$claude_version" ]; then
+      claude_version="$claude_version (run: claude login if needed)"
+    else
+      claude_version="available (run: claude login)"
+    fi
   else
     claude_version="not available"
   fi

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Shared functions for VADE environment setup scripts.
+# Sourced by bootstrap.sh (devcontainer) and cloud-setup.sh (web).
+
+log() { echo "[vade-setup] $*"; }
+
+check_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+ensure_dirs() {
+  mkdir -p "$HOME/.vade/library/canvases" \
+           "$HOME/.vade/library/entities" 2>/dev/null || \
+    log "Warning: could not create $HOME/.vade subdirs. Check permissions."
+}
+
+ensure_tsx() {
+  if check_cmd tsx; then
+    log "tsx already installed: $(tsx --version 2>&1 | head -1)"
+    return 0
+  fi
+  log "Installing tsx globally..."
+  npm install -g tsx@4.21.0 --no-audit --no-fund
+}
+
+install_deps() {
+  local dir="${1:-.}"
+  if [ -f "$dir/package.json" ]; then
+    log "Installing npm dependencies in $dir..."
+    (cd "$dir" && npm install --no-audit --no-fund)
+  fi
+}
+
+print_versions() {
+  log "Tool versions:"
+  log "  node: $(node --version 2>/dev/null || echo 'not found')"
+  log "  npm:  $(npm --version 2>/dev/null || echo 'not found')"
+  log "  git:  $(git --version 2>/dev/null || echo 'not found')"
+  log "  tsx:  $(tsx --version 2>/dev/null | head -1 || echo 'not found')"
+  log "  claude: $(claude --version 2>/dev/null || echo 'not available')"
+}

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -32,10 +32,26 @@ install_deps() {
 }
 
 print_versions() {
+  local tsx_version claude_version
+
+  if check_cmd tsx; then
+    tsx_version="$(tsx --version 2>/dev/null | head -1)"
+  else
+    tsx_version="$(npx tsx --version 2>/dev/null | head -1 || true)"
+    [ -n "$tsx_version" ] || tsx_version="not found"
+  fi
+
+  if check_cmd claude; then
+    claude_version="$(claude --version 2>/dev/null || true)"
+    [ -n "$claude_version" ] || claude_version="installed but not logged in (run: claude login)"
+  else
+    claude_version="not available"
+  fi
+
   log "Tool versions:"
   log "  node: $(node --version 2>/dev/null || echo 'not found')"
   log "  npm:  $(npm --version 2>/dev/null || echo 'not found')"
   log "  git:  $(git --version 2>/dev/null || echo 'not found')"
-  log "  tsx:  $(tsx --version 2>/dev/null | head -1 || echo 'not found')"
-  log "  claude: $(claude --version 2>/dev/null || echo 'not available')"
+  log "  tsx:  $tsx_version"
+  log "  claude: $claude_version"
 }


### PR DESCRIPTION
## Summary

Factor the devcontainer bootstrap logic into shared shell functions and add a new `cloud-setup.sh` entry point for Claude Code web cloud environments.

- **`scripts/lib/common.sh`** — shared functions: `ensure_dirs`, `ensure_tsx`, `install_deps`, `print_versions`, `check_cmd`, `log`
- **`scripts/bootstrap.sh`** — refactored to source `lib/common.sh` (same behavior, less duplication)
- **`scripts/cloud-setup.sh`** — new entry point for Claude Code web sessions. Detects baseline, installs tsx if missing, clones vade-core if not present, runs npm install. Idempotent.

### How to use in cloud env UI

**Setup script** (paste into the "Setup script" field):
```bash
#!/bin/bash
git clone --depth 1 https://github.com/vade-app/vade-runtime /tmp/vade-runtime
bash /tmp/vade-runtime/scripts/cloud-setup.sh
```

**Environment variables** (paste into the "Environment variables" field):
```
VADE_REPOS_ROOT=$HOME/repos
NODE_ENV=development
```

Tracks `main` — no SHA pinning needed for personal prototype phase.

### Test results (Claude Code web environment)

Baseline: Node 22.22.2, npm 10.9.7, git 2.43.0, no tsx pre-installed.

| Run | tsx | clone | npm install | Total |
|---|---|---|---|---|
| First | installed 4.21.0 (3s) | vade-core cloned | 357 packages (14s) | ~17s |
| Second (idempotent) | skipped | skipped | up to date (2s) | ~2s |

### Design decisions

- **Don't merge Dockerfile and cloud setup.** Different artifacts (OCI image vs. pre-session script), different lifecycles. Share the logic via `lib/common.sh`, not the entry point.
- **Track main, no SHA pinning.** Personal prototype — stability isn't the constraint, iteration speed is.
- **Single cloud env for now.** The COO/nightly sessions don't need Node tooling, but adding a second environment is configuration, not code. Can split later if boot time matters.

### What this doesn't do

- Doesn't modify the Dockerfile (still builds the same image)
- Doesn't modify devcontainer.json (still calls bootstrap.sh)
- Doesn't add secrets or credentials (Mem0/GitHub use OAuth on web)