### PR TITLE
integrity-check: fix B3/D3 false negatives so summary.ok is a gate

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -105,17 +105,30 @@ done
 [ "$B1_ok" = true ] && B1_detail="all 5 hook scripts present in runtime"
 _add B1 "$B1_ok" "$B1_detail"
 
-# B3: last SessionStart chain outcomes in claude-code.log
+# B3: hook chain outcomes for the current session in boot.log.
+# The prior implementation grepped /tmp/claude-code.log cumulatively,
+# which (a) includes pre-fix historical failures forever and (b) over-
+# matched 'No such file or directory' from unrelated subsystems (e.g.
+# ripgrep probing a missing plugin cache). boot.log is per-hook-run
+# structured JSON; scoping to the most recent cse_* session gives a
+# current-state signal. Issue vade-runtime#41.
 B3_ok=skip
-B3_detail="claude-code.log not readable"
-if [ -r /tmp/claude-code.log ]; then
-  failures="$(grep -c 'Hook SessionStart:startup.*exit_code.*127\|No such file or directory' /tmp/claude-code.log 2>/dev/null || echo 0)"
-  if [ "$failures" -gt 0 ]; then
-    B3_ok=false
-    B3_detail="$failures failing hook entries in claude-code.log (grep on 'No such file')"
+B3_detail="boot.log not readable"
+if [ -r "$HOME/.vade/boot.log" ]; then
+  latest_session="$(grep -oE '"session":"cse_[^"]+' "$HOME/.vade/boot.log" 2>/dev/null | tail -1 | sed 's/^"session":"//')"
+  if [ -n "$latest_session" ]; then
+    failures="$(grep -F "\"session\":\"${latest_session}\"" "$HOME/.vade/boot.log" 2>/dev/null | grep -c '"ok":false' || true)"
+    failures="${failures:-0}"
+    if [ "$failures" -gt 0 ]; then
+      B3_ok=false
+      B3_detail="$failures failing hook entries in current session ($latest_session)"
+    else
+      B3_ok=true
+      B3_detail="no hook failures in current session ($latest_session)"
+    fi
   else
     B3_ok=true
-    B3_detail="no hook failure pattern in claude-code.log"
+    B3_detail="no tagged session in boot.log yet (pre-first-session)"
   fi
 fi
 _add B3 "$B3_ok" "$B3_detail"
@@ -179,7 +192,10 @@ fi
 
 if [ -f "$HOME/.vade/coo-bootstrap.log" ]; then
   tail_line="$(tail -n 1 "$HOME/.vade/coo-bootstrap.log" 2>/dev/null || true)"
-  if printf '%s' "$tail_line" | grep -qE 'OK step=complete|OK step=skip-'; then
+  # 'SKIP marker present' is the idempotent-skip terminal written by
+  # coo-bootstrap.sh when the marker file exists; it is a healthy
+  # resumed-container outcome. Issue vade-runtime#41.
+  if printf '%s' "$tail_line" | grep -qE 'OK step=complete|OK step=skip-|SKIP marker present'; then
     _add D3 true "coo-bootstrap.log tail: $tail_line"
   else
     _add D3 false "coo-bootstrap.log tail non-terminal: $tail_line"


### PR DESCRIPTION
## Summary

- **B3** switched from cumulative grep on `/tmp/claude-code.log` to a per-session negative check on `~/.vade/boot.log`. The old probe accumulated pre-fix historical failures forever and over-matched `"No such file or directory"` from unrelated subsystems (today's false-positive was ripgrep probing a missing `/root/.claude/plugins/cache`).
- **D3** regex extended to accept `SKIP marker present` as a valid idempotent-skip terminal in `~/.vade/coo-bootstrap.log`.

## Verification

On the current session before the fix:

```json
{"summary": {"ok": false, "passed": 14, "total": 16, "degraded": ["B3", "D3"]}}
```

After the fix:

```json
{"summary": {"ok": true, "passed": 16, "total": 16, "degraded": []}}
{"B3": {"ok": true, "detail": "no hook failures in current session (cse_01QDt419razUsRDKj8u85Ym5)"}}
{"D3": {"ok": true, "detail": "coo-bootstrap.log tail: 2026-04-24T17:39:26Z SKIP marker present at /root/.vade/.coo-bootstrap-done"}}
```

Regression test: injected a synthetic `{"session":"cse_01QD…","phase":"end","ok":false,"rc":"127"}` record into `boot.log` — B3 correctly flipped to `ok:false`, `summary.ok=false`. Removed — back to 16/16.

## Design notes

- B3 scopes by the latest `cse_*` session ID found in `boot.log`. Pre-session hook fires (before the harness has assigned a session ID) carry `"session":"unknown"` and are correctly excluded from the window. A brand-new container with no cse_* session yet returns `ok:true` ("pre-first-session") rather than `skip`.
- B3 uses a *negative* check (`count ok:false`) rather than a positive "all starts have matching ends" assertion because `coo-bootstrap.sh`'s idempotent-skip branch clears its `EXIT` trap before `exit 0`, so skip runs emit a dangling `phase:"start"` in `boot.log`. That's pre-existing cosmetic debt unrelated to this bug; deferred as called out in MEMO 2026-04-24-11. A positive check would false-negative on every healthy resumed container.
- D3 chose the regex-extension fix over patching `coo-bootstrap.sh` because the bootstrap-side fix would either emit duplicate log lines per skip run or touch the hot path for no signal gain.

## Test plan

- [x] Fresh cloud session: `summary.ok=true`, 16/16.
- [x] Injected hook failure into `boot.log`: B3 flips to `ok:false`, `summary.ok=false`.
- [x] Removed injection: B3 back to `ok:true`, `summary.ok=true`.

## Paired memo

Merges alongside **MEMO 2026-04-24-11** on `vade-coo-memory` ([companion PR](https://github.com/vade-app/vade-coo-memory/pull/new/claude/audit-bootstrap-logs-32RAq)), which retires MEMO 2026-04-23-03's named-invariant-subset gate and replaces it with `summary.ok=true` + Group E manual discharge. Satisfies issue #41 acceptance clauses 1–4.

Closes #41.

https://claude.ai/code/session_01QDt419razUsRDKj8u85Ym5