### PR TITLE
cloud-env: make discussions-digest wait for coo-bootstrap

### DIFF
--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -105,43 +105,12 @@ echo "────────────────────────�
 # degraded even when coo-bootstrap eventually completes cleanly (the
 # first user-visible regression after PR #20 landed: verification
 # run reported "degraded" despite OK-step=complete in the log).
-#
-# Strategy: poll the bootstrap log for a terminal state (OK/FAIL/SKIP)
-# timestamped at-or-after this digest's start. If bootstrap hasn't
-# written for this session yet, wait — but only as long as a
-# coo-bootstrap.sh process is actually running, plus a short grace
-# window. A hook that never fires (or a standalone digest invocation)
-# exits the wait quickly instead of wedging boot for the full timeout.
-_digest_start_epoch="$(date -u +%s)"
-_digest_wait_timeout=60
-_digest_wait_elapsed=0
-_digest_saw_fresh=0
-while [ "$_digest_wait_elapsed" -lt "$_digest_wait_timeout" ]; do
-  if [ -f "$BOOTSTRAP_LOG" ]; then
-    _last_line="$(tail -n 1 "$BOOTSTRAP_LOG" 2>/dev/null || true)"
-    _last_ts="${_last_line%% *}"
-    _last_state="$(printf '%s' "$_last_line" | awk '{print $2}')"
-    case "$_last_state" in
-      OK|FAIL|SKIP)
-        # Portable ISO-8601 → epoch. `date -d` is GNU-only (no-op on macOS);
-        # node handles both hosts and is already a hard dep for this script.
-        _last_epoch="$(node -e 'const t=Date.parse(process.argv[1]); process.stdout.write(isNaN(t)?"0":String(Math.floor(t/1000)))' "$_last_ts" 2>/dev/null || echo 0)"
-        if [ "$_last_epoch" -ge "$_digest_start_epoch" ]; then
-          _digest_saw_fresh=1
-          break
-        fi
-        ;;
-    esac
-  fi
-  # Fast-exit when bootstrap isn't running and we've given it a 2s
-  # grace to start. Covers three cases: hook disabled, bootstrap
-  # already finished before digest started, standalone debug invocation.
-  if [ "$_digest_wait_elapsed" -ge 2 ] && ! pgrep -f coo-bootstrap.sh >/dev/null 2>&1; then
-    break
-  fi
-  sleep 1
-  _digest_wait_elapsed=$((_digest_wait_elapsed + 1))
-done
+# Shared helper in lib/common.sh; exposes
+# VADE_BOOTSTRAP_WAIT_{SAW_FRESH,ELAPSED,TIMEOUT}.
+wait_for_coo_bootstrap 60
+_digest_saw_fresh="${VADE_BOOTSTRAP_WAIT_SAW_FRESH:-0}"
+_digest_wait_elapsed="${VADE_BOOTSTRAP_WAIT_ELAPSED:-0}"
+_digest_wait_timeout="${VADE_BOOTSTRAP_WAIT_TIMEOUT:-60}"
 
 echo ""
 echo "───────────────────────────────────────────────────────────────"
@@ -162,12 +131,6 @@ if [ "$_digest_saw_fresh" -eq 0 ]; then
     echo "  Note: no fresh bootstrap state this session (hook didn't fire, or finished before digest started)."
   fi
 fi
-
-# Re-source coo-env in case bootstrap just wrote it. common.sh sourced
-# the file once at script load; a second source picks up any keys
-# added during the wait above.
-# shellcheck source=/dev/null
-[ -f "${HOME}/.vade/coo-env" ] && . "${HOME}/.vade/coo-env"
 
 env_has_pat="no"; env_has_mail="no"
 [ -n "${GITHUB_MCP_PAT:-}" ]    && env_has_pat="yes"

--- a/scripts/discussions-digest.sh
+++ b/scripts/discussions-digest.sh
@@ -17,6 +17,12 @@ source "$SCRIPT_DIR/lib/common.sh"
 boot_log_record discussions-digest start
 trap '_rc=$?; boot_log_record discussions-digest end $([ $_rc -eq 0 ] && echo ok || echo fail) rc=$_rc' EXIT
 
+# SessionStart hooks run in parallel; coo-bootstrap may still be
+# writing ~/.vade/coo-env when we reach the TOKEN check below. Wait
+# for a fresh bootstrap terminal state before sampling env (no-op and
+# fast-exits when bootstrap isn't running).
+wait_for_coo_bootstrap 60
+
 TOKEN="${GITHUB_TOKEN:-${GITHUB_MCP_PAT:-}}"
 if [ -z "$TOKEN" ]; then
   log "GITHUB_TOKEN unset; skipping discussions digest."

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -221,6 +221,59 @@ retry() {
 # shellcheck source=/dev/null
 [ -f "${HOME}/.vade/coo-env" ] && . "${HOME}/.vade/coo-env"
 
+# Block until coo-bootstrap.sh reaches a terminal state (OK/FAIL/SKIP)
+# in this session, then re-source coo-env so vars written during the
+# wait land in the calling process. SessionStart hooks run in parallel,
+# so any hook that consumes GITHUB_TOKEN / GITHUB_MCP_PAT / AGENTMAIL_API_KEY
+# (e.g. discussions-digest, coo-identity-digest's posture block) would
+# otherwise sample before bootstrap finishes and falsely report
+# "unset / degraded". Fast-exits after a 2s grace if no coo-bootstrap.sh
+# process is running (covers standalone invocations, hook disabled,
+# and bootstrap-already-finished cases).
+#
+# Args: $1 = timeout in seconds (default 60)
+# Exposes:
+#   VADE_BOOTSTRAP_WAIT_SAW_FRESH  — 1 if a fresh terminal state was seen, else 0
+#   VADE_BOOTSTRAP_WAIT_ELAPSED    — seconds actually waited
+#   VADE_BOOTSTRAP_WAIT_TIMEOUT    — configured timeout
+# Always returns 0.
+wait_for_coo_bootstrap() {
+  local timeout="${1:-60}"
+  local bootstrap_log="${HOME}/.vade/coo-bootstrap.log"
+  local start_epoch elapsed=0
+  start_epoch="$(date -u +%s)"
+  VADE_BOOTSTRAP_WAIT_SAW_FRESH=0
+  VADE_BOOTSTRAP_WAIT_TIMEOUT="$timeout"
+  while [ "$elapsed" -lt "$timeout" ]; do
+    if [ -f "$bootstrap_log" ]; then
+      local last_line last_ts last_state last_epoch
+      last_line="$(tail -n 1 "$bootstrap_log" 2>/dev/null || true)"
+      last_ts="${last_line%% *}"
+      last_state="$(printf '%s' "$last_line" | awk '{print $2}')"
+      case "$last_state" in
+        OK|FAIL|SKIP)
+          # Portable ISO-8601 → epoch via node (already a hard dep of
+          # the digest scripts; `date -d` is GNU-only).
+          last_epoch="$(node -e 'const t=Date.parse(process.argv[1]); process.stdout.write(isNaN(t)?"0":String(Math.floor(t/1000)))' "$last_ts" 2>/dev/null || echo 0)"
+          if [ "$last_epoch" -ge "$start_epoch" ]; then
+            VADE_BOOTSTRAP_WAIT_SAW_FRESH=1
+            break
+          fi
+          ;;
+      esac
+    fi
+    if [ "$elapsed" -ge 2 ] && ! pgrep -f coo-bootstrap.sh >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  VADE_BOOTSTRAP_WAIT_ELAPSED="$elapsed"
+  # shellcheck source=/dev/null
+  [ -f "${HOME}/.vade/coo-env" ] && . "${HOME}/.vade/coo-env"
+  return 0
+}
+
 check_cmd() {
   command -v "$1" >/dev/null 2>&1
 }


### PR DESCRIPTION
## Summary

- SessionStart hooks run in parallel, so `discussions-digest.sh` was sampling `GITHUB_TOKEN` before `coo-bootstrap.sh` wrote `~/.vade/coo-env`. First sessions after container boot always logged `GITHUB_TOKEN unset; skipping discussions digest` and dropped the digest silently.
- Factored the wait-for-bootstrap loop out of `coo-identity-digest.sh` into a shared `wait_for_coo_bootstrap()` helper in `scripts/lib/common.sh`, then called it from `discussions-digest.sh` before the token check.
- `coo-identity-digest.sh` now reads `VADE_BOOTSTRAP_WAIT_{SAW_FRESH,ELAPSED,TIMEOUT}` globals exposed by the helper; its diagnostic output is unchanged.

Same 60s ceiling, same 2s fast-exit when no `coo-bootstrap.sh` process is running, same re-source of `coo-env` on completion.

## Test plan

- [x] `bash -n` on all three modified scripts
- [x] Manual run of `bash scripts/discussions-digest.sh` in this session printed the digest (token was available post-bootstrap)
- [ ] Next fresh-container session should print the digest on boot instead of `GITHUB_TOKEN unset; skipping`

🤖 Generated with [Claude Code](https://claude.com/claude-code)