### PR TITLE
cloud-env: allow-list mem0 MCP tools in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,16 @@
     "allow": [
       "mcp__github-coo__*",
 
+      "mcp__mem0__get_memories",
+      "mcp__mem0__search_memories",
+      "mcp__mem0__add_memory",
+      "mcp__mem0__update_memory",
+      "mcp__mem0__delete_memory",
+      "mcp__mem0__get_memory",
+      "mcp__mem0__list_entities",
+      "mcp__mem0__list_events",
+      "mcp__mem0__get_event_status",
+
       "mcp__github__get_me",
       "mcp__github__get_file_contents",
       "mcp__github__get_commit",


### PR DESCRIPTION
## Summary
- Adds `mcp__mem0__*` operational tools (read + safe-write) to `permissions.allow` in `.claude/settings.json`.
- Excludes destructive corpus-wide ops (`delete_all_memories`, `delete_entities`) so they still prompt.
- Mirrors the `mcp__github-coo__*` pattern in place since PR #26 / MEMO 2026-04-22-08.

## Test plan
- [ ] In a fresh cloud session, `mcp__mem0__get_memories({user_id:"coo"})` runs without a permission prompt.
- [ ] `mcp__mem0__delete_all_memories` still prompts (sanity check on the exclusion).
- [ ] `bash scripts/integrity-check.sh` reports D4 still ok.

Closes #69