### PR TITLE
cloud-env: add git-push-with-fallback wrapper for proxy 403 (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,28 @@ Fingerprints validated at boot:
 Mismatch = boot fails. Rotate keys → update fingerprints in
 `scripts/lib/common.sh` (`COO_AUTH_FP_EXPECTED`, `COO_SIGN_FP_EXPECTED`).
 
+### Push fallback for the cloud git proxy
+
+The Claude Code cloud sandbox routes git through a local proxy
+(`http://local_proxy@127.0.0.1:<port>/git/<owner>/<repo>`) that
+intermittently 403s on push and, separately, substitutes a token
+without `workflow` scope on workflow-file pushes
+(`vade-app/vade-runtime#67`).
+
+`scripts/git-push-with-fallback.sh` wraps `git push` and, on a
+proxy-class failure, retries once via
+`https://vade-coo:${GITHUB_MCP_PAT}@github.com/<owner>/<repo>.git`,
+preserving `vade-coo` attribution. Genuine failures (permission
+denied, bad refspec, network down) pass through untouched with
+the original exit status.
+
+```bash
+scripts/git-push-with-fallback.sh -u origin claude/my-branch
+```
+
+Requires `GITHUB_MCP_PAT` in env — populated by `coo-bootstrap.sh`
+at session start.
+
 ### Extending to other sub-agents
 
 The pattern is copyable. For a new agent (e.g., Night's Watch, PM

--- a/scripts/git-push-with-fallback.sh
+++ b/scripts/git-push-with-fallback.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# git push wrapper with direct-URL fallback for the cloud git-proxy 403 issue.
+#
+# The Claude Code cloud sandbox routes git through a local proxy at
+# 127.0.0.1:<port>/git/<owner>/<repo>. The proxy intermittently returns
+# HTTP 403 on push (often only the second push onward of a session) and,
+# separately, substitutes a token without `workflow` scope on workflow-file
+# pushes. Pushing directly to github.com with the COO PAT is reliable.
+# See vade-app/vade-runtime#67 for the diagnostic write-up.
+#
+# Usage:
+#   scripts/git-push-with-fallback.sh [<git push args>...]
+#
+# Behaviour:
+#   1. Run `git push <args>`.
+#   2. On non-zero exit, scan output for proxy-class failure markers.
+#      Match → reconstruct the same push against
+#      https://vade-coo:${GITHUB_MCP_PAT}@github.com/<owner>/<repo>.git
+#      and retry exactly once.
+#      No match (genuine permission denial, bad refspec, etc.) → exit
+#      with the original status, no retry.
+#
+# Requires GITHUB_MCP_PAT in the environment for the fallback path. If
+# unset, the wrapper passes the original failure through with a
+# pointer at coo-bootstrap.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+. "$SCRIPT_DIR/lib/common.sh"
+
+# Patterns that indicate the harness git proxy refused or dropped the push.
+# Anything matching is eligible for the direct-URL fallback. Keep this
+# list narrow — we don't want to retry genuine permission errors.
+readonly PROXY_FAILURE_PATTERNS='HTTP 403|send-pack: unexpected disconnect|the remote end hung up unexpectedly|refusing to allow an OAuth App|workflow.*scope'
+
+resolve_remote_from_args() {
+  local a
+  for a in "$@"; do
+    case "$a" in
+      -*) continue ;;
+      *) printf '%s' "$a"; return 0 ;;
+    esac
+  done
+  printf 'origin'
+}
+
+extract_repo_path() {
+  local url="$1"
+  local path
+  # Proxy form: http(s)://[user@]host[:port]/git/owner/repo[.git]
+  path="$(printf '%s' "$url" | sed -nE 's#^https?://[^/]+/git/(.+)$#\1#p')"
+  printf '%s' "${path%.git}"
+}
+
+PUSH_OUT_TMP=""
+cleanup() { [ -n "${PUSH_OUT_TMP:-}" ] && rm -f "$PUSH_OUT_TMP"; }
+trap cleanup EXIT
+
+main() {
+  if ! PUSH_OUT_TMP="$(mktemp 2>/dev/null)"; then
+    log_err "mktemp failed; running git push directly with no fallback"
+    exec git push "$@"
+  fi
+  local tmp="$PUSH_OUT_TMP"
+
+  local rc=0
+  git push "$@" 2>&1 | tee "$tmp"
+  rc="${PIPESTATUS[0]}"
+  if [ "$rc" -eq 0 ]; then
+    return 0
+  fi
+
+  if ! grep -qE "$PROXY_FAILURE_PATTERNS" "$tmp"; then
+    log_err "git push failed (rc=$rc) with no proxy-failure marker; passing through"
+    return "$rc"
+  fi
+
+  if [ -z "${GITHUB_MCP_PAT:-}" ]; then
+    log_err "git proxy push failed but GITHUB_MCP_PAT is unset; cannot fall back"
+    log_err "  run scripts/coo-bootstrap.sh (or source ~/.vade/coo-env) to populate it"
+    return "$rc"
+  fi
+
+  local remote current_url repo_path
+  remote="$(resolve_remote_from_args "$@")"
+  if ! current_url="$(git remote get-url "$remote" 2>/dev/null)" || [ -z "$current_url" ]; then
+    log_err "could not resolve remote '$remote'; not falling back"
+    return "$rc"
+  fi
+  case "$current_url" in
+    *github.com*)
+      log_err "remote '$remote' already targets github.com; failure is not proxy-related"
+      return "$rc"
+      ;;
+  esac
+  repo_path="$(extract_repo_path "$current_url")"
+  if [ -z "$repo_path" ]; then
+    log_err "could not extract owner/repo from '$current_url'; not falling back"
+    return "$rc"
+  fi
+
+  local direct_url="https://vade-coo:${GITHUB_MCP_PAT}@github.com/${repo_path}.git"
+  local masked_url="https://vade-coo:***@github.com/${repo_path}.git"
+  log_err "git proxy push failed; retrying via $masked_url"
+
+  local -a new_args=()
+  local seen=0 a
+  for a in "$@"; do
+    if [ "$seen" -eq 0 ] && [ "$a" = "$remote" ]; then
+      new_args+=("$direct_url")
+      seen=1
+    else
+      new_args+=("$a")
+    fi
+  done
+  if [ "$seen" -eq 0 ]; then
+    local current_branch
+    current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+    if [ -z "$current_branch" ]; then
+      log_err "no remote in args and detached HEAD; cannot construct fallback push"
+      return "$rc"
+    fi
+    new_args+=("$direct_url" "HEAD:refs/heads/$current_branch")
+  fi
+
+  git push "${new_args[@]}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds `scripts/git-push-with-fallback.sh`, a thin wrapper around `git push` that retries once via a direct `https://vade-coo:$GITHUB_MCP_PAT@github.com/<owner>/<repo>.git` URL when the cloud git-proxy returns a known proxy-class failure. Closes the third investigation direction in #67 ("git's RPC retry — wrapper that retries on these specific errors with the direct URL fallback would be a low-cost mitigation while the root cause is investigated").

The wrapper:

- runs `git push <args>` first
- on non-zero exit, scans for `HTTP 403`, `send-pack: unexpected disconnect`, `the remote end hung up unexpectedly`, `refusing to allow an OAuth App`, or `workflow.*scope`
- on a match, rebuilds the args with the direct URL and retries exactly once
- on no match (genuine permission denial, bad refspec, network down), passes the original failure through with its exit code

Preserves `vade-coo` attribution because the same PAT is used. Requires `GITHUB_MCP_PAT` in env — `coo-bootstrap.sh` populates it.

This is a mitigation, not a root-cause fix. The two remaining investigation directions from #67 — proxy auth-state decay and per-session token-scope drift — stay open. Issue stays open until those are diagnosed or the mitigation is widely adopted.

## Test plan

- [x] `bash -n` passes on the wrapper
- [x] No-arg-style passthrough on a clean working tree returns "Everything up-to-date" with exit 0 (verified locally on `claude/vade-runtime-issue-67-Csg05`)
- [x] `bash scripts/git-push-with-fallback.sh -u origin <branch>` pushed this very PR's commit `76912ef` through the proxy with exit 0 (proxy healthy on this push; fallback path not exercised)
- [ ] Fallback path exercised on a proxy 403 (opportunistic — fires the next time the proxy degrades; acceptable as future evidence rather than CI-gated)

## Adoption

The wrapper is callable from any session. Future sessions can adopt it implicitly by calling `scripts/git-push-with-fallback.sh` instead of `git push` from agent loops, hooks, or interactive shells. No SessionStart wiring is included in this PR — adopting it as the default `git push` path is a separate decision that merits its own discussion (could be a `git config alias.push 'push-with-fallback'`-style indirection, or a settings.json hook).

Refs MEMO 2026-04-23-02 (cloud-env posture: own tokens, keep attribution under vade-coo when MCP fails) — same reliability class, different transport.