### PR TITLE
ci(auto-tag): v2 — comprehensive labeling + VADE project assignment

### DIFF
--- a/.github/workflows/auto-tag-issues.yml
+++ b/.github/workflows/auto-tag-issues.yml
@@ -1,7 +1,12 @@
 name: Auto-tag new issues
 
 # Canonical taxonomy: https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md
-# When taxonomy v2 lands, batch-update all 5 repos' workflows together.
+# Canonical project:  https://github.com/orgs/vade-app/projects/1 (VADE)
+#   Project node ID:  PVT_kwDOEGdN_84BUV2r
+#   State field ID:   PVTSSF_lADOEGdN_84BUV2rzhBesRM
+#   planned option:   a5c0cccb
+# When taxonomy v2 lands or the VADE project is rebuilt, batch-update
+# all 5 repos' workflows together.
 #
 # Mirrors the pilot on vade-coo-memory (see MEMO 2026-04-23-04 and the
 # five-PR debug chain on vade-coo-memory: #70, #73, #74, #75, #76).
@@ -11,14 +16,19 @@ name: Auto-tag new issues
 #     fields (PR #74)
 #   - `--permission-mode bypassPermissions` is required in headless CI
 #     (PR #75)
-#   - prompt must mandate exact `gh issue edit` + `gh issue view
-#     --json labels` verification; the model will otherwise declare
-#     success in text without calling the tool (PR #76)
+#   - prompt must mandate exact `gh issue edit` + `gh issue view`
+#     verification; the model will otherwise declare success in text
+#     without calling the tool (PR #76)
 #
 # Prerequisites:
 #   - secrets.ANTHROPIC_API_KEY set (org-level preferred, repo-level OK)
 #   - Claude GitHub App installed on this repo
 #     (https://github.com/apps/claude)
+# Optional (graceful skip if absent):
+#   - secrets.VADE_PROJECT_PAT — PAT with `project` scope for the
+#     vade-app org. Enables auto-add to the VADE project with
+#     State=planned. If missing, labeling still runs; the project
+#     step logs a warning and skips.
 
 on:
   issues:
@@ -46,93 +56,159 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.issue.user.type != 'Bot' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Classify and label
+      - name: Classify, label, and add to VADE project
         uses: anthropics/claude-code-action@v1
+        env:
+          # Optional: PAT with `project` scope for the vade-app org.
+          # Propagated to the subprocess so the prompt's project
+          # GraphQL mutations can use it via `GH_TOKEN=…`. If unset,
+          # the project step in the prompt gracefully skips.
+          VADE_PROJECT_PAT: ${{ secrets.VADE_PROJECT_PAT }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # bypassPermissions because the subprocess runs headless in CI —
           # no interactive prompt available, so default-deny blocks the
-          # label-write path. Blast radius is bounded by the workflow's
-          # `permissions:` block (issues:write + contents:read) and the
-          # prompt's explicit "labels only" constraint.
+          # label-write and project-mutation paths. Blast radius is
+          # bounded by the workflow's `permissions:` block (issues:write
+          # + contents:read) and the prompt's explicit "labels + one
+          # project item only" constraint.
           claude_args: --model claude-haiku-4-5-20251001 --permission-mode bypassPermissions
           # Surface full SDK output in the Actions log so future failures
-          # (permission denials, tool errors) are visible without a rerun.
+          # (permission denials, tool errors, GraphQL 4xx) are visible
+          # without a rerun.
           show_full_output: true
           prompt: |
-            You are a small, deterministic labeling routine for the
-            `vade-app/vade-runtime` repo. You apply labels to one
-            specific issue and do nothing else.
+            You are a small, deterministic triage routine for the
+            `vade-app/vade-runtime` repo. You classify one specific
+            issue, apply labels, and add it to the VADE project with
+            State=planned. You do nothing else.
 
             Target issue number: ${{ github.event.issue.number || inputs.issue_number }}
 
             Procedure:
-              1. Fetch the target issue via `Bash`:
 
-                     gh issue view <NUMBER> --repo vade-app/vade-runtime --json title,body,author
+            1. Fetch the target issue via `Bash`:
 
-                 (Do not request `authorAssociation` — it is not a valid
-                 `gh` JSON field; the author's `login` is sufficient.)
-              2. Decide on labels. Dimensions (canonical taxonomy at
-                 https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md):
-                   - `type:*`       exactly one of: type:bug, type:feat,
-                                     type:chore, type:docs, type:refactor,
-                                     type:test, type:research, type:epic
-                   - `area:*`       one or two, from this repo's
-                                     vocabulary: area:cloud-env, area:mcp,
-                                     area:bootstrap, area:hooks (plus
-                                     universal area:docs / area:ci /
-                                     area:deploy)
-                   - `readiness:*`  exactly one **only if confident**; omit
-                                     when the description is too thin to
-                                     judge (implicit "untriaged"); apply
-                                     `readiness:ready` only when the issue
-                                     is well-scoped, the approach is clear,
-                                     and there are no blockers. Options:
-                                     readiness:ready, readiness:needs-design,
-                                     readiness:needs-research,
-                                     readiness:needs-breakdown.
-                   - `prio:*`       zero or one (prio:P0..P3), only if the
-                                     issue explicitly signals urgency
-                   - qualifiers     zero or more: `needs:bdfl-approval`,
-                                     `blocked:bdfl-go-ahead`, `blocked:upstream`,
-                                     `emancipatory`, `external-code`
-                 Prefer omitting a dimension over guessing.
-              3. **Apply the labels — this step is mandatory and is not
-                 optional text.** Execute exactly this `Bash` command
-                 (one `--add-label` flag per label):
+                   gh issue view <NUMBER> --repo vade-app/vade-runtime --json title,body,author,id
 
-                     gh issue edit <NUMBER> --repo vade-app/vade-runtime \
-                       --add-label "<label1>" --add-label "<label2>" ...
+               The `id` field is the GraphQL node ID — keep it; step 5
+               needs it. Do NOT request `authorAssociation` (not a
+               valid `gh` JSON field).
 
-                 If `gh` reports a label does not exist in the repo, first
-                 create it:
+            2. Classify across all five dimensions. Canonical taxonomy:
+               https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md
 
-                     gh label create "<label>" --repo vade-app/vade-runtime
+               - `type:*` — exactly one (mandatory):
+                   type:bug, type:feat, type:chore, type:docs,
+                   type:refactor, type:test, type:research, type:epic
 
-                 then retry the `gh issue edit`. Keep going until the
-                 `gh issue edit` command exits successfully.
-              4. **Verify** by running:
+               - `area:*` — one or two (mandatory), from this repo's
+                 vocabulary: area:cloud-env, area:mcp, area:bootstrap, area:hooks (plus the universal
+                 area:docs / area:ci / area:deploy available to every
+                 repo)
 
-                     gh issue view <NUMBER> --repo vade-app/vade-runtime --json labels
+               - `readiness:*` — exactly one (mandatory):
+                   readiness:ready — ONLY if the issue is well-scoped,
+                     the approach is clear, and there are no blockers.
+                     Strict bar. When in any doubt, do NOT pick ready.
+                   readiness:needs-design — the WHAT is clear but the
+                     HOW requires design work.
+                   readiness:needs-research — facts, requirements, or
+                     dependencies are unknown and must be investigated
+                     before coding.
+                   readiness:needs-breakdown — too large or under-
+                     specified to start on; must be decomposed into
+                     smaller actionable issues. DEFAULT FALLBACK for
+                     thin / vague / partially-written issues.
 
-                 and confirming the `labels[*].name` array contains every
-                 label you intended to apply. If any are missing, retry
-                 step 3 for the missing ones.
+               - `prio:*` — exactly one (mandatory):
+                   prio:P0 — explicit urgency, production-critical, or
+                     blocker for multiple agents/people.
+                   prio:P1 — important soon; unblocking near-term work.
+                   prio:P2 — DEFAULT for normal work.
+                   prio:P3 — nice-to-have, backlog, or "someday"
+                     phrasing.
 
-            Do not stop until step 4's verification shows the labels on
-            the issue. Merely declaring "applied" in text is not enough —
-            the terminal state must be a verified `gh issue view` output
-            with the labels present.
+               - qualifiers — apply each that matches (zero or more):
+                   needs:bdfl-approval — decision requires the BDFL
+                     (Ven) before implementation.
+                   blocked:bdfl-go-ahead — explicitly awaiting BDFL
+                     sign-off right now.
+                   blocked:upstream — waiting on upstream work in
+                     another repo or external dependency.
+                   emancipatory — issue concerns agent autonomy, self-
+                     infrastructure, or agent society design.
+                   external-code — touches code outside this repo's
+                     canonical ownership (vendored or cross-repo).
 
-            Side-effect budget: labels only. Do not edit the title or
-            body, do not post a comment, do not assign, do not close.
+               Expect 3–5 labels total on a typical issue (one each
+               from type, readiness, prio; one or two area; zero or
+               more qualifiers). If you find yourself applying fewer
+               than 3, re-read the issue — you probably missed a
+               dimension.
 
-            If a label you want does not yet exist and is additive under
-            the taxonomy's maintenance rules, `gh label create` is allowed
-            (step 3 above handles this). Do not invent new *dimensions* —
-            only new values under existing prefixes (`type:`, `area:`,
-            `readiness:`, `prio:`, `needs:`, `blocked:`).
+            3. **Apply all labels.** This step is mandatory. Execute
+               exactly this `Bash` command (one `--add-label` flag per
+               label, every label from step 2):
 
-            Be brief in your final message. One line naming the labels
-            that are now on the issue.
+                   gh issue edit <NUMBER> --repo vade-app/vade-runtime \
+                     --add-label "<label1>" --add-label "<label2>" ...
+
+               If `gh` reports a label does not exist in the repo,
+               first create it with `gh label create "<label>" --repo
+               vade-app/vade-runtime` and retry. Keep going until
+               `gh issue edit` exits 0.
+
+            4. **Verify labels** by running:
+
+                   gh issue view <NUMBER> --repo vade-app/vade-runtime --json labels
+
+               and confirming `labels[*].name` contains every label
+               you intended to apply. If any are missing, retry step
+               3 for those.
+
+            5. **Add the issue to the VADE project with State=planned.**
+               Run this exact Bash block, replacing `<ISSUE_ID>` with
+               the `id` you got in step 1:
+
+                   if [ -z "$VADE_PROJECT_PAT" ]; then
+                     echo "VADE_PROJECT_PAT not set — skipping project assignment"
+                   else
+                     ITEM_ID=$(GH_TOKEN="$VADE_PROJECT_PAT" gh api graphql \
+                       -f query='mutation { addProjectV2ItemById(input: {projectId: "PVT_kwDOEGdN_84BUV2r", contentId: "<ISSUE_ID>"}) { item { id } } }' \
+                       -q '.data.addProjectV2ItemById.item.id')
+                     echo "Added to VADE as item $ITEM_ID"
+                     GH_TOKEN="$VADE_PROJECT_PAT" gh api graphql \
+                       -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"PVT_kwDOEGdN_84BUV2r\", itemId: \"$ITEM_ID\", fieldId: \"PVTSSF_lADOEGdN_84BUV2rzhBesRM\", value: { singleSelectOptionId: \"a5c0cccb\" } }) { projectV2Item { id } } }"
+                     echo "Set State=planned"
+                   fi
+
+               If the PAT is set and either mutation returns an error,
+               report the error in your final message but do not retry
+               destructively.
+
+            6. **Verify project membership** (only if step 5 ran the
+               mutation path, not the skip path):
+
+                   gh issue view <NUMBER> --repo vade-app/vade-runtime --json projectItems
+
+               Confirm a project item whose `title` is "VADE" appears
+               in the output. If step 5 took the skip path, note that
+               in your final message instead.
+
+            Do not stop until BOTH:
+              - Step 4's verification shows every intended label on the
+                issue, AND
+              - Step 6 confirms the VADE project item, OR step 5
+                logged the "VADE_PROJECT_PAT not set" warning.
+
+            Merely declaring "applied" in text is not enough — the
+            terminal state must be verified via `gh` output.
+
+            Side-effect budget: labels only, plus the one VADE project
+            item from step 5 (with its State set). Do not edit the
+            title or body, do not post a comment, do not assign, do
+            not close.
+
+            Final message: one line naming the labels now on the
+            issue, one line on project state (added / skipped / error).


### PR DESCRIPTION
Follow-up to the original rollout PR (#46, merged). First live run
of that workflow on #44 applied only `type:chore` + `area:ci` and
did not add the issue to VADE. This PR evolves the workflow to
cover the full taxonomy and add the issue to the VADE project.

Sibling v2 PRs opened in parallel on the other four repos:
vade-coo-memory#<TBD>, vade-core#62, vade-agent-logs#13,
vade-governance#2.

## What changes

1. **Rebalanced classification** (prompt rewrite):
   - `readiness:*` — now always exactly one. Strict bar on
     `readiness:ready` preserved from MEMO 2026-04-23-04 (false
     positives poison the routing filter). When not ready, pick
     `needs-design`, `needs-research`, or `needs-breakdown`
     (default for thin / vague issues) instead of omitting.
   - `prio:*` — now always exactly one. `P2` default; `P0`/`P1`
     require explicit urgency signal; `P3` for backlog phrasing.
   - Qualifiers listed with trigger conditions so the model
     actively applies them when matched.
   - Explicit: expect 3–5 labels on a typical issue.

2. **VADE project assignment** (new step 5 in the prompt). After
   labels are applied and verified, two GraphQL mutations via
   `GH_TOKEN="$VADE_PROJECT_PAT" gh api graphql …`:
   - `addProjectV2ItemById` to project
     `PVT_kwDOEGdN_84BUV2r`.
   - `updateProjectV2ItemFieldValue` on field
     `PVTSSF_lADOEGdN_84BUV2rzhBesRM` (State) to option
     `a5c0cccb` (planned).

   Exposed to the subprocess via a step-level `env:` binding:
   ```yaml
   env:
     VADE_PROJECT_PAT: ${{ secrets.VADE_PROJECT_PAT }}
   ```

   **Graceful degradation.** If `VADE_PROJECT_PAT` is unset, the
   prompt logs a warning and skips. Labeling still works.

3. **Cleanup** (aligns with what the rolled-out repos already
   did):
   - Dropped `actions/checkout@v4` (nothing read it anymore).
   - Dropped the prompt step that read `coo/label_taxonomy.md`
     (lived only on vade-coo-memory; values now hard-coded in
     the prompt and cited by URL in the header comment).

## Invariants preserved (from the five-PR debug chain)

- `permissions.id-token: write`.
- `--permission-mode bypassPermissions`.
- `show_full_output: true`.
- Fetch via `gh --json title,body,author,id` (no
  `authorAssociation`; new `id` for node lookup).
- Mandatory verification step (now two — labels and project
  membership).
- Bot-author skip.
- Concurrency group on issue number.

## Provisioning

Adds one new optional secret:

- [ ] **`VADE_PROJECT_PAT`** — org-level secret on `vade-app`,
  PAT with `project` scope. If absent, project step skips
  gracefully; labeling works regardless.

## Verification plan (post-merge)

1. `gh workflow run auto-tag-issues.yml --repo vade-app/vade-runtime
   -f issue_number=<N>` on a recently-closed issue.
2. Expect 3–5 labels, issue in VADE with `State=planned` (if the
   PAT is set).
3. Roll back dry-run side effects afterwards.

## Manual catch-up on #44

I manually backfilled `readiness:ready` + `prio:P2` on
vade-runtime#44 and added it to VADE with `State=done` (it's
resolved). That was the action that verified
`GITHUB_MCP_PAT` has `project` scope, so the secret pattern will
work once Ven provisions `VADE_PROJECT_PAT`.

## Refs

- Prior rollout PR (merged): #46
- Tracking issue: #44
- Pilot install memo: `vade-coo-memory/coo/memos.md` MEMO 2026-04-23-04
- Taxonomy adoption memo: `vade-coo-memory/coo/memos.md` MEMO 2026-04-22-09
- Canonical taxonomy:
  https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md
- Sibling v2 PRs: vade-coo-memory, vade-core#62,
  vade-agent-logs#13, vade-governance#2