### PR TITLE
cloud-env: workspace-scope .mcp.json so MCP servers load at /home/user

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
       {
         "matcher": "startup",
         "hooks": [
+          { "type": "command", "command": "bash /home/user/vade-runtime/scripts/ensure-workspace-mcp.sh" },
           { "type": "command", "command": "bash /home/user/vade-runtime/scripts/coo-bootstrap.sh" },
           { "type": "command", "command": "bash /home/user/vade-runtime/scripts/coo-identity-digest.sh" },
           { "type": "command", "command": "bash /home/user/vade-runtime/scripts/discussions-digest.sh" }

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -20,6 +20,7 @@ log "Baseline: node=$(node --version 2>/dev/null || echo 'missing') npm=$(npm --
 
 ensure_dirs
 sync_claude_config /home/user/vade-runtime/.claude
+ensure_workspace_mcp_config
 
 # Workspace deps (npm install vade-core, install tsx) are opt-in:
 # nothing in the SessionStart hook pipeline imports from node_modules,

--- a/scripts/ensure-workspace-mcp.sh
+++ b/scripts/ensure-workspace-mcp.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Ensure /home/user/.mcp.json symlinks to the workspace MCP config so
+# Claude Code picks up mem0 + agentmail MCPs when booting from its
+# default cwd (/home/user/). Cheap idempotent no-op when already
+# linked; logs one line when it has to (re)create the symlink.
+#
+# Wired into SessionStart:startup so the current container gets the
+# link without waiting for a snapshot rebuild. Also called from
+# cloud-setup.sh so the snapshot itself bakes the link in.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+ensure_workspace_mcp_config

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -188,6 +188,32 @@ _sync_claude_settings() {
   chmod 600 "$dst_file"
 }
 
+# Ensure /home/user/.mcp.json is a symlink to the workspace-scope MCP
+# config (mem0 + agentmail). Claude Code loads project-scope .mcp.json
+# from its cwd, and in the cloud env cwd is /home/user, which has no
+# .mcp.json of its own — so project MCPs stay dark even when env vars
+# are populated. Symlinking to the runtime repo's workspace-mcp.json
+# fixes this without polluting any per-repo .mcp.json (github is
+# omitted intentionally: the cloud harness provides github MCP already).
+# Idempotent: if the symlink already points at the right target, no-op.
+ensure_workspace_mcp_config() {
+  local src="${1:-/home/user/vade-runtime/workspace-mcp.json}"
+  local dst="${2:-/home/user/.mcp.json}"
+  if [ ! -f "$src" ]; then
+    log "workspace-mcp: source $src missing; skipping"
+    return 0
+  fi
+  if [ -L "$dst" ] && [ "$(readlink -f "$dst" 2>/dev/null)" = "$(readlink -f "$src" 2>/dev/null)" ]; then
+    return 0
+  fi
+  if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+    log "workspace-mcp: $dst exists and is not a symlink; leaving it alone"
+    return 0
+  fi
+  ln -snf "$src" "$dst"
+  log "workspace-mcp: linked $dst → $src"
+}
+
 print_versions() {
   local tsx_version claude_version
 

--- a/workspace-mcp.json
+++ b/workspace-mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "mem0": {
+      "type": "http",
+      "url": "https://mcp.mem0.ai/mcp"
+    },
+    "agentmail": {
+      "command": "npx",
+      "args": ["-y", "agentmail-mcp"],
+      "env": {
+        "AGENTMAIL_API_KEY": "${AGENTMAIL_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PR #20 got `GITHUB_MCP_PAT` and `AGENTMAIL_API_KEY` into `settings.json` cleanly, but `mcp__agentmail__*` tools still weren't available on the next session. Root cause turned out to be orthogonal to the bootstrap: Claude Code loads project-scope `.mcp.json` from its cwd, and in the cloud env cwd is `/home/user/` — which has no `.mcp.json`. The per-repo `.mcp.json` files under `vade-coo-memory/`, `vade-runtime/`, and `vade-core/` are invisible until you `cd` into one of those dirs. So env was populated but no server was ever asked to start.

## Changes

- **`workspace-mcp.json`** — new file at the repo root. Declares `mem0` (HTTP) and `agentmail` (stdio via `npx agentmail-mcp`). `github` is intentionally omitted: the cloud harness provides it directly; layering project config on top would double-register.
- **`scripts/lib/common.sh`** — new `ensure_workspace_mcp_config` helper. Idempotent symlink from `/home/user/.mcp.json` → `workspace-mcp.json`. No-ops when the link already points at the right target; refuses to clobber a real file.
- **`scripts/cloud-setup.sh`** — calls the helper at snapshot-build time, so new images bake the link into the snapshot.
- **`scripts/ensure-workspace-mcp.sh`** + **`.claude/settings.json`** — tiny standalone script wired into `SessionStart:startup` so current containers get the link on next session without waiting for a snapshot rebuild.

## Test plan

- [x] `rm /home/user/.mcp.json && bash scripts/ensure-workspace-mcp.sh` creates the symlink with a single log line
- [x] Second invocation is silent (idempotent)
- [ ] Next session in this container: `mcp__agentmail__*` tools surface in `ToolSearch "agentmail"`
- [ ] End-to-end: list threads from `vade-coo@agentmail.to` using an MCP tool (not curl)
- [ ] Snapshot rebuild: `/home/user/.mcp.json` exists pre-session-1 (verifies `cloud-setup.sh` path)

https://claude.ai/code/session_017A2CJh9pTAXocQVX3rvDfX