### PR TITLE
cloud-env: fix retry() silent-success bug; harden _op_to_file

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -128,11 +128,23 @@ retry() {
   err_file="$(mktemp 2>/dev/null)" || { "$@"; return $?; }
   while [ "$attempt" -lt "$tries" ]; do
     attempt=$((attempt+1))
-    if "$@" 2>"$err_file"; then
+    # Capture the actual exit of "$@" via `|| rc=$?`. The prior
+    # `if "$@"; then ...; fi; rc=$?` pattern is a bash gotcha: after
+    # an if-compound where no branch was taken, $? is 0, not the
+    # failed command's exit. That made `retry` log rc=0 on every
+    # retry line AND made `return "$rc"` after a full-failure loop
+    # return 0, silently signalling success. Callers like `_op_to_file`
+    # with `if ! content="$(retry 3 op read "$ref")"; then return 1`
+    # never saw the failure: content came back empty, the ssh key
+    # file got a bare newline, and install_coo_ssh_keys FATALed at
+    # the fingerprint check instead of upstream at _op_to_file.
+    # Witnessed on snapshot run-2026-04-22T091701.
+    rc=0
+    "$@" 2>"$err_file" || rc=$?
+    if [ "$rc" -eq 0 ]; then
       rm -f "$err_file"
       return 0
     fi
-    rc=$?
     if [ "$attempt" -lt "$tries" ]; then
       log_err "  retry ${attempt}/${tries} for: $* (rc=$rc; sleeping ${delay}s)"
       sleep "$delay"
@@ -141,7 +153,7 @@ retry() {
   done
   local last_err
   last_err="$(tr '\n' ' ' < "$err_file" 2>/dev/null | cut -c1-240)"
-  log_err "  FAIL after ${tries} attempts: $* (last err: ${last_err:-<empty>})"
+  log_err "  FAIL after ${tries} attempts: $* (last err: ${last_err:-<empty>}; final rc=$rc)"
   cat "$err_file" >&2 2>/dev/null || true
   rm -f "$err_file"
   return "$rc"
@@ -627,8 +639,23 @@ install_coo_ssh_keys() {
 _op_to_file() {
   local ref="$1" path="$2" mode="$3"
   local content
-  if ! content="$(retry 3 op read "$ref")"; then
+  # 5 attempts (sleeps 1+2+4+8 = 15s of tolerance) absorbs 1Password
+  # service-account cold-start latency on first `op read` of a fresh
+  # container. Observed on run-2026-04-22T091701: first bootstrap
+  # attempt FAILED at install_coo_ssh_keys; second attempt
+  # (`VADE_FORCE_COO_BOOTSTRAP=1`) succeeded after 2 retries on the
+  # same ref, suggesting 3 attempts was inside the cold-start window
+  # but 5 clears it comfortably.
+  if ! content="$(retry 5 op read "$ref")"; then
     log "Failed to read $ref after retries"
+    return 1
+  fi
+  # Empty content from a rc=0 `op read` indicates a 1Password API
+  # soft-fail that didn't set an exit code — fail loudly rather than
+  # writing a bare-newline file that trips the fingerprint check
+  # downstream with a confusing error.
+  if [ -z "$content" ]; then
+    log "Failed to read $ref: empty content (op read returned rc=0 with no output)"
     return 1
   fi
   (


### PR DESCRIPTION
## Root cause

`retry()` in `scripts/lib/common.sh` had a classic bash if-after-fi gotcha that made it silently return success on full failure. The log line said `rc=0` on every retry attempt, and after an exhausted loop the function returned 0 too, so callers like `_op_to_file` that did `if ! content="$(retry 3 op read "$ref")"; then return 1` never saw the failure — `content` came back empty, the SSH key file got a bare newline, and `install_coo_ssh_keys` FATALed three steps downstream at the fingerprint check with a confusing "fingerprint mismatch (got empty, expected …)" instead of the real "Failed to read op://COO/… after retries" error.

Verified:

```
$ bash -c 'if false; then :; fi; echo rc=$?'
rc=0
```

Observed on cloud snapshot `run-2026-04-22T091701`: SessionStart bootstrap FAILED at `install_coo_ssh_keys rc=1`; force-re-run 24s later succeeded after 2 retries on the first `op read`, which suggests the 3-attempt budget was inside the 1Password service-account cold-start window and the real cause was cold-start latency — but the silent-success bug made that root cause invisible from the bootstrap log.

## Fix

1. **Capture `rc` via `cmd || rc=$?`** right after the command, before any compound boundary. `$rc` now reflects the real exit code across all paths. Log line now reports actual rc, and `return "$rc"` at end-of-loop returns the actual final rc.

2. **Bumped `_op_to_file`'s retry count from 3 to 5.** Sleep schedule 1+2+4+8 = 15s of cold-start tolerance vs 3s before. Observed cold-start window on the second run was 2 attempts; 5 clears it with margin. Adds at most ~15s on a pathological first-session boot where every attempt fails; subsequent sessions short-circuit on the bootstrap marker and see zero impact.

3. **Added an empty-content guard in `_op_to_file`.** A `rc=0` with empty stdout from `op read` was the masked failure mode before the retry fix; after the retry fix it's no longer silent, but making the guard explicit keeps the error message clear ("empty content" instead of a downstream fingerprint mismatch) in case 1Password ever surfaces a new variant of the same soft-fail.

## Tests

Smoke-tested `retry()` behaviour by sourcing the lib in a clean bash and calling it against mock commands.

**Flaky command** (fails 2×, succeeds 3rd):

```
retry 5 flaky  →  exit 0, stdout "SUCCESS-OUTPUT" preserved
stderr:
  retry 1/5 for: flaky (rc=17; sleeping 1s)
  retry 2/5 for: flaky (rc=17; sleeping 2s)
```

Real rc=17 logged (pre-fix logged "rc=0"). Stdout pass-through preserved so callers using `x="$(retry N op read ref)"` continue to work.

**Always-failing command** (exhaust retries):

```
retry 3 always_fail  →  exit 42 (pre-fix returned 0)
stderr:
  retry 1/3 for: always_fail (rc=42; sleeping 1s)
  retry 2/3 for: always_fail (rc=42; sleeping 2s)
  FAIL after 3 attempts: always_fail (last err: <empty>; final rc=42)
```

With pre-fix code this returned 0, masking failure from the caller and causing `install_coo_ssh_keys` to surface a fingerprint error instead of the upstream op-read failure.

**Bash syntax check**: `bash -n scripts/lib/common.sh` clean.

## Expected first-session behaviour after this lands

A fresh cloud snapshot that previously would have exited `install_coo_ssh_keys rc=1` on SessionStart:

- Now sees up to 15s of retry tolerance, so if the cold-start window was the real cause, bootstrap succeeds on the first run without needing `VADE_FORCE_COO_BOOTSTRAP=1`.
- If retries still exhaust, the bootstrap log shows the real final `rc` and a clear `FAIL after 5 attempts: op read op://COO/vade-coo-auth/private key (last err: …; final rc=N)` line — upstream of the fingerprint check, with the actual error from `op read` captured. No more chasing phantom fingerprint mismatches.
- `mcp__github-coo__*` / `mcp__agentmail__*` / `mcp__mem0__*` mount on the first session instead of requiring a `/resume` after a mid-session self-heal.

## Scope

One file. 31 lines added (mostly the explanatory comment block citing this session's observation), 4 lines removed. No API changes; existing callers of `retry` that already tolerated both success-with-empty and full-fail-as-zero (like `fetch_coo_secrets`, which guards with `&& [ -n "$var" ]`) continue to behave identically. Behaviour change is strictly on the silent-failure path, which is the target.

## Not in scope

- Bumping `fetch_coo_secrets` retries from 3 to 5. That path tolerates retry=0-on-failure gracefully today via `[ -n "$github_pat" ]` guards; not broken.
- Bumping `op whoami`'s retry in `coo-bootstrap.sh`. That ran and passed on both of this session's attempts, so it's not in the observed cold-start window.
- Retrofitting a warmup call on cold-boot. The retry bump is the smaller intervention and should be sufficient; revisit only if a future session shows retries exhausting past 15s.

## Opener attribution note

Opened via direct `curl` to the GitHub PR API with `GITHUB_MCP_PAT` sourced from `/root/.vade/coo-env` — same session as vade-coo-memory PRs #40/#41. `mcp__github-coo__*` not available in-session because MCP resolution happened before the bootstrap self-healed. Commit author and signature `vade-coo`, verified.