### PR TITLE
cloud-env: fix sync_claude_config nesting + env clobber

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -47,6 +47,21 @@ install_deps() {
 # settings.json is copied so coo-bootstrap can mutate the env block
 # without dirtying the git working tree. Plans/, projects/, todos/,
 # statsig/ and other Claude Code-managed dirs are left alone.
+#
+# Subdir strategy: Claude Code itself ships some of these dirs
+# pre-populated (e.g. ~/.claude/skills/session-start-hook/). Replacing
+# a real directory with a symlink via `ln -snf` silently nests
+# instead, so when the destination already exists as a real dir we
+# merge per-entry: each source child is symlinked in alongside the
+# built-ins. Name collisions with a built-in are skipped with a
+# warning rather than clobbered.
+#
+# settings.json: the source tree's copy is the source of truth for
+# hooks and other top-level keys, but the destination's `.env` is
+# populated at runtime by coo-bootstrap and must survive a re-sync
+# (coo-bootstrap's idempotency marker short-circuits re-merging on
+# subsequent runs). We preserve dest env via a node-based merge when
+# both files exist; otherwise we fall back to a plain copy.
 sync_claude_config() {
   local src="${1:-/home/user/vade-runtime/.claude}"
   local dst="${2:-$HOME/.claude}"
@@ -56,13 +71,59 @@ sync_claude_config() {
   fi
   mkdir -p "$dst"
   for sub in skills agents commands hooks; do
-    [ -d "$src/$sub" ] && ln -snf "$src/$sub" "$dst/$sub"
+    [ -d "$src/$sub" ] || continue
+    _sync_claude_subdir "$src/$sub" "$dst/$sub"
   done
   if [ -f "$src/settings.json" ]; then
-    cp -f "$src/settings.json" "$dst/settings.json"
-    chmod 600 "$dst/settings.json"
+    _sync_claude_settings "$src/settings.json" "$dst/settings.json"
   fi
   log "Synced $src → $dst (subdirs symlinked, settings.json copied)"
+}
+
+_sync_claude_subdir() {
+  local src_sub="$1" dst_sub="$2"
+  if [ -L "$dst_sub" ] || [ ! -e "$dst_sub" ]; then
+    ln -snf "$src_sub" "$dst_sub"
+    return 0
+  fi
+  # Destination exists as a real directory (e.g. Claude Code built-in
+  # skills). Merge per-entry so both coexist.
+  local entry name target
+  for entry in "$src_sub"/*; do
+    [ -e "$entry" ] || continue
+    name="$(basename "$entry")"
+    target="$dst_sub/$name"
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+      log "  warn: $target exists and is not a symlink; skipping to avoid clobbering built-in"
+      continue
+    fi
+    ln -snf "$entry" "$target"
+  done
+}
+
+_sync_claude_settings() {
+  local src_file="$1" dst_file="$2"
+  if [ -f "$dst_file" ] && check_cmd node; then
+    if node -e '
+      const fs = require("fs");
+      const [srcPath, dstPath] = process.argv.slice(1);
+      const src = JSON.parse(fs.readFileSync(srcPath, "utf8"));
+      let dstEnv = {};
+      try {
+        const dst = JSON.parse(fs.readFileSync(dstPath, "utf8")) || {};
+        dstEnv = dst.env || {};
+      } catch {}
+      const merged = Object.assign({}, src);
+      merged.env = Object.assign({}, src.env || {}, dstEnv);
+      fs.writeFileSync(dstPath, JSON.stringify(merged, null, 2) + "\n");
+    ' "$src_file" "$dst_file" 2>/dev/null; then
+      chmod 600 "$dst_file"
+      return 0
+    fi
+    log "  warn: settings.json merge via node failed; falling back to plain copy"
+  fi
+  cp -f "$src_file" "$dst_file"
+  chmod 600 "$dst_file"
 }
 
 print_versions() {


### PR DESCRIPTION
## Summary

Two regressions surfaced while verifying #16 in a live cloud session:

1. **Subdir symlinks nested inside Claude Code built-ins.**
   `ln -snf $src/skills $dst/skills` silently nests the symlink inside the pre-existing `~/.claude/skills/` directory that Claude Code ships (containing built-ins like `session-start-hook/`), so committed skills landed at `~/.claude/skills/skills/<name>` where Claude Code never looks for them. `-n` only short-circuits when the destination is already a symlink, not when it's a real directory.

   Fix: extract `_sync_claude_subdir`. Replace the destination when it's missing or already a symlink; otherwise merge per-entry (symlink each source child alongside the built-ins) and warn-and-skip on name collisions with a real dir.

2. **`cp -f` of settings.json clobbered the merged env block.**
   Source settings.json has `env: {}`; coo-bootstrap populates the destination's env block at runtime with COO secrets (`AGENTMAIL_API_KEY`, `GITHUB_MCP_PAT` when the 1P item is accessible). On a re-run of `cloud-setup.sh`, the bootstrap marker short-circuits re-merging, so the plain copy turns a working container into one where `${AGENTMAIL_API_KEY}` etc. in `.mcp.json` no longer resolve.

   Fix: extract `_sync_claude_settings`. When both files exist, merge via node preserving dest's `.env`; fall back to plain copy on first run or when node is missing.

## Test plan

- [x] First-run (dest settings.json missing): plain copy path → `.env` = `{}` from source, then coo-bootstrap merges secrets. Verified.
- [x] Re-run `cloud-setup.sh` with bootstrap marker present: merged `.env` survives (`AGENTMAIL_API_KEY` preserved in `/root/.claude/settings.json`).
- [x] Live-edit: create `vade-runtime/.claude/skills/test-skill.md`, re-run setup → `/root/.claude/skills/test-skill.md` is a symlink pointing at source (no nesting), alongside the built-in `session-start-hook/` dir.
- [x] Name-collision guard: put a `session-start-hook/` in source; re-run → warning logged, real built-in dir left intact, symlink not created.
- [x] Idempotent: second re-run makes no changes and produces the same final state.

https://claude.ai/code/session_01L3CcBiNWkz6N9pQJcMBxMy