### PR TITLE
Add session-lifecycle hooks for SOP-MEM-001 discipline

### DIFF
--- a/scripts/install-agent-hooks.sh
+++ b/scripts/install-agent-hooks.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Install the vade SessionStart hook into ~/.claude/settings.json.
+# Install the vade hooks into ~/.claude/settings.json.
 #
-# The hook runs scripts/discussions-digest.sh on every Claude Code
-# session start, printing a short digest of new org discussions.
+# Hooks installed (event → command):
+#   SessionStart → scripts/discussions-digest.sh
+#   SessionStart → scripts/session-lifecycle.sh
+#   Stop         → scripts/session-lifecycle.sh --end
 #
-# Idempotent: does not add a duplicate entry if already installed.
+# Idempotent: does not add duplicate entries if already installed.
 # Safe no-op if node is unavailable or settings.json is unparseable.
 set -euo pipefail
 
@@ -22,11 +24,21 @@ SETTINGS_FILE="$SETTINGS_DIR/settings.json"
 mkdir -p "$SETTINGS_DIR"
 
 DIGEST_CMD="bash $SCRIPT_DIR/discussions-digest.sh"
+LIFECYCLE_START_CMD="bash $SCRIPT_DIR/session-lifecycle.sh"
+LIFECYCLE_END_CMD="bash $SCRIPT_DIR/session-lifecycle.sh --end"
+
+# Pairs of "event|command" for the node script to install.
+HOOK_SPEC="$(cat <<EOF
+SessionStart|$DIGEST_CMD
+SessionStart|$LIFECYCLE_START_CMD
+Stop|$LIFECYCLE_END_CMD
+EOF
+)"
 
 node -e '
 const fs = require("fs");
 const path = process.argv[1];
-const cmd = process.argv[2];
+const spec = process.argv[2];
 
 let cfg = {};
 if (fs.existsSync(path)) {
@@ -39,22 +51,29 @@ if (fs.existsSync(path)) {
 }
 
 cfg.hooks = cfg.hooks || {};
-cfg.hooks.SessionStart = cfg.hooks.SessionStart || [];
 
-const already = cfg.hooks.SessionStart.some(entry =>
-  entry && Array.isArray(entry.hooks) &&
-  entry.hooks.some(h => h && h.command === cmd)
-);
-
-if (already) {
-  console.log("[vade-setup] SessionStart hook already installed.");
-  process.exit(0);
-}
-
-cfg.hooks.SessionStart.push({
-  hooks: [{ type: "command", command: cmd }],
+const entries = spec.split("\n").filter(Boolean).map(line => {
+  const [event, ...cmdParts] = line.split("|");
+  return { event, command: cmdParts.join("|") };
 });
 
-fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
-console.log("[vade-setup] Installed SessionStart hook → " + cmd);
-' "$SETTINGS_FILE" "$DIGEST_CMD"
+let dirty = false;
+for (const { event, command } of entries) {
+  cfg.hooks[event] = cfg.hooks[event] || [];
+  const already = cfg.hooks[event].some(entry =>
+    entry && Array.isArray(entry.hooks) &&
+    entry.hooks.some(h => h && h.command === command)
+  );
+  if (already) {
+    console.log("[vade-setup] " + event + " hook already installed → " + command);
+    continue;
+  }
+  cfg.hooks[event].push({ hooks: [{ type: "command", command }] });
+  console.log("[vade-setup] Installed " + event + " hook → " + command);
+  dirty = true;
+}
+
+if (dirty) {
+  fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
+}
+' "$SETTINGS_FILE" "$HOOK_SPEC"

--- a/scripts/session-lifecycle.sh
+++ b/scripts/session-lifecycle.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Print a session-lifecycle reminder for Claude Code agents working in
+# any vade-app repo. Two modes:
+#
+#   session-lifecycle.sh         → boot reminder (SessionStart hook)
+#   session-lifecycle.sh --end   → end-of-session reminder (Stop hook)
+#
+# Reminder-only. The script does not call Mem0, does not read Mem0,
+# does not commit files. Its output tells Claude what to do; Claude
+# does the work via MCP tools.
+#
+# See vade-coo-memory/coo/mem0_sop.md for the full SOP.
+# See docs/briefings/003-claude-code-cross-session-state.md in
+# vade-core for the design rationale.
+#
+# Graceful no-op if sourced libraries or node are missing; never
+# breaks session start or stop.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+MODE="start"
+if [ "${1:-}" = "--end" ]; then
+  MODE="end"
+fi
+
+PLANS_DIR="$HOME/.claude/plans"
+STATE_DIR="$HOME/.vade/agent-state"
+RUN_ID_FILE="$STATE_DIR/current-run-id"
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+list_plans() {
+  if [ -d "$PLANS_DIR" ]; then
+    find "$PLANS_DIR" -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort
+  fi
+}
+
+if [ "$MODE" = "start" ]; then
+  RUN_ID="run-$(date -u +%Y-%m-%dT%H%M%S)"
+  echo "$RUN_ID" > "$RUN_ID_FILE" 2>/dev/null || true
+
+  echo "───────────────────────────────────────────────────────────────"
+  echo "Session lifecycle (SOP-MEM-001 §5)"
+  echo ""
+  echo "Runtime identity: agent_id=\"claude-code\""
+  echo "Suggested run_id: $RUN_ID"
+  echo ""
+  echo "On start:"
+  echo "  • Run search_memories with filter"
+  echo "    {AND: [{user_id: \"ven\"}, {agent_id: \"claude-code\"}]}"
+  echo "    Pull the most recent episodic entries. Check artifact_refs"
+  echo "    for any in-flight plan files from prior sessions."
+  echo ""
+
+  plans="$(list_plans || true)"
+  if [ -n "$plans" ]; then
+    echo "  • Plan files already present in $PLANS_DIR:"
+    while IFS= read -r p; do
+      [ -n "$p" ] && echo "      - $p"
+    done <<< "$plans"
+    echo "    These may be stale from a prior session or pre-committed"
+    echo "    work. Cross-reference with the Mem0 hand-off above."
+    echo ""
+  fi
+
+  echo "Full SOP: vade-coo-memory/coo/mem0_sop.md"
+  echo "───────────────────────────────────────────────────────────────"
+  exit 0
+fi
+
+# --- end mode ---
+
+RUN_ID=""
+if [ -f "$RUN_ID_FILE" ] && [ -s "$RUN_ID_FILE" ]; then
+  RUN_ID="$(cat "$RUN_ID_FILE")"
+fi
+
+echo "───────────────────────────────────────────────────────────────"
+echo "Session lifecycle — end of session (SOP-MEM-001 §5)"
+echo ""
+if [ -n "$RUN_ID" ]; then
+  echo "run_id: $RUN_ID"
+  echo ""
+fi
+echo "Before the container tears down:"
+echo ""
+echo "  1. Commit any plan files worth preserving."
+echo "     Path convention: <working-repo>/.vade/plans/<slug>.md"
+echo "     Commit via git CLI if GITHUB_TOKEN is set, else via"
+echo "     GitHub MCP (create_or_update_file)."
+
+plans="$(list_plans || true)"
+if [ -n "$plans" ]; then
+  echo ""
+  echo "     Candidate files in $PLANS_DIR:"
+  while IFS= read -r p; do
+    [ -n "$p" ] && echo "       - $p"
+  done <<< "$plans"
+fi
+
+echo ""
+echo "  2. Write ONE episodic Mem0 entry with full scope:"
+echo "       user_id    = \"ven\""
+echo "       agent_id   = \"claude-code\""
+if [ -n "$RUN_ID" ]; then
+  echo "       run_id     = \"$RUN_ID\""
+else
+  echo "       run_id     = (current session run_id)"
+fi
+echo "       metadata   = { memory_type: \"episodic\","
+echo "                      event: \"session_summary\","
+echo "                      artifact_refs: [\"<repo>/.vade/plans/<slug>.md@<sha>\"],"
+echo "                      retention: \"ephemeral\","
+echo "                      expiration_date: <now + 30 days> }"
+echo ""
+echo "  3. If this session was the COO working in vade-coo-memory,"
+echo "     also write a session log to vade-agent-logs per that"
+echo "     repo's CLAUDE.md template."
+echo ""
+echo "Full SOP: vade-coo-memory/coo/mem0_sop.md"
+echo "───────────────────────────────────────────────────────────────"


### PR DESCRIPTION
## Summary

Implements step 1 of the approved plan in response to briefing 003
(`vade-app/vade-core` PR #59, merged 2026-04-21). Lays the
infrastructure for Claude Code cross-session state discipline; the
follow-up work is CLAUDE.md updates in each vade-app repo.

- **New `scripts/session-lifecycle.sh`** — reminder-only script that
  prints Mem0 session-lifecycle instructions per SOP-MEM-001 §5
  (`vade-coo-memory/coo/mem0_sop.md`). Two modes:
  - Default (SessionStart): remind Claude to `search_memories` with
    `{AND: [{user_id: "ven"}, {agent_id: "claude-code"}]}`, list any
    pre-existing plan files in `~/.claude/plans/`, generate and
    persist a suggested `run_id`.
  - `--end` (Stop): remind Claude to write one episodic summary,
    commit any plan files into `<repo>/.vade/plans/` (via git CLI
    when `GITHUB_TOKEN` set, else via GitHub MCP), and reference
    them in the summary's `artifact_refs`.
- **`scripts/install-agent-hooks.sh` extended** to install three
  hook entries idempotently in one node pass: the existing
  `discussions-digest.sh` SessionStart hook plus the two new
  session-lifecycle entries (SessionStart and Stop). Existing
  installations detected and preserved; upgrades are additive.

## Design notes

- **Reminder-only.** The script never calls Mem0, commits files, or
  reads/writes the repo. That keeps it simple and lets Claude use
  MCP tools for the actual work. Follows the existing
  `discussions-digest.sh` graceful-no-op pattern.
- **No new `harness/` namespace.** Plans commit to
  `<working-repo>/.vade/plans/<slug>.md` — using the `.vade/`
  convention already established by `common.sh` (`~/.vade/library/`)
  and `install-agent-hooks.sh` state (`~/.vade/agent-state/`). Cross-repo
  sessions (typical COO work) continue to use
  `vade-coo-memory/coo/plans/` (precedent from briefing 001).
- **Mem0 stores pointers, not contents.** Per SOP §2c, episodic
  summaries carry `artifact_refs` with `<path>@<sha>` so the next
  session can dereference via `git show`.

## Test plan

- [x] `bash -n` both scripts: syntax clean.
- [x] `session-lifecycle.sh` (start) emits the boot reminder with a
      suggested `run_id` and lists any plans in `~/.claude/plans/`.
- [x] `session-lifecycle.sh --end` emits the end-of-session
      reminder and picks up the persisted `run_id`.
- [x] `install-agent-hooks.sh` installs all three hooks on a fresh
      `~/.claude/settings.json` (tested under a scratch HOME).
- [x] Second run is a no-op; detects all three as already installed.
- [x] Upgrade path: starting from a settings.json with only the old
      digest hook, the new entries are added and the existing one
      is preserved.
- [ ] End-to-end verification in a fresh Claude Code cloud session
      after merge. See `vade-coo-memory/.claude/plans/temporal-tumbling-pudding.md`
      for the full verification checklist.

## Follow-ups (not in this PR)

- Per-repo `CLAUDE.md` addition of a "Mem0 session lifecycle" section
  pointing at SOP-MEM-001 (vade-core first, then vade-runtime,
  vade-governance, vade-agent-logs).
- Separate one-line default-model flip (Opus 4.7 1M → 200K).
- Adoption memo in `vade-coo-memory/coo/memos.md` after BDFL approval.

Links: briefing 003 (`vade-app/vade-core` PR #59), approved plan
at `vade-coo-memory/.claude/plans/temporal-tumbling-pudding.md`
(local-only for now; can lift into the repo if useful).