### PR TITLE
cloud-env: make coo-bootstrap durable and loud on failure

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -39,10 +39,17 @@ print_versions
 # Anthropic cloud envs may scope custom env vars to the session process
 # only; the SessionStart hook in .claude/settings.json picks up the
 # slack in that case.
+#
+# Probe: record token visibility and settings.json state so the next
+# session's identity-digest can tell us whether setup-script time is
+# a viable bootstrap site (structurally superior to the hook because
+# MCP servers pick up env at Claude Code startup, not post-hook).
 if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+  bootstrap_log_record PROBE "cloud-setup: OP_SERVICE_ACCOUNT_TOKEN visible at setup time (len=${#OP_SERVICE_ACCOUNT_TOKEN})"
   bash /home/user/vade-runtime/scripts/coo-bootstrap.sh || \
     log "Warning: coo-bootstrap failed; continuing without COO identity."
 else
+  bootstrap_log_record PROBE "cloud-setup: OP_SERVICE_ACCOUNT_TOKEN unset at setup time; hook fallback required"
   log "OP_SERVICE_ACCOUNT_TOKEN not visible at setup time; SessionStart hook will run coo-bootstrap."
 fi
 

--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -16,8 +16,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
+# Record every exit path in ~/.vade/coo-bootstrap.log so silent failures
+# still leave a trail. The identity-digest hook surfaces the tail of
+# this file on each session start.
+COO_BOOTSTRAP_STEP="init"
+_on_exit() {
+  local rc=$?
+  if [ "$rc" -eq 0 ]; then
+    bootstrap_log_record OK "step=${COO_BOOTSTRAP_STEP} rc=0"
+  else
+    bootstrap_log_record FAIL "step=${COO_BOOTSTRAP_STEP} rc=${rc}"
+  fi
+  return $rc
+}
+trap _on_exit EXIT
+
 if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
   log "coo-bootstrap: OP_SERVICE_ACCOUNT_TOKEN unset; skipping COO identity setup."
+  COO_BOOTSTRAP_STEP="skip-no-op-token"
+  bootstrap_log_record SKIP "OP_SERVICE_ACCOUNT_TOKEN unset"
+  trap - EXIT
   exit 0
 fi
 
@@ -32,27 +50,44 @@ COO_BOOT_MARKER="${HOME}/.vade/.coo-bootstrap-done"
 if [ "${VADE_FORCE_COO_BOOTSTRAP:-0}" != "1" ] \
    && [ -f "$COO_ENV_FILE" ] && [ -f "$COO_BOOT_MARKER" ]; then
   log "coo-bootstrap: already complete this container; skipping."
+  COO_BOOTSTRAP_STEP="skip-marker-present"
+  bootstrap_log_record SKIP "marker present at $COO_BOOT_MARKER"
+  trap - EXIT
   exit 0
 fi
 
 log "coo-bootstrap: starting"
+bootstrap_log_record START "VADE_FORCE_COO_BOOTSTRAP=${VADE_FORCE_COO_BOOTSTRAP:-0}"
 
+COO_BOOTSTRAP_STEP="ensure_op_cli"
 ensure_op_cli
 
-# Verify the service-account token before attempting any reads.
-if ! op whoami >/dev/null 2>&1; then
-  log "FATAL: op whoami failed. Check OP_SERVICE_ACCOUNT_TOKEN and vault access."
+# Verify the service-account token before attempting any reads. Retry
+# to absorb transient 1Password API errors (503s).
+COO_BOOTSTRAP_STEP="op_whoami"
+if ! retry 3 op whoami >/dev/null; then
+  log "FATAL: op whoami failed after retries. Check OP_SERVICE_ACCOUNT_TOKEN and vault access."
   exit 1
 fi
 log "1Password service account authenticated: $(op whoami 2>/dev/null | head -1)"
 
+COO_BOOTSTRAP_STEP="install_coo_ssh_keys"
 install_coo_ssh_keys
+
+COO_BOOTSTRAP_STEP="fetch_coo_secrets"
 fetch_coo_secrets
+
+COO_BOOTSTRAP_STEP="write_coo_gitconfig"
 write_coo_gitconfig
+
+COO_BOOTSTRAP_STEP="validate_coo_identity"
 validate_coo_identity
+
+COO_BOOTSTRAP_STEP="summarize_coo_identity"
 summarize_coo_identity
 
 mkdir -p "$(dirname "$COO_BOOT_MARKER")"
 touch "$COO_BOOT_MARKER"
 
+COO_BOOTSTRAP_STEP="complete"
 log "coo-bootstrap: complete"

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -12,9 +12,15 @@
 # files, does not fail the session if the repo is missing.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
 MEM_REPO="${COO_MEMORY_DIR:-/home/user/vade-coo-memory}"
 CLAUDE_MD="$MEM_REPO/CLAUDE.md"
 MEMOS="$MEM_REPO/coo/memos.md"
+BOOTSTRAP_LOG="${HOME}/.vade/coo-bootstrap.log"
+SETTINGS_FILE="${HOME}/.claude/settings.json"
 
 if [ ! -f "$CLAUDE_MD" ]; then
   echo "[vade-setup] coo-identity-digest: $CLAUDE_MD not found; skipping."
@@ -43,6 +49,62 @@ if [ -f "$MEMOS" ]; then
   }'
   echo ""
   echo "Full file: $MEMOS"
+fi
+
+echo "───────────────────────────────────────────────────────────────"
+
+# Bootstrap posture — loud surface of whether this session boots with
+# a full identity. Three signals:
+#   (a) last coo-bootstrap outcome (from the log)
+#   (b) env vars actually present in this hook's process
+#   (c) env vars present in ~/.claude/settings.json (what MCP servers got)
+# When (b) diverges from (c), the current session's MCP tools are
+# stale — a restart will pick up the populated env block.
+echo ""
+echo "───────────────────────────────────────────────────────────────"
+echo "Bootstrap posture"
+echo "───────────────────────────────────────────────────────────────"
+
+if [ -f "$BOOTSTRAP_LOG" ]; then
+  last_line="$(tail -n 1 "$BOOTSTRAP_LOG" 2>/dev/null || true)"
+  [ -n "$last_line" ] && echo "  Last bootstrap: $last_line"
+else
+  echo "  Last bootstrap: (no log at $BOOTSTRAP_LOG)"
+fi
+
+env_has_pat="no"; env_has_mail="no"
+[ -n "${GITHUB_MCP_PAT:-}" ]    && env_has_pat="yes"
+[ -n "${AGENTMAIL_API_KEY:-}" ] && env_has_mail="yes"
+
+settings_pat="unknown"; settings_mail="unknown"
+if [ -f "$SETTINGS_FILE" ] && check_cmd node; then
+  probe="$(node -e '
+    const fs = require("fs");
+    try {
+      const cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+      const e = cfg.env || {};
+      console.log((e.GITHUB_MCP_PAT ? "yes" : "no") + " " + (e.AGENTMAIL_API_KEY ? "yes" : "no"));
+    } catch (_) { console.log("unknown unknown"); }
+  ' "$SETTINGS_FILE" 2>/dev/null || echo "unknown unknown")"
+  settings_pat="${probe%% *}"
+  settings_mail="${probe##* }"
+fi
+
+echo "  Process env:       GITHUB_MCP_PAT=$env_has_pat  AGENTMAIL_API_KEY=$env_has_mail"
+echo "  settings.json env: GITHUB_MCP_PAT=$settings_pat  AGENTMAIL_API_KEY=$settings_mail"
+
+if [ "$env_has_pat" = "yes" ] && [ "$env_has_mail" = "yes" ]; then
+  echo "  Full identity loaded; MCP tools (github, agentmail) should have env."
+elif [ "$settings_pat" = "yes" ] && [ "$settings_mail" = "yes" ]; then
+  echo ""
+  echo "  WARN: env populated in settings.json but not in this process."
+  echo "  MCP servers were spawned before the env block was written."
+  echo "  Next session in this container will boot fully loaded."
+else
+  echo ""
+  echo "  WARN: identity is degraded — required env vars are missing."
+  echo "  Inspect $BOOTSTRAP_LOG for the failing step, then re-run:"
+  echo "    VADE_FORCE_COO_BOOTSTRAP=1 bash /home/user/vade-runtime/scripts/coo-bootstrap.sh"
 fi
 
 echo "───────────────────────────────────────────────────────────────"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -4,6 +4,68 @@
 
 log() { echo "[vade-setup] $*"; }
 
+# Stderr-only variant so the message doesn't pollute stdout captures.
+# Used inside retry loops where the caller wraps us in $(...) to grab
+# a secret off stdout.
+log_err() { echo "[vade-setup] $*" >&2; }
+
+# Persistent bootstrap log. Every coo-bootstrap invocation appends one
+# line with a timestamp, status (OK / FAIL / SKIP), and a short message.
+# Identity-digest reads the tail of this file to surface the last
+# outcome on each session start, so silent failures leave a trail.
+COO_BOOTSTRAP_LOG="${HOME}/.vade/coo-bootstrap.log"
+
+bootstrap_log_record() {
+  local status="$1"; shift
+  local message="$*"
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "$(dirname "$COO_BOOTSTRAP_LOG")" 2>/dev/null || return 0
+  printf '%s %s %s\n' "$ts" "$status" "$message" >> "$COO_BOOTSTRAP_LOG" 2>/dev/null || return 0
+  # Keep the log bounded. 200 lines is ~10 KB, plenty for recent history.
+  if [ "$(wc -l < "$COO_BOOTSTRAP_LOG" 2>/dev/null || echo 0)" -gt 200 ]; then
+    tail -n 200 "$COO_BOOTSTRAP_LOG" > "${COO_BOOTSTRAP_LOG}.tmp" 2>/dev/null \
+      && mv -f "${COO_BOOTSTRAP_LOG}.tmp" "$COO_BOOTSTRAP_LOG" 2>/dev/null
+  fi
+}
+
+# Retry a command with exponential backoff. Absorbs transient 1Password
+# API failures (503s, network blips) that killed past bootstrap runs —
+# one 503 on `op read` under `set -euo pipefail` was enough to bail the
+# whole chain silently. Stdout of the successful attempt is passed
+# through unchanged so callers can still do `x="$(retry 3 op read ref)"`.
+# All log output goes to stderr.
+#
+# Usage: retry <tries> <cmd...>
+#   retry 3 op read 'op://COO/foo/credential'
+#   retry 3 op whoami >/dev/null
+retry() {
+  local tries="${1:-3}"
+  shift
+  local delay=1 attempt=0 rc=0
+  local err_file
+  err_file="$(mktemp 2>/dev/null)" || { "$@"; return $?; }
+  while [ "$attempt" -lt "$tries" ]; do
+    attempt=$((attempt+1))
+    if "$@" 2>"$err_file"; then
+      rm -f "$err_file"
+      return 0
+    fi
+    rc=$?
+    if [ "$attempt" -lt "$tries" ]; then
+      log_err "  retry ${attempt}/${tries} for: $* (rc=$rc; sleeping ${delay}s)"
+      sleep "$delay"
+      delay=$((delay * 2))
+    fi
+  done
+  local last_err
+  last_err="$(tr '\n' ' ' < "$err_file" 2>/dev/null | cut -c1-240)"
+  log_err "  FAIL after ${tries} attempts: $* (last err: ${last_err:-<empty>})"
+  cat "$err_file" >&2 2>/dev/null || true
+  rm -f "$err_file"
+  return "$rc"
+}
+
 # Pick up COO env vars (GITHUB_TOKEN, GITHUB_MCP_PAT, AGENTMAIL_API_KEY)
 # if coo-bootstrap.sh has written them. No-op otherwise. Every script
 # that sources common.sh benefits — this covers the case where a
@@ -232,7 +294,7 @@ fetch_coo_secrets() {
   local github_pat="" agentmail_key=""
   local got=0
 
-  if github_pat="$(op read 'op://COO/vade-coo-self-2026-04/credential' 2>/dev/null)" && [ -n "$github_pat" ]; then
+  if github_pat="$(retry 3 op read 'op://COO/vade-coo-self-2026-04/credential')" && [ -n "$github_pat" ]; then
     log "  read GitHub PAT (len=${#github_pat})"
     got=$((got+1))
   else
@@ -240,7 +302,7 @@ fetch_coo_secrets() {
     log "  WARN: op://COO/vade-coo-self-2026-04/credential unavailable; GITHUB_MCP_PAT/GITHUB_TOKEN will be unset"
   fi
 
-  if agentmail_key="$(op read 'op://COO/agentmail-vade-coo/credential' 2>/dev/null)" && [ -n "$agentmail_key" ]; then
+  if agentmail_key="$(retry 3 op read 'op://COO/agentmail-vade-coo/credential')" && [ -n "$agentmail_key" ]; then
     log "  read AgentMail API key (len=${#agentmail_key})"
     got=$((got+1))
   else
@@ -428,8 +490,8 @@ install_coo_ssh_keys() {
 _op_to_file() {
   local ref="$1" path="$2" mode="$3"
   local content
-  if ! content="$(op read "$ref" 2>/dev/null)"; then
-    log "Failed to read $ref"
+  if ! content="$(retry 3 op read "$ref")"; then
+    log "Failed to read $ref after retries"
     return 1
   fi
   (
@@ -460,11 +522,14 @@ validate_coo_identity() {
     log "Skipping GitHub PAT validation (GITHUB_MCP_PAT unset; degraded bootstrap)"
     return 0
   fi
-  local login
-  login="$(curl -sfH "Authorization: Bearer ${GITHUB_MCP_PAT}" https://api.github.com/user \
-    | grep -o '"login":"[^"]*"' \
-    | head -1 \
-    | cut -d'"' -f4)"
+  local body login
+  if ! body="$(retry 3 curl -sfH "Authorization: Bearer ${GITHUB_MCP_PAT}" https://api.github.com/user)"; then
+    log "FATAL: GitHub /user lookup failed after retries; cannot confirm identity"
+    return 1
+  fi
+  # GitHub's JSON is indented with spaces around the colon ("login": "...").
+  # Tolerate optional whitespace so this doesn't silently fail.
+  login="$(printf '%s' "$body" | grep -oE '"login"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"([^"]*)"$/\1/')"
   if [ "$login" != "vade-coo" ]; then
     log "FATAL: GitHub PAT validates as '${login:-unknown}', expected 'vade-coo'"
     return 1


### PR DESCRIPTION
## Summary

Today's session surfaced a silent failure in `coo-bootstrap.sh`: a transient 1Password 503 on `op read op://COO/vade-coo-sign/public key` tripped `set -euo pipefail` before any log line flushed, and the hook harness only surfaces successful hooks' output in the boot stream — so the failure was invisible. Session ended up degraded (no `GITHUB_MCP_PAT`, no `AGENTMAIL_API_KEY` in env, MCP servers spawned without credentials). Three fixes, one observation for a follow-up.

## Changes

- **`retry` helper in `lib/common.sh`.** Exponential backoff (1s, 2s) around any subcommand. Absorbs transient 1Password and GitHub API errors. Applied to `op whoami`, both `op read` calls in `fetch_coo_secrets`, all `op read` calls in `_op_to_file`, and the `curl` in `validate_coo_identity`. Log messages go to stderr so callers capturing stdout via `$(...)` still get the secret cleanly.
- **Persistent bootstrap log at `~/.vade/coo-bootstrap.log`.** `coo-bootstrap.sh` records `START / OK / FAIL / SKIP` with the step name via an EXIT trap. Silent failures now leave a trail. Log is bounded at 200 lines.
- **Bootstrap posture section in `coo-identity-digest.sh`.** Every session start now prints the last bootstrap outcome plus a side-by-side of **process env** vs. **settings.json env** for `GITHUB_MCP_PAT` and `AGENTMAIL_API_KEY`. Three clear states: full identity loaded; env populated in `settings.json` but not yet in this process (next session will be clean); or degraded (points at the log + force-re-run command).
- **Pre-existing bug in `validate_coo_identity`.** The `"login":"..."` regex didn't match GitHub's actual whitespace-padded JSON (`"login": "vade-coo"`). Masked until today because prior sessions always early-returned with `GITHUB_MCP_PAT` unset; once the PAT landed, bootstrap bailed at validate. Now uses `grep -oE '"login"[[:space:]]*:[[:space:]]*"[^"]*"'`. The bootstrap log caught this on first retry-path run — good proof the observability works.
- **Setup-time token probe in `cloud-setup.sh`.** Logs whether `OP_SERVICE_ACCOUNT_TOKEN` is visible at snapshot-build time. Structurally the bootstrap belongs there, not in a SessionStart hook — `settings.json` env is read once at Claude Code startup, so the hook path can't populate env for the current session's MCP servers (they already spawned). If the next snapshot build shows the token *is* visible at setup time, a follow-up PR can retire the hook path and session 1 boots with full tooling.

## Test plan

- [x] Clean run against real 1Password vault produces marker + log + full identity in settings.json (`rm -f /root/.vade/.coo-bootstrap-done /root/.vade/coo-env && VADE_FORCE_COO_BOOTSTRAP=1 bash scripts/coo-bootstrap.sh`)
- [x] Re-run on same container hits the skip-marker path and appends `SKIP` to the log
- [x] Identity-digest output shows `Full identity loaded` when env is populated
- [x] Log correctly records `FAIL step=validate_coo_identity rc=1` then `OK step=complete rc=0` across fix-and-rerun
- [ ] Next cloud session: verify `Bootstrap posture` section renders at the end of the identity boot digest
- [ ] Next snapshot build: inspect `~/.vade/coo-bootstrap.log` for `PROBE cloud-setup: OP_SERVICE_ACCOUNT_TOKEN visible at setup time` to decide the follow-up architectural move

https://claude.ai/code/session_017A2CJh9pTAXocQVX3rvDfX