### PR TITLE
fix(session-lifecycle): pick up plans from Claude Code's home

### DIFF
--- a/scripts/session-lifecycle.sh
+++ b/scripts/session-lifecycle.sh
@@ -26,15 +26,24 @@ if [ "${1:-}" = "--end" ]; then
   MODE="end"
 fi
 
+# Claude Code's Write tool resolves ~/ to /home/user in the cloud
+# container while bash $HOME is /root. Plans authored through
+# Claude's tools therefore land at a different path than the hook
+# would see. Search both so the candidate list is complete
+# regardless of which home a writer used.
 PLANS_DIR="$HOME/.claude/plans"
+CLAUDE_PLANS_DIR="/home/user/.claude/plans"
+
 STATE_DIR="$HOME/.vade/agent-state"
 RUN_ID_FILE="$STATE_DIR/current-run-id"
 mkdir -p "$STATE_DIR" 2>/dev/null || true
 
 list_plans() {
-  if [ -d "$PLANS_DIR" ]; then
-    find "$PLANS_DIR" -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort
-  fi
+  {
+    [ -d "$PLANS_DIR" ]        && find "$PLANS_DIR"        -maxdepth 1 -type f -name '*.md' 2>/dev/null
+    [ "$PLANS_DIR" != "$CLAUDE_PLANS_DIR" ] && [ -d "$CLAUDE_PLANS_DIR" ] \
+                               && find "$CLAUDE_PLANS_DIR" -maxdepth 1 -type f -name '*.md' 2>/dev/null
+  } | sort -u
 }
 
 if [ "$MODE" = "start" ]; then
@@ -56,7 +65,7 @@ if [ "$MODE" = "start" ]; then
 
   plans="$(list_plans || true)"
   if [ -n "$plans" ]; then
-    echo "  • Plan files already present in $PLANS_DIR:"
+    echo "  • Plan files already present:"
     while IFS= read -r p; do
       [ -n "$p" ] && echo "      - $p"
     done <<< "$plans"
@@ -94,7 +103,7 @@ echo "     GitHub MCP (create_or_update_file)."
 plans="$(list_plans || true)"
 if [ -n "$plans" ]; then
   echo ""
-  echo "     Candidate files in $PLANS_DIR:"
+  echo "     Candidate files:"
   while IFS= read -r p; do
     [ -n "$p" ] && echo "       - $p"
   done <<< "$plans"


### PR DESCRIPTION
## Summary

Fixes a bug surfaced while verifying briefing 003 end-to-end (see vade-core #60): the Stop-hook's candidate plan list came up empty even when Claude had just written a plan file to `~/.claude/plans/`.

## Root cause

Two different processes see different values of `~/`:

| Process                         | `~/` resolves to            |
|---------------------------------|-----------------------------|
| Claude Code's Write tool        | `/home/user`                |
| Bash (and hook subprocesses)    | `/root` (env `HOME=/root`)  |

`session-lifecycle.sh` was reading `$HOME/.claude/plans` → `/root/.claude/plans`, but Claude-authored plans land under `/home/user/.claude/plans`. Net effect: in the cloud container the Stop reminder *never* lists any plan files, defeating the whole artefact-commit prompt.

## Fix

Search both `$HOME/.claude/plans` and `/home/user/.claude/plans` in `list_plans`, dedupe via `sort -u`, and drop the now-misleading `$PLANS_DIR` mention from the display text (full paths are still shown per file).

Minimal and defensive — the script remains reminder-only and a no-op when neither directory exists.

## Alternative considered

A deeper fix would normalise `HOME` at container bootstrap so both processes agree. That's a bigger change in ownership (runtime bootstrap / devcontainer config) and risks breaking other assumptions about `/root`. Worth a follow-up, but this small change unblocks the hook today without touching anything outside `session-lifecycle.sh`.

## Test plan

- [x] `bash -n scripts/session-lifecycle.sh` — syntax clean.
- [x] Manual run with plan at `/home/user/.claude/plans/verify-003.md` and `HOME=/root` — file appears in both start (`• Plan files already present:`) and end (`Candidate files:`) reminders.
- [x] Run with no plans in either dir — output unchanged (no candidate section).
- [x] Run with a plan in `$HOME/.claude/plans` only — output unchanged.
- [ ] In-session check after vade-runtime image rebuild.

## Linked work

- vade-core #60 (verification PR) — references this fix as a known follow-up.
- Follows vade-runtime #10 (session-lifecycle hooks introduction, merged 2026-04-21).