### PR TITLE
cloud-env: install op CLI at snapshot-build time

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -68,6 +68,19 @@ fi
 
 print_versions
 
+# Install the op CLI at snapshot-build time so the SessionStart-hook
+# bootstrap fallback never has to fetch it through the egress proxy
+# mid-session. The binary lands in /home/user/.local/bin/op which
+# survives the snapshot → resume transition. Idempotent: if a prior
+# build already installed it, this is a no-op. Non-fatal: a failure
+# here just means the SessionStart hook will retry (same as before).
+if ensure_op_cli; then
+  build_log_record OK "cloud-setup: op CLI installed at build time"
+else
+  build_log_record WARN "cloud-setup: op CLI install failed at build time; SessionStart hook will retry"
+  log "Warning: op CLI install failed at build time; SessionStart hook will retry."
+fi
+
 # COO identity bootstrap runs only when OP_SERVICE_ACCOUNT_TOKEN is set
 # in the cloud environment config. Non-fatal on failure — the base VADE
 # env should still come up even if 1Password is unreachable.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -459,6 +459,20 @@ COO_AUTH_FP_EXPECTED="SHA256:9vxJc6c69L8eaR6CvwdZoYDco24W6yN6GkKwnsm8Uys"
 COO_SIGN_FP_EXPECTED="SHA256:pZeA8xycAtIsVGwhMzR3mg4KG05n9ksFuy4F1ZVXn3A"
 
 ensure_op_cli() {
+  # Install into a snapshot-persistent path so a build-time install is
+  # still on disk at session-resume time. /root/ resets each resume in
+  # the cloud image; /home/user/ survives the snapshot. Without this,
+  # the SessionStart-hook bootstrap fallback has to re-fetch op from
+  # cache.agilebits.com mid-session and dies whenever Anthropic's
+  # egress proxy is flaky (see run-2026-04-22T062313 and
+  # run-2026-04-22T213126: "DNS cache overflow" 503 from the egress
+  # gateway, both times).
+  local bindir="/home/user/.local/bin"
+  case ":$PATH:" in
+    *":$bindir:"*) ;;
+    *) export PATH="$bindir:$PATH" ;;
+  esac
+
   if check_cmd op; then
     log "op CLI present: $(op --version 2>&1 | head -1)"
     return 0
@@ -473,17 +487,15 @@ ensure_op_cli() {
     *) log "op CLI: unsupported arch '$arch'"; return 1 ;;
   esac
 
-  local bindir="${HOME}/.local/bin"
   mkdir -p "$bindir"
 
   local url="https://cache.agilebits.com/dist/1P/op2/pkg/v${version}/op_linux_${arch}_v${version}.zip"
   local tmp
   tmp="$(mktemp -d)"
-  log "Downloading op CLI v${version} (${arch})"
+  log "Downloading op CLI v${version} (${arch}) → $bindir"
   # cache.agilebits.com occasionally returns 5xx; retry absorbs the transient
-  # window. Without this, a single 503 kills the whole bootstrap chain and
-  # the session comes up with no COO identity — root cause of the
-  # run-2026-04-22T062313 degradation.
+  # window. Even with the build-time install above, retries are still useful
+  # when the snapshot is cold and this is the first install.
   if ! retry 3 curl -sfL "$url" -o "$tmp/op.zip"; then
     log "op CLI download failed after retries: $url"
     rm -rf "$tmp"
@@ -502,11 +514,6 @@ ensure_op_cli() {
 
   install -m 0755 "$tmp/op" "$bindir/op"
   rm -rf "$tmp"
-
-  case ":$PATH:" in
-    *":$bindir:"*) ;;
-    *) export PATH="$bindir:$PATH" ;;
-  esac
 
   if ! op --version >/dev/null 2>&1; then
     log "op CLI install appears broken"


### PR DESCRIPTION
## Summary

Move the `op` CLI install from a SessionStart-hook network fetch into snapshot-build time. The binary now lives at `/home/user/.local/bin/op`, which survives the snapshot → resume transition, so the bootstrap chain no longer depends on `cache.agilebits.com` being reachable through Anthropic's egress proxy at the moment the session boots.

## Why

Two recorded failures of the same pattern:

- `run-2026-04-22T062313` (prior degradation, cited in the existing retry comment).
- `run-2026-04-22T213126` (this session — `ensure_op_cli` failed at 21:31:26Z with what surfaced as `rc=9`, root cause was HTTP 503 from the egress proxy returning `"DNS cache overflow"` as the body. TLS cert on the response was issued by `Egress Gateway Subordinate CA` with `NotBefore = 21:30:26Z`, confirming the failure was the Anthropic-side MITM proxy, not 1Password's CDN).

The existing 3-attempt retry (1s + 2s window) is too short to absorb a proxy-side DNS miss; a manual re-run ~4 minutes later succeeded because the proxy had settled. Baking the binary into the snapshot removes the network dependency from the hot path entirely.

## Changes

**`scripts/lib/common.sh` — `ensure_op_cli`**

- Install target moved from `$HOME/.local/bin` (under `/root/`, wiped on resume) to `/home/user/.local/bin` (snapshot-persistent per `common.sh:33-38`).
- PATH update moved to the top of the function, **before** the `check_cmd op` presence check, so a snapshot-installed binary is discovered even when the calling shell starts with a clean PATH (the SessionStart-hook fallback case).

**`scripts/cloud-setup.sh`**

- Call `ensure_op_cli` unconditionally at build time, before the `OP_SERVICE_ACCOUNT_TOKEN` gate. The binary install needs no secrets, so it runs regardless of whether the token is visible at setup time.
- Non-fatal: a build-time install failure logs `WARN` to `build.log` and lets the SessionStart hook retry — preserves the current fallback behavior as a belt-and-braces measure.

## Test plan

- [x] `bash -n` parses both modified files.
- [x] Cold install path: removed all `op` binaries, cleared PATH of `/home/user/.local/bin`, sourced `common.sh`, ran `ensure_op_cli` → downloaded 24.7 MB binary to `/home/user/.local/bin/op`, `op --version` returns `2.31.0`.
- [x] Idempotency path: with binary in place but PATH *not* including `/home/user/.local/bin`, ran `ensure_op_cli` → PATH self-updated, `check_cmd op` hit, no re-download, `rc=0`.
- [x] End-to-end: `VADE_FORCE_COO_BOOTSTRAP=1 bash scripts/coo-bootstrap.sh` → full pipeline OK (op CLI present, SSH keys, secrets fetched, settings.json env merged, gitconfig, GitHub PAT validated as `vade-coo`).
- [ ] Snapshot rebuild + fresh session resume confirms `coo-bootstrap.sh` takes the no-op branch of `ensure_op_cli` instead of re-downloading. Needs the next cloud snapshot rebuild to verify; I'll follow up with a brief memo once observed.

## Follow-ups

A memo in `vade-coo-memory/coo/memos.md` is warranted once the fix lands and a clean resume confirms the behavior — this is the second recurrence of the same egress-proxy failure pattern, and the memo should document the snapshot-persistent install convention (`/home/user/.local/bin/`) so future tools follow the same discipline.

🤖 Generated with [Claude Code](https://claude.ai/code)