### PR TITLE
cloud-env: dispatch shim for SessionStart hooks; integrity-check probe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,22 +4,22 @@
       {
         "matcher": "startup",
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/session-start-sync.sh\"" },
-          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/coo-bootstrap.sh\"" },
-          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/coo-identity-digest.sh\"" },
-          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/discussions-digest.sh\"" }
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" session-start-sync" },
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" coo-bootstrap" },
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" coo-identity-digest" },
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" discussions-digest" }
         ]
       },
       {
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/session-lifecycle.sh\"" }
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" session-lifecycle" }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/session-lifecycle.sh\" --end" }
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" session-lifecycle --end" }
         ]
       }
     ]

--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -16,6 +16,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
+boot_log_record coo-bootstrap start
+
 # Record every exit path in ~/.vade/coo-bootstrap.log so silent failures
 # still leave a trail. The identity-digest hook surfaces the tail of
 # this file on each session start.
@@ -24,8 +26,10 @@ _on_exit() {
   local rc=$?
   if [ "$rc" -eq 0 ]; then
     bootstrap_log_record OK "step=${COO_BOOTSTRAP_STEP} rc=0"
+    boot_log_record coo-bootstrap end ok "step=${COO_BOOTSTRAP_STEP}"
   else
     bootstrap_log_record FAIL "step=${COO_BOOTSTRAP_STEP} rc=${rc}"
+    boot_log_record coo-bootstrap end fail "step=${COO_BOOTSTRAP_STEP}" "rc=${rc}"
   fi
   return $rc
 }

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 
 boot_log_record coo-identity-digest start
-trap 'boot_log_record coo-identity-digest end ok' EXIT
+trap '_rc=$?; boot_log_record coo-identity-digest end $([ $_rc -eq 0 ] && echo ok || echo fail) rc=$_rc' EXIT
 
 if [ -n "${COO_MEMORY_DIR:-}" ]; then
   MEM_REPO="$COO_MEMORY_DIR"

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -16,6 +16,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
+boot_log_record coo-identity-digest start
+trap 'boot_log_record coo-identity-digest end ok' EXIT
+
 if [ -n "${COO_MEMORY_DIR:-}" ]; then
   MEM_REPO="$COO_MEMORY_DIR"
 elif [ "$HOME" != "/home/user" ] && [ -d "$HOME/GitHub/vade-app/vade-coo-memory" ]; then

--- a/scripts/discussions-digest.sh
+++ b/scripts/discussions-digest.sh
@@ -15,13 +15,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 
 boot_log_record discussions-digest start
-trap 'boot_log_record discussions-digest end ok' EXIT
+trap '_rc=$?; boot_log_record discussions-digest end $([ $_rc -eq 0 ] && echo ok || echo fail) rc=$_rc' EXIT
 
 TOKEN="${GITHUB_TOKEN:-${GITHUB_MCP_PAT:-}}"
 if [ -z "$TOKEN" ]; then
   log "GITHUB_TOKEN unset; skipping discussions digest."
-  boot_log_record discussions-digest end skip "reason=no-token"
   trap - EXIT
+  boot_log_record discussions-digest end skip "reason=no-token"
   exit 0
 fi
 

--- a/scripts/discussions-digest.sh
+++ b/scripts/discussions-digest.sh
@@ -14,9 +14,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
+boot_log_record discussions-digest start
+trap 'boot_log_record discussions-digest end ok' EXIT
+
 TOKEN="${GITHUB_TOKEN:-${GITHUB_MCP_PAT:-}}"
 if [ -z "$TOKEN" ]; then
   log "GITHUB_TOKEN unset; skipping discussions digest."
+  boot_log_record discussions-digest end skip "reason=no-token"
+  trap - EXIT
   exit 0
 fi
 

--- a/scripts/hooks-dispatch.sh
+++ b/scripts/hooks-dispatch.sh
@@ -42,12 +42,25 @@ if [ -z "$HOOK_NAME" ]; then
 fi
 
 BOOT_LOG="${HOME}/.vade/boot.log"
+# Inline JSON-string escape (handles \, ", and the four control chars
+# bash callers might pass). Duplicated from common.sh::_json_escape
+# because the dispatch shim deliberately does not source common.sh —
+# this script is the bootstrap entry point and must not depend on
+# anything that could itself be missing or stale.
+_je() {
+  local s="$1"
+  s="${s//\\/\\\\}"; s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"; s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"; s="${s//$'\b'/\\b}"
+  printf '%s' "$s"
+}
+
 _log() {
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
   mkdir -p "$(dirname "$BOOT_LOG")" 2>/dev/null || return 0
   printf '{"ts":"%s","script":"hooks-dispatch","hook":"%s","rule":"%s","runtime":"%s","ok":%s,"detail":"%s"}\n' \
-    "$ts" "$HOOK_NAME" "$1" "${2:-}" "$3" "${4:-}" \
+    "$ts" "$(_je "$HOOK_NAME")" "$(_je "$1")" "$(_je "${2:-}")" "$3" "$(_je "${4:-}")" \
     >> "$BOOT_LOG" 2>/dev/null || return 0
 }
 

--- a/scripts/hooks-dispatch.sh
+++ b/scripts/hooks-dispatch.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SessionStart/Stop hook dispatcher.
+#
+# Installed as $HOME/.claude/vade-hooks/dispatch.sh (symlink, maintained
+# by sync_claude_config → ensure_hooks_dispatch_shim). Every hook command
+# in .claude/settings.json invokes this script with a hook name as $1
+# and any additional flags as $2+, e.g.:
+#
+#   bash "$HOME/.claude/vade-hooks/dispatch.sh" session-lifecycle --end
+#
+# The shim's job is to find the real script in vade-runtime/scripts/
+# without settings.json baking in a repo-specific path. Portability is
+# concentrated here — settings.json references only $HOME-relative
+# paths, which are defined on every platform Claude Code runs on.
+#
+# Resolver rules, first match wins:
+#   1. $VADE_RUNTIME_DIR env var (explicit override)
+#   2. $CLAUDE_PROJECT_DIR (Mac single-root case, where cwd=repo)
+#   3. Parent of this shim's real path — i.e. vade-runtime/ itself when
+#      the shim was installed via symlink by sync_claude_config
+#   4. readlink of /home/user/.mcp.json — the MCP-config symlink target's
+#      parent is vade-runtime (cloud case, layout-agnostic)
+#   5. $HOME/GitHub/vade-app/vade-runtime (local Mac default)
+#
+# Every invocation appends one line to ~/.vade/boot.log recording which
+# rule won + whether the target script was found. Non-fatal on every
+# path: exit 0 even when nothing resolves, so a missing runtime doesn't
+# cascade a hook chain failure. The integrity-check probe catches
+# failures loudly on the next read.
+#
+# Contract: MEMO pairing this fix, vade-runtime PR closing the
+# CLAUDE_PROJECT_DIR regression from #28.
+set -euo pipefail
+
+HOOK_NAME="${1:-}"
+shift || true
+HOOK_ARGS=("$@")
+
+if [ -z "$HOOK_NAME" ]; then
+  echo "hooks-dispatch: no hook name supplied" >&2
+  exit 0
+fi
+
+BOOT_LOG="${HOME}/.vade/boot.log"
+_log() {
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "$(dirname "$BOOT_LOG")" 2>/dev/null || return 0
+  printf '{"ts":"%s","script":"hooks-dispatch","hook":"%s","rule":"%s","runtime":"%s","ok":%s,"detail":"%s"}\n' \
+    "$ts" "$HOOK_NAME" "$1" "${2:-}" "$3" "${4:-}" \
+    >> "$BOOT_LOG" 2>/dev/null || return 0
+}
+
+_script_for() {
+  local base="$1" name="$2"
+  local candidate="$base/scripts/$name.sh"
+  [ -f "$candidate" ] && printf '%s' "$candidate"
+}
+
+RESOLVED_RUNTIME=""
+RESOLVED_RULE=""
+RESOLVED_SCRIPT=""
+
+# Rule 1: explicit override
+if [ -n "${VADE_RUNTIME_DIR:-}" ] && target="$(_script_for "$VADE_RUNTIME_DIR" "$HOOK_NAME")" && [ -n "$target" ]; then
+  RESOLVED_RUNTIME="$VADE_RUNTIME_DIR"
+  RESOLVED_RULE="env_VADE_RUNTIME_DIR"
+  RESOLVED_SCRIPT="$target"
+fi
+
+# Rule 2: CLAUDE_PROJECT_DIR (when cwd is the repo itself)
+if [ -z "$RESOLVED_SCRIPT" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+  if target="$(_script_for "$CLAUDE_PROJECT_DIR" "$HOOK_NAME")" && [ -n "$target" ]; then
+    RESOLVED_RUNTIME="$CLAUDE_PROJECT_DIR"
+    RESOLVED_RULE="CLAUDE_PROJECT_DIR"
+    RESOLVED_SCRIPT="$target"
+  fi
+fi
+
+# Rule 3: self-referential via shim's install path
+if [ -z "$RESOLVED_SCRIPT" ]; then
+  self_path="$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+  if [ -n "$self_path" ]; then
+    self_runtime="$(cd "$(dirname "$self_path")/.." 2>/dev/null && pwd)"
+    if [ -n "$self_runtime" ] && target="$(_script_for "$self_runtime" "$HOOK_NAME")" && [ -n "$target" ]; then
+      RESOLVED_RUNTIME="$self_runtime"
+      RESOLVED_RULE="self_path"
+      RESOLVED_SCRIPT="$target"
+    fi
+  fi
+fi
+
+# Rule 4: derive from MCP-config symlink (cloud case, layout-agnostic)
+if [ -z "$RESOLVED_SCRIPT" ] && [ -L /home/user/.mcp.json ]; then
+  mcp_target="$(readlink -f /home/user/.mcp.json 2>/dev/null || true)"
+  if [ -n "$mcp_target" ]; then
+    mcp_runtime="$(dirname "$mcp_target")"
+    if target="$(_script_for "$mcp_runtime" "$HOOK_NAME")" && [ -n "$target" ]; then
+      RESOLVED_RUNTIME="$mcp_runtime"
+      RESOLVED_RULE="mcp_symlink"
+      RESOLVED_SCRIPT="$target"
+    fi
+  fi
+fi
+
+# Rule 5: local Mac default
+if [ -z "$RESOLVED_SCRIPT" ] && [ -d "$HOME/GitHub/vade-app/vade-runtime" ]; then
+  if target="$(_script_for "$HOME/GitHub/vade-app/vade-runtime" "$HOOK_NAME")" && [ -n "$target" ]; then
+    RESOLVED_RUNTIME="$HOME/GitHub/vade-app/vade-runtime"
+    RESOLVED_RULE="mac_default"
+    RESOLVED_SCRIPT="$target"
+  fi
+fi
+
+if [ -z "$RESOLVED_SCRIPT" ]; then
+  _log "none" "" "false" "no resolver rule matched; hook skipped"
+  echo "hooks-dispatch: could not locate $HOOK_NAME.sh in any known runtime location" >&2
+  exit 0
+fi
+
+_log "$RESOLVED_RULE" "$RESOLVED_RUNTIME" "true" "dispatching to $RESOLVED_SCRIPT"
+
+# Forward. Use `bash` explicitly (matches settings.json convention) and
+# pass through additional args. Don't use exec — we want the logged
+# dispatch line even if the hook crashes.
+bash "$RESOLVED_SCRIPT" "${HOOK_ARGS[@]}"

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# VADE cloud-session integrity check.
+#
+# Runs a fixed set of invariants (Groups A-E) against the current
+# session and writes a structured JSON report to
+# $VADE_CLOUD_STATE_DIR/integrity-check.json. Also prints a one-line
+# human-readable summary to stderr so an agent invoking this directly
+# sees the result without parsing JSON.
+#
+# Non-fatal on every path: always exits 0 even when invariants fail.
+# This is a probe, not a repair tool.
+#
+# Invocation modes:
+#   1. Automatic at boot — session-start-sync.sh calls it at end.
+#   2. On-demand — `bash /home/user/vade-runtime/scripts/integrity-check.sh`
+#   3. CI — tests run it after faking a SessionStart chain; Groups
+#      A/B/C gate PR merges, D/E are secret-dependent and skip in CI.
+#
+# See the VADE integrity protocol memo (paired with this file's PR)
+# for the full invariant list and rationale.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+OUT_FILE="${VADE_CLOUD_STATE_DIR}/integrity-check.json"
+RUNTIME_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Array of "key|ok|detail" triples. Flat for shell; node groups by
+# key prefix (A1 → A, B1 → B, etc) at write time.
+RESULTS=()
+_add() {
+  local key="$1" ok="$2" detail="${3:-}"
+  RESULTS+=("$key|$ok|$detail")
+}
+
+# ── Group A: Build-time setup ──────────────────────────────────
+A1_receipt="$VADE_SETUP_RECEIPT"
+if [ -f "$A1_receipt" ] && node -e 'JSON.parse(require("fs").readFileSync(process.argv[1]))' "$A1_receipt" 2>/dev/null; then
+  _add A1 true "receipt at $A1_receipt parses"
+else
+  _add A1 false "receipt missing or unparseable at $A1_receipt"
+fi
+
+if [ -f "$VADE_BUILD_LOG" ] && grep -q 'OK cloud-setup: complete\|OK local-setup: complete' "$VADE_BUILD_LOG" 2>/dev/null; then
+  _add A2 true "build.log has terminal OK line"
+else
+  _add A2 false "build.log missing or no terminal OK line at $VADE_BUILD_LOG"
+fi
+
+# A3: receipt asserts workspace_mcp_symlinked=true/identity_link_ok=true
+# but the link is currently wrong → drift. Vice versa is also flagged.
+A3_detail=""
+A3_ok=true
+if [ -f "$A1_receipt" ] && check_cmd node; then
+  claim_mcp="$(node -e 'const r=JSON.parse(require("fs").readFileSync(process.argv[1])); process.stdout.write(String(!!r.workspace_mcp_symlinked))' "$A1_receipt" 2>/dev/null || echo unknown)"
+  claim_id="$(node -e 'const r=JSON.parse(require("fs").readFileSync(process.argv[1])); process.stdout.write(String(!!r.identity_link_ok))' "$A1_receipt" 2>/dev/null || echo unknown)"
+  observed_mcp=false
+  observed_id=false
+  [ -L /home/user/.mcp.json ] && observed_mcp=true
+  [ -L /home/user/CLAUDE.md ] && observed_id=true
+  [ "$claim_mcp" = "$observed_mcp" ] || { A3_ok=false; A3_detail="mcp_link drift: receipt=$claim_mcp observed=$observed_mcp; "; }
+  [ "$claim_id" = "$observed_id" ] || { A3_ok=false; A3_detail="${A3_detail}identity_link drift: receipt=$claim_id observed=$observed_id"; }
+  [ "$A3_ok" = true ] && A3_detail="receipt matches observed symlinks"
+else
+  A3_ok=skip
+  A3_detail="receipt or node unavailable"
+fi
+_add A3 "$A3_ok" "$A3_detail"
+
+# ── Group B: SessionStart hooks executable ────────────────────
+SHIM_DST="$HOME/.claude/vade-hooks/dispatch.sh"
+SHIM_SRC="$RUNTIME_DIR/scripts/hooks-dispatch.sh"
+if [ -L "$SHIM_DST" ] && [ -f "$(readlink -f "$SHIM_DST" 2>/dev/null)" ] && [ -x "$(readlink -f "$SHIM_DST" 2>/dev/null)" ]; then
+  _add B2 true "dispatch shim → $(readlink "$SHIM_DST")"
+elif [ -f "$SHIM_DST" ] && [ -x "$SHIM_DST" ]; then
+  _add B2 true "dispatch shim present (non-symlink) at $SHIM_DST"
+else
+  _add B2 false "dispatch shim missing or not executable at $SHIM_DST"
+fi
+
+# B1: re-run the resolver for each expected hook name
+B1_ok=true
+B1_detail=""
+for name in session-start-sync coo-bootstrap coo-identity-digest discussions-digest session-lifecycle; do
+  if ! [ -f "$RUNTIME_DIR/scripts/$name.sh" ]; then
+    B1_ok=false
+    B1_detail="${B1_detail}missing: $name.sh; "
+  fi
+done
+[ "$B1_ok" = true ] && B1_detail="all 5 hook scripts present in runtime"
+_add B1 "$B1_ok" "$B1_detail"
+
+# B3: last SessionStart chain outcomes in claude-code.log
+B3_ok=skip
+B3_detail="claude-code.log not readable"
+if [ -r /tmp/claude-code.log ]; then
+  failures="$(grep -c 'Hook SessionStart:startup.*exit_code.*127\|No such file or directory' /tmp/claude-code.log 2>/dev/null || echo 0)"
+  if [ "$failures" -gt 0 ]; then
+    B3_ok=false
+    B3_detail="$failures failing hook entries in claude-code.log (grep on 'No such file')"
+  else
+    B3_ok=true
+    B3_detail="no hook failure pattern in claude-code.log"
+  fi
+fi
+_add B3 "$B3_ok" "$B3_detail"
+
+# B4: hooks section hash matches repo
+B4_ok=skip
+B4_detail="node missing"
+if check_cmd node; then
+  B4_ok=$(node -e '
+    const fs = require("fs"); const [src, dst] = process.argv.slice(1);
+    try {
+      const s = JSON.parse(fs.readFileSync(src, "utf8"));
+      const d = JSON.parse(fs.readFileSync(dst, "utf8"));
+      const sh = JSON.stringify(s.hooks || {});
+      const dh = JSON.stringify(d.hooks || {});
+      process.stdout.write(sh === dh ? "true" : "false");
+    } catch { process.stdout.write("skip"); }
+  ' "$RUNTIME_DIR/.claude/settings.json" "$HOME/.claude/settings.json" 2>/dev/null || echo skip)
+  case "$B4_ok" in
+    true)  B4_detail="settings.json hooks section matches repo" ;;
+    false) B4_detail="settings.json hooks drift from repo; re-run session-start-sync" ;;
+    *)     B4_detail="comparison failed" ;;
+  esac
+fi
+_add B4 "$B4_ok" "$B4_detail"
+
+# B5: diagnostic, not pass/fail
+_add B5 info "CLAUDE_PROJECT_DIR=${CLAUDE_PROJECT_DIR:-<unset>} cwd=$(pwd) HOME=$HOME"
+
+# ── Group C: Symlinks & MCP config ────────────────────────────
+if [ -L /home/user/CLAUDE.md ] && [ "$(readlink -f /home/user/CLAUDE.md)" = "$(readlink -f /home/user/vade-coo-memory/CLAUDE.md 2>/dev/null)" ]; then
+  _add C1 true "/home/user/CLAUDE.md → vade-coo-memory/CLAUDE.md"
+else
+  _add C1 false "/home/user/CLAUDE.md symlink missing or wrong target"
+fi
+
+if [ -L /home/user/.mcp.json ] && [ "$(readlink -f /home/user/.mcp.json)" = "$(readlink -f /home/user/vade-runtime/.mcp.json 2>/dev/null)" ]; then
+  _add C2 true "/home/user/.mcp.json → vade-runtime/.mcp.json"
+else
+  _add C2 false "/home/user/.mcp.json symlink missing or wrong target"
+fi
+
+if [ -f /home/user/.mcp.json ] && node -e 'JSON.parse(require("fs").readFileSync(process.argv[1]))' /home/user/.mcp.json 2>/dev/null; then
+  _add C3 true "mcp.json parses"
+else
+  _add C3 false "mcp.json missing or unparseable"
+fi
+
+# ── Group D: COO identity & secrets ──────────────────────────
+if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+  _add D1 true "OP_SERVICE_ACCOUNT_TOKEN set (len=${#OP_SERVICE_ACCOUNT_TOKEN})"
+else
+  _add D1 false "OP_SERVICE_ACCOUNT_TOKEN unset in session process"
+fi
+
+if [ -f "$HOME/.vade/.coo-bootstrap-done" ]; then
+  _add D2 true "marker present"
+else
+  _add D2 false "marker $HOME/.vade/.coo-bootstrap-done missing"
+fi
+
+if [ -f "$HOME/.vade/coo-bootstrap.log" ]; then
+  tail_line="$(tail -n 1 "$HOME/.vade/coo-bootstrap.log" 2>/dev/null || true)"
+  if printf '%s' "$tail_line" | grep -qE 'OK step=complete|OK step=skip-'; then
+    _add D3 true "coo-bootstrap.log tail: $tail_line"
+  else
+    _add D3 false "coo-bootstrap.log tail non-terminal: $tail_line"
+  fi
+else
+  _add D3 false "coo-bootstrap.log missing"
+fi
+
+if check_cmd node && [ -f "$HOME/.claude/settings.json" ]; then
+  D4_missing="$(node -e '
+    const fs = require("fs");
+    let c = {};
+    try { c = JSON.parse(fs.readFileSync(process.argv[1], "utf8")) || {}; } catch { process.exit(0); }
+    const env = c.env || {};
+    const req = ["GITHUB_MCP_PAT","GITHUB_TOKEN","AGENTMAIL_API_KEY"];
+    process.stdout.write(req.filter(k => !env[k]).join(","));
+  ' "$HOME/.claude/settings.json" 2>/dev/null)"
+  if [ -z "$D4_missing" ]; then
+    _add D4 true "settings.json env has GITHUB_MCP_PAT, GITHUB_TOKEN, AGENTMAIL_API_KEY"
+  else
+    _add D4 false "settings.json env missing: $D4_missing"
+  fi
+else
+  _add D4 skip "node or settings.json unavailable"
+fi
+
+GIT_EMAIL="$(git config --global user.email 2>/dev/null || true)"
+if [ "$GIT_EMAIL" = "coo@vade-app.dev" ]; then
+  _add D5 true "gitconfig user.email=coo@vade-app.dev"
+else
+  _add D5 false "gitconfig user.email=$GIT_EMAIL (expected coo@vade-app.dev)"
+fi
+
+if [ -f "$HOME/.ssh/vade-coo-auth" ] && [ -f "$HOME/.ssh/vade-coo-sign" ]; then
+  _add D6 true "vade-coo-auth and vade-coo-sign keys installed"
+else
+  _add D6 false "vade-coo-{auth,sign} keys missing in $HOME/.ssh"
+fi
+
+# ── Group E: MCP surface ─────────────────────────────────────
+# Requires MCP tool calls (get_me on github and github-coo namespaces).
+# An agent invoking this directly should fill E1/E2/E3/E4 into the
+# JSON afterwards. CI skips E entirely.
+_add E1 skip "requires-agent: call mcp__github__get_me"
+_add E2 skip "requires-agent: call mcp__github-coo__get_me"
+_add E3 skip "requires-agent: inspect mcp-needs-auth-cache.json"
+_add E4 skip "requires-agent: observe tool namespaces"
+
+# ── Serialize ────────────────────────────────────────────────
+mkdir -p "$VADE_CLOUD_STATE_DIR" 2>/dev/null || true
+
+if check_cmd node; then
+  printf '%s\n' "${RESULTS[@]}" | node -e '
+    const fs = require("fs");
+    const [outFile, sessionId] = process.argv.slice(1);
+    const groups = {};
+    const degraded = [];
+    let total = 0, okCount = 0;
+    const input = fs.readFileSync(0, "utf8");
+    for (const line of input.split("\n")) {
+      if (!line) continue;
+      const [key, ok, ...detailParts] = line.split("|");
+      const detail = detailParts.join("|");
+      const g = key[0];
+      groups[g] = groups[g] || {};
+      const isOk = ok === "true";
+      const isInfo = ok === "info";
+      const isSkip = ok === "skip";
+      groups[g][key] = { ok: isOk, detail };
+      if (isInfo) groups[g][key] = { info: true, detail };
+      if (isSkip) groups[g][key] = { ok: null, skipped: true, detail };
+      if (!isInfo && !isSkip) {
+        total += 1;
+        if (isOk) okCount += 1;
+        else degraded.push(key);
+      }
+    }
+    const out = {
+      checked_at: new Date().toISOString(),
+      session_id: sessionId || "unknown",
+      schema_version: "1.0",
+      summary: { ok: degraded.length === 0, passed: okCount, total, degraded },
+      groups,
+    };
+    fs.writeFileSync(outFile, JSON.stringify(out, null, 2) + "\n");
+    const tag = out.summary.ok ? "OK" : "DEGRADED";
+    process.stderr.write(`VADE integrity: ${okCount}/${total} ${tag}`
+      + (degraded.length ? ` — degraded (${degraded.join(",")})` : "")
+      + ` — ${outFile}\n`);
+  ' "$OUT_FILE" "${CLAUDE_CODE_SESSION_ID:-unknown}" || {
+    echo "[vade-setup] integrity-check: node writer failed; leaving stale file" >&2
+  }
+else
+  # Fallback: newline-separated triples, no JSON.
+  {
+    printf 'checked_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'session_id=%s\n' "${CLAUDE_CODE_SESSION_ID:-unknown}"
+    printf '%s\n' "${RESULTS[@]}"
+  } > "$OUT_FILE" 2>/dev/null || true
+  echo "[vade-setup] integrity-check: node missing; wrote key=value file to $OUT_FILE" >&2
+fi
+
+exit 0

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -50,19 +50,32 @@ else
 fi
 
 # A3: receipt asserts workspace_mcp_symlinked=true/identity_link_ok=true
-# but the link is currently wrong → drift. Vice versa is also flagged.
+# but the link is currently absent OR points at the wrong target → drift.
+# A symlink pointing at the wrong place is just as bad as no symlink for
+# the receipt's purposes (the receipt's invariant is "the workspace-scope
+# overrides land where downstream consumers expect"), so we resolve and
+# compare end targets rather than just checking existence. C1/C2 also
+# validate the live targets in their own group; A3 specifically gates
+# receipt-vs-reality drift between snapshot build and current resume.
 A3_detail=""
 A3_ok=true
 if [ -f "$A1_receipt" ] && check_cmd node; then
   claim_mcp="$(node -e 'const r=JSON.parse(require("fs").readFileSync(process.argv[1])); process.stdout.write(String(!!r.workspace_mcp_symlinked))' "$A1_receipt" 2>/dev/null || echo unknown)"
   claim_id="$(node -e 'const r=JSON.parse(require("fs").readFileSync(process.argv[1])); process.stdout.write(String(!!r.identity_link_ok))' "$A1_receipt" 2>/dev/null || echo unknown)"
-  observed_mcp=false
-  observed_id=false
-  [ -L /home/user/.mcp.json ] && observed_mcp=true
-  [ -L /home/user/CLAUDE.md ] && observed_id=true
-  [ "$claim_mcp" = "$observed_mcp" ] || { A3_ok=false; A3_detail="mcp_link drift: receipt=$claim_mcp observed=$observed_mcp; "; }
-  [ "$claim_id" = "$observed_id" ] || { A3_ok=false; A3_detail="${A3_detail}identity_link drift: receipt=$claim_id observed=$observed_id"; }
-  [ "$A3_ok" = true ] && A3_detail="receipt matches observed symlinks"
+  expected_mcp_target="$(readlink -f /home/user/vade-runtime/.mcp.json 2>/dev/null || true)"
+  expected_id_target="$(readlink -f /home/user/vade-coo-memory/CLAUDE.md 2>/dev/null || true)"
+  observed_mcp=false; observed_id=false
+  if [ -L /home/user/.mcp.json ] && [ -n "$expected_mcp_target" ] \
+     && [ "$(readlink -f /home/user/.mcp.json 2>/dev/null)" = "$expected_mcp_target" ]; then
+    observed_mcp=true
+  fi
+  if [ -L /home/user/CLAUDE.md ] && [ -n "$expected_id_target" ] \
+     && [ "$(readlink -f /home/user/CLAUDE.md 2>/dev/null)" = "$expected_id_target" ]; then
+    observed_id=true
+  fi
+  [ "$claim_mcp" = "$observed_mcp" ] || { A3_ok=false; A3_detail="mcp_link drift: receipt=$claim_mcp observed-correct-target=$observed_mcp; "; }
+  [ "$claim_id" = "$observed_id" ] || { A3_ok=false; A3_detail="${A3_detail}identity_link drift: receipt=$claim_id observed-correct-target=$observed_id"; }
+  [ "$A3_ok" = true ] && A3_detail="receipt matches observed (resolved) symlink targets"
 else
   A3_ok=skip
   A3_detail="receipt or node unavailable"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -74,14 +74,35 @@ build_log_record() {
 #   boot_log_record session-start-sync sync_claude_config ok
 #   boot_log_record session-start-sync end ok duration_ms=9
 VADE_BOOT_LOG="${HOME}/.vade/boot.log"
+
+# Minimal JSON-string escape: backslash, double-quote, and the four
+# control chars that bash callers might plausibly pass (newline, CR,
+# tab, backspace). Keeps each boot.log line a valid JSON object even
+# when callers pass unescaped detail strings (e.g. shell command output,
+# error messages with quotes).
+_json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\b'/\\b}"
+  printf '%s' "$s"
+}
+
 boot_log_record() {
   local script="$1" phase="$2"; shift 2
   local status="${1:-}"
   [ "$#" -gt 0 ] && shift
-  local extras=""
+  local extras="" k v
   for kv in "$@"; do
     case "$kv" in
-      *=*) extras="$extras,\"${kv%%=*}\":\"${kv#*=}\"" ;;
+      *=*)
+        k="$(_json_escape "${kv%%=*}")"
+        v="$(_json_escape "${kv#*=}")"
+        extras="$extras,\"$k\":\"$v\""
+        ;;
     esac
   done
   local ts ok_field=""
@@ -91,11 +112,13 @@ boot_log_record() {
     fail|FAIL) ok_field=',"ok":false' ;;
     skip|SKIP) ok_field=',"ok":true,"skipped":true' ;;
     "")      ok_field='' ;;
-    *)       ok_field=",\"status\":\"$status\"" ;;
+    *)       ok_field=",\"status\":\"$(_json_escape "$status")\"" ;;
   esac
   mkdir -p "$(dirname "$VADE_BOOT_LOG")" 2>/dev/null || return 0
   printf '{"ts":"%s","session":"%s","script":"%s","phase":"%s"%s%s}\n' \
-    "$ts" "${CLAUDE_CODE_SESSION_ID:-unknown}" "$script" "$phase" "$ok_field" "$extras" \
+    "$ts" "$(_json_escape "${CLAUDE_CODE_SESSION_ID:-unknown}")" \
+    "$(_json_escape "$script")" "$(_json_escape "$phase")" \
+    "$ok_field" "$extras" \
     >> "$VADE_BOOT_LOG" 2>/dev/null || return 0
   # Bounded retention: 1000 lines ~ 100 KB, a few hundred sessions worth.
   if [ "$(wc -l < "$VADE_BOOT_LOG" 2>/dev/null || echo 0)" -gt 1000 ]; then

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -63,6 +63,47 @@ build_log_record() {
   fi
 }
 
+# Per-session structured boot log. One JSON line per event, written by
+# every SessionStart/Stop hook at key phases (start, major step, end).
+# Lets integrity-check.sh reconstruct the boot timeline from a single
+# file rather than correlating across claude-code.log, env-manager.log,
+# and the per-script logs. Safe to call without node (pure printf).
+#
+# Usage:
+#   boot_log_record session-start-sync start
+#   boot_log_record session-start-sync sync_claude_config ok
+#   boot_log_record session-start-sync end ok duration_ms=9
+VADE_BOOT_LOG="${HOME}/.vade/boot.log"
+boot_log_record() {
+  local script="$1" phase="$2"; shift 2
+  local status="${1:-}"
+  [ "$#" -gt 0 ] && shift
+  local extras=""
+  for kv in "$@"; do
+    case "$kv" in
+      *=*) extras="$extras,\"${kv%%=*}\":\"${kv#*=}\"" ;;
+    esac
+  done
+  local ts ok_field=""
+  ts="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
+  case "$status" in
+    ok|OK)   ok_field=',"ok":true' ;;
+    fail|FAIL) ok_field=',"ok":false' ;;
+    skip|SKIP) ok_field=',"ok":true,"skipped":true' ;;
+    "")      ok_field='' ;;
+    *)       ok_field=",\"status\":\"$status\"" ;;
+  esac
+  mkdir -p "$(dirname "$VADE_BOOT_LOG")" 2>/dev/null || return 0
+  printf '{"ts":"%s","session":"%s","script":"%s","phase":"%s"%s%s}\n' \
+    "$ts" "${CLAUDE_CODE_SESSION_ID:-unknown}" "$script" "$phase" "$ok_field" "$extras" \
+    >> "$VADE_BOOT_LOG" 2>/dev/null || return 0
+  # Bounded retention: 1000 lines ~ 100 KB, a few hundred sessions worth.
+  if [ "$(wc -l < "$VADE_BOOT_LOG" 2>/dev/null || echo 0)" -gt 1000 ]; then
+    tail -n 1000 "$VADE_BOOT_LOG" > "${VADE_BOOT_LOG}.tmp" 2>/dev/null \
+      && mv -f "${VADE_BOOT_LOG}.tmp" "$VADE_BOOT_LOG" 2>/dev/null
+  fi
+}
+
 # Write a JSON receipt at the end of cloud-setup.sh recording what
 # succeeded. coo-identity-digest reads this to surface build-time state
 # in the SessionStart digest block; missing file = cloud-setup didn't
@@ -220,7 +261,41 @@ sync_claude_config() {
   if [ -f "$src/settings.json" ]; then
     _sync_claude_settings "$src/settings.json" "$dst/settings.json"
   fi
-  log "Synced $src → $dst (subdirs symlinked, settings.json copied)"
+  # settings.json hooks reference $HOME/.claude/vade-hooks/dispatch.sh;
+  # install the shim alongside settings.json so both land atomically
+  # from a single sync_claude_config call.
+  ensure_hooks_dispatch_shim "$src" "$dst"
+  log "Synced $src → $dst (subdirs symlinked, settings.json copied, dispatch shim installed)"
+}
+
+# Install $HOME/.claude/vade-hooks/dispatch.sh pointing at the runtime
+# repo's hooks-dispatch.sh. Called from sync_claude_config, so every
+# build-time and session-start sync refreshes the shim — it self-heals
+# if the snapshot is stale or the target moved.
+#
+# The source is derived from the passed-in .claude dir, not hardcoded,
+# so local-setup.sh's custom runtime path works without extra plumbing.
+# Idempotent: if the symlink already points at the right target, no-op.
+ensure_hooks_dispatch_shim() {
+  local claude_src="$1" claude_dst="$2"
+  local runtime_src shim_src shim_dst
+  runtime_src="$(cd "$claude_src/.." 2>/dev/null && pwd)"
+  shim_src="$runtime_src/scripts/hooks-dispatch.sh"
+  shim_dst="$claude_dst/vade-hooks/dispatch.sh"
+  if [ ! -f "$shim_src" ]; then
+    log "hooks-dispatch: source $shim_src missing; skipping"
+    return 0
+  fi
+  mkdir -p "$(dirname "$shim_dst")"
+  if [ -L "$shim_dst" ] && [ "$(readlink -f "$shim_dst" 2>/dev/null)" = "$(readlink -f "$shim_src" 2>/dev/null)" ]; then
+    return 0
+  fi
+  if [ -e "$shim_dst" ] && [ ! -L "$shim_dst" ]; then
+    log "hooks-dispatch: $shim_dst exists and is not a symlink; leaving it alone"
+    return 0
+  fi
+  ln -snf "$shim_src" "$shim_dst"
+  log "hooks-dispatch: linked $shim_dst → $shim_src"
 }
 
 _sync_claude_subdir() {

--- a/scripts/session-lifecycle.sh
+++ b/scripts/session-lifecycle.sh
@@ -27,7 +27,7 @@ if [ "${1:-}" = "--end" ]; then
 fi
 
 boot_log_record "session-lifecycle-$MODE" start
-trap 'boot_log_record "session-lifecycle-$MODE" end ok' EXIT
+trap '_rc=$?; boot_log_record "session-lifecycle-'"$MODE"'" end $([ $_rc -eq 0 ] && echo ok || echo fail) rc=$_rc' EXIT
 
 # Claude Code's Write tool resolves ~/ to /home/user in the cloud
 # container while bash $HOME is /root. Plans authored through

--- a/scripts/session-lifecycle.sh
+++ b/scripts/session-lifecycle.sh
@@ -26,6 +26,9 @@ if [ "${1:-}" = "--end" ]; then
   MODE="end"
 fi
 
+boot_log_record "session-lifecycle-$MODE" start
+trap 'boot_log_record "session-lifecycle-$MODE" end ok' EXIT
+
 # Claude Code's Write tool resolves ~/ to /home/user in the cloud
 # container while bash $HOME is /root. Plans authored through
 # Claude's tools therefore land at a different path than the hook

--- a/scripts/session-start-sync.sh
+++ b/scripts/session-start-sync.sh
@@ -27,6 +27,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
-sync_claude_config /home/user/vade-runtime/.claude
+boot_log_record session-start-sync start
+sync_claude_config "$SCRIPT_DIR/../.claude"
 ensure_workspace_mcp_config
 ensure_workspace_identity_link
+# Emit integrity-check.json so its snapshot is on disk before the
+# digest hook runs (which may surface a one-line summary). Non-fatal.
+bash "$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true
+boot_log_record session-start-sync end ok


### PR DESCRIPTION
## Summary

Closes the cloud-side regression introduced in #28: hook commands in `.claude/settings.json` referenced `${CLAUDE_PROJECT_DIR}/scripts/…`, but cloud sessions launch with five `--add-dir` repos so `CLAUDE_PROJECT_DIR` resolves to `/home/user` (multi-root parent), not `/home/user/vade-runtime`. All five `SessionStart` hooks failed with exit 127, the three-phase self-heal from MEMO 2026-04-22-05 never ran, and the loud surface probe was itself a casualty — the agent booted into a fully degraded state with no warning.

The test-plan item in #28 flagged exactly this risk: *"Cloud-env regression check: confirm `${CLAUDE_PROJECT_DIR}` resolves to `/home/user/vade-runtime`, hook chain still runs"*. It was left unchecked and is what this PR closes.

This PR keeps #28's portability intent — one `settings.json` for cloud + Mac — by concentrating platform knowledge in a single dispatch shim instead of in settings.json hook commands.

## Design

**Dispatch shim at a stable path.** The only path guaranteed on every platform Claude Code runs on is `$HOME/.claude/` (it has to exist for settings.json to be found). Hooks now invoke `bash "$HOME/.claude/vade-hooks/dispatch.sh" <hook-name>`. The shim resolves the real runtime dir via layered fallback (first match wins):

1. `$VADE_RUNTIME_DIR` explicit override
2. `$CLAUDE_PROJECT_DIR` (Mac single-root where cwd is the repo)
3. Self-referential: `readlink -f` this shim → parent is vade-runtime/
4. `readlink -f /home/user/.mcp.json` → dirname is vade-runtime/ (cloud, layout-agnostic)
5. `$HOME/GitHub/vade-app/vade-runtime` (local Mac default)

Every invocation logs which rule won to `~/.vade/boot.log`. Non-fatal on every path.

**Robust to future harness changes:**
- Anthropic changes cloud cwd → rules 2/3/4 still fire
- Anthropic changes `/home/user/` base → rules 3 (self-path) + 4 (MCP symlink probe) still resolve
- Anthropic removes `CLAUDE_PROJECT_DIR` → rules 3 + 4 + 5 cover it
- Mac user clones repo anywhere → rules 2 or 5 or explicit override

## What's in this PR

- **`scripts/hooks-dispatch.sh`** (new) — ~140-line resolver shim
- **`.claude/settings.json`** — hook commands swapped to `$HOME/.claude/vade-hooks/dispatch.sh <name>` form; no repo-specific paths
- **`scripts/lib/common.sh`** — adds `ensure_hooks_dispatch_shim` (symlinks the shim from `$HOME/.claude/vade-hooks/dispatch.sh` to `$runtime/scripts/hooks-dispatch.sh`; installed via `sync_claude_config` so every build + resume refreshes it). Adds `boot_log_record` — per-session structured JSON log at `~/.vade/boot.log`.
- **`scripts/integrity-check.sh`** (new) — standardized on-demand probe, 16 invariants across Groups A–D (build-receipt, hook resolution, symlinks, COO identity). Writes `/home/user/.vade-cloud-state/integrity-check.json` + one-line stderr summary. Group E (MCP surface) stubbed for agent follow-up. Designed for three invocation modes: automatic at boot, on-demand, CI pre-merge gate. Non-fatal.
- **All 5 hook scripts** (`session-start-sync`, `coo-bootstrap`, `coo-identity-digest`, `discussions-digest`, `session-lifecycle`) — add `boot_log_record start`/`end` markers so the boot timeline is reconstructible from a single file. `session-start-sync` also calls `integrity-check.sh` at end so the probe snapshot is on disk before any digest renders.
- **`scripts/session-start-sync.sh`** — `sync_claude_config` arg now derived from `$SCRIPT_DIR`, removing the last hardcoded `/home/user/` path from the hot boot path.

## Test plan

- [x] `bash -n` clean on every modified and new script
- [x] `settings.json` parses; `hooks` section valid per Claude Code schema
- [x] Dispatch shim unit test in this session: `bash dispatch.sh session-start-sync` resolves via `self_path` rule, logs `{"rule":"self_path","runtime":"/home/user/vade-runtime","ok":true}` to `~/.vade/boot.log`, forwards correctly
- [x] Dispatch shim negative case: `bash dispatch.sh nonexistent-hook` logs `{"rule":"none","ok":false}` and exits 0 (non-fatal)
- [x] `integrity-check.sh` run in this (still-degraded) session: reports 15/16 OK; only remaining degraded invariant is `B3` (historical hook-failure grep on `claude-code.log`), which is expected — those failures happened earlier this session pre-fix and can't be unwritten. `B1` (hook paths resolve), `B2` (dispatch shim installed), `B4` (settings.json matches repo) all pass after `sync_claude_config` ran.
- [x] `boot.log` captures start/end lines per hook script. Example after `session-start-sync` dispatch:
  ```json
  {"ts":"2026-04-22T14:34:52.156Z","script":"hooks-dispatch","hook":"session-start-sync","rule":"self_path","runtime":"/home/user/vade-runtime","ok":true,"detail":"dispatching to …"}
  {"ts":"2026-04-22T14:34:52.166Z","session":"cse_…","script":"session-start-sync","phase":"start"}
  {"ts":"2026-04-22T14:34:52.477Z","session":"cse_…","script":"session-start-sync","phase":"end","ok":true}
  ```
- [ ] **Fresh cloud session after merge** — force a new cloud session (not a resume), confirm: `integrity-check.json` reports `summary.ok: true`; `readlink $HOME/.claude/vade-hooks/dispatch.sh` returns the repo target; `B5` records whatever `CLAUDE_PROJECT_DIR` resolves to in the new harness config (diagnostic data point for future drift); `git config --global user.email` is `coo@vade-app.dev`; `mcp__github-coo__get_me` returns `vade-coo`
- [ ] **Mac parity** — launch Claude Code from `~/GitHub/vade-app/vade-runtime/`, confirm dispatch resolves via rule 2 (`CLAUDE_PROJECT_DIR`), all hooks still fire as #28 intended

## Attribution note

Ironically this PR couldn't be opened as `vade-coo` because `github-coo` MCP's auth depends on `GITHUB_MCP_PAT`, which gets populated by `coo-bootstrap.sh`, which is itself a `SessionStart` hook that failed with exit 127 this session — the very regression this PR fixes. The **commit** is signed by the `vade-coo-sign` SSH key (verified via `git cat-file -p HEAD` showing `gpgsig -----BEGIN SSH SIGNATURE-----`), authored as `COO <coo@vade-app.dev>`. The PR opener resolves to `venpopov` only because `mcp__github-coo__create_pull_request` is unavailable this session. Once this PR merges, the next fresh session will have `github-coo` live and future PRs will open cleanly as `vade-coo`.

## Follow-ups (out of scope for this PR)

- CI smoke test on vade-runtime that fakes a SessionStart chain under two distinct `CLAUDE_PROJECT_DIR` values (`/home/user` multi-root and `$PWD` single-root), runs `integrity-check.sh`, and gates on Groups A/B/C. This test pattern would have blocked #28 pre-merge.
- Companion memo in `vade-coo-memory` (next PR in this stack) documenting the dispatch-shim invariant and the integrity-check protocol.

https://claude.ai/code/session_01UnzP8U2LpQrQ3fqmyEGbSZ