### PR TITLE
cloud-env: disable git signing when harness substitutes the key

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -214,7 +214,27 @@ else
 fi
 
 if [ -f "$HOME/.ssh/vade-coo-auth" ] && [ -f "$HOME/.ssh/vade-coo-sign" ]; then
-  _add D6 true "vade-coo-auth and vade-coo-sign keys installed"
+  # Keys present; now check the signing posture is internally consistent.
+  # Per MEMO 2026-04-23-04, cloud sessions (harness sets gpg.ssh.program
+  # to a code-sign wrapper at /tmp/code-sign that substitutes the signing
+  # key) must have commit.gpgsign=false and tag.gpgsign=false; Mac
+  # sessions (no wrapper) must have both =true so the registered
+  # vade-coo-sign key is actually used.
+  D6_commit="$(git config --global commit.gpgsign 2>/dev/null || echo '<unset>')"
+  D6_tag="$(git config --global tag.gpgsign 2>/dev/null || echo '<unset>')"
+  if [ -x /tmp/code-sign ] || [ -n "${CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE:-}" ]; then
+    if [ "$D6_commit" = "false" ] && [ "$D6_tag" = "false" ]; then
+      _add D6 true "keys+signing-off (cloud, per MEMO 2026-04-23-04)"
+    else
+      _add D6 false "cloud harness detected but commit.gpgsign=$D6_commit tag.gpgsign=$D6_tag (expect false/false; MEMO 2026-04-23-04)"
+    fi
+  else
+    if [ "$D6_commit" = "true" ] && [ "$D6_tag" = "true" ]; then
+      _add D6 true "keys+signing-on (local, vade-coo-sign)"
+    else
+      _add D6 false "no harness but commit.gpgsign=$D6_commit tag.gpgsign=$D6_tag (expect true/true)"
+    fi
+  fi
 else
   _add D6 false "vade-coo-{auth,sign} keys missing in $HOME/.ssh"
 fi

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -920,10 +920,26 @@ _op_to_file() {
 }
 
 # Write gitconfig with COO identity + SSH signing + auth-key push.
-# Per MEMO 2026-04-22-03, cloud sessions share the Mac's commit discipline.
 # Target path is overridable via VADE_COO_GITCONFIG so local-setup.sh can
 # route Claude's git through ~/.vade/gitconfig-coo (via GIT_CONFIG_GLOBAL)
 # without touching the user's personal ~/.gitconfig.
+#
+# Signing posture is platform-dependent (MEMO 2026-04-23-04).
+# The Claude Code cloud harness sets `gpg.ssh.program=/tmp/code-sign`, a
+# wrapper that intercepts `ssh-keygen -Y sign` and substitutes a
+# harness-managed key for the one user.signingkey names. Signed output
+# produced in cloud is therefore bound to a key that is not on any
+# GitHub account and can never pass verification (observed: local key
+# SHA256:pZeA8xyc…3nA; signer in signature SHA256:32dP45eS…2wc).
+# We detect the harness by the presence of the wrapper at /tmp/code-sign
+# OR CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE being set, and turn
+# commit.gpgsign/tag.gpgsign off there. Keys, allowed-signers file, and
+# core.sshCommand stay set on both platforms so Mac sessions still sign
+# normally and SSH auth works on both.
+_coo_signing_is_intercepted() {
+  [ -x /tmp/code-sign ] || [ -n "${CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE:-}" ]
+}
+
 write_coo_gitconfig() {
   local gc="${VADE_COO_GITCONFIG:-${HOME}/.gitconfig}"
   mkdir -p "$(dirname "$gc")"
@@ -931,11 +947,17 @@ write_coo_gitconfig() {
   git config --file "$gc" user.email "coo@vade-app.dev"
   git config --file "$gc" gpg.format ssh
   git config --file "$gc" user.signingkey "${HOME}/.ssh/vade-coo-sign.pub"
-  git config --file "$gc" commit.gpgsign true
-  git config --file "$gc" tag.gpgsign true
+  if _coo_signing_is_intercepted; then
+    git config --file "$gc" commit.gpgsign false
+    git config --file "$gc" tag.gpgsign false
+    log "Configured $gc (user=COO, signing=OFF — cloud harness detected; MEMO 2026-04-23-04)"
+  else
+    git config --file "$gc" commit.gpgsign true
+    git config --file "$gc" tag.gpgsign true
+    log "Configured $gc (user=COO, signing=ssh via vade-coo-sign.pub)"
+  fi
   git config --file "$gc" gpg.ssh.allowedSignersFile "${HOME}/.ssh/allowed_signers"
   git config --file "$gc" core.sshCommand "ssh -i ${HOME}/.ssh/vade-coo-auth -o IdentitiesOnly=yes -o UserKnownHostsFile=${HOME}/.ssh/known_hosts"
-  log "Configured $gc (user=COO, signing=ssh via vade-coo-sign.pub)"
 }
 
 validate_coo_identity() {


### PR DESCRIPTION
## Summary

Stops producing git signatures in cloud sessions that can never pass GitHub verification, because the Claude Code cloud harness intercepts `ssh-keygen -Y sign` and signs with its own key.

## Evidence

Captured while cutting `milestone-2026-04-23-rude-goldberg-machine` from vade-coo-memory#65:

- `/root/.ssh/vade-coo-sign.pub` on this cloud container has fingerprint `SHA256:pZeA8xycAtIsVGwhMzR3mg4KG05n9ksFuy4F1ZVXn3A`. That's byte-identical to the Signing Key registered on the `vade-coo` GitHub account.
- The public-key blob embedded in every cloud-produced signature (commits and tags alike) has fingerprint `SHA256:32dP45eSMmVSt/G/CGvcxl/P+MO3Nwj9xeTh/GSA2wc`. Different key entirely.
- `ssh-keygen -Y verify` against `/root/.ssh/vade-coo-sign.pub` on any such signature returns `Could not verify signature` — the signature was genuinely not made by that key.
- Root cause: git's `gpg.ssh.program` points at `/tmp/code-sign`, a harness-installed symlink to `/opt/env-runner/environment-manager`. It wraps `ssh-keygen -Y sign`, substitutes its own signing key, and returns a valid-looking signature bound to a key that isn't on any account.

GitHub's `unknown_key` verification failure is literally correct. The current "Signed (SSH)" posture on cloud commits/tags is a misleading signal — better absent than wrong.

## Change

- **`scripts/lib/common.sh` — `write_coo_gitconfig()`**: add a helper `_coo_signing_is_intercepted` that returns true if `/tmp/code-sign` exists (executable) or `$CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE` is non-empty. When intercepted, set `commit.gpgsign=false` and `tag.gpgsign=false`. Otherwise write `=true` as before. `user.signingkey`, `gpg.format`, `gpg.ssh.allowedSignersFile`, `core.sshCommand` stay set on both platforms — the keys are still used for SSH auth, and Mac sessions still sign normally.

- **`scripts/integrity-check.sh` — D6**: upgraded from a presence-only check to a three-way semantic check. Keys present + wrapper detected + `commit.gpgsign=false` + `tag.gpgsign=false` → PASS (`keys+signing-off (cloud, per MEMO 2026-04-23-04)`). Keys present + no wrapper + both `true` → PASS (`keys+signing-on (local, vade-coo-sign)`). Any mismatch fails with a detail naming the conflict.

## Detection signal choice

`/tmp/code-sign` is the direct causal test — it IS the wrapper. `CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE` is the higher-level Claude Code cloud signal. OR'd for belt-and-braces; false-positive requires both signals absent on a Mac, which is the normal local case.

Originally considered `command -v environment-runner` but rejected: the harness ships `/tmp/code-sign → /opt/env-runner/environment-manager` as a direct symlink, not a PATH entry; nothing named `environment-runner` is on PATH in an ordinary subshell even though the wrapper is active.

## Test plan

- [x] `bash -n` clean on both scripts.
- [x] Simulated cloud probe (this container): `VADE_COO_GITCONFIG=/tmp/probe write_coo_gitconfig` → writes `commit.gpgsign=false`, `tag.gpgsign=false`, log line says "signing=OFF — cloud harness detected".
- [x] Simulated local probe (stubbed `_coo_signing_is_intercepted() { return 1; }`): writes `=true` on both, log line says "signing=ssh via vade-coo-sign.pub".
- [x] `GIT_CONFIG_GLOBAL=/tmp/probe bash scripts/integrity-check.sh` — D6 passes with detail `keys+signing-off (cloud, per MEMO 2026-04-23-04)`.
- [x] With current (pre-merge) global gitconfig (still has `=true`), integrity-check correctly reports D6 false with the inconsistency detail — self-resolves on next fresh session's coo-bootstrap.
- [ ] **Post-merge**: next fresh cloud session shows `git config --global commit.gpgsign` → `false`, `git commit` produces a commit with no `gpgsig` header, `integrity-check.json` D6 `ok:true`.
- [ ] **Mac parity**: next local session on Mac keeps `=true`, commits still carry the real `vade-coo-sign` signature with green "Verified" badge.

## Not in scope

- The five `milestone-2026-04-23-*` tags keep their wrapper-signed signatures. Rewriting would change tag object SHAs and invalidate the restoration narrative already posted on vade-coo-memory#65.
- Paired memo (MEMO 2026-04-23-04) will land in `vade-coo-memory/coo/memos.md` in a follow-up PR so it can cite this commit's merged SHA.

## Attribution

Opened via `gh` + `\$GITHUB_MCP_PAT` per MEMO 2026-04-23-02. This container pre-dates the auto-installed gh; bootstrapped by calling `ensure_gh_cli` out of the fast-forwarded `scripts/lib/common.sh`. `gh api user -q .login` → `vade-coo`.

Commit is itself wrapper-signed (current session's config hasn't been re-bootstrapped mid-flight); a later memo commit after this PR merges will be the first unsigned commit and will demonstrate the fix.