### PR TITLE
cloud-env: wire mem0 MCP through MEM0_API_KEY; skip OAuth on cloud

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "mem0": {
       "type": "http",
-      "url": "https://mcp.mem0.ai/mcp"
+      "url": "https://mcp.mem0.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer ${MEM0_API_KEY}"
+      }
     },
     "agentmail": {
       "command": "npx",

--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -70,7 +70,7 @@ _settings_env_complete() {
     try { cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8")) || {}; }
     catch { process.exit(1); }
     const env = cfg.env || {};
-    const required = ["GITHUB_MCP_PAT", "GITHUB_TOKEN", "AGENTMAIL_API_KEY"];
+    const required = ["GITHUB_MCP_PAT", "GITHUB_TOKEN", "AGENTMAIL_API_KEY", "MEM0_API_KEY"];
     for (const k of required) { if (!env[k]) process.exit(1); }
     process.exit(0);
   ' "$settings" 2>/dev/null

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -210,11 +210,11 @@ if check_cmd node && [ -f "$HOME/.claude/settings.json" ]; then
     let c = {};
     try { c = JSON.parse(fs.readFileSync(process.argv[1], "utf8")) || {}; } catch { process.exit(0); }
     const env = c.env || {};
-    const req = ["GITHUB_MCP_PAT","GITHUB_TOKEN","AGENTMAIL_API_KEY"];
+    const req = ["GITHUB_MCP_PAT","GITHUB_TOKEN","AGENTMAIL_API_KEY","MEM0_API_KEY"];
     process.stdout.write(req.filter(k => !env[k]).join(","));
   ' "$HOME/.claude/settings.json" 2>/dev/null)"
   if [ -z "$D4_missing" ]; then
-    _add D4 true "settings.json env has GITHUB_MCP_PAT, GITHUB_TOKEN, AGENTMAIL_API_KEY"
+    _add D4 true "settings.json env has GITHUB_MCP_PAT, GITHUB_TOKEN, AGENTMAIL_API_KEY, MEM0_API_KEY"
   else
     _add D4 false "settings.json env missing: $D4_missing"
   fi


### PR DESCRIPTION
## Symptom

Mem0 MCP is silently unauthenticated on every cloud-session resume. Episodic Mem0 writes and `/memo-sync` (which depends on Mem0 write access) fail without an explicit error in the agent's view; the deferred-tool list surfaces only `mcp__mem0__authenticate` and `mcp__mem0__complete_authentication`. Recurring across sessions — most recently `cse_0129gcLbVu7tCctAGZiQ8GTe` (2026-04-25T16:08Z–17:35Z) and the prior session log `vade-agent-logs/sessions/2026/04/24/coo-vade-core-44-canvas-save-load-ui-ship.md` ("Mem0 MCP unauthenticated this session; file-only fallback").

## Root cause

The `mem0` entry in `.mcp.json` had no `headers` block:

```json
"mem0": {
  "type": "http",
  "url": "https://mcp.mem0.ai/mcp"
}
```

With no headers, the Claude Code MCP client falls through to its OAuth provider. The Mem0 server returns `401 + WWW-Authenticate: Bearer error="invalid_token"`, advertises `https://mcp.mem0.ai/.well-known/oauth-protected-resource`, and the client builds an authorization URL with `redirect_uri=http://localhost:3118/callback`. On a cloud container, `localhost:3118` is not reachable from Ven's browser, so the OAuth flow can never complete; even when it does on a local surface, the issued tokens live under `/root/.claude/` (ephemeral; resets on every cloud-session resume — see `mcp-needs-auth-cache.json` lifecycle). MCP-client log from the failing session shows the failure mode unambiguously:

```
"hasAuthProvider":true … "No token data found" … "No client info found" …
"Authorization URL: https://mcp.mem0.ai/authorize?…redirect_uri=http%3A%2F%2Flocalhost%3A3118%2Fcallback…"
"HTTP Connection failed after 1400ms: Unauthorized"
"Authentication required for HTTP server"
```

## What I checked

- **Direct probe of the hosted endpoint.** `curl -L -H "Authorization: Bearer ${MEM0_API_KEY}" -X POST https://mcp.mem0.ai/mcp/` with a valid `initialize` payload returns HTTP 200 and a valid MCP `initialize` response (server `mem0` v1.27.0). Same shape works with `Authorization: Token <key>` (Mem0's REST style). API-key Bearer auth is supported on the hosted MCP, in addition to OAuth.
- **Env state.** `MEM0_API_KEY` (len=43, prefix `m0-`) is already present in `~/.claude/settings.json` env, plumbed from `op://COO/mem0-vade-coo/credential` by `_write_claude_settings_env`. No new credential surface required.
- **Pattern precedent.** The `github-coo` MCP entry has used `headers: {Authorization: Bearer ${GITHUB_MCP_PAT}}` since PR #26 / MEMO 2026-04-22-08, with `${...}` substitution resolving against `settings.json` env at MCP-client startup. Same pattern, transferable directly.
- **REST fallback.** `scripts/mem0-rest.sh` already exists and works (`ping` returns 200 with `count: 269` on this container) per MEMO 2026-04-23-02 ("same token, different wire"). It stays in place as the break-glass for future MCP-transport degradations.

## What I ruled out

- Token persistence path. Even if OAuth tokens stored cleanly, the `/root/.claude/` path is wiped on every cloud-session resume — OAuth wouldn't survive across sessions. The Bearer-header fix sidesteps the question entirely.
- "No fix without Ven's auth in the loop." False — the hosted MCP server accepts API-key Bearer auth directly (probed). No browser flow needed.

## Fix

Two coordinated changes:

1. **`.mcp.json`**: add `headers: {Authorization: Bearer ${MEM0_API_KEY}}` to the mem0 entry. Pattern-match the github-coo entry. The substitution resolves at MCP-client startup against `settings.json` env. After this lands, the MCP client sends the Bearer header on first request and gets a valid `initialize` response — OAuth provider is never engaged.

2. **`coo-bootstrap.sh` + `integrity-check.sh`**: extend the env-completeness check to require `MEM0_API_KEY` alongside the existing three keys. This is the same marker-staleness invariant PR #26 / MEMO 2026-04-22-07 added for the GitHub PAT — a snapshot that predates 1Password access to `op://COO/mem0-vade-coo/credential` (or any other reason `_write_claude_settings_env` skipped MEM0) would carry the bootstrap marker forward with `MEM0_API_KEY` unset, the `${MEM0_API_KEY}` substitution would resolve to empty, and Mem0 MCP would 401 silently. With this PR, MEM0 becomes a first-class boot invariant; if it's missing, bootstrap reruns.

## Verification

- `.mcp.json` parses (`integrity-check.sh` C3 still passes).
- `bash scripts/integrity-check.sh` on this container reports D4 ok with the new check: `"settings.json env has GITHUB_MCP_PAT, GITHUB_TOKEN, AGENTMAIL_API_KEY, MEM0_API_KEY"`. Only F4 (commit attribution) remains degraded, unrelated to this PR.
- The MCP transport effect is observable only at session start (the running session can't re-init the mem0 transport). Confidence is high because:
  - The Mem0 server itself accepts the header (probed live).
  - The same `headers + ${ENV_VAR}` pattern already runs cleanly for `github-coo` in this same session.
  - No new code paths are introduced — just a config field, in a place the MCP client already supports.

## Refs

- `vade-coo-memory/CLAUDE.md` §6 (graceful-degradation chain)
- MEMO 2026-04-11-10 (hosted HTTP + OAuth architecture; PAT-fallback noted as available)
- MEMO 2026-04-22-07 (marker-staleness fix; the env-completeness check this extends)
- MEMO 2026-04-22-08 (unified `.mcp.json`)
- MEMO 2026-04-23-02 ("same token, different wire" precedent — `mem0-rest.sh` is the REST break-glass)
- Prior session log: `vade-agent-logs/sessions/2026/04/24/coo-vade-core-44-canvas-save-load-ui-ship.md`

## Test plan

- [ ] After merge, in a fresh cloud session: confirm the deferred-tool list surfaces `get_memories`, `search_memories`, `add_memory` (etc.), not just `authenticate` / `complete_authentication`.
- [ ] In that session, run `mcp__mem0__get_memories({AND: [{user_id: "coo"}]})` to confirm a populated read (CB-* / OG-* records).
- [ ] Run `/memo-sync --dry-run` and confirm a clean diff against `coo/memo_index.json`.
- [ ] Re-run `bash scripts/integrity-check.sh`; D4 detail line should include `MEM0_API_KEY`.

https://claude.ai/code/session_01Ahw3XACMxmYaBrAiYzNHTa