### PR TITLE
hooks: fix unbound HOOK_ARGS[@] under bash 3.2 nounset

### DIFF
--- a/scripts/hooks-dispatch.sh
+++ b/scripts/hooks-dispatch.sh
@@ -136,4 +136,4 @@ _log "$RESOLVED_RULE" "$RESOLVED_RUNTIME" "true" "dispatching to $RESOLVED_SCRIP
 # Forward. Use `bash` explicitly (matches settings.json convention) and
 # pass through additional args. Don't use exec — we want the logged
 # dispatch line even if the hook crashes.
-bash "$RESOLVED_SCRIPT" "${HOOK_ARGS[@]}"
+bash "$RESOLVED_SCRIPT" ${HOOK_ARGS[@]+"${HOOK_ARGS[@]}"}


### PR DESCRIPTION
## Summary
- macOS bash 3.2.57 + `set -u` + empty `HOOK_ARGS=()` array → `unbound variable` error on the final `bash "$RESOLVED_SCRIPT" "${HOOK_ARGS[@]}"` line of `scripts/hooks-dispatch.sh`. (bash 4.4+ fixed this; Apple ships 3.2 forever.)
- Fix uses the standard `${HOOK_ARGS[@]+"${HOOK_ARGS[@]}"}` idiom — expands to nothing when unset, preserves quoting when populated.

## Impact
Every SessionStart hook dispatched on macOS without trailing args was crashing **after** logging `"ok":true` to `~/.vade/boot.log` (resolution succeeded on line 134, exec died on line 139). Target scripts never ran. Affected this session:
- `coo-bootstrap`
- `coo-identity-digest`
- `discussions-digest`
- `session-lifecycle`
- `session-start-sync`

Visible to the user as 5 `SessionStart:startup hook error … HOOK_ARGS[@]: unbound variable` lines on session start.

## Test plan
- [x] Repro under bash 3.2.57: `set -u; arr=(); echo "${arr[@]}"` → `unbound variable`
- [x] Patched form `${arr[@]+"${arr[@]}"}` returns empty cleanly
- [x] Patched form preserves quoted args (`"foo bar"` stays one arg)
- [x] Manual invocation `bash ~/.claude/vade-hooks/dispatch.sh nonexistent-hook` exits 0 with the expected "could not locate" message
- [x] Re-ran all 5 affected hooks via the dispatch shim — all completed successfully and recovered the boot context for the live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)