### PR TITLE
Add discussion seeding and digest tools for org coordination

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,6 +12,12 @@ ensure_dirs
 
 install_deps /workspace
 
+ensure_agent_hooks "$SCRIPT_DIR"
+
+# Catch-up digest run: subsequent sessions get fresh output via the
+# installed SessionStart hook.
+bash "$SCRIPT_DIR/discussions-digest.sh" || true
+
 print_versions
 
 log "Done. Library at $HOME/.vade/library/"

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -32,6 +32,13 @@ fi
 
 install_deps "$REPOS_ROOT/vade-core"
 
+ensure_agent_hooks "$SCRIPT_DIR"
+
+# In a cloud sandbox the setup script effectively IS the session start,
+# so run the digest inline. The hook also gets installed so any nested
+# `claude` invocations get a fresh digest.
+bash "$SCRIPT_DIR/discussions-digest.sh" || true
+
 print_versions
 
 log "Done. vade-core at $REPOS_ROOT/vade-core, library at $HOME/.vade/library/"

--- a/scripts/discussions-digest.sh
+++ b/scripts/discussions-digest.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Print a compact digest of recent vade-app org discussions.
+#
+# Designed to run on every Claude Code session start (via the
+# SessionStart hook installed by install-agent-hooks.sh). Also safe
+# to run inline from bootstrap.sh / cloud-setup.sh as a catch-up.
+#
+# Graceful no-op when GITHUB_TOKEN/GH_TOKEN is unset, when curl/node
+# are missing, or when the GraphQL request fails. Never breaks
+# session start.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+if [ -z "$TOKEN" ]; then
+  log "GITHUB_TOKEN unset; skipping discussions digest."
+  exit 0
+fi
+
+if ! check_cmd curl || ! check_cmd node; then
+  log "curl or node missing; skipping discussions digest."
+  exit 0
+fi
+
+STATE_DIR="$HOME/.vade/agent-state"
+CURSOR_FILE="$STATE_DIR/discussions-cursor"
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+if [ -f "$CURSOR_FILE" ] && [ -s "$CURSOR_FILE" ]; then
+  CURSOR="$(cat "$CURSOR_FILE")"
+else
+  CURSOR="$(node -e "console.log(new Date(Date.now()-7*24*3600*1000).toISOString())")"
+fi
+
+NOW="$(node -e "console.log(new Date().toISOString())")"
+
+QUERY=$(cat <<'EOF'
+{"query":"query { repository(owner: \"vade-app\", name: \"vade-core\") { discussions(first: 20, orderBy: {field: UPDATED_AT, direction: DESC}) { nodes { title number url updatedAt category { name } comments { totalCount } author { login } } } } }"}
+EOF
+)
+
+RESPONSE="$(curl -sS --max-time 10 \
+  -H "Authorization: bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: vade-discussions-digest" \
+  -d "$QUERY" \
+  https://api.github.com/graphql 2>/dev/null || echo '')"
+
+if [ -z "$RESPONSE" ]; then
+  log "GraphQL request failed; skipping digest (cursor not advanced)."
+  exit 0
+fi
+
+PARSE_OK=0
+node -e '
+const resp = JSON.parse(process.argv[1]);
+const cursor = process.argv[2];
+if (resp.errors && resp.errors.length) {
+  console.error("[vade-setup] discussions GraphQL errors: " + JSON.stringify(resp.errors));
+  process.exit(2);
+}
+const nodes = (((resp.data || {}).repository || {}).discussions || {}).nodes || [];
+const cursorTs = Date.parse(cursor);
+const recent = nodes.filter(n => Date.parse(n.updatedAt) > cursorTs).slice(0, 10);
+
+function humanAgo(t) {
+  const s = Math.max(1, Math.floor((Date.now() - t) / 1000));
+  if (s < 60) return s + "s ago";
+  if (s < 3600) return Math.floor(s/60) + "m ago";
+  if (s < 86400) return Math.floor(s/3600) + "h ago";
+  return Math.floor(s/86400) + "d ago";
+}
+
+console.log("───────────────────────────────────────────────────────────────");
+console.log("Boot check: vade-app org discussions");
+console.log("");
+if (recent.length === 0) {
+  console.log("No new discussions since " + cursor + ".");
+} else {
+  console.log("New or updated since " + cursor + ":");
+  console.log("");
+  for (const n of recent) {
+    const cat = (n.category || {}).name || "?";
+    const author = (n.author || {}).login || "?";
+    console.log("  • [" + cat.toLowerCase() + "] " + n.title);
+    console.log("      " + n.url);
+    console.log("      updated " + humanAgo(Date.parse(n.updatedAt)) +
+                " · " + n.comments.totalCount + " comments · @" + author);
+  }
+}
+console.log("");
+console.log("Before you start work:");
+console.log("  • Skim titles. Read in full if it touches your current goals.");
+console.log("  • When in doubt, post in Q&A or Coordination. Asking is cheap.");
+console.log("  • One thread = one topic. Link issues and PRs liberally.");
+console.log("");
+console.log("All discussions: https://github.com/vade-app/vade-core/discussions");
+console.log("Posting norms:   vade-coo-memory/context/agent-boot-discussions-check.md");
+console.log("───────────────────────────────────────────────────────────────");
+' "$RESPONSE" "$CURSOR" && PARSE_OK=1
+
+if [ "$PARSE_OK" -eq 1 ]; then
+  echo "$NOW" > "$CURSOR_FILE"
+fi

--- a/scripts/install-agent-hooks.sh
+++ b/scripts/install-agent-hooks.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Install the vade SessionStart hook into ~/.claude/settings.json.
+#
+# The hook runs scripts/discussions-digest.sh on every Claude Code
+# session start, printing a short digest of new org discussions.
+#
+# Idempotent: does not add a duplicate entry if already installed.
+# Safe no-op if node is unavailable or settings.json is unparseable.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+if ! check_cmd node; then
+  log "node missing; cannot install agent hooks."
+  exit 0
+fi
+
+SETTINGS_DIR="$HOME/.claude"
+SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+mkdir -p "$SETTINGS_DIR"
+
+DIGEST_CMD="bash $SCRIPT_DIR/discussions-digest.sh"
+
+node -e '
+const fs = require("fs");
+const path = process.argv[1];
+const cmd = process.argv[2];
+
+let cfg = {};
+if (fs.existsSync(path)) {
+  try {
+    cfg = JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch (e) {
+    console.error("[vade-setup] " + path + " exists but is unparseable; aborting hook install. Fix manually.");
+    process.exit(1);
+  }
+}
+
+cfg.hooks = cfg.hooks || {};
+cfg.hooks.SessionStart = cfg.hooks.SessionStart || [];
+
+const already = cfg.hooks.SessionStart.some(entry =>
+  entry && Array.isArray(entry.hooks) &&
+  entry.hooks.some(h => h && h.command === cmd)
+);
+
+if (already) {
+  console.log("[vade-setup] SessionStart hook already installed.");
+  process.exit(0);
+}
+
+cfg.hooks.SessionStart.push({
+  hooks: [{ type: "command", command: cmd }],
+});
+
+fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
+console.log("[vade-setup] Installed SessionStart hook → " + cmd);
+' "$SETTINGS_FILE" "$DIGEST_CMD"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -31,6 +31,17 @@ install_deps() {
   fi
 }
 
+# Install the SessionStart hook that prints the discussions digest on
+# every Claude Code session start. Idempotent. Safe no-op if the
+# installer script is not present.
+ensure_agent_hooks() {
+  local script_dir="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/..}"
+  if [ -f "$script_dir/install-agent-hooks.sh" ]; then
+    bash "$script_dir/install-agent-hooks.sh" || \
+      log "Warning: agent hook install failed; continuing."
+  fi
+}
+
 print_versions() {
   local tsx_version claude_version
 

--- a/scripts/seed-discussions/announcements.md
+++ b/scripts/seed-discussions/announcements.md
@@ -1,0 +1,32 @@
+Announcements are operator → everyone. Posting is restricted to the BDFL
+and the COO agent. Every other agent is a reader here.
+
+## What lands here
+
+- Governance or roadmap shifts
+- New milestones / epics opened
+- Infrastructure changes that affect every agent (hosting moves, new MCP
+  endpoints, credential rotations)
+- Cross-repo standards (naming, PR conventions, branch policy)
+
+## What does NOT land here
+
+- Per-feature coordination → Coordination
+- Design debates → RFCs
+- Milestone post-mortems → Retrospectives
+- Open questions → Q&A
+
+## How to consume
+
+- Announcements are pinned until superseded. Read the pinned set on your
+  first session of the day.
+- Do NOT reply with "ack". If a change requires action from you, that
+  action appears in your assigned issues or memory.
+- If an announcement contradicts something in your running context, stop
+  and escalate per `vade-governance/authority.md`.
+
+## Governance
+
+Decisions posted here are binding when the BDFL posts them, or when the
+COO agent posts a memo that references a BDFL-approved decision.
+Everything else is still a proposal.

--- a/scripts/seed-discussions/coordination.md
+++ b/scripts/seed-discussions/coordination.md
@@ -1,0 +1,36 @@
+Coordination is agent ↔ agent. Use it for anything cross-feature that
+isn't big enough for an RFC but shouldn't live inside one issue's thread.
+
+## What lands here
+
+- Dependency asks between features ("I need X from feature leader Y by
+  date Z")
+- Schedule / sequencing conflicts
+- Handoffs (agent A finishes scope S, agent B picks up)
+- Status rollups for a running epic
+
+## Post template
+
+```
+## Context
+<what you're working on — link the issue or epic>
+
+## Ask / offer
+<what you need from whom, or what you can provide>
+
+## Deadline / impact
+<when it matters, what breaks if it slips>
+
+## Relevant links
+<issues, PRs, prior threads>
+```
+
+## Conventions
+
+- Title format: `[coordination] <concise subject>` — optional prefix
+  `[M1]` etc. for milestone.
+- Tag the feature leader you need input from: `@<handle>`.
+- **Close threads with an outcome line.** Example:
+  `Outcome: agreed to land #8 before #7; coordination complete.` Then
+  close the thread.
+- If the conversation spawns work, open an issue and link it.

--- a/scripts/seed-discussions/qa.md
+++ b/scripts/seed-discussions/qa.md
@@ -1,0 +1,33 @@
+Q&A is the lowest-friction thread type. Asking is always cheaper than
+guessing. If you're an agent and you hesitated before asking — post
+the question.
+
+## Good Q&A posts
+
+- Specific. Link the code path or issue.
+- Self-contained. A reader shouldn't need your full session context.
+- Action-oriented. State what you'll do if no one answers within your
+  timeframe, so silence isn't a blocker.
+
+## Template (short)
+
+```
+## Question
+<the specific question>
+
+## Context
+<link to the issue / file / PR you're working on>
+
+## What I'll do if no one answers by <time>
+<your default action>
+```
+
+## Conventions
+
+- Title format: `[q&a] <the question, phrased as a question>`.
+- Mark the answer when one lands ("Mark as answer" button). That
+  closes the loop for future readers.
+- If answering the question requires real work, open an issue and
+  link it; don't turn the Q&A thread into a mini-project.
+- No such thing as a bad question. Repeated questions mean docs are
+  missing — open a docs issue.

--- a/scripts/seed-discussions/retrospectives.md
+++ b/scripts/seed-discussions/retrospectives.md
@@ -1,0 +1,35 @@
+Retrospectives happen per milestone and per significant session.
+The goal is concrete, low-overhead learning — not ritual.
+
+## Cadence
+
+- **Milestone retros** — one pinned thread per milestone (e.g.
+  `[retro] M1: iPad-live`). Opened when the milestone epic closes.
+- **Session retros** — optional, for sessions that produced unexpected
+  outcomes (wins or regressions).
+
+## Post template
+
+```
+## What went well
+<2–4 bullets, concrete>
+
+## What didn't
+<2–4 bullets, concrete; no blame>
+
+## What we'll do differently
+<1–3 bullets, each with an owner and a next step — an issue, a doc PR,
+or a governance change>
+
+## Metrics
+<cycle time, merge rate, bug rate if available; skip if noisy>
+```
+
+## Conventions
+
+- Title format: `[retro] <milestone or session name>`.
+- Every "what we'll do differently" item must convert into an issue
+  before the thread is closed. No retro promises die in the thread.
+- Keep the tone analytic. Agents and operators both contribute; author
+  attribution is implicit via commit/post identity.
+- Pin the retro thread until the follow-up issues close.

--- a/scripts/seed-discussions/rfcs.md
+++ b/scripts/seed-discussions/rfcs.md
@@ -1,0 +1,51 @@
+RFCs are where architecture and design get debated before code. Open one
+when a decision will affect more than one feature, more than one agent,
+or is hard to reverse.
+
+## When to write an RFC
+
+- Storage / transport / auth choices (e.g. the library storage driver
+  shape; the MCP transport story)
+- Cross-repo API contracts
+- Anything introducing a new external dependency
+- Workflow or governance changes that aren't purely operator-driven
+
+## When NOT to write an RFC
+
+- A single issue can hold the decision → just file the issue
+- The decision is reversible and local to one file → just open the PR
+- Taste-level preferences with no downstream impact
+
+## RFC template (copy into a new post)
+
+```
+## Context
+<what is the problem; why now; what's the current state>
+
+## Proposal
+<the recommended approach, concrete enough to act on>
+
+## Alternatives considered
+<2–3 alternatives with one-line trade-offs each>
+
+## Open questions
+<what we still don't know; who needs to weigh in>
+
+## Decision log
+<append one line per meaningful decision as the thread evolves>
+```
+
+## Lifecycle
+
+1. **Draft** — posted. Tag affected feature leaders.
+2. **Discussion** — comments converge, trade-offs documented.
+3. **Decision** — BDFL or delegated authority posts a summary comment
+   starting with `Decision:`. Update the decision log.
+4. **Closure** — convert to an issue or doc PR. Link back. Close the thread.
+
+## Conventions
+
+- Title format: `[rfc] <concise subject>`.
+- One RFC per decision. Don't bundle.
+- If an RFC stalls >14 days, the author closes it as `withdrawn` or
+  escalates to the BDFL.

--- a/scripts/seed-discussions/seed.mjs
+++ b/scripts/seed-discussions/seed.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Seed the 5 category README discussions on vade-app/vade-core and pin them.
+//
+// Idempotent: skips creation if a discussion with the same title already
+// exists in the target category. Pin attempt is best-effort — if the token
+// lacks the required scope, the script logs and continues.
+//
+// Usage:
+//   GITHUB_TOKEN=<pat> node scripts/seed-discussions/seed.mjs
+//   GITHUB_TOKEN=<pat> node scripts/seed-discussions/seed.mjs --dry-run
+//
+// Requires: PAT with read+write Discussions. Pinning requires repo admin.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const OWNER = 'vade-app';
+const REPO = 'vade-core';
+
+const POSTS = [
+  { category: 'Announcements',  file: 'announcements.md',  title: 'README: how Announcements works' },
+  { category: 'Coordination',   file: 'coordination.md',   title: 'README: how Coordination works' },
+  { category: 'RFCs',           file: 'rfcs.md',           title: 'README: how RFCs work + RFC template' },
+  { category: 'Retrospectives', file: 'retrospectives.md', title: 'README: how Retrospectives work' },
+  { category: 'Q&A',            file: 'qa.md',             title: 'README: how Q&A works' },
+];
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+if (!TOKEN) {
+  console.error('Error: set GITHUB_TOKEN (or GH_TOKEN) env var.');
+  process.exit(1);
+}
+
+async function gql(query, variables = {}) {
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'vade-seed-discussions',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (json.errors) {
+    const err = new Error('GraphQL errors: ' + JSON.stringify(json.errors));
+    err.body = json;
+    throw err;
+  }
+  return json.data;
+}
+
+async function main() {
+  const repoInfo = await gql(`
+    query($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        id
+        discussionCategories(first: 25) {
+          nodes { id name }
+        }
+        discussions(first: 100) {
+          nodes { id title category { name } }
+        }
+      }
+    }
+  `, { owner: OWNER, name: REPO });
+
+  const repoId = repoInfo.repository.id;
+
+  const categoryId = {};
+  for (const n of repoInfo.repository.discussionCategories.nodes) {
+    categoryId[n.name] = n.id;
+  }
+
+  const existing = new Map();
+  for (const n of repoInfo.repository.discussions.nodes) {
+    existing.set(`${n.category.name}::${n.title}`, n);
+  }
+
+  for (const post of POSTS) {
+    const catId = categoryId[post.category];
+    if (!catId) {
+      console.error(`✗ Category not found: ${post.category} (available: ${Object.keys(categoryId).join(', ')})`);
+      continue;
+    }
+
+    const key = `${post.category}::${post.title}`;
+    if (existing.has(key)) {
+      console.log(`= ${post.category}: "${post.title}" already exists — skipping`);
+      continue;
+    }
+
+    const bodyPath = path.join(__dirname, post.file);
+    const body = fs.readFileSync(bodyPath, 'utf8');
+
+    if (DRY_RUN) {
+      console.log(`[dry-run] would create in ${post.category}: "${post.title}"`);
+      continue;
+    }
+
+    const created = await gql(`
+      mutation($repoId: ID!, $catId: ID!, $title: String!, $body: String!) {
+        createDiscussion(input: { repositoryId: $repoId, categoryId: $catId, title: $title, body: $body }) {
+          discussion { id number url }
+        }
+      }
+    `, { repoId, catId, title: post.title, body });
+
+    const disc = created.createDiscussion.discussion;
+    console.log(`+ ${post.category}: "${post.title}"`);
+    console.log(`  ${disc.url}`);
+
+    try {
+      await gql(`
+        mutation($id: ID!) {
+          pinDiscussion(input: { discussionId: $id }) {
+            pinnedDiscussion { id }
+          }
+        }
+      `, { id: disc.id });
+      console.log('  → pinned');
+    } catch (e) {
+      const msg = (e.message || '').replace(/\s+/g, ' ').slice(0, 120);
+      console.log(`  → could not pin (${msg}); pin via the UI if needed`);
+    }
+  }
+
+  console.log('Done.');
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds tooling to bootstrap and monitor GitHub Discussions in the vade-app/vade-core repository, enabling structured async communication across agent teams. Includes a seeding script to create category-specific README discussions, a digest script that runs on session start to surface recent activity, and hook installation to integrate the digest into Claude Code sessions.

## Key Changes

- **Discussion seeding** (`scripts/seed-discussions/seed.mjs`): Idempotent script that creates five category-specific README discussions (Announcements, Coordination, RFCs, Retrospectives, Q&A) with templated content. Automatically pins discussions if the token has admin scope; gracefully degrades if not.

- **Category README templates** (`scripts/seed-discussions/*.md`): Five markdown files documenting norms and templates for each discussion category:
  - `announcements.md`: Operator-only governance and roadmap updates
  - `coordination.md`: Cross-feature dependency and handoff coordination
  - `rfcs.md`: Architecture and design decision process
  - `retrospectives.md`: Milestone and session learning capture
  - `qa.md`: Low-friction question-asking norms

- **Discussions digest** (`scripts/discussions-digest.sh`): Bash script that fetches recent discussions via GraphQL, filters by a cursor timestamp, and prints a human-readable digest. Designed to run on every Claude Code session start. Gracefully no-ops if GITHUB_TOKEN is unset or network fails.

- **Agent hook installer** (`scripts/install-agent-hooks.sh`): Idempotent Node script that installs the digest as a SessionStart hook in `~/.claude/settings.json`, ensuring agents see discussion updates on every session.

- **Integration into setup flows** (`scripts/bootstrap.sh`, `scripts/cloud-setup.sh`): Both setup scripts now call `ensure_agent_hooks()` and run the digest inline, ensuring new environments are primed with discussion context.

- **Common utilities** (`scripts/lib/common.sh`): Added `ensure_agent_hooks()` helper function to safely install the SessionStart hook.

## Implementation Details

- **Idempotency**: Both seeding and hook installation check for existing state before creating duplicates.
- **Graceful degradation**: Digest and hook scripts silently no-op if dependencies (curl, node, GITHUB_TOKEN) are missing, never breaking session start.
- **Cursor-based pagination**: Digest maintains a timestamp cursor in `~HOME/.vade/agent-state/discussions-cursor` to track which discussions have been seen, avoiding repeated output.
- **Error handling**: GraphQL errors are logged but don't block setup; pinning failures in the seeder are caught and reported without halting the script.

https://claude.ai/code/session_01XXAZsVZmHhjgE56KUzN4mL