### PR TITLE
memo-query: slash command for interactive memo retrieval

### DIFF
--- a/.claude/commands/memo-query.md
+++ b/.claude/commands/memo-query.md
@@ -1,0 +1,9 @@
+---
+description: Query the COO memo index (coo/memo_index.json) by memo ID, keyword, or date range. Returns matching entries with body-retrieval hints; full text is opt-in via the printed sed command.
+argument-hint: [memo-id | keyword | YYYY-MM-DD..YYYY-MM-DD]
+allowed-tools: Bash
+---
+
+!bash /home/user/vade-runtime/scripts/memo-query.sh "$ARGUMENTS"
+
+Present the output above verbatim to the user inside a single fenced code block. Add no preamble, no summary, no commentary. If the output includes a `body: sed -n ...` line and the user clearly wants the full memo text, offer to run the printed `sed` command — don't run it automatically.

--- a/scripts/memo-query.sh
+++ b/scripts/memo-query.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# memo-query: query coo/memo_index.json for memos by ID, keyword, or date range.
+#
+# Companion to vade-runtime/scripts/memo-index.sh (which produces the
+# index this script reads). Implements Track 2 of the memo-system
+# transition ratified in MEMO 2026-04-24-03.
+#
+# Usage: memo-query.sh [query]
+#   query forms:
+#     YYYY-MM-DD-NN          -> return the single matching memo + sed hint
+#     YYYY-MM-DD..YYYY-MM-DD -> return all memos in range, newest-first
+#     <keyword>              -> case-insensitive substring match on title +
+#                               summary_one_line, newest-first
+#     (empty)                -> print the 10 most recent memos
+#
+# Exit codes: 0 on any successful query (including zero matches); non-zero
+# only on environment errors (missing index, missing jq). Zero matches
+# prints a one-liner explaining the empty result.
+#
+# Invoked from ~/.claude/commands/memo-query.md as:
+#   !bash /home/user/vade-runtime/scripts/memo-query.sh "$ARGUMENTS"
+
+set -euo pipefail
+
+if [ -n "${COO_MEMORY_DIR:-}" ]; then
+  MEM_REPO="$COO_MEMORY_DIR"
+elif [ "$HOME" != "/home/user" ] && [ -d "$HOME/GitHub/vade-app/vade-coo-memory" ]; then
+  MEM_REPO="$HOME/GitHub/vade-app/vade-coo-memory"
+else
+  MEM_REPO="/home/user/vade-coo-memory"
+fi
+INDEX="$MEM_REPO/coo/memo_index.json"
+MEMOS_REL="coo/memos.md"
+MEMOS_ABS="$MEM_REPO/$MEMOS_REL"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "memo-query: jq not on PATH; cannot run." >&2
+  exit 2
+fi
+
+if [ ! -f "$INDEX" ]; then
+  cat <<EOF
+memo-query: index not found at $INDEX
+Regenerate with:
+  bash /home/user/vade-runtime/scripts/memo-index.sh
+EOF
+  exit 2
+fi
+
+# Trim whitespace from the raw argument string (Claude Code passes the
+# full $ARGUMENTS as a single positional).
+raw="${1:-}"
+raw="${raw#"${raw%%[![:space:]]*}"}"
+raw="${raw%"${raw##*[![:space:]]}"}"
+
+# Render a list of index entries as a compact human-readable block.
+# Reads entries on stdin as a JSON array; emits one entry per three lines
+# (header, one-liner, body-hint) separated by blank lines.
+render_entries() {
+  jq -r --arg memos "$MEMOS_REL" '
+    .[] |
+    "\(.id) (\(.date)) [\(.status)]  L\(.line_start)-\(.line_end)\n" +
+    "  \(.summary_one_line)\n" +
+    "  body: sed -n \(.line_start),\(.line_end)p " + $memos
+  '
+}
+
+if [ -z "$raw" ]; then
+  echo "=== 10 most recent memos (from $(basename "$INDEX")) ==="
+  echo
+  jq '.[:10]' "$INDEX" | render_entries
+  echo
+  echo "Tip: /memo-query <id>  |  /memo-query <keyword>  |  /memo-query YYYY-MM-DD..YYYY-MM-DD"
+  exit 0
+fi
+
+# Memo-ID form: exact YYYY-MM-DD-NN.
+if [[ "$raw" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
+  # The corpus contains duplicate IDs (three pairs as of 2026-04-24);
+  # the index disambiguates by line_start. Return every match.
+  matches=$(jq --arg id "$raw" '[.[] | select(.id == $id)]' "$INDEX")
+  count=$(jq 'length' <<<"$matches")
+  if [ "$count" -eq 0 ]; then
+    echo "memo-query: no memo with id '$raw' in $INDEX"
+    exit 0
+  fi
+  if [ "$count" -gt 1 ]; then
+    echo "=== $count entries for id $raw (duplicate-id disambiguated by line_start) ==="
+  else
+    echo "=== memo $raw ==="
+  fi
+  echo
+  render_entries <<<"$matches"
+  exit 0
+fi
+
+# Date-range form: YYYY-MM-DD..YYYY-MM-DD (inclusive both ends).
+if [[ "$raw" =~ ^([0-9]{4}-[0-9]{2}-[0-9]{2})\.\.([0-9]{4}-[0-9]{2}-[0-9]{2})$ ]]; then
+  from="${BASH_REMATCH[1]}"
+  to="${BASH_REMATCH[2]}"
+  if [[ "$from" > "$to" ]]; then
+    # Swap so either order works.
+    tmp="$from"; from="$to"; to="$tmp"
+  fi
+  matches=$(jq --arg from "$from" --arg to "$to" \
+    '[.[] | select(.date >= $from and .date <= $to)]' "$INDEX")
+  count=$(jq 'length' <<<"$matches")
+  echo "=== $count memos in $from..$to (newest-first) ==="
+  echo
+  if [ "$count" -gt 0 ]; then
+    render_entries <<<"$matches"
+  fi
+  exit 0
+fi
+
+# Default: keyword substring match on title + summary_one_line (case-insensitive).
+# Escape characters that jq's ascii_downcase + contains treats specially:
+# jq `contains` takes a literal substring, so we pass the lowercased query
+# via --arg (no regex involved); no escaping needed.
+q_lower=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')
+matches=$(jq --arg q "$q_lower" '
+  [.[] | select(
+    (.title | ascii_downcase | contains($q)) or
+    (.summary_one_line | ascii_downcase | contains($q))
+  )]
+' "$INDEX")
+count=$(jq 'length' <<<"$matches")
+echo "=== $count memos matching \"$raw\" (case-insensitive; title + summary) ==="
+echo
+if [ "$count" -gt 0 ]; then
+  render_entries <<<"$matches"
+fi


### PR DESCRIPTION
## Summary

Track 2 of the memo-system transition ratified in MEMO 2026-04-24-03.
Commissioned via `vade-app/vade-coo-memory#100`. Companion to Track 1
(indexer + SessionStart hook) shipped in `668cce0` on this branch.

Ships a user-scoped slash command plus a backing shell script:

- `.claude/commands/memo-query.md` — slash command definition. Lives
  in `vade-runtime/.claude/` because that path is synced to
  `/root/.claude/` at SessionStart (same global-distribution channel
  as the `tagging-taxonomy` / `agentmail` / `skill-creator` skills).
  Commands under `vade-coo-memory/.claude/commands/` would only load
  when the project root is `vade-coo-memory/` — the COO operates from
  `/home/user/`, which wouldn't pick them up.
- `scripts/memo-query.sh` — the jq/bash logic. Factored into a script
  so the four invocation shapes are testable standalone; the slash
  command is a thin `!bash …` wrapper.

## Argument surface (issue #100 verbatim)

| Form | Behaviour |
|---|---|
| `/memo-query 2026-04-23-05` | Single memo by ID; returns the index entry + a `sed -n L,Lp` hint for the body. Duplicate-ID pairs (three exist in the corpus) return every match, disambiguated by line_start. |
| `/memo-query committee` | Case-insensitive substring match on `title` + `summary_one_line`, newest-first. |
| `/memo-query 2026-04-20..2026-04-24` | Inclusive date range, newest-first. Either argument order is accepted (swapped internally). |
| `/memo-query` | Top 10 most recent entries. |

Full memo bodies are **not** auto-loaded into context. The command
prints the `sed -n L,Lp coo/memos.md` line and leaves resolution to
the caller — design doc §4 Track 2 rule for keeping the command cheap.

## Graceful degradation

- Index missing → one-liner pointing at `scripts/memo-index.sh`
  (exit 2, no noise).
- `jq` missing → exit 2 with a clear message.
- Zero-match keyword / unknown memo ID → readable "0 memos matching"
  or "no memo with id" headers, exit 0.

## Smoke test

All four invocation shapes verified against the current 45-memo corpus
(2026-04-24):

- No args → 10 most recent memos + tip line ✓
- `2026-04-23-05` → single entry for the committee-protocol memo ✓
- `committee` → 3 hits (MEMOs -24-03, -24-01, -23-05) ✓
- `2026-04-20..2026-04-24` → 24 entries, newest-first, duplicate-ID
  pairs both shown ✓
- Edge cases (missing index, zero-match keyword, unknown id) ✓

## Dependencies

No new deps — `jq` + `bash` only, both present in every container epoch.

## Test plan

- [x] Four invocation shapes return expected output on current corpus
- [x] Graceful degradation: missing index prints regen hint, exit 2
- [x] Zero-match paths (keyword + id) print readable headers, exit 0
- [x] Duplicate-ID memos all returned (not silently collapsed)
- [x] Script is executable (`chmod +x`)
- [ ] Fresh cloud session: `/memo-query` surfaces under the command
      autocomplete after `.claude` sync (needs verification post-merge
      in a new session; can't verify pre-merge because the sync copies
      from `main`)
- [ ] No regression in boot integrity-check (this PR adds files; no
      hook-chain or settings.json changes)

## Out of scope

- Track 3 (`memo_protocol.md` reassessment) — separate track; expected
  no committee pass per §4 Track 3 analysis.
- Track 4 (Mem0 semantic layer) — deferred 5–10 sessions.
- Track 6 (Discussions publication) — deferred.
- CLAUDE.md edits referencing `/memo-query` — quorum-4 commissioning
  issue (sibling to #100) handles that.
- `/memo` authoring slash command — different direction, tracked in
  `vade-coo-memory#45`.

## Closes

- `vade-app/vade-coo-memory#100`

(Cross-repo close — this PR closes the issue in vade-coo-memory; GitHub
won't auto-close cross-repo, so I'll close #100 manually with a pointer
to this PR after merge.)