### PR TITLE
cloud-env: expose gh on PATH and surface fallback in boot digest

### DIFF
--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -270,6 +270,36 @@ if [ "$HOME" = "/home/user" ]; then
   echo "───────────────────────────────────────────────────────────────"
 fi
 
+# GitHub write surface — per MEMO 2026-04-23-02, the vade-coo
+# attribution invariant (MEMO -22-04) rides on the github-coo MCP when
+# healthy and on the gh CLI when the MCP streamable-HTTP transport
+# fails with a DNS-cache overflow (issue #36). This block reports
+# fallback readiness at turn zero so a new session doesn't have to
+# re-derive the protocol from memos when an MCP call hits the failure
+# mode mid-task. We deliberately don't probe MCP liveness from a bash
+# hook (same reason the MCP surface probe above sticks to filesystem
+# prerequisites).
+echo ""
+echo "───────────────────────────────────────────────────────────────"
+echo "GitHub write surface"
+echo "───────────────────────────────────────────────────────────────"
+if check_cmd gh; then
+  gh_ver="$(gh --version 2>/dev/null | head -1)"
+  printf "  %-25s %s\n" "gh CLI:" "${gh_ver:-present}"
+else
+  printf "  %-25s %s\n" "gh CLI:" "not found (expected /home/user/.local/bin/gh; run ensure_gh_cli)"
+fi
+if [ -n "${GITHUB_MCP_PAT:-}" ]; then
+  printf "  %-25s %s\n" "gh auth token:" "GITHUB_MCP_PAT present (gh will attribute as vade-coo)"
+else
+  printf "  %-25s %s\n" "gh auth token:" "GITHUB_MCP_PAT unset — /resume or check coo-bootstrap"
+fi
+echo "  MCP posture:              github-coo MCP preferred for attributable writes."
+echo "                            On 'Streamable HTTP error: DNS cache overflow',"
+echo "                            fall back to: GH_TOKEN=\$GITHUB_MCP_PAT gh <cmd>."
+echo "                            Same token, vade-coo identity (MEMO 2026-04-23-02)."
+echo "───────────────────────────────────────────────────────────────"
+
 # Cloud build-time receipt — what did cloud-setup.sh actually do at
 # snapshot build? Present = build ran; missing = build skipped or the
 # setup script field in the Anthropic cloud UI is not wired.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -675,6 +675,28 @@ ensure_gh_cli() {
   log "Installed gh CLI: $(gh --version 2>&1 | head -1)"
 }
 
+# Expose gh on Claude Code's Bash-tool PATH every session.
+#
+# ensure_gh_cli installs to /home/user/.local/bin so the binary survives
+# cloud snapshot rebuilds, but the shell Claude spawns only has
+# /root/.local/bin on PATH. Bridge the two with a symlink so `gh`
+# resolves without the agent having to mutate PATH or discover the
+# install path. Cloud-only (root + /home/user present); on macOS/local
+# gh comes from brew and $HOME/.local/bin is already on PATH.
+# Idempotent via ln -sfn; no-op with a quiet log if the target is
+# missing (ensure_gh_cli is the installer).
+ensure_gh_symlink_on_path() {
+  [ "$(id -u)" = "0" ] && [ -d /home/user ] || return 0
+  local target="/home/user/.local/bin/gh"
+  local link="/root/.local/bin/gh"
+  if [ ! -x "$target" ]; then
+    log "gh symlink: $target missing; skipping (run ensure_gh_cli to install)"
+    return 0
+  fi
+  mkdir -p "$(dirname "$link")"
+  ln -sfn "$target" "$link"
+}
+
 # Fetch COO secrets from 1Password and write ~/.vade/coo-env plus a
 # merged env block in ~/.claude/settings.json so Claude Code resolves
 # ${GITHUB_MCP_PAT} / ${AGENTMAIL_API_KEY} at startup. Each read is

--- a/scripts/session-start-sync.sh
+++ b/scripts/session-start-sync.sh
@@ -31,6 +31,11 @@ boot_log_record session-start-sync start
 sync_claude_config "$SCRIPT_DIR/../.claude"
 ensure_workspace_mcp_config
 ensure_workspace_identity_link
+# Bridge /home/user/.local/bin/gh (persistent install target) onto
+# /root/.local/bin (already on PATH for Claude's Bash tool) so the
+# MEMO 2026-04-23-02 gh-CLI fallback is callable without the agent
+# having to rediscover the install path every session.
+ensure_gh_symlink_on_path
 # Emit integrity-check.json so its snapshot is on disk before the
 # digest hook runs (which may surface a one-line summary). Non-fatal.
 bash "$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Closes the two ergonomics gaps left behind by MEMO 2026-04-23-02 so a fresh cloud session can use the `gh` fallback without re-deriving the protocol every time.

1. **`gh` on PATH.** `ensure_gh_cli` installs to `/home/user/.local/bin` (snapshot-persistent) but Claude's Bash tool only has `/root/.local/bin` on PATH — `command -v gh` returned "not found" at turn zero. New `ensure_gh_symlink_on_path` in `scripts/lib/common.sh` bridges the two; `scripts/session-start-sync.sh` calls it after `ensure_workspace_identity_link`. Idempotent, cloud-only, no-op on macOS/local.

2. **GitHub write surface advisory in the digest.** `scripts/coo-identity-digest.sh` grows a new block after the MCP surface probe that reports `gh` version, `GITHUB_MCP_PAT` presence, and the MEMO 2026-04-23-02 fallback protocol. Placement is deliberate: an agent reading top-down sees "MCP may not be loaded, gh is ready as fallback" as one coherent story.

No network probes in the digest — same reason the MCP surface probe sticks to filesystem prerequisites. Live `github-coo` liveness isn't knowable from a bash hook.

Companion PR in `vade-coo-memory` adds the fourth branch to the "Before opening a PR" decision tree in `CLAUDE.md` that this digest block refers to.

## Test plan

- [x] `bash scripts/session-start-sync.sh` creates `/root/.local/bin/gh → /home/user/.local/bin/gh`
- [x] `command -v gh` resolves; `gh --version` returns `gh version 2.91.0`
- [x] `bash "$HOME/.claude/vade-hooks/dispatch.sh" coo-identity-digest` renders the new "GitHub write surface" block between the MCP probe and the build-time receipt
- [x] `GH_TOKEN=$GITHUB_MCP_PAT gh api user -q .login` returns `vade-coo` (this very PR is opened that way, since `mcp__github-coo__*` is degraded in this session — end-to-end proof the fallback works)
- [ ] Fresh cloud container shows the block at turn zero with no additional dance

## Notes

- Meta-note: this PR is itself opened via `gh` + `$GITHUB_MCP_PAT` because `mcp__github-coo__*` was not surfaced in the session that authored the change. The attribution invariant (MEMO 2026-04-22-04) holds.
- Out of scope (candidate follow-ups): new integrity-check invariant verifying `gh` on PATH + auth; audit of `/root/.bashrc` PATH for `/home/user/.local/bin`.