### PR TITLE
Lift retry budget for 1P egress paths from 3 to 5 attempts

### DIFF
--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -96,9 +96,13 @@ COO_BOOTSTRAP_STEP="ensure_op_cli"
 ensure_op_cli
 
 # Verify the service-account token before attempting any reads. Retry
-# to absorb transient 1Password API errors (503s).
+# to absorb transient 1Password API errors (503s). 5 attempts
+# (~15s tolerance) matches _op_to_file's already-tuned budget
+# (lib/common.sh _op_to_file) — same flake mode. #76 propagates the
+# proven budget here after run-2026-04-25T182206 exhausted the
+# prior 3-attempt budget on a transient api.1password.com hiccup.
 COO_BOOTSTRAP_STEP="op_whoami"
-if ! retry 3 op whoami >/dev/null; then
+if ! retry 5 op whoami >/dev/null; then
   log "FATAL: op whoami failed after retries. Check OP_SERVICE_ACCOUNT_TOKEN and vault access."
   exit 1
 fi

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -631,10 +631,12 @@ ensure_op_cli() {
   local tmp
   tmp="$(mktemp -d)"
   log "Downloading op CLI v${version} (${arch}) → $bindir"
-  # cache.agilebits.com occasionally returns 5xx; retry absorbs the transient
-  # window. Even with the build-time install above, retries are still useful
-  # when the snapshot is cold and this is the first install.
-  if ! retry 3 curl -sfL "$url" -o "$tmp/op.zip"; then
+  # cache.agilebits.com occasionally returns 5xx; retry absorbs the
+  # transient window. 5 attempts (~15s tolerance) matches _op_to_file's
+  # already-tuned budget (line ~942) — same egress origin class, same
+  # flake pattern. Witnessed exhaustion of the prior 3-attempt budget
+  # in run-2026-04-25T182206; #76 propagates the proven budget here.
+  if ! retry 5 curl -sfL "$url" -o "$tmp/op.zip"; then
     log "op CLI download failed after retries: $url"
     rm -rf "$tmp"
     return 1


### PR DESCRIPTION
## Summary

Two-line retry-budget tuning, plus a comment update that captures the rationale + witnessed-failure reference. Closes #76.

`retry()` in `lib/common.sh` defaults to `tries=3` (~3s of network tolerance via 1s+2s backoff). Two of the three SessionStart-critical 1Password egress paths inherited this default and were demonstrably killed by transient hiccups exceeding the budget:

| Caller | Endpoint | Was | Now |
|---|---|---|---|
| `ensure_op_cli` curl | `cache.agilebits.com` | `retry 3` | `retry 5` |
| `op_whoami` (coo-bootstrap.sh) | `api.1password.com` | `retry 3` | `retry 5` |

`_op_to_file` is already at `retry 5` (~15s tolerance) per the cold-start precedent on `run-2026-04-22T091701`; that lesson didn't propagate to its siblings. `run-2026-04-25T182206` exhausted both 3-attempt budgets in the same session (the trigger event for #76).

## What stays the same
- The `retry()` helper itself.
- Happy path: first attempt succeeds → returns immediately. No behavior change.
- `_op_to_file` (already at 5).

## Test plan

### Cloud (REQUIRED before merge)
- [x] `bash -n` on both modified scripts: pass.
- [ ] **Witnessed-failure repro:** simulate a 5-second egress hiccup at SessionStart (e.g. iptables drop on `cache.agilebits.com` or `api.1password.com` for 5s, then release). Confirm bootstrap clears past it without operator `VADE_FORCE_COO_BOOTSTRAP=1` intervention. Pre-PR baseline: bootstrap dies at the failing step.
- [ ] **Happy-path no-regression:** healthy SessionStart on a fresh container completes within current p50 timing (no extra latency from the budget bump because retries only fire on failure).

### Mac
Mac doesn't share the cloud egress topology, but a smoke check of bootstrap timing on the happy path confirms no regression. Retry only kicks in on failure; first-attempt-success is byte-for-byte identical.

## Out of scope (per audit)

- Circuit breaker or alternate egress path. Architectural, not a budget tweak.
- Re-shaping `retry()` itself (jittered backoff, configurable strategy). Exponential 1+2+4+8+16 already gives more late-attempt headroom; raising `tries` is the cheapest correct fix.
- Git-push proxy 403 (#67/#74). Same reliability family, different transport (proxy vs direct egress), different mitigation (URL fallback vs longer retry).

## References
- Parent epic: #75
- Audit doc: `vade-coo-memory/.vade/plans/bootstrap-cloud-env-hardening-audit-2026-04-25.md`
- In-source precedent: `lib/common.sh` `_op_to_file` (retry 5)

Closes #76
## Handoff prompt for next instance

> Verify vade-runtime#79 (retry budget 3→5 for ensure_op_cli + op_whoami) on a fresh container after merge. No Mac verification needed — Mac doesn't share the cloud egress topology.
>
> **Happy-path verification (any healthy SessionStart):**
>
> 1. Confirm changes landed:
>    `grep -E 'retry 5 (curl|op whoami)' /home/user/vade-runtime/scripts/coo-bootstrap.sh /home/user/vade-runtime/scripts/lib/common.sh`
>    Expect: 2 hits (one per call site).
>
> 2. SessionStart timing not regressed:
>    `tail -20 ~/.vade/coo-bootstrap.log` — first attempt of `ensure_op_cli` and `op_whoami` should still succeed in <1s on the happy path. The retry budget only kicks in on failure; first-attempt-success is byte-for-byte identical to pre-PR.
>
> **Witnessed-failure repro (REQUIRED before merging):**
>
> 3. Simulate a 5-second egress hiccup at SessionStart and confirm bootstrap clears past it without operator intervention. Easiest path:
>    - In a fresh container, before the first SessionStart fires, ask Ven to do `iptables -A OUTPUT -d cache.agilebits.com -j DROP` (or use a userspace `tc qdisc` rule). Wait 5 seconds. `iptables -D OUTPUT -d cache.agilebits.com -j DROP`.
>    - During the drop window, the existing snapshot's `ensure_op_cli` is being re-fetched if `op_installed_at_build=false`; with retry 5 it should clear past the 5s hiccup.
>    - Pre-PR baseline: bootstrap dies at `step=ensure_op_cli rc=1` (1+2 = 3s budget; hiccup wins). Post-PR: retries continue past the drop, succeed on attempt 3 or 4.
>    - Same shape applies to `op_whoami` against `api.1password.com`.
>
> **If repro is too involved to set up:** the diff is two retry-count changes. Visual review of the diff + happy-path no-regression is sufficient evidence to merge — the budget bump is reversible if it surfaces an unexpected interaction.
>
> **Followup blocked by #79:** none — independent of #78 and #80.
>
> **Greeting:** verify happy-path first, then greet.
