### PR TITLE
settings: raise Claude Code stream idle timeout to 10 min

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,7 +25,9 @@
       }
     ]
   },
-  "env": {},
+  "env": {
+    "CLAUDE_STREAM_IDLE_TIMEOUT_MS": "600000"
+  },
   "permissions": {
     "allow": [
       "mcp__github-coo__*",


### PR DESCRIPTION
## Summary
- Adds `CLAUDE_STREAM_IDLE_TIMEOUT_MS=600000` to the cloud `env` block in `.claude/settings.json`.
- Widens the Anthropic byte-watchdog floor from its default 5 min (300000 ms) to 10 min so long Opus extended-thinking stretches don't trip "API Error: Stream idle timeout" on proxied/buffered paths.
- No change to `CLAUDE_ENABLE_STREAM_WATCHDOG` (event-level watchdog stays off by default on the Anthropic API path, which is what vade-runtime uses).

## Why
Ven reported recurring "Stream Idle timeout" failures and surfaced a GitHub tip suggesting `CLAUDE_ENABLE_STREAM_WATCHDOG` is the culprit. Verified against the official env-vars docs (https://code.claude.com/docs/en/env-vars): on the Anthropic API path only the **byte** watchdog runs, with a hard 5-min floor — so the community tip's "90 s kill" story doesn't actually apply here. Bumping `CLAUDE_STREAM_IDLE_TIMEOUT_MS` to 600000 is the documented-safe widening: no-op for anything under the 5-min floor, but buys headroom when proxy buffering stacks on top of a long think phase.

## Test plan
- [ ] Start a new cloud session after merge, confirm SessionStart sync copies the updated `settings.json` to `/root/.claude/settings.json`.
- [ ] `jq .env /root/.claude/settings.json` shows `CLAUDE_STREAM_IDLE_TIMEOUT_MS: "600000"`.
- [ ] Run a deliberately long Opus extended-thinking task (>5 min think phase) and confirm no "Stream Idle timeout" surface.

https://claude.ai/code/session_01SpUYa1Jd4y3eiX9iQhtcdT