### PR TITLE
coo-bootstrap: read PAT from `token` field, not `credential`

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -723,12 +723,12 @@ fetch_coo_secrets() {
   local github_pat="" agentmail_key="" mem0_key=""
   local got=0
 
-  if github_pat="$(retry 3 op read 'op://COO/vade-coo-self-2026-04/credential')" && [ -n "$github_pat" ]; then
+  if github_pat="$(retry 3 op read 'op://COO/vade-coo-self-2026-04/token')" && [ -n "$github_pat" ]; then
     log "  read GitHub PAT (len=${#github_pat})"
     got=$((got+1))
   else
     github_pat=""
-    log "  WARN: op://COO/vade-coo-self-2026-04/credential unavailable; GITHUB_MCP_PAT/GITHUB_TOKEN will be unset"
+    log "  WARN: op://COO/vade-coo-self-2026-04/token unavailable; GITHUB_MCP_PAT/GITHUB_TOKEN will be unset"
   fi
 
   if agentmail_key="$(retry 3 op read 'op://COO/agentmail-vade-coo/credential')" && [ -n "$agentmail_key" ]; then


### PR DESCRIPTION
## Summary

The 1P item `op://COO/vade-coo-self-2026-04` is in the `API_CREDENTIAL` category, which mandates a `token` field. We added a duplicate `credential` field to match the convention used by other COO 1P items — and that duplication is a divergence trap.

This session (`cse_0129gcLbVu7tCctAGZiQ8GTe`) found the two fields holding **different** PATs:
- `token` → 93 chars → authenticates as `vade-coo` ✓
- `credential` → 93 chars → authenticates as `venpopov` ❌

`fetch_coo_secrets` reads `credential`, so it merged a `venpopov`-scoped PAT into `/root/.claude/settings.json` and then failed identity validation. The bad PAT silently propagated for at least one session before validation caught it (per integrity-check Group F4: 5/26 attribution mismatches since the cutoff).

This change reads from the mandatory `token` field instead. Two-line diff in `scripts/lib/common.sh`.

## Operator follow-up (post-merge)

1. Revoke the leaked `venpopov`-scoped PAT on github.com.
2. Delete the now-unused `credential` field on the 1P item.
3. Run `VADE_FORCE_COO_BOOTSTRAP=1` in a fresh cloud session and confirm `summary.ok=true`.

## Lessons (memo-worthy after merge)

- Bootstrap merges fetched env into `settings.json` **before** validating identity. A bad credential degrades the harness on every boot until manually cleaned. Fail-closed (no PAT) is consistent with MEMO 2026-04-23-02; fail-open with a wrong-identity PAT is not. Worth a follow-up to invert the order or stash env until validation passes.
- Mirroring 1P field conventions across templates that mandate different field names (the `API_CREDENTIAL` template forces `token`) creates duplicate slots that can diverge. Convention should follow the template, not fight it.

## Test plan

- [x] Merge to `main`.
- [x] In 1P, delete the `credential` field on `vade-coo-self-2026-04`.
- [ ] In a fresh cloud session, confirm `coo-bootstrap.log` shows `OK step=complete rc=0` and `/root/.vade/.coo-bootstrap-done` marker present.
- [ ] Confirm integrity-check `summary.ok=true` and D2/D3/D4/D5/D6 all pass.