### PR TITLE
coo-bootstrap: load MEM0_API_KEY from op://COO/mem0-vade-coo

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,13 @@ no-op and the cloud env comes up in plain VADE mode.
 ### 1Password vault contract
 
 The service account must have **read** access to a vault named `COO`
-containing four items:
+containing five items:
 
 | Item reference | Type | What it holds |
 |---|---|---|
 | `op://COO/vade-coo-self-2026-04` | API Credential | GitHub fine-grained PAT (`credential` field) |
 | `op://COO/agentmail-vade-coo` | API Credential | AgentMail API key (`credential` field) |
+| `op://COO/mem0-vade-coo` | API Credential | Mem0 Platform API key (`credential` field; prefix `m0-`) — powers the `mem0-rest.sh` break-glass fallback when the Mem0 MCP OAuth transport is degraded |
 | `op://COO/vade-coo-auth` | SSH Key | GitHub auth key (`ed25519`) |
 | `op://COO/vade-coo-sign` | SSH Key | GitHub signing key (`ed25519`) |
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -708,7 +708,7 @@ ensure_gh_symlink_on_path() {
 # read failed.
 fetch_coo_secrets() {
   log "Fetching COO secrets from 1Password vault COO"
-  local github_pat="" agentmail_key=""
+  local github_pat="" agentmail_key="" mem0_key=""
   local got=0
 
   if github_pat="$(retry 3 op read 'op://COO/vade-coo-self-2026-04/credential')" && [ -n "$github_pat" ]; then
@@ -727,6 +727,14 @@ fetch_coo_secrets() {
     log "  WARN: op://COO/agentmail-vade-coo/credential unavailable; AGENTMAIL_API_KEY will be unset"
   fi
 
+  if mem0_key="$(retry 3 op read 'op://COO/mem0-vade-coo/credential')" && [ -n "$mem0_key" ]; then
+    log "  read Mem0 API key (len=${#mem0_key})"
+    got=$((got+1))
+  else
+    mem0_key=""
+    log "  WARN: op://COO/mem0-vade-coo/credential unavailable; MEM0_API_KEY will be unset (mem0-rest.sh break-glass path disabled)"
+  fi
+
   if [ "$got" -eq 0 ]; then
     log "  no COO secrets could be fetched; skipping env file write"
     return 1
@@ -741,15 +749,17 @@ fetch_coo_secrets() {
       [ -n "$github_pat" ]    && echo "export GITHUB_MCP_PAT='$github_pat'"
       [ -n "$github_pat" ]    && echo "export GITHUB_TOKEN='$github_pat'"
       [ -n "$agentmail_key" ] && echo "export AGENTMAIL_API_KEY='$agentmail_key'"
+      [ -n "$mem0_key" ]      && echo "export MEM0_API_KEY='$mem0_key'"
     } > "$env_file"
   )
   chmod 600 "$env_file"
   log "  wrote $env_file (0600)"
 
-  _write_claude_settings_env "$github_pat" "$agentmail_key"
+  _write_claude_settings_env "$github_pat" "$agentmail_key" "$mem0_key"
 
   [ -n "$github_pat" ]    && export GITHUB_MCP_PAT="$github_pat" GITHUB_TOKEN="$github_pat"
   [ -n "$agentmail_key" ] && export AGENTMAIL_API_KEY="$agentmail_key"
+  [ -n "$mem0_key" ]      && export MEM0_API_KEY="$mem0_key"
   return 0
 }
 
@@ -766,7 +776,7 @@ fetch_coo_secrets() {
 # Both are only exported when the corresponding filesystem path
 # exists, so this is a no-op outside the Claude cloud image.
 _write_claude_settings_env() {
-  local pat="$1" agentmail="$2"
+  local pat="$1" agentmail="$2" mem0="$3"
   if ! check_cmd node; then
     log "Warning: node missing; skipping ~/.claude/settings.json env merge"
     return 0
@@ -781,7 +791,7 @@ _write_claude_settings_env() {
   local pw_browsers=""
   [ -d "/opt/pw-browsers" ] && pw_browsers="/opt/pw-browsers"
 
-  GITHUB_MCP_PAT="$pat" AGENTMAIL_API_KEY="$agentmail" \
+  GITHUB_MCP_PAT="$pat" AGENTMAIL_API_KEY="$agentmail" MEM0_API_KEY="$mem0" \
   NODE_PATH="$node_path" PLAYWRIGHT_BROWSERS_PATH="$pw_browsers" node -e '
     const fs = require("fs");
     const path = process.argv[1];
@@ -798,6 +808,9 @@ _write_claude_settings_env() {
     }
     if (process.env.AGENTMAIL_API_KEY) {
       merged.AGENTMAIL_API_KEY = process.env.AGENTMAIL_API_KEY;
+    }
+    if (process.env.MEM0_API_KEY) {
+      merged.MEM0_API_KEY = process.env.MEM0_API_KEY;
     }
     if (process.env.NODE_PATH) {
       merged.NODE_PATH = process.env.NODE_PATH;


### PR DESCRIPTION
## Summary

Wires the Mem0 Platform API key into `fetch_coo_secrets` so the `mem0-rest.sh` break-glass fallback (shipped in #55, documented in MEMO 2026-04-24-05) actually has a key to use in cloud sessions.

- `scripts/lib/common.sh:fetch_coo_secrets` — third `op read` block for `op://COO/mem0-vade-coo/credential`, following the same pattern as `vade-coo-self-2026-04` and `agentmail-vade-coo` (independent missing-item handling; logs a warning, leaves `MEM0_API_KEY` unset, proceeds).
- `scripts/lib/common.sh:_write_claude_settings_env` — accepts a `mem0` arg, propagates it through the node merge into `~/.claude/settings.json` `env` so Claude Code process env picks it up at startup.
- `README.md` — 1Password vault contract table bumped "four items" → "five items" with the new row.

## How it wires end-to-end

1. `coo-bootstrap` SessionStart hook calls `fetch_coo_secrets`.
2. Three independent `op read` calls pull PAT, AgentMail key, Mem0 key. Each failure is isolated.
3. Successful reads write `export VAR=...` to `~/.vade/coo-env` (chmod 600) and merge into `~/.claude/settings.json` `env`.
4. Claude Code reads `settings.json` at process startup; `${MEM0_API_KEY}` substitution in `.mcp.json` and direct access from `mem0-rest.sh` both work.
5. Current shell also gets `export MEM0_API_KEY` so the bootstrap session itself can use it immediately (same pattern as `GITHUB_MCP_PAT`).

## Required op setup (owner)

Create the item in the COO vault before merging — item name **`mem0-vade-coo`**, field **`credential`**, value is the Mem0 Platform API key (prefix `m0-`). Matches the `agentmail-vade-coo` naming.

## Test plan

- [ ] Ven creates `op://COO/mem0-vade-coo` with the Mem0 key
- [ ] New session: `coo-bootstrap` log shows `read Mem0 API key (len=N)` alongside the GitHub PAT + AgentMail lines
- [ ] `env | grep MEM0_API_KEY` shows the key in a fresh shell
- [ ] `~/.claude/settings.json` `env.MEM0_API_KEY` is populated
- [ ] `bash /home/user/vade-runtime/scripts/mem0-rest.sh ping` returns 2xx
- [ ] Delete the op item temporarily; next bootstrap logs the `WARN` line and proceeds without breaking the other two secrets

https://claude.ai/code/session_015G9epcwzNpYkjbGynybgx2