### PR TITLE
cloud-env: digest waits for fresh bootstrap terminal state before sampling env

### DIFF
--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -60,6 +60,48 @@ echo "────────────────────────�
 #   (c) env vars present in ~/.claude/settings.json (what MCP servers got)
 # When (b) diverges from (c), the current session's MCP tools are
 # stale — a restart will pick up the populated env block.
+#
+# SessionStart hooks run in parallel. Without the wait below, we'd
+# sample env and settings.json mid-bootstrap and falsely report
+# degraded even when coo-bootstrap eventually completes cleanly (the
+# first user-visible regression after PR #20 landed: verification
+# run reported "degraded" despite OK-step=complete in the log).
+#
+# Strategy: poll the bootstrap log for a terminal state (OK/FAIL/SKIP)
+# timestamped at-or-after this digest's start. If bootstrap hasn't
+# written for this session yet, wait — but only as long as a
+# coo-bootstrap.sh process is actually running, plus a short grace
+# window. A hook that never fires (or a standalone digest invocation)
+# exits the wait quickly instead of wedging boot for the full timeout.
+_digest_start_epoch="$(date -u +%s)"
+_digest_wait_timeout=60
+_digest_wait_elapsed=0
+_digest_saw_fresh=0
+while [ "$_digest_wait_elapsed" -lt "$_digest_wait_timeout" ]; do
+  if [ -f "$BOOTSTRAP_LOG" ]; then
+    _last_line="$(tail -n 1 "$BOOTSTRAP_LOG" 2>/dev/null || true)"
+    _last_ts="${_last_line%% *}"
+    _last_state="$(printf '%s' "$_last_line" | awk '{print $2}')"
+    case "$_last_state" in
+      OK|FAIL|SKIP)
+        _last_epoch="$(date -u -d "$_last_ts" +%s 2>/dev/null || echo 0)"
+        if [ "$_last_epoch" -ge "$_digest_start_epoch" ]; then
+          _digest_saw_fresh=1
+          break
+        fi
+        ;;
+    esac
+  fi
+  # Fast-exit when bootstrap isn't running and we've given it a 2s
+  # grace to start. Covers three cases: hook disabled, bootstrap
+  # already finished before digest started, standalone debug invocation.
+  if [ "$_digest_wait_elapsed" -ge 2 ] && ! pgrep -f coo-bootstrap.sh >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+  _digest_wait_elapsed=$((_digest_wait_elapsed + 1))
+done
+
 echo ""
 echo "───────────────────────────────────────────────────────────────"
 echo "Bootstrap posture"
@@ -71,6 +113,20 @@ if [ -f "$BOOTSTRAP_LOG" ]; then
 else
   echo "  Last bootstrap: (no log at $BOOTSTRAP_LOG)"
 fi
+
+if [ "$_digest_saw_fresh" -eq 0 ]; then
+  if [ "$_digest_wait_elapsed" -ge "$_digest_wait_timeout" ]; then
+    echo "  WARN: timed out after ${_digest_wait_timeout}s waiting for a fresh bootstrap terminal state."
+  else
+    echo "  Note: no fresh bootstrap state this session (hook didn't fire, or finished before digest started)."
+  fi
+fi
+
+# Re-source coo-env in case bootstrap just wrote it. common.sh sourced
+# the file once at script load; a second source picks up any keys
+# added during the wait above.
+# shellcheck source=/dev/null
+[ -f "${HOME}/.vade/coo-env" ] && . "${HOME}/.vade/coo-env"
 
 env_has_pat="no"; env_has_mail="no"
 [ -n "${GITHUB_MCP_PAT:-}" ]    && env_has_pat="yes"


### PR DESCRIPTION
## Summary

Fix the false-degraded bootstrap posture reported by the fresh-container verification run. `SessionStart` hooks run in parallel in Claude Code, so `coo-identity-digest.sh` was sampling `settings.json` and process env while `coo-bootstrap.sh` was still mid-flight. The digest then reported "degraded — required env vars are missing" on a session that ended with `OK step=complete` in the bootstrap log. Misleading, and led to the whole github-MCP-name investigation in PR #23 before we realized a separate root cause was cascading into the symptoms.

## Change

Poll the bootstrap log for a terminal state (`OK` / `FAIL` / `SKIP`) whose timestamp is at-or-after the digest's own start, before running the posture checks. 1-second sleep per tick, 60s cap.

Three fast-exit paths so standalone / broken-hook scenarios don't wedge boot:

1. **2s grace + `pgrep -f coo-bootstrap.sh` check.** If bootstrap isn't running, assume the hook isn't going to fire and break the wait. Covers: hook disabled, bootstrap already finished before digest started, standalone debug invocations.
2. **Re-source `~/.vade/coo-env`** after the wait so env vars that bootstrap just wrote are reflected in the sampling that follows (common.sh sourced the file once at digest startup; a second source picks up keys added during the wait).
3. **Three-state outcome note** at the top of the posture block: saw fresh terminal state (no message, proceed to sampling); gave up because bootstrap wasn't running (`no fresh bootstrap state this session`); hit full timeout (`WARN: timed out after 60s`).

## Test plan

- [x] Standalone digest with no bootstrap running: 2s exit, "no fresh bootstrap state this session" note
- [x] Backgrounded bootstrap + digest: 1s wait for fresh SKIP, correct "Full identity loaded" verdict
- [ ] Next cloud session: posture block should render within a few seconds of the actual bootstrap outcome, no false degraded reports
- [ ] Session with deliberately slow bootstrap (e.g. network throttled): posture block accurately reflects whatever state bootstrap settled on

https://claude.ai/code/session_017A2CJh9pTAXocQVX3rvDfX