### PR TITLE
cloud-env: surface COO identity, AgentMail MCP, and Playwright paths on boot

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,7 @@
         "matcher": "startup",
         "hooks": [
           { "type": "command", "command": "bash /home/user/vade-runtime/scripts/coo-bootstrap.sh" },
+          { "type": "command", "command": "bash /home/user/vade-runtime/scripts/coo-identity-digest.sh" },
           { "type": "command", "command": "bash /home/user/vade-runtime/scripts/discussions-digest.sh" }
         ]
       },

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,6 +10,13 @@
       "headers": {
         "Authorization": "Bearer ${GITHUB_MCP_PAT}"
       }
+    },
+    "agentmail": {
+      "command": "npx",
+      "args": ["-y", "agentmail-mcp"],
+      "env": {
+        "AGENTMAIL_API_KEY": "${AGENTMAIL_API_KEY}"
+      }
     }
   }
 }

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# COO identity digest for cloud Claude Code sessions.
+#
+# Prints the vade-coo-memory boot instructions (CLAUDE.md) and the
+# latest memo header(s) so the identity reading order lands in the
+# session's context on startup, rather than requiring a manual read
+# pass. Called from the SessionStart: startup hook after
+# coo-bootstrap.sh.
+#
+# No-op if vade-coo-memory is not checked out at the expected path.
+# Output is reminder-only — it does not load Mem0, does not commit
+# files, does not fail the session if the repo is missing.
+set -euo pipefail
+
+MEM_REPO="${COO_MEMORY_DIR:-/home/user/vade-coo-memory}"
+CLAUDE_MD="$MEM_REPO/CLAUDE.md"
+MEMOS="$MEM_REPO/coo/memos.md"
+
+if [ ! -f "$CLAUDE_MD" ]; then
+  echo "[vade-setup] coo-identity-digest: $CLAUDE_MD not found; skipping."
+  exit 0
+fi
+
+echo "───────────────────────────────────────────────────────────────"
+echo "COO identity boot (vade-coo-memory/CLAUDE.md)"
+echo "───────────────────────────────────────────────────────────────"
+cat "$CLAUDE_MD"
+
+if [ -f "$MEMOS" ]; then
+  echo ""
+  echo "───────────────────────────────────────────────────────────────"
+  echo "Latest memo headers (newest first; see coo/memos.md for bodies)"
+  echo "───────────────────────────────────────────────────────────────"
+  # Emit the last three memo headers (lines starting with '## MEMO ').
+  # Case-law is read bottom-up; grep -n + tail gives the tail, then we
+  # format as a short list.
+  grep -n '^## MEMO ' "$MEMOS" | tail -n 3 | awk -F: '{
+    line=$1
+    sub(/^[^:]+:/, "", $0)
+    header=$0
+    sub(/^## /, "", header)
+    printf "  L%-5s %s\n", line, header
+  }'
+  echo ""
+  echo "Full file: $MEMOS"
+fi
+
+echo "───────────────────────────────────────────────────────────────"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -277,6 +277,15 @@ fetch_coo_secrets() {
 # Merge COO env vars into ~/.claude/settings.json "env" object. Claude
 # Code reads this at process startup, so ${GITHUB_MCP_PAT} etc. in
 # .mcp.json substitute correctly. Idempotent.
+#
+# Also surfaces cloud-sandbox tool paths that Claude Code doesn't pick
+# up by default but that scripts/agents regularly need:
+#   - NODE_PATH points to the sandbox's global node_modules so
+#     `import 'playwright'` etc. resolves from any cwd.
+#   - PLAYWRIGHT_BROWSERS_PATH points to the pre-installed browser
+#     bundle so Playwright finds chromium without a download.
+# Both are only exported when the corresponding filesystem path
+# exists, so this is a no-op outside the Claude cloud image.
 _write_claude_settings_env() {
   local pat="$1" agentmail="$2"
   if ! check_cmd node; then
@@ -288,7 +297,13 @@ _write_claude_settings_env() {
   mkdir -p "$settings_dir"
   [ -f "$settings_file" ] || echo '{}' > "$settings_file"
 
-  GITHUB_MCP_PAT="$pat" AGENTMAIL_API_KEY="$agentmail" node -e '
+  local node_path=""
+  [ -d "/opt/node22/lib/node_modules" ] && node_path="/opt/node22/lib/node_modules"
+  local pw_browsers=""
+  [ -d "/opt/pw-browsers" ] && pw_browsers="/opt/pw-browsers"
+
+  GITHUB_MCP_PAT="$pat" AGENTMAIL_API_KEY="$agentmail" \
+  NODE_PATH="$node_path" PLAYWRIGHT_BROWSERS_PATH="$pw_browsers" node -e '
     const fs = require("fs");
     const path = process.argv[1];
     let cfg = {};
@@ -304,6 +319,12 @@ _write_claude_settings_env() {
     }
     if (process.env.AGENTMAIL_API_KEY) {
       merged.AGENTMAIL_API_KEY = process.env.AGENTMAIL_API_KEY;
+    }
+    if (process.env.NODE_PATH) {
+      merged.NODE_PATH = process.env.NODE_PATH;
+    }
+    if (process.env.PLAYWRIGHT_BROWSERS_PATH) {
+      merged.PLAYWRIGHT_BROWSERS_PATH = process.env.PLAYWRIGHT_BROWSERS_PATH;
     }
     cfg.env = merged;
     fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");


### PR DESCRIPTION
## Summary

Three gaps came up during the session that accepted the `@vade-app` org invite for `vade-coo`:

- `vade-coo-memory/CLAUDE.md` did not auto-load on cloud boot, so the 13-step identity reading order had to be fetched manually.
- `AGENTMAIL_API_KEY` was set but no MCP server/skill was wired up, so email capability required raw `curl` calls against the API.
- Playwright was pre-installed at `/opt/node22/lib/node_modules` and `/opt/pw-browsers` but `NODE_PATH`/`PLAYWRIGHT_BROWSERS_PATH` were not set, so `import 'playwright'` did not resolve from `/tmp`.

## Changes

- **`scripts/coo-identity-digest.sh`** — new SessionStart hook that emits `vade-coo-memory/CLAUDE.md` plus the trailing three memo headers. Reminder-only — does not hit Mem0. No-op when the repo is absent.
- **`.claude/settings.json`** — threads the hook into the `SessionStart: startup` chain between `coo-bootstrap.sh` and `discussions-digest.sh`.
- **`scripts/lib/common.sh::_write_claude_settings_env`** — also writes `NODE_PATH` and `PLAYWRIGHT_BROWSERS_PATH` to `~/.claude/settings.json`'s env block when those cloud paths exist on disk. No-op outside the Claude cloud image.
- **`.mcp.json`** — adds the `agentmail` MCP server (`npx -y agentmail-mcp`, `AGENTMAIL_API_KEY` substituted from env). Gives the COO 20+ email tools (`send_message`, `list_threads`, `reply_to_message`, etc.) without manual API calls.

Paired memo: `vade-coo-memory` MEMO 2026-04-22-02 (companion PR).

## Test plan

- [ ] Fresh cloud session: `coo-identity-digest.sh` output appears in the boot stream; first three memo headers listed.
- [ ] Session inherits `NODE_PATH=/opt/node22/lib/node_modules` and `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`; `node -e "import('playwright')"` resolves from any cwd.
- [ ] AgentMail MCP tools (`list_threads`, `send_message`, …) show up in the tool list when working in `vade-coo-memory` or `vade-runtime`.
- [ ] Devcontainer / local (non-cloud) build: `_write_claude_settings_env` does not write `NODE_PATH` / `PLAYWRIGHT_BROWSERS_PATH` when those paths are absent.

https://claude.ai/code/session_0166DECNrPMh6nXPZQAKBkk1