### PR TITLE
local-env: mirror cloud COO bootstrap on macOS

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -34,8 +34,9 @@ bootstrap_log_record() {
 # /root/ in the cloud image and gets fresh on every session boot, which
 # is useful for session-scope logs but useless for recording what
 # cloud-setup.sh actually did at build time. Keep session-scope state in
-# ~/.vade/, snapshot-scope state here.
-VADE_CLOUD_STATE_DIR="/home/user/.vade-cloud-state"
+# ~/.vade/, snapshot-scope state here. Overridable so local-setup.sh
+# can point it at ~/.vade/local-state on macOS.
+VADE_CLOUD_STATE_DIR="${VADE_CLOUD_STATE_DIR:-/home/user/.vade-cloud-state}"
 VADE_BUILD_LOG="${VADE_CLOUD_STATE_DIR}/build.log"
 VADE_SETUP_RECEIPT="${VADE_CLOUD_STATE_DIR}/setup-receipt.json"
 
@@ -638,10 +639,14 @@ _op_to_file() {
   log "  wrote $path ($mode)"
 }
 
-# Write ~/.gitconfig with COO identity + SSH signing + auth-key push.
+# Write gitconfig with COO identity + SSH signing + auth-key push.
 # Per MEMO 2026-04-22-03, cloud sessions share the Mac's commit discipline.
+# Target path is overridable via VADE_COO_GITCONFIG so local-setup.sh can
+# route Claude's git through ~/.vade/gitconfig-coo (via GIT_CONFIG_GLOBAL)
+# without touching the user's personal ~/.gitconfig.
 write_coo_gitconfig() {
-  local gc="${HOME}/.gitconfig"
+  local gc="${VADE_COO_GITCONFIG:-${HOME}/.gitconfig}"
+  mkdir -p "$(dirname "$gc")"
   git config --file "$gc" user.name "COO"
   git config --file "$gc" user.email "coo@vade-app.dev"
   git config --file "$gc" gpg.format ssh

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Local (macOS) equivalent of cloud-setup.sh. Runs from a user-scope
+# SessionStart hook when Claude Code is launched from any repo under
+# ~/GitHub/vade-app/. Delegates to coo-bootstrap.sh for the full COO
+# identity pipeline (SSH keys, gitconfig, MCP env vars, receipt, logs) —
+# same code path as cloud, with two env-var redirects so the artifacts
+# land in ~/.vade/local-state/ and ~/.vade/gitconfig-coo rather than the
+# cloud-specific /home/user/ paths and the user's personal ~/.gitconfig.
+#
+# Expects OP_SERVICE_ACCOUNT_TOKEN in the process env. The dotfiles
+# claude() wrapper is the intended provisioner:
+# zsh/.config/zsh/functions.zsh `op read`s the COO vault's sandbox SA
+# token into OP_SERVICE_ACCOUNT_TOKEN only when $PWD is under
+# ~/GitHub/vade-app/, so normal shells and non-vade projects stay
+# untouched.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export VADE_CLOUD_STATE_DIR="${VADE_CLOUD_STATE_DIR:-${HOME}/.vade/local-state}"
+export VADE_COO_GITCONFIG="${VADE_COO_GITCONFIG:-${HOME}/.vade/gitconfig-coo}"
+
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+log "Local environment setup starting"
+build_log_record START "local-setup: begin (mode=local)"
+
+ensure_dirs
+
+OP_TOKEN_VISIBLE=false
+COO_BOOTSTRAP_RAN=false
+if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+  OP_TOKEN_VISIBLE=true
+  build_log_record PROBE "local-setup: OP_SERVICE_ACCOUNT_TOKEN present (len=${#OP_SERVICE_ACCOUNT_TOKEN})"
+  if bash "$SCRIPT_DIR/coo-bootstrap.sh"; then
+    COO_BOOTSTRAP_RAN=true
+    build_log_record OK "local-setup: coo-bootstrap completed"
+  else
+    build_log_record FAIL "local-setup: coo-bootstrap failed; continuing without COO identity"
+    log "Warning: coo-bootstrap failed; continuing without COO identity."
+  fi
+else
+  build_log_record PROBE "local-setup: OP_SERVICE_ACCOUNT_TOKEN unset; skipping"
+  log "OP_SERVICE_ACCOUNT_TOKEN unset; skipping COO bootstrap. (Claude launched outside the claude() wrapper?)"
+fi
+
+GIT_SHA="$(git -C "$SCRIPT_DIR/.." rev-parse --short HEAD 2>/dev/null || echo unknown)"
+build_receipt_write \
+  built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  mode=local \
+  op_token_visible="$OP_TOKEN_VISIBLE" \
+  coo_bootstrap_ran="$COO_BOOTSTRAP_RAN" \
+  git_sha="$GIT_SHA"
+
+build_log_record OK "local-setup: complete (op_token=$OP_TOKEN_VISIBLE coo_bootstrap=$COO_BOOTSTRAP_RAN)"
+log "Done."


### PR DESCRIPTION
## Summary
- New `scripts/local-setup.sh` mirrors `cloud-setup.sh` for local macOS Claude Code sessions: points `VADE_CLOUD_STATE_DIR` at `~/.vade/local-state/` and `VADE_COO_GITCONFIG` at `~/.vade/gitconfig-coo`, then delegates to `coo-bootstrap.sh` — same helpers, same idempotency marker, same logs, same receipt.
- `scripts/lib/common.sh` picks up two env-var overrides (`VADE_CLOUD_STATE_DIR`, `VADE_COO_GITCONFIG`). Cloud behavior is byte-identical when unset.

## Activation (outside this repo)
- A user-scope `~/.claude/settings.json` SessionStart hook runs `local-setup.sh` only when `CLAUDE_PROJECT_DIR` is under `~/GitHub/vade-app/`.
- The `claude()` zsh wrapper (in dotfiles) `op read`s `OP_SERVICE_ACCOUNT_TOKEN` and sets `GIT_CONFIG_GLOBAL=~/.vade/gitconfig-coo` only when `$PWD` is under `~/GitHub/vade-app/`.

Result: `github-coo` MCP authenticates as `vade-coo`, and Claude's git commits/pushes inside any vade-app repo are signed and authored as COO — while the user's terminal stays on their personal gitconfig and SSH agent.

## Test plan
- [x] `bash -n` syntax clean on `common.sh`, `local-setup.sh`, `coo-bootstrap.sh`; `zsh -n` clean on dotfiles `functions.zsh`; `settings.json` parses.
- [x] Full bootstrap run: PAT validates as `vade-coo`, SSH key fingerprints match `COO_AUTH_FP_EXPECTED` / `COO_SIGN_FP_EXPECTED`, `~/.claude/settings.json` env block populated with `GITHUB_MCP_PAT` / `GITHUB_TOKEN` / `AGENTMAIL_API_KEY`.
- [x] Idempotent re-run: second invocation of `local-setup.sh` skips via `~/.vade/.coo-bootstrap-done` marker + settings.json env completeness check.
- [x] Cwd-scoped git identity: with `GIT_CONFIG_GLOBAL=~/.vade/gitconfig-coo` → `COO / coo@vade-app.dev / commit.gpgsign=true`; without → user's personal identity intact (`Ven Popov / vencislav.popov@gmail.com / gpgsign=false`).
- [x] This PR itself: commit signed by `SHA256:pZeA8xycAtIsVGwhMzR3mg4KG05n9ksFuy4F1ZVXn3A` (vade-coo-sign), pushed via `vade-coo-auth` SSH key, opened as `vade-coo`.
- [ ] Next fresh Claude session launched via the updated `claude()` wrapper from a vade-app repo: verify `mcp__github-coo__get_me` returns `vade-coo` (the currently running session was initialized pre-bootstrap so still shows `venpopov`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)