### PR TITLE
memo-index: fail loud on duplicate IDs; memo-sync: restore memo_id primary-key invariant

### DIFF
--- a/.claude/commands/memo-sync.md
+++ b/.claude/commands/memo-sync.md
@@ -14,7 +14,7 @@ Follow the **memo-sync** skill to reconcile Mem0 with the current `coo/memo_inde
 2. Fetch current pointer records: call `mcp__mem0__search_memories` with an empty query and filter
    `{AND: [{user_id: "ven"}, {metadata: {created_by: "coo"}}, {metadata: {memory_type: "memo_pointer"}}]}`,
    `top_k: 100`.
-3. Build a map `{memo_id → [mem0_id, metadata]}` from the results. Any `memo_id` with more than one record is a previous-sync bug: keep the newest by `created_at`, plan to delete the rest.
+3. Build a map `{memo_id → {mem0_id, metadata}}` from the results. `memo_id` is the primary key (mem0_sop.md §2g; `memo-index.sh` enforces uniqueness in the source). Any `memo_id` returning more than one record is a previous-sync or 503-retry duplicate: keep the one whose `(line_start, line_end)` match the index entry, plan to delete the rest.
 4. Diff by `memo_id`:
    - entry in index but **not** in Mem0 → **ADD**
    - entry in Mem0 with `line_start` / `line_end` / `title` / `status` differing from the index → **REPLACE** (delete the old record first, then add — SOP-MEM-001 §3 forbids bare re-add)

--- a/.claude/skills/memo-sync/SKILL.md
+++ b/.claude/skills/memo-sync/SKILL.md
@@ -69,9 +69,11 @@ only:
 - `top_k`: ≥100 (a ceiling large enough to return every pointer;
   the corpus is ~45 memos today).
 
-Build a map `{memo_id → [{mem0_id, metadata}, ...]}` from the
-results. Any memo_id with more than one record is a sync bug from
-a previous run — handle per §Failure modes below.
+Build a map `{memo_id → {mem0_id, metadata}}` from the results.
+`memo_id` is the primary key (mem0_sop.md §2g, enforced by the
+`memo-index.sh` duplicate check). Any memo_id returning more than
+one record is a sync bug from a previous run — handle per
+§Failure modes below.
 
 ### 3. Diff
 
@@ -150,9 +152,17 @@ Always report, even when idle — the point is to confirm currency.
 - **Index and `memos.md` disagree** (e.g., `memo-index.sh` just
   ran but the index still looks stale vs. the markdown). Bug
   upstream. Report line numbers of the disagreement; stop.
-- **More than one Mem0 record shares a `memo_id`.** Previous sync
-  left duplicates. Keep the newest by `created_at`; delete the
-  rest; proceed. Report the cleanup in step 5.
+- **More than one Mem0 record shares a `memo_id`.** Either a
+  previous sync left duplicates, or a Cloudflare-edge 503 retry
+  double-added (the 2026-04-24 failure mode: edge returns 503
+  *after* the Mem0 backend has already committed the write, so a
+  naive retry creates a second record). The `memo-index.sh`
+  fail-loud check rules out duplicate-index-entry as a cause.
+  Keep the record whose `(line_start, line_end)` match the index
+  entry; delete the rest; proceed. Report the cleanup in step 5.
+- **Duplicate memo IDs in `memos.md`.** Should be impossible —
+  `memo-index.sh` exits non-zero before this skill runs. If it
+  happens anyway, stop and report; do not try to sync around it.
 
 ## REST fallback — when the MCP transport is degraded
 

--- a/scripts/mem0-rest.sh
+++ b/scripts/mem0-rest.sh
@@ -171,7 +171,7 @@ case "$cmd" in
       --argjson supersedes "$sup_arg" \
       --arg run_id "$run_id" \
       '{
-        messages: [{role: "system", content: $text}],
+        messages: [{role: "user", content: $text}],
         user_id: "ven",
         infer: false,
         metadata: {

--- a/scripts/memo-index.sh
+++ b/scripts/memo-index.sh
@@ -16,9 +16,11 @@
 #    superseded_by, linked_issues, summary_one_line,
 #    line_start, line_end}
 #
-# Note: the corpus contains duplicate memo IDs (three pairs as of
-# 2026-04-24), so the index must be a JSON *array*, not an object
-# keyed by id. line_start disambiguates duplicates.
+# memo_id is the primary key (per mem0_sop.md §2g). Duplicate IDs
+# in memos.md are a protocol violation and fail the build: the
+# downstream Mem0 memo_pointer layer and the memo-sync skill both
+# key on memo_id, and silent duplicates orphan entries in the
+# semantic layer. Fix the source, not the index.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -156,10 +158,23 @@ for i in "${!headers[@]}"; do
     }' >> "$entries_file"
 done
 
+# Fail loud on duplicate memo IDs. memo_id is the primary key for
+# the downstream Mem0 memo_pointer layer (mem0_sop.md §2g); silent
+# duplicates orphan entries in the semantic layer. If this trips,
+# fix memos.md — do not paper over it in the index.
+dup_ids=$(jq -sr 'group_by(.id) | map(select(length>1)) | .[][0].id' "$entries_file")
+if [ -n "$dup_ids" ]; then
+  echo "[vade-setup] memo-index: FATAL: duplicate memo IDs found in $MEMOS:" >&2
+  while IFS= read -r dup_id; do
+    echo "  $dup_id:" >&2
+    grep -n "^## MEMO $dup_id " "$MEMOS" | sed 's/^/    L/' >&2
+  done <<< "$dup_ids"
+  echo "[vade-setup] memo-index: renumber the later occurrence (convention: append to end of day's -NN sequence). See coo/memo_protocol.md." >&2
+  exit 1
+fi
+
 # Merge entries into an array, compute superseded_by by inverting
 # supersedes_refs across the corpus, and sort newest-first.
-# Tie-break on line_start so duplicate-id pairs have stable order
-# (later-in-file wins, matching chronological intuition).
 generated=$(
   jq -s '
     . as $all |
@@ -167,7 +182,7 @@ generated=$(
       . as $m |
       .superseded_by = ([$all[] | select(.supersedes_refs | index($m.id)) | .id] | unique)
     ) |
-    sort_by([.id, .line_start]) |
+    sort_by(.id) |
     reverse
   ' "$entries_file"
 )


### PR DESCRIPTION
## Summary

Three linked fixes for defects surfaced during Mem0 key-plumbing verification:

1. **`scripts/mem0-rest.sh`** (`role: "system"` → `role: "user"`; commit c6a7fa3). Mem0's `/v1/memories/` REST endpoint silently drops `role: "system"` messages under `infer=false` — returns HTTP 200 with `{"results":[]}` and no record created. Verified: same payload with `role: "user"` → record lands; with `role: "system"` → silent zero. Fix isolated to this one call site.
2. **`scripts/memo-index.sh`** now exits 1 when any memo ID appears more than once in `coo/memos.md`. Prints both offending line numbers and a fix pointer. Prevents the silent-orphan failure mode (see below) from recurring.
3. **`.claude/skills/memo-sync/SKILL.md` + `.claude/commands/memo-sync.md`** simplified: map shape goes back to `{memo_id → single record}` (primary-key invariant from `mem0_sop.md` §2g, now enforced at index time). Failure-modes block re-documents the Cloudflare-503 retry-duplicate case diagnosed 2026-04-24: the edge returns 503 *after* Mem0 has already committed the write, so a naive retry double-adds. Clean up by keeping the record whose `(line_start, line_end)` match the index entry.

## Why this matters

`memo_id` is declared primary key in `mem0_sop.md` §2g. Before this PR: `memo-index.sh` silently tolerated duplicate IDs (a comment at L19-21 acknowledged the issue), the resulting index had duplicate-ID entries, and the `memo-sync` skill's `memo_id →` map silently orphaned second entries. Verification of the semantic layer caught this today.

## Pairs with

[vade-app/vade-coo-memory#109](https://github.com/vade-app/vade-coo-memory/pull/109) — renumber the three duplicate 2026-04-22 IDs to `-10/-11/-12` and update all cross-references. **Merge this PR first** so the new fail-loud check ships before the renumber lands.

## Test plan

- [x] `bash scripts/memo-index.sh` succeeds with the current (post-renumber) corpus
- [x] Injected a duplicate header into a scratch copy of `memos.md`; script exits 1 with both line numbers
- [x] `bash scripts/mem0-rest.sh ping` → HTTP 200 (sanity; unchanged by this PR)
- [x] `bash scripts/mem0-rest.sh add-memo-pointer …` round-trip (add/list/delete) with the `role: "user"` fix — record lands with verbatim text and metadata intact
- [ ] After vade-coo-memory PR merges: `/memo-sync` shows 3 REPLACEs + 44 NOOPs; re-run shows 0 changes

https://claude.ai/code/session_016fJHVFUAy4ccuCSMny9Mws