### PR TITLE
Invert identity-digest MCP-posture banner to match MEMO 2026-04-24-08

### DIFF
--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -310,10 +310,9 @@ if [ -n "${GITHUB_MCP_PAT:-}" ]; then
 else
   printf "  %-25s %s\n" "gh auth token:" "GITHUB_MCP_PAT unset — /resume or check coo-bootstrap"
 fi
-echo "  MCP posture:              github-coo MCP preferred for attributable writes."
-echo "                            On 'Streamable HTTP error: DNS cache overflow',"
-echo "                            fall back to: GH_TOKEN=\$GITHUB_MCP_PAT gh <cmd>."
-echo "                            Same token, vade-coo identity (MEMO 2026-04-23-02)."
+echo "  gh write path:            GH_TOKEN=\$GITHUB_MCP_PAT gh <cmd>  (attributes as vade-coo)."
+echo "                            Harness github MCP is NOT for attributable writes —"
+echo "                            resolves inconsistently. See CLAUDE.md, MEMO 2026-04-24-08."
 echo "───────────────────────────────────────────────────────────────"
 
 # Integrity check summary — the authoritative "did this session's boot


### PR DESCRIPTION
## Summary

SessionStart banner (`scripts/coo-identity-digest.sh` L313–316) previously read *"MCP posture: github-coo MCP preferred for attributable writes"*, which contradicts the post-quorum-#4 CLAUDE.md directive ratified by MEMO 2026-04-24-08 (`vade-coo-memory/pull/101`): `gh + \$GITHUB_MCP_PAT` is the canonical write path; the harness `github` MCP is not for attributable writes (resolves inconsistently — sometimes `venpopov`, sometimes `vade-coo`, sometimes unreachable mid-session).

The old banner's DNS-cache-overflow fallback chain is retired with this patch as well — it framed MCP as primary with `gh` as escape hatch, which is the opposite of the ratified stance.

Discharges **follow-up item 4** from MEMO 2026-04-24-08's post-merge punch list.

## Test plan

- [ ] `bash scripts/coo-identity-digest.sh` at session start prints the new three-line `gh write path` banner and no longer prints the old `MCP posture: github-coo MCP preferred` text
- [ ] The banner text matches the CLAUDE.md "Before opening a PR — use gh" section conceptually: one canonical invocation line + harness-MCP-not-for-writes caveat + citation
- [ ] No other occurrences of the old "MCP preferred" phrasing remain in `scripts/`