### PR TITLE
Bootstrap identity hygiene bundle: env-merge order, cached-PAT recheck, bindir, digest path

### DIFF
--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -77,16 +77,28 @@ _settings_env_complete() {
 }
 if [ "${VADE_FORCE_COO_BOOTSTRAP:-0}" != "1" ] \
    && [ -f "$COO_ENV_FILE" ] && [ -f "$COO_BOOT_MARKER" ] \
-   && _settings_env_complete; then
+   && _settings_env_complete \
+   && _cached_pat_still_valid; then
   log "coo-bootstrap: already complete this container; skipping."
   COO_BOOTSTRAP_STEP="skip-marker-present"
-  bootstrap_log_record SKIP "marker present at $COO_BOOT_MARKER"
+  bootstrap_log_record SKIP "marker present at $COO_BOOT_MARKER (cached PAT validated)"
   trap - EXIT
   exit 0
 fi
 if [ -f "$COO_BOOT_MARKER" ] && [ "${VADE_FORCE_COO_BOOTSTRAP:-0}" != "1" ]; then
-  log "coo-bootstrap: marker present but settings.json env incomplete; re-running"
-  bootstrap_log_record START "marker stale (settings.json env missing keys); forcing re-run"
+  # Marker exists but at least one shortcut precondition failed:
+  # settings.json env block is missing a key (pre-#18 bootstrap, see
+  # comment above), or the cached PAT no longer authenticates as
+  # vade-coo (#72 — revocation/scope-change/expiry between snapshots).
+  # Fall through to the full bootstrap to refresh both.
+  if [ -f "$COO_ENV_FILE" ] && _settings_env_complete \
+     && ! _cached_pat_still_valid; then
+    log "coo-bootstrap: marker present but cached GITHUB_MCP_PAT no longer authenticates as vade-coo; re-running"
+    bootstrap_log_record START "marker stale (cached PAT failed validation); forcing re-run"
+  else
+    log "coo-bootstrap: marker present but settings.json env incomplete; re-running"
+    bootstrap_log_record START "marker stale (settings.json env missing keys); forcing re-run"
+  fi
 fi
 
 log "coo-bootstrap: starting"
@@ -113,8 +125,18 @@ fetch_coo_secrets
 COO_BOOTSTRAP_STEP="write_coo_gitconfig"
 write_coo_gitconfig
 
+# Validate BEFORE merging into ~/.claude/settings.json (#66): a
+# wrong-identity PAT must never land in the harness's persistent env
+# block. fetch_coo_secrets stages secrets in ~/.vade/coo-env and exports
+# them to this shell so validate_coo_identity can hit api.github.com;
+# only after that succeeds does merge_coo_settings_env write the PAT
+# into settings.json. set -e ensures we exit before merge on validate
+# failure.
 COO_BOOTSTRAP_STEP="validate_coo_identity"
 validate_coo_identity
+
+COO_BOOTSTRAP_STEP="merge_coo_settings_env"
+merge_coo_settings_env
 
 COO_BOOTSTRAP_STEP="summarize_coo_identity"
 summarize_coo_identity

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -185,7 +185,7 @@ else
   echo ""
   echo "  WARN: identity is degraded — required env vars are missing."
   echo "  Inspect $BOOTSTRAP_LOG for the failing step, then re-run:"
-  echo "    VADE_FORCE_COO_BOOTSTRAP=1 bash \"${CLAUDE_PROJECT_DIR:-/home/user/vade-runtime}/scripts/coo-bootstrap.sh\""
+  echo "    VADE_FORCE_COO_BOOTSTRAP=1 bash \"${SCRIPT_DIR}/coo-bootstrap.sh\""
 fi
 
 # Classify OP_SERVICE_ACCOUNT_TOKEN visibility across build/session. The

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -596,6 +596,18 @@ GH_VERSION_DEFAULT="2.91.0"
 COO_AUTH_FP_EXPECTED="SHA256:9vxJc6c69L8eaR6CvwdZoYDco24W6yN6GkKwnsm8Uys"
 COO_SIGN_FP_EXPECTED="SHA256:pZeA8xycAtIsVGwhMzR3mg4KG05n9ksFuy4F1ZVXn3A"
 
+# Snapshot-persistent user bindir. Cloud harness runs as root and the
+# /home/user/ tree survives snapshot → resume; local Mac has no
+# /home/user/ and runs as the operator's user, so $HOME/.local/bin is
+# the right target. Both ensure_op_cli and ensure_gh_cli install here.
+_snapshot_user_bindir() {
+  if [ "$(id -u)" = "0" ] && [ -d /home/user ]; then
+    printf '/home/user/.local/bin'
+  else
+    printf '%s/.local/bin' "$HOME"
+  fi
+}
+
 ensure_op_cli() {
   # Install into a snapshot-persistent path so a build-time install is
   # still on disk at session-resume time. /root/ resets each resume in
@@ -605,7 +617,8 @@ ensure_op_cli() {
   # egress proxy is flaky (see run-2026-04-22T062313 and
   # run-2026-04-22T213126: "DNS cache overflow" 503 from the egress
   # gateway, both times).
-  local bindir="/home/user/.local/bin"
+  local bindir
+  bindir="$(_snapshot_user_bindir)"
   case ":$PATH:" in
     *":$bindir:"*) ;;
     *) export PATH="$bindir:$PATH" ;;
@@ -672,9 +685,8 @@ ensure_op_cli() {
 # Linux-only auto-install. On macOS (Darwin) the expectation is that
 # `brew install gh` has already satisfied check_cmd; if it hasn't, this
 # function refuses rather than dropping a non-runnable Linux binary
-# into ${HOME}/.local/bin. ensure_op_cli is currently Linux-only too
-# but hardcodes its bindir; aligning that pattern is tracked separately
-# so this PR stays scoped.
+# into ${HOME}/.local/bin. Bindir resolution is shared with ensure_op_cli
+# via _snapshot_user_bindir.
 #
 # Rationale: vade-app/vade-runtime#36 documents the mcp__github-coo__*
 # streamable-HTTP transport failure ("DNS cache overflow") that forces
@@ -686,11 +698,7 @@ ensure_op_cli() {
 # invariant stays load-bearing even when the primary MCP is down.
 ensure_gh_cli() {
   local bindir
-  if [ "$(id -u)" = "0" ] && [ -d /home/user ]; then
-    bindir="/home/user/.local/bin"
-  else
-    bindir="${HOME}/.local/bin"
-  fi
+  bindir="$(_snapshot_user_bindir)"
   case ":$PATH:" in
     *":$bindir:"*) ;;
     *) export PATH="$bindir:$PATH" ;;
@@ -839,12 +847,27 @@ fetch_coo_secrets() {
   chmod 600 "$env_file"
   log "  wrote $env_file (0600)"
 
-  _write_claude_settings_env "$github_pat" "$agentmail_key" "$mem0_key"
-
+  # Export to current shell so validate_coo_identity (which reads
+  # $GITHUB_MCP_PAT) sees the freshly-fetched PAT. settings.json mutation
+  # happens later in merge_coo_settings_env, only after validation
+  # passes — see #66 (env-merge-before-validate).
   [ -n "$github_pat" ]    && export GITHUB_MCP_PAT="$github_pat" GITHUB_TOKEN="$github_pat"
   [ -n "$agentmail_key" ] && export AGENTMAIL_API_KEY="$agentmail_key"
   [ -n "$mem0_key" ]      && export MEM0_API_KEY="$mem0_key"
   return 0
+}
+
+# Merge the (now-validated) COO env into ~/.claude/settings.json. Called
+# from coo-bootstrap.sh AFTER validate_coo_identity, so a wrong-identity
+# PAT never lands in the harness's persistent state. Reads from the
+# already-exported environment populated by fetch_coo_secrets — keeps
+# the call symmetric with the shell-export step there. See #66 for
+# the env-merge-before-validate failure mode this ordering closes.
+merge_coo_settings_env() {
+  _write_claude_settings_env \
+    "${GITHUB_MCP_PAT:-}" \
+    "${AGENTMAIL_API_KEY:-}" \
+    "${MEM0_API_KEY:-}"
 }
 
 # Merge COO env vars into ~/.claude/settings.json "env" object. Claude
@@ -1090,6 +1113,23 @@ validate_coo_identity() {
     return 1
   fi
   log "GitHub PAT valid for: $login"
+}
+
+# Quiet variant for the marker-shortcut precondition (#72): probes the
+# already-cached $GITHUB_MCP_PAT and returns 0 only when GitHub
+# confirms login=vade-coo. No retries (the marker shortcut is a fast
+# path; if the network is down, fall through to the full bootstrap
+# which has its own retry budget). No log output on the happy path —
+# only on fail-and-fall-through, so the operator sees why the marker
+# was bypassed. Single curl, hard 5s timeout — keeps the SessionStart
+# happy path within the existing budget envelope.
+_cached_pat_still_valid() {
+  [ -n "${GITHUB_MCP_PAT:-}" ] || return 1
+  local body login
+  body="$(curl -sfH "Authorization: Bearer ${GITHUB_MCP_PAT}" --max-time 5 \
+                  https://api.github.com/user 2>/dev/null)" || return 1
+  login="$(printf '%s' "$body" | grep -oE '"login"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"([^"]*)"$/\1/')"
+  [ "$login" = "vade-coo" ]
 }
 
 summarize_coo_identity() {


### PR DESCRIPTION
## Summary

Bundle B1 from the bootstrap / cloud-env hardening audit (#75). Closes four issues that converge on `scripts/coo-bootstrap.sh`, `scripts/lib/common.sh`, and `scripts/coo-identity-digest.sh`.

| # | Failure mode | Fix shape |
|---|---|---|
| **#66** | env-merge-before-validate: a wrong-identity PAT lands in `~/.claude/settings.json` *before* `validate_coo_identity` runs, poisoning harness state across sessions even when validation FATAL's loudly. | Split `fetch_coo_secrets` into stage (writes only `~/.vade/coo-env` + exports to current shell) and `merge_coo_settings_env` (writes settings.json). `coo-bootstrap.sh` calls `merge_coo_settings_env` only after `validate_coo_identity`; `set -e` keeps a failed validate from reaching the merge. |
| **#72** | Marker-shortcut trusts a previously-cached PAT even after revocation/expiry/scope-change. | Add `_cached_pat_still_valid` quiet probe (single curl, 5s timeout, no retries) as a third precondition to the shortcut. On failure, fall through to the full bootstrap and re-fetch. |
| **#39** | `ensure_op_cli` hardcodes `/home/user/.local/bin`; on Mac via `local-setup.sh → coo-bootstrap.sh → ensure_op_cli`, `mkdir -p /home/user/.local/bin` permission-denies. | Extract `_snapshot_user_bindir` helper; both `ensure_op_cli` and `ensure_gh_cli` use it. Cloud path byte-for-byte identical; Mac falls back to `$HOME/.local/bin`. |
| **#73** | `coo-identity-digest.sh:188` SessionStart remediation hint uses `${CLAUDE_PROJECT_DIR:-/home/user/vade-runtime}/scripts/coo-bootstrap.sh`. When the harness sets `CLAUDE_PROJECT_DIR=/home/user` (witnessed in run-2026-04-25T182206 per integrity invariant B5 drift), the rendered string points at a path that does not exist. | Use the script's own `SCRIPT_DIR` (already defined at line 15). Sibling-file resolution; immune to `CLAUDE_PROJECT_DIR` drift. |

## Files

- `scripts/coo-bootstrap.sh` — new ordering (`fetch → validate → merge`); marker-shortcut adds `_cached_pat_still_valid` precondition + clearer log when the cached PAT is the reason for falling through.
- `scripts/lib/common.sh` — adds `_snapshot_user_bindir`, `_cached_pat_still_valid`, `merge_coo_settings_env`. `fetch_coo_secrets` no longer touches settings.json (only the env file + shell exports).
- `scripts/coo-identity-digest.sh` — one-line change: `${CLAUDE_PROJECT_DIR:-…}/scripts/coo-bootstrap.sh` → `${SCRIPT_DIR}/coo-bootstrap.sh`.

## Test plan

### Cloud (this session, ad-hoc)
- [x] `bash -n` on all three modified scripts: pass.
- [x] `source common.sh; type` on the three new functions: all defined.
- [x] `_snapshot_user_bindir` → `/home/user/.local/bin` on cloud surface.
- [x] `_cached_pat_still_valid` with current `$GITHUB_MCP_PAT` → 0; with bogus PAT → 1.
- [x] Rendered remediation string under `CLAUDE_PROJECT_DIR=/home/user`: `bash "/home/user/vade-runtime/scripts/coo-bootstrap.sh"` — correct.

### Cloud (REQUIRED before merge — #66 / #72 are the witnessed failure surface)
- [ ] **#66 fail-closed:** stage wrong-identity PAT in 1P sibling field; force-bootstrap; assert `~/.claude/settings.json` env contains no `GITHUB_MCP_PAT` after exit; assert `~/.vade/.coo-bootstrap-done` not created; integrity-check D4 reports `settings.json env missing` (correct fail-closed) rather than carrying the wrong PAT forward.
- [ ] **#66 happy path:** with a correct PAT in 1P, full bootstrap completes end-to-end, settings.json gets the merged env, marker is created.
- [ ] **#72 stale-PAT:** revoke cached PAT externally; re-run `bash scripts/coo-bootstrap.sh` with marker present; assert it does NOT skip via the shortcut, proceeds to re-fetch.
- [ ] **#72 happy path:** with valid cached PAT, shortcut still fires (no regression).

### Mac (BLOCKING for #39 and #73 — failure modes are Mac-specific)
- [x] **#39:** with `op` not pre-installed (uninstall via `brew uninstall 1password-cli` if present), run `bash scripts/local-setup.sh` (or invoke `ensure_op_cli` directly). Assert it does NOT die on `mkdir: Permission denied` for `/home/user/`. Assert `op` lands at `${HOME}/.local/bin/op` and is runnable. With `brew install 1password-cli` pre-staged, assert `check_cmd op` short-circuits and the install branch never runs.
- [x] **#73:** `bash scripts/coo-identity-digest.sh` with `CLAUDE_PROJECT_DIR` unset, then with `CLAUDE_PROJECT_DIR=~/GitHub/vade-app/vade-runtime`, then with `CLAUDE_PROJECT_DIR=/some/wrong/path`. In all three cases the remediation block (when it fires) should print the absolute path of the *actual* `coo-bootstrap.sh`, never a path that doesn't exist. To trigger the remediation block, run with no `$GITHUB_MCP_PAT` so the env-degraded branch fires.

## Deferred / out-of-scope

- Option (c) from #66 (active strip of GITHUB_MCP_PAT/GITHUB_TOKEN from settings.json on validate failure). With this PR's option-(a) fix in place, settings.json is untouched on validate failure — a previously-good cached PAT survives (desirable; clobbering it would be the wrong default), and a wrong-identity PAT was never persisted (the failure mode this issue exists to close).
- F4 historical attribution (5 commits): tracked separately at vade-coo-memory#130 + MEMO 2026-04-25-02's `ven-human-action:` convention, per audit §6.

## References

- Parent epic: #75
- Audit doc: `vade-coo-memory/.vade/plans/bootstrap-cloud-env-hardening-audit-2026-04-25.md`
- Memos: 2026-04-25-02 (#66 source), 2026-04-25-04 (data-ownership refactor for transport policy that landed via #137)

Closes #66
Closes #72
Closes #39
Closes #73
## Handoff prompt for next instance

> Verify vade-runtime#78 (bootstrap identity hygiene bundle) — `coo-bootstrap.sh`, `lib/common.sh`, `coo-identity-digest.sh` were modified. Cloud verification for #66/#72 + Mac verification for #39/#73 are gating the merge.
>
> **On a fresh CLOUD container after #78 lands:**
>
> 1. Confirm scripts updated:
>    `grep -c 'merge_coo_settings_env\|_cached_pat_still_valid\|_snapshot_user_bindir' /home/user/vade-runtime/scripts/lib/common.sh`
>    Expect: ≥3 (one per new function definition).
>
> 2. **#66 happy path:** the boot you're in already exercised the new ordering. Check `cat ~/.vade/coo-bootstrap.log | tail -5` — last line should be `OK step=complete rc=0`. Inspect `cat ~/.claude/settings.json | jq '.env | keys'` — expect `GITHUB_MCP_PAT`, `GITHUB_TOKEN`, `AGENTMAIL_API_KEY`, `MEM0_API_KEY` all present. If degraded, fail this step; investigate per `~/.vade/coo-bootstrap.log`.
>
> 3. **#66 fail-closed (manual):** ask Ven to temporarily put a wrong-identity PAT in `op://COO/vade-coo-self-2026-04/token`. Then `rm -f ~/.vade/.coo-bootstrap-done && VADE_FORCE_COO_BOOTSTRAP=1 bash /home/user/vade-runtime/scripts/coo-bootstrap.sh` — it must FATAL at `validate_coo_identity` AND leave `~/.claude/settings.json` env without `GITHUB_MCP_PAT` (run `cat ~/.claude/settings.json | jq '.env.GITHUB_MCP_PAT // empty'` — expect empty output) AND not create `~/.vade/.coo-bootstrap-done`. Restore the correct PAT and re-run to recover.
>
> 4. **#72 stale-PAT shortcut bypass:** with marker present and a *previously-valid PAT now revoked*, run `bash /home/user/vade-runtime/scripts/coo-bootstrap.sh` and confirm log says `marker stale (cached PAT failed validation); forcing re-run`. (If you can't revoke a PAT for this test, simulate by hand-editing `~/.claude/settings.json` to put a bogus token in `env.GITHUB_MCP_PAT`, then re-run.)
>
> 5. **#73 path resolver:** \`CLAUDE_PROJECT_DIR=/home/user bash /home/user/vade-runtime/scripts/coo-identity-digest.sh 2>&1 | grep VADE_FORCE_COO_BOOTSTRAP\` — must print the literal \`bash "/home/user/vade-runtime/scripts/coo-bootstrap.sh"\` (correct path), not \`/home/user/scripts/coo-bootstrap.sh\`. Trigger the remediation block by unsetting GITHUB_MCP_PAT in the digest's process: \`env -u GITHUB_MCP_PAT bash /home/user/vade-runtime/scripts/coo-identity-digest.sh | tail -20\` and look for the \`WARN: identity is degraded\` block.
>
> **On Mac (BLOCKING for #39 and #73 — must run on a Mac before clicking merge):**
>
> 6. **#39 — without brew op:** \`brew uninstall 1password-cli 2>/dev/null; rm -f ~/.local/bin/op\` then \`bash ~/GitHub/vade-app/vade-runtime/scripts/coo-bootstrap.sh\` (with a valid OP_SERVICE_ACCOUNT_TOKEN in env). Must NOT die on \`mkdir: Permission denied\` for \`/home/user/\`. After completion, \`ls -la ~/.local/bin/op\` and \`~/.local/bin/op --version\` should both succeed. Then \`brew install 1password-cli\` and re-run \`bash scripts/coo-bootstrap.sh\` — \`ensure_op_cli\` should short-circuit at \`check_cmd op\`.
>
> 7. **#73 on Mac:** \`unset CLAUDE_PROJECT_DIR; env -u GITHUB_MCP_PAT bash ~/GitHub/vade-app/vade-runtime/scripts/coo-identity-digest.sh | grep VADE_FORCE_COO_BOOTSTRAP\` — must print \`bash "/Users/<you>/GitHub/vade-app/vade-runtime/scripts/coo-bootstrap.sh"\` (or wherever the user's clone is). Then \`CLAUDE_PROJECT_DIR=/some/wrong/path env -u GITHUB_MCP_PAT bash ~/GitHub/vade-app/vade-runtime/scripts/coo-identity-digest.sh | grep VADE_FORCE_COO_BOOTSTRAP\` — same correct absolute path, regardless of \`CLAUDE_PROJECT_DIR\`.
>
> **On any failure:** check \`~/.vade/coo-bootstrap.log\` and \`~/.vade-cloud-state/build.log\` (cloud) or equivalent under \`~/.vade/local-state/\` (Mac). The trap in \`coo-bootstrap.sh\` records exit step + rc on every run. If the regression is not obvious, revert this PR rather than patch-on-top.
>
> **Followup blocked by #78:** none — Phase 1 of the audit is independent across the three PRs (#78, #79, #80). After #78 merges, no other queued work depends on it.
>
> **Greeting:** verify first, then greet with the bottom-line state-of-the-bundle.
