### PR TITLE
cloud-env: classify OP token visibility, surface platform fix

### DIFF
--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -167,6 +167,50 @@ else
   echo "    VADE_FORCE_COO_BOOTSTRAP=1 bash \"${CLAUDE_PROJECT_DIR:-/home/user/vade-runtime}/scripts/coo-bootstrap.sh\""
 fi
 
+# Classify OP_SERVICE_ACCOUNT_TOKEN visibility across build/session. The
+# build receipt records whether the token was in env when cloud-setup.sh
+# ran at snapshot-build time; session env tells us where it is now.
+# Four labeled outcomes:
+#   ok           — token at build: first-session MCPs authenticate from turn 0
+#   session-only — token only at session boot: first session of every fresh
+#                  container boots with empty ${GITHUB_MCP_PAT}, github-coo
+#                  MCP hits HTTP 400, /resume recovers it. Platform-level fix
+#                  is to declare OP_SERVICE_ACCOUNT_TOKEN in the Anthropic
+#                  cloud "Setup script" environment, not just the session env.
+#   missing      — absent at both: COO identity dark until env is provisioned
+#   unknown      — no receipt to compare against (build-time setup didn't run)
+_op_build_seen="unknown"
+if [ -f "$SETUP_RECEIPT" ] && check_cmd node; then
+  _op_build_seen="$(node -e '
+    try {
+      const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+      console.log(r.op_token_visible === true ? "yes" : "no");
+    } catch (_) { console.log("unknown"); }
+  ' "$SETUP_RECEIPT" 2>/dev/null || echo unknown)"
+fi
+_op_session_seen="no"
+[ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && _op_session_seen="yes"
+
+case "$_op_build_seen/$_op_session_seen" in
+  yes/*)
+    ;;
+  no/yes)
+    echo ""
+    echo "  ⚠ OP_SERVICE_ACCOUNT_TOKEN is injected at session-boot only, not build."
+    echo "    Every fresh container's FIRST session has github-coo MCP unauthenticated"
+    echo "    (empty \${GITHUB_MCP_PAT} substitution → HTTP 400). /resume recovers it."
+    echo "    Platform fix: add OP_SERVICE_ACCOUNT_TOKEN to the Anthropic cloud"
+    echo "    'Setup script' environment — then coo-bootstrap runs at build and"
+    echo "    MCPs authenticate from turn zero."
+    ;;
+  no/no)
+    echo ""
+    echo "  ⚠ OP_SERVICE_ACCOUNT_TOKEN absent at build AND session. COO identity is dark."
+    ;;
+  unknown/*)
+    ;;
+esac
+
 echo "───────────────────────────────────────────────────────────────"
 
 # MCP surface probe — prerequisites that Claude Code needed at process


### PR DESCRIPTION
## Summary

Today's fresh-container first session caught `github-coo` MCP failing to authenticate (`mcp-logs-github-coo/*.jsonl` at 22:14:43Z: `Authorization header is badly formatted`, HTTP 400). Root cause: `OP_SERVICE_ACCOUNT_TOKEN` was unset when `cloud-setup.sh` ran at snapshot-build time, so `coo-bootstrap` couldn't populate `${GITHUB_MCP_PAT}` before Claude Code initialized MCPs. The token only became visible at session boot (~23s too late).

The existing `Bootstrap posture` block collapses four distinct states into one "degraded" warning. This PR adds a classifier that cross-references the build receipt's `op_token_visible` against the current session env to distinguish:

- `ok` — token at both build and session: no action needed
- `session-only` — token at session boot only: every fresh container's first session has `github-coo` dead until `/resume`. Platform-level fix is to declare `OP_SERVICE_ACCOUNT_TOKEN` in the Anthropic cloud "Setup script" environment so `coo-bootstrap` runs at build and MCPs authenticate from turn zero.
- `missing` — token nowhere: COO identity permanently dark
- `unknown` — no receipt to compare against

Only `session-only` and `missing` print a warning; `ok` and `unknown` are silent so the digest stays concise when healthy.

## Why this shape

- The build receipt already persists `op_token_visible` across the snapshot→session boundary, so no new storage is needed.
- The comparator reads both sides atomically at digest time. One `case` statement → four labeled outcomes. No log-parsing, no guessing.
- Self-testing: if Ven toggles the Anthropic cloud UI "Setup script" env and we rebuild, the receipt flips to `op_token_visible: true`, classifier returns `ok`, the `session-only` warning disappears, and first-session MCPs authenticate. No code change needed to validate the fix.
- Co-located with the existing `env_has_pat` / `settings_pat` signals it refines — same diagnostic block, deeper analysis.

## Test plan

- [x] `bash -n` on the edited script
- [x] Direct invocation on today's container (session-only state): classifier correctly prints the platform-fix warning (see commit msg for the observed output)
- [ ] After a rebuild with `OP_SERVICE_ACCOUNT_TOKEN` declared in the Anthropic cloud "Setup script" env: classifier should return `ok` silently and `github-coo` MCP should be in the tool surface from turn zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)