### PR TITLE
local-env: mirror cloud COO bootstrap on macOS, make hooks portable

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,22 +4,22 @@
       {
         "matcher": "startup",
         "hooks": [
-          { "type": "command", "command": "bash /home/user/vade-runtime/scripts/session-start-sync.sh" },
-          { "type": "command", "command": "bash /home/user/vade-runtime/scripts/coo-bootstrap.sh" },
-          { "type": "command", "command": "bash /home/user/vade-runtime/scripts/coo-identity-digest.sh" },
-          { "type": "command", "command": "bash /home/user/vade-runtime/scripts/discussions-digest.sh" }
+          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/session-start-sync.sh\"" },
+          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/coo-bootstrap.sh\"" },
+          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/coo-identity-digest.sh\"" },
+          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/discussions-digest.sh\"" }
         ]
       },
       {
         "hooks": [
-          { "type": "command", "command": "bash /home/user/vade-runtime/scripts/session-lifecycle.sh" }
+          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/session-lifecycle.sh\"" }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "bash /home/user/vade-runtime/scripts/session-lifecycle.sh --end" }
+          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/session-lifecycle.sh\" --end" }
         ]
       }
     ]

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -16,7 +16,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
-MEM_REPO="${COO_MEMORY_DIR:-/home/user/vade-coo-memory}"
+if [ -n "${COO_MEMORY_DIR:-}" ]; then
+  MEM_REPO="$COO_MEMORY_DIR"
+elif [ "$HOME" != "/home/user" ] && [ -d "$HOME/GitHub/vade-app/vade-coo-memory" ]; then
+  MEM_REPO="$HOME/GitHub/vade-app/vade-coo-memory"
+else
+  MEM_REPO="/home/user/vade-coo-memory"
+fi
 CLAUDE_MD="$MEM_REPO/CLAUDE.md"
 MEMOS="$MEM_REPO/coo/memos.md"
 BOOTSTRAP_LOG="${HOME}/.vade/coo-bootstrap.log"
@@ -24,7 +30,14 @@ SETTINGS_FILE="${HOME}/.claude/settings.json"
 WORKSPACE_IDENTITY_LINK="/home/user/CLAUDE.md"
 WORKSPACE_MCP_LINK="/home/user/.mcp.json"
 WORKSPACE_MCP_SRC="/home/user/vade-runtime/.mcp.json"
-SETUP_RECEIPT="/home/user/.vade-cloud-state/setup-receipt.json"
+# common.sh seeds VADE_CLOUD_STATE_DIR with a cloud-host default; on Mac
+# local-setup.sh writes the receipt under ~/.vade/local-state/ and hook
+# subprocesses don't inherit its env exports. Redirect when the cloud
+# path is absent and the local path exists.
+if [ ! -d "$VADE_CLOUD_STATE_DIR" ] && [ -d "$HOME/.vade/local-state" ]; then
+  VADE_CLOUD_STATE_DIR="$HOME/.vade/local-state"
+fi
+SETUP_RECEIPT="${VADE_CLOUD_STATE_DIR}/setup-receipt.json"
 
 if [ ! -f "$CLAUDE_MD" ]; then
   echo "[vade-setup] coo-identity-digest: $CLAUDE_MD not found; skipping."
@@ -107,7 +120,9 @@ while [ "$_digest_wait_elapsed" -lt "$_digest_wait_timeout" ]; do
     _last_state="$(printf '%s' "$_last_line" | awk '{print $2}')"
     case "$_last_state" in
       OK|FAIL|SKIP)
-        _last_epoch="$(date -u -d "$_last_ts" +%s 2>/dev/null || echo 0)"
+        # Portable ISO-8601 → epoch. `date -d` is GNU-only (no-op on macOS);
+        # node handles both hosts and is already a hard dep for this script.
+        _last_epoch="$(node -e 'const t=Date.parse(process.argv[1]); process.stdout.write(isNaN(t)?"0":String(Math.floor(t/1000)))' "$_last_ts" 2>/dev/null || echo 0)"
         if [ "$_last_epoch" -ge "$_digest_start_epoch" ]; then
           _digest_saw_fresh=1
           break
@@ -183,7 +198,7 @@ else
   echo ""
   echo "  WARN: identity is degraded — required env vars are missing."
   echo "  Inspect $BOOTSTRAP_LOG for the failing step, then re-run:"
-  echo "    VADE_FORCE_COO_BOOTSTRAP=1 bash /home/user/vade-runtime/scripts/coo-bootstrap.sh"
+  echo "    VADE_FORCE_COO_BOOTSTRAP=1 bash \"${CLAUDE_PROJECT_DIR:-/home/user/vade-runtime}/scripts/coo-bootstrap.sh\""
 fi
 
 echo "───────────────────────────────────────────────────────────────"
@@ -194,49 +209,56 @@ echo "────────────────────────�
 # any prerequisite is missing the tools cannot have been loaded.
 # Surface these loudly so the agent knows to avoid attributable writes
 # until a /resume picks up the fix we've just applied.
-echo ""
-echo "───────────────────────────────────────────────────────────────"
-echo "MCP surface probe"
-echo "───────────────────────────────────────────────────────────────"
-
-mcp_link_ok=false
-mcp_link_state="missing"
-if [ -L "$WORKSPACE_MCP_LINK" ]; then
-  if [ "$(readlink -f "$WORKSPACE_MCP_LINK" 2>/dev/null)" = "$(readlink -f "$WORKSPACE_MCP_SRC" 2>/dev/null)" ]; then
-    mcp_link_ok=true
-    mcp_link_state="ok (→ $(readlink "$WORKSPACE_MCP_LINK" 2>/dev/null))"
-  else
-    mcp_link_state="wrong target (→ $(readlink "$WORKSPACE_MCP_LINK" 2>/dev/null))"
-  fi
-elif [ -e "$WORKSPACE_MCP_LINK" ]; then
-  mcp_link_state="present but not a symlink"
-fi
-echo "  /home/user/.mcp.json:     $mcp_link_state"
-
-id_link_state="missing"
-if [ -L "$WORKSPACE_IDENTITY_LINK" ]; then
-  if [ "$identity_link_live" = "true" ]; then
-    id_link_state="ok (→ $(readlink "$WORKSPACE_IDENTITY_LINK" 2>/dev/null))"
-  else
-    id_link_state="wrong target (→ $(readlink "$WORKSPACE_IDENTITY_LINK" 2>/dev/null))"
-  fi
-elif [ -e "$WORKSPACE_IDENTITY_LINK" ]; then
-  id_link_state="present but not a symlink"
-fi
-echo "  /home/user/CLAUDE.md:     $id_link_state"
-
-# Any failure = session started without the workspace-scope overrides.
-# Surface the fix path instead of letting the agent guess.
-if [ "$mcp_link_ok" != "true" ] || [ "$identity_link_live" != "true" ]; then
+#
+# Cloud-only: the /home/user/.mcp.json and /home/user/CLAUDE.md symlinks
+# exist because the cloud container's cwd is /home/user, not the project
+# dir. On local Mac, Claude Code's cwd is the project dir itself, so it
+# loads .mcp.json and CLAUDE.md natively without the workspace bridge.
+if [ "$HOME" = "/home/user" ]; then
   echo ""
-  echo "  ⚠ Workspace-scope overrides were NOT in place at Claude Code startup."
-  echo "    Project-scope MCPs (agentmail, github-coo, mem0) did not load this session,"
-  echo "    and COO identity was not auto-loaded by the harness memory system."
-  echo "    session-start-sync.sh has re-applied the symlinks in this hook pass."
-  echo "    Resume the session (/resume) to pick up the full MCP + identity surface."
-fi
+  echo "───────────────────────────────────────────────────────────────"
+  echo "MCP surface probe"
+  echo "───────────────────────────────────────────────────────────────"
 
-echo "───────────────────────────────────────────────────────────────"
+  mcp_link_ok=false
+  mcp_link_state="missing"
+  if [ -L "$WORKSPACE_MCP_LINK" ]; then
+    if [ "$(readlink -f "$WORKSPACE_MCP_LINK" 2>/dev/null)" = "$(readlink -f "$WORKSPACE_MCP_SRC" 2>/dev/null)" ]; then
+      mcp_link_ok=true
+      mcp_link_state="ok (→ $(readlink "$WORKSPACE_MCP_LINK" 2>/dev/null))"
+    else
+      mcp_link_state="wrong target (→ $(readlink "$WORKSPACE_MCP_LINK" 2>/dev/null))"
+    fi
+  elif [ -e "$WORKSPACE_MCP_LINK" ]; then
+    mcp_link_state="present but not a symlink"
+  fi
+  echo "  /home/user/.mcp.json:     $mcp_link_state"
+
+  id_link_state="missing"
+  if [ -L "$WORKSPACE_IDENTITY_LINK" ]; then
+    if [ "$identity_link_live" = "true" ]; then
+      id_link_state="ok (→ $(readlink "$WORKSPACE_IDENTITY_LINK" 2>/dev/null))"
+    else
+      id_link_state="wrong target (→ $(readlink "$WORKSPACE_IDENTITY_LINK" 2>/dev/null))"
+    fi
+  elif [ -e "$WORKSPACE_IDENTITY_LINK" ]; then
+    id_link_state="present but not a symlink"
+  fi
+  echo "  /home/user/CLAUDE.md:     $id_link_state"
+
+  # Any failure = session started without the workspace-scope overrides.
+  # Surface the fix path instead of letting the agent guess.
+  if [ "$mcp_link_ok" != "true" ] || [ "$identity_link_live" != "true" ]; then
+    echo ""
+    echo "  ⚠ Workspace-scope overrides were NOT in place at Claude Code startup."
+    echo "    Project-scope MCPs (agentmail, github-coo, mem0) did not load this session,"
+    echo "    and COO identity was not auto-loaded by the harness memory system."
+    echo "    session-start-sync.sh has re-applied the symlinks in this hook pass."
+    echo "    Resume the session (/resume) to pick up the full MCP + identity surface."
+  fi
+
+  echo "───────────────────────────────────────────────────────────────"
+fi
 
 # Cloud build-time receipt — what did cloud-setup.sh actually do at
 # snapshot build? Present = build ran; missing = build skipped or the

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -34,8 +34,9 @@ bootstrap_log_record() {
 # /root/ in the cloud image and gets fresh on every session boot, which
 # is useful for session-scope logs but useless for recording what
 # cloud-setup.sh actually did at build time. Keep session-scope state in
-# ~/.vade/, snapshot-scope state here.
-VADE_CLOUD_STATE_DIR="/home/user/.vade-cloud-state"
+# ~/.vade/, snapshot-scope state here. Overridable so local-setup.sh
+# can point it at ~/.vade/local-state on macOS.
+VADE_CLOUD_STATE_DIR="${VADE_CLOUD_STATE_DIR:-/home/user/.vade-cloud-state}"
 VADE_BUILD_LOG="${VADE_CLOUD_STATE_DIR}/build.log"
 VADE_SETUP_RECEIPT="${VADE_CLOUD_STATE_DIR}/setup-receipt.json"
 
@@ -638,10 +639,14 @@ _op_to_file() {
   log "  wrote $path ($mode)"
 }
 
-# Write ~/.gitconfig with COO identity + SSH signing + auth-key push.
+# Write gitconfig with COO identity + SSH signing + auth-key push.
 # Per MEMO 2026-04-22-03, cloud sessions share the Mac's commit discipline.
+# Target path is overridable via VADE_COO_GITCONFIG so local-setup.sh can
+# route Claude's git through ~/.vade/gitconfig-coo (via GIT_CONFIG_GLOBAL)
+# without touching the user's personal ~/.gitconfig.
 write_coo_gitconfig() {
-  local gc="${HOME}/.gitconfig"
+  local gc="${VADE_COO_GITCONFIG:-${HOME}/.gitconfig}"
+  mkdir -p "$(dirname "$gc")"
   git config --file "$gc" user.name "COO"
   git config --file "$gc" user.email "coo@vade-app.dev"
   git config --file "$gc" gpg.format ssh

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Local (macOS) equivalent of cloud-setup.sh. Runs from a user-scope
+# SessionStart hook when Claude Code is launched from any repo under
+# ~/GitHub/vade-app/. Delegates to coo-bootstrap.sh for the full COO
+# identity pipeline (SSH keys, gitconfig, MCP env vars, receipt, logs) —
+# same code path as cloud, with two env-var redirects so the artifacts
+# land in ~/.vade/local-state/ and ~/.vade/gitconfig-coo rather than the
+# cloud-specific /home/user/ paths and the user's personal ~/.gitconfig.
+#
+# Expects OP_SERVICE_ACCOUNT_TOKEN in the process env. The dotfiles
+# claude() wrapper is the intended provisioner:
+# zsh/.config/zsh/functions.zsh `op read`s the COO vault's sandbox SA
+# token into OP_SERVICE_ACCOUNT_TOKEN only when $PWD is under
+# ~/GitHub/vade-app/, so normal shells and non-vade projects stay
+# untouched.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export VADE_CLOUD_STATE_DIR="${VADE_CLOUD_STATE_DIR:-${HOME}/.vade/local-state}"
+export VADE_COO_GITCONFIG="${VADE_COO_GITCONFIG:-${HOME}/.vade/gitconfig-coo}"
+
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+log "Local environment setup starting"
+build_log_record START "local-setup: begin (mode=local)"
+
+ensure_dirs
+
+OP_TOKEN_VISIBLE=false
+COO_BOOTSTRAP_RAN=false
+if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+  OP_TOKEN_VISIBLE=true
+  build_log_record PROBE "local-setup: OP_SERVICE_ACCOUNT_TOKEN present (len=${#OP_SERVICE_ACCOUNT_TOKEN})"
+  if bash "$SCRIPT_DIR/coo-bootstrap.sh"; then
+    COO_BOOTSTRAP_RAN=true
+    build_log_record OK "local-setup: coo-bootstrap completed"
+  else
+    build_log_record FAIL "local-setup: coo-bootstrap failed; continuing without COO identity"
+    log "Warning: coo-bootstrap failed; continuing without COO identity."
+  fi
+else
+  build_log_record PROBE "local-setup: OP_SERVICE_ACCOUNT_TOKEN unset; skipping"
+  log "OP_SERVICE_ACCOUNT_TOKEN unset; skipping COO bootstrap. (Claude launched outside the claude() wrapper?)"
+fi
+
+GIT_SHA="$(git -C "$SCRIPT_DIR/.." rev-parse --short HEAD 2>/dev/null || echo unknown)"
+build_receipt_write \
+  built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  mode=local \
+  op_token_visible="$OP_TOKEN_VISIBLE" \
+  coo_bootstrap_ran="$COO_BOOTSTRAP_RAN" \
+  git_sha="$GIT_SHA"
+
+build_log_record OK "local-setup: complete (op_token=$OP_TOKEN_VISIBLE coo_bootstrap=$COO_BOOTSTRAP_RAN)"
+log "Done."


### PR DESCRIPTION
## Summary

Brings Claude Code's local Mac launches under `~/GitHub/vade-app/vade-runtime/` to parity with the cloud container, so the same SessionStart/Stop hook chain fires cleanly in both environments.

- **New `scripts/local-setup.sh`** (commit 92823a4): user-scope SessionStart entry point that runs the existing `coo-bootstrap.sh` with `VADE_CLOUD_STATE_DIR=~/.vade/local-state` and `VADE_COO_GITCONFIG=~/.vade/gitconfig-coo` overrides, so COO SSH keys, gitconfig, env file, and receipt land under `~/.vade/` rather than the cloud-specific `/home/user/` paths.
- **Portable hook paths** (commit fdccc3b): project-scope `.claude/settings.json` now resolves all five hook scripts via `${CLAUDE_PROJECT_DIR}` instead of hardcoded `/home/user/vade-runtime/`. Fixes the five `SessionStart:startup` / `Stop` "No such file or directory" errors that Mac launches produced.
- **`coo-identity-digest.sh` is now platform-aware**: platform-probed default for `COO_MEMORY_DIR` (Mac → `~/GitHub/vade-app/vade-coo-memory`), `SETUP_RECEIPT` routed through `VADE_CLOUD_STATE_DIR` with `~/.vade/local-state` fallback, node-based ISO parsing (GNU-only `date -d` silently broke the bootstrap-wait loop on macOS), cloud-only MCP surface probe skipped on non-cloud hosts, `$CLAUDE_PROJECT_DIR` in the fix-path hint.

`session-start-sync.sh`, `coo-bootstrap.sh`, `discussions-digest.sh`, and `session-lifecycle.sh` were already portable (internal "source missing; skipping" guards or `$HOME`-relative paths) so no changes needed there.

## Test plan

- [x] Dry-run `bash scripts/coo-identity-digest.sh` from local clone — identity block loads from `~/GitHub/vade-app/vade-coo-memory/CLAUDE.md`, bootstrap posture reads local `~/.vade/coo-bootstrap.log`, build-time receipt reads `~/.vade/local-state/setup-receipt.json` with `mode: local`, MCP surface probe cleanly skipped.
- [x] Bash syntax check on both modified files passes.
- [x] User verified end-to-end: fresh `claude` launch from `~/GitHub/vade-app/vade-runtime/` no longer emits the five "No such file or directory" hook errors.
- [ ] Cloud-env regression check: open a Claude session in the cloud web env, confirm `${CLAUDE_PROJECT_DIR}` resolves to `/home/user/vade-runtime`, hook chain still runs, MCP surface probe still fires (`$HOME = /home/user`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)