### PR TITLE
cloud-env: rename project github MCP to github-coo; retry op CLI download

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -275,8 +275,12 @@ ensure_op_cli() {
   local tmp
   tmp="$(mktemp -d)"
   log "Downloading op CLI v${version} (${arch})"
-  if ! curl -sfL "$url" -o "$tmp/op.zip"; then
-    log "op CLI download failed: $url"
+  # cache.agilebits.com occasionally returns 5xx; retry absorbs the transient
+  # window. Without this, a single 503 kills the whole bootstrap chain and
+  # the session comes up with no COO identity — root cause of the
+  # run-2026-04-22T062313 degradation.
+  if ! retry 3 curl -sfL "$url" -o "$tmp/op.zip"; then
+    log "op CLI download failed after retries: $url"
     rm -rf "$tmp"
     return 1
   fi

--- a/workspace-mcp.json
+++ b/workspace-mcp.json
@@ -11,7 +11,7 @@
         "AGENTMAIL_API_KEY": "${AGENTMAIL_API_KEY}"
       }
     },
-    "github": {
+    "github-coo": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/",
       "headers": {


### PR DESCRIPTION
## Summary

Two fixes exposed by a fresh-container verification run (`run-2026-04-22T062313`):

### 1. Harness wins the `github` name race → rename to `github-coo`

PR #22 added a project-scope `github` MCP authenticating as COO, on the assumption that project-scope overrides harness. Verification showed otherwise: the harness's `github` MCP keeps the `github` name; the project-scope entry gets collision-renamed to a GUID like `mcp__210f0bc3-8592-4a4d-ae9c-b552bc8b241e__*`, which can't be predictably targeted.

Fix: rename project-scope to `github-coo`. Tools surface as `mcp__github-coo__*` — distinct from harness's `mcp__github__*`. Both coexist; no collision.

This was the documented fallback in memo 2026-04-22-04 §3: *"the documented fallback is renaming the project-scope entry to `github-coo` and using `mcp__github-coo__*` tools explicitly."*

**Operational change:** open PRs via `mcp__github-coo__create_pull_request` → attributed to vade-coo. `mcp__github__*` still available as harness fallback for read-only queries.

### 2. `ensure_op_cli` curl download was unretried

`cache.agilebits.com` returned a 503 during the verification run, killing the whole bootstrap chain under `set -euo pipefail` before any secret could be fetched (failure logged as `FAIL step=ensure_op_cli rc=1`). The retry helper already wraps `op read` / `op whoami` / validation curl — now wraps this download too. Same 1s→2s backoff, 3 attempts.

## Test plan

- [ ] Next session: `ToolSearch "github-coo"` returns `mcp__github-coo__*` schemas
- [ ] `mcp__github-coo__get_me` returns `{"login": "vade-coo"}`
- [ ] `mcp__github__get_me` still returns `venpopov` (harness intact; no regression)
- [ ] Open a PR via `mcp__github-coo__create_pull_request` → opener shows as vade-coo on the GitHub UI
- [ ] Deliberately break network for cache.agilebits.com and confirm ensure_op_cli retries visibly in log before giving up

https://claude.ai/code/session_017A2CJh9pTAXocQVX3rvDfX