### PR TITLE
ci: extend auto-tag-issues workflow from vade-coo-memory pilot

### DIFF
--- a/.github/workflows/auto-tag-issues.yml
+++ b/.github/workflows/auto-tag-issues.yml
@@ -1,0 +1,138 @@
+name: Auto-tag new issues
+
+# Canonical taxonomy: https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md
+# When taxonomy v2 lands, batch-update all 5 repos' workflows together.
+#
+# Mirrors the pilot on vade-coo-memory (see MEMO 2026-04-23-04 and the
+# five-PR debug chain on vade-coo-memory: #70, #73, #74, #75, #76).
+# Do not regress the invariants without reviewing that history first:
+#   - permissions.id-token:write is required (OIDC; PR #73)
+#   - fetch the issue via `gh` tool call, not YAML-inlined event
+#     fields (PR #74)
+#   - `--permission-mode bypassPermissions` is required in headless CI
+#     (PR #75)
+#   - prompt must mandate exact `gh issue edit` + `gh issue view
+#     --json labels` verification; the model will otherwise declare
+#     success in text without calling the tool (PR #76)
+#
+# Prerequisites:
+#   - secrets.ANTHROPIC_API_KEY set (org-level preferred, repo-level OK)
+#   - Claude GitHub App installed on this repo
+#     (https://github.com/apps/claude)
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to re-tag (manual dry-run or retry)"
+        required: true
+        type: number
+
+permissions:
+  issues: write
+  contents: read
+  id-token: write  # anthropics/claude-code-action@v1 mints its GitHub token via OIDC
+
+concurrency:
+  group: auto-tag-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    # Skip bot-authored issues so the router can't retrigger itself
+    # once agents start filing issues.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.issue.user.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Classify and label
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # bypassPermissions because the subprocess runs headless in CI —
+          # no interactive prompt available, so default-deny blocks the
+          # label-write path. Blast radius is bounded by the workflow's
+          # `permissions:` block (issues:write + contents:read) and the
+          # prompt's explicit "labels only" constraint.
+          claude_args: --model claude-haiku-4-5-20251001 --permission-mode bypassPermissions
+          # Surface full SDK output in the Actions log so future failures
+          # (permission denials, tool errors) are visible without a rerun.
+          show_full_output: true
+          prompt: |
+            You are a small, deterministic labeling routine for the
+            `vade-app/vade-runtime` repo. You apply labels to one
+            specific issue and do nothing else.
+
+            Target issue number: ${{ github.event.issue.number || inputs.issue_number }}
+
+            Procedure:
+              1. Fetch the target issue via `Bash`:
+
+                     gh issue view <NUMBER> --repo vade-app/vade-runtime --json title,body,author
+
+                 (Do not request `authorAssociation` — it is not a valid
+                 `gh` JSON field; the author's `login` is sufficient.)
+              2. Decide on labels. Dimensions (canonical taxonomy at
+                 https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md):
+                   - `type:*`       exactly one of: type:bug, type:feat,
+                                     type:chore, type:docs, type:refactor,
+                                     type:test, type:research, type:epic
+                   - `area:*`       one or two, from this repo's
+                                     vocabulary: area:cloud-env, area:mcp,
+                                     area:bootstrap, area:hooks (plus
+                                     universal area:docs / area:ci /
+                                     area:deploy)
+                   - `readiness:*`  exactly one **only if confident**; omit
+                                     when the description is too thin to
+                                     judge (implicit "untriaged"); apply
+                                     `readiness:ready` only when the issue
+                                     is well-scoped, the approach is clear,
+                                     and there are no blockers. Options:
+                                     readiness:ready, readiness:needs-design,
+                                     readiness:needs-research,
+                                     readiness:needs-breakdown.
+                   - `prio:*`       zero or one (prio:P0..P3), only if the
+                                     issue explicitly signals urgency
+                   - qualifiers     zero or more: `needs:bdfl-approval`,
+                                     `blocked:bdfl-go-ahead`, `blocked:upstream`,
+                                     `emancipatory`, `external-code`
+                 Prefer omitting a dimension over guessing.
+              3. **Apply the labels — this step is mandatory and is not
+                 optional text.** Execute exactly this `Bash` command
+                 (one `--add-label` flag per label):
+
+                     gh issue edit <NUMBER> --repo vade-app/vade-runtime \
+                       --add-label "<label1>" --add-label "<label2>" ...
+
+                 If `gh` reports a label does not exist in the repo, first
+                 create it:
+
+                     gh label create "<label>" --repo vade-app/vade-runtime
+
+                 then retry the `gh issue edit`. Keep going until the
+                 `gh issue edit` command exits successfully.
+              4. **Verify** by running:
+
+                     gh issue view <NUMBER> --repo vade-app/vade-runtime --json labels
+
+                 and confirming the `labels[*].name` array contains every
+                 label you intended to apply. If any are missing, retry
+                 step 3 for the missing ones.
+
+            Do not stop until step 4's verification shows the labels on
+            the issue. Merely declaring "applied" in text is not enough —
+            the terminal state must be a verified `gh issue view` output
+            with the labels present.
+
+            Side-effect budget: labels only. Do not edit the title or
+            body, do not post a comment, do not assign, do not close.
+
+            If a label you want does not yet exist and is additive under
+            the taxonomy's maintenance rules, `gh label create` is allowed
+            (step 3 above handles this). Do not invent new *dimensions* —
+            only new values under existing prefixes (`type:`, `area:`,
+            `readiness:`, `prio:`, `needs:`, `blocked:`).
+
+            Be brief in your final message. One line naming the labels
+            that are now on the issue.


### PR DESCRIPTION
Rolls the auto-label workflow out from the `vade-coo-memory` pilot
to `vade-runtime`. First of four rollout PRs tracked under
`vade-runtime#44`.

## What this does

Adds `.github/workflows/auto-tag-issues.yml`. On `issues.opened` (and
on `workflow_dispatch` for retries), runs `claude-haiku-4-5-20251001`
via `anthropics/claude-code-action@v1` to classify the issue and
apply v1 taxonomy labels (`type:*`, `area:*`, optional `readiness:*`
/ `prio:*` / qualifiers) via `gh issue edit --add-label`. Labels
only — no title/body edits, no comments, no assign/close.

## What differs from the vade-coo-memory pilot

Two parameterized fields and two removed steps. Everything else —
`permissions:`, `claude_args`, `show_full_output`, concurrency group,
bot-author skip, fetch-via-`gh`, mandatory `gh issue view --json
labels` verification — carries verbatim.

- **Repo name** swapped to `vade-app/vade-runtime` (5 occurrences).
- **`area:*` vocabulary** swapped to this repo's list from
  [`coo/label_taxonomy.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md):
  `area:cloud-env`, `area:mcp`, `area:bootstrap`, `area:hooks`
  (plus universal `area:docs` / `area:ci` / `area:deploy`).
- **`actions/checkout@v4` step removed** — no step in the workflow
  needs a repo checkout; all operations go through `gh` API calls.
- **Prompt step "read `coo/label_taxonomy.md`" removed** — that file
  only exists on `vade-coo-memory`. The prompt hard-codes the relevant
  dimensions and values, and cites the canonical URL in a header
  comment for future taxonomy v2 sweeps.

## Pilot invariants carried forward

From the five-PR debug chain on `vade-coo-memory`
(#70 → #73 → #74 → #75 → #76). Regressing any of these re-opens a
closed bug — please do not edit without checking those PR bodies:

- `permissions.id-token: write` is mandatory (OIDC; PR #73).
- Fetch the issue via `gh` tool call, not YAML-inlined event fields
  (needed so `workflow_dispatch` retries have a title/body; PR #74).
- Do **not** request `authorAssociation` in `gh issue view --json`
  (not a valid field; PR #74).
- `--permission-mode bypassPermissions` in `claude_args` — headless
  CI auto-denies the subprocess permission prompt otherwise (PR #75).
- `show_full_output: true` keeps the SDK trace visible in Actions
  logs for future failure diagnosis (PR #75).
- Prompt mandates the exact `gh issue edit --add-label` command +
  a post-apply `gh issue view <N> --json labels` verification call.
  The model has previously declared "applied" in text without calling
  any tool; requiring verification closes that hallucination path
  (PR #76).
- Bot-author skip (`github.event.issue.user.type != 'Bot'` on
  `issues` events, allow `workflow_dispatch` unconditionally) —
  prevents router self-retrigger once other agents file issues.

## Prerequisites before the first live run

Must be in place before the workflow can successfully run:

- [x] `ANTHROPIC_API_KEY` secret available to this repo. Org-level
  on `vade-app` is preferred (covers all four rollout repos with
  zero per-repo config). Repo-level is an acceptable fallback.
- [x] Claude GitHub App installed on `vade-app/vade-runtime`
  (<https://github.com/apps/claude>). This is the action's write
  surface and cannot be waived.

Both require org/repo owner access and are outside my write surface.
**Ven**, please confirm or arrange before merge — the workflow lands
inert otherwise (first `issues.opened` event would fail loudly with
a missing-secret error; no silent failure).

## Verification plan (post-merge)

1. `gh workflow run auto-tag-issues.yml --repo vade-app/vade-runtime
   -f issue_number=<N>` on a recently-closed issue (blast radius
   contained).
2. `gh run list --workflow=auto-tag-issues.yml --repo
   vade-app/vade-runtime --limit 1` — expect `conclusion: success`.
3. Inspect SDK output in the Actions UI — expect
   `permission_denials_count: 0` and a `gh issue edit` Bash tool call
   followed by a `gh issue view --json labels` verification call.
4. `gh issue view <N> --repo vade-app/vade-runtime --json labels` —
   confirm reasonable `type:*` + `area:*` values are applied.
5. Remove the dry-run labels with `gh issue edit --remove-label …`.
6. Wait for a real `issues.opened` event; log that first real run
   in `vade-coo-memory/docs/auto-tag-routine.md`.

## Rollback

- **One misfired label**: note in the run log, move on.
- **Two consecutive wrong `type:*` labels on this repo, OR any
  `readiness:ready` false positive**: disable the workflow in the
  Actions UI and open a remediation PR. Does not require disabling
  the other rollout repos.
- **Org-wide regression**: revoke `ANTHROPIC_API_KEY` (takes down all
  five repos — coarse knob for a <1-minute blast-radius cap).

## Refs

- Tracking issue: #44
- Pilot install memo: `vade-coo-memory/coo/memos.md` MEMO 2026-04-23-04
- Taxonomy adoption memo: `vade-coo-memory/coo/memos.md` MEMO 2026-04-22-09
- Pilot workflow:
  https://github.com/vade-app/vade-coo-memory/blob/main/.github/workflows/auto-tag-issues.yml
- Debug-chain PRs: vade-coo-memory #70, #73, #74, #75, #76