### PR TITLE
Surface build-time op-install failure in receipt + SessionStart digest

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -81,7 +81,9 @@ print_versions
 # survives the snapshot → resume transition. Idempotent: if a prior
 # build already installed it, this is a no-op. Non-fatal: a failure
 # here just means the SessionStart hook will retry (same as before).
+OP_INSTALLED_AT_BUILD=false
 if ensure_op_cli; then
+  OP_INSTALLED_AT_BUILD=true
   build_log_record OK "cloud-setup: op CLI installed at build time"
 else
   build_log_record WARN "cloud-setup: op CLI install failed at build time; SessionStart hook will retry"
@@ -137,6 +139,7 @@ GIT_SHA="$(git -C /home/user/vade-runtime rev-parse --short HEAD 2>/dev/null || 
 build_receipt_write \
   built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   op_token_visible="$OP_TOKEN_VISIBLE" \
+  op_installed_at_build="$OP_INSTALLED_AT_BUILD" \
   coo_bootstrap_ran="$COO_BOOTSTRAP_RAN" \
   workspace_mcp_symlinked="$WORKSPACE_MCP_SYMLINKED" \
   identity_link_ok="$IDENTITY_LINK_OK" \

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -201,13 +201,21 @@ fi
 #   missing      — absent at both: COO identity dark until env is provisioned
 #   unknown      — no receipt to compare against (build-time setup didn't run)
 _op_build_seen="unknown"
+_op_installed_at_build="unknown"
 if [ -f "$SETUP_RECEIPT" ] && check_cmd node; then
-  _op_build_seen="$(node -e '
+  _op_receipt_probe="$(node -e '
     try {
       const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
-      console.log(r.op_token_visible === true ? "yes" : "no");
-    } catch (_) { console.log("unknown"); }
-  ' "$SETUP_RECEIPT" 2>/dev/null || echo unknown)"
+      const tok = r.op_token_visible === true ? "yes" : "no";
+      let inst;
+      if (r.op_installed_at_build === true) inst = "yes";
+      else if (r.op_installed_at_build === false) inst = "no";
+      else inst = "unknown";
+      console.log(tok + " " + inst);
+    } catch (_) { console.log("unknown unknown"); }
+  ' "$SETUP_RECEIPT" 2>/dev/null || echo "unknown unknown")"
+  _op_build_seen="${_op_receipt_probe%% *}"
+  _op_installed_at_build="${_op_receipt_probe##* }"
 fi
 _op_session_seen="no"
 [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && _op_session_seen="yes"
@@ -231,6 +239,25 @@ case "$_op_build_seen/$_op_session_seen" in
   unknown/*)
     ;;
 esac
+
+# Snapshot is degraded when build-time op-install failed (#77): the
+# whole point of cloud-setup.sh:ensure_op_cli is to take egress flake
+# off the SessionStart critical path. When it failed at build, the
+# binary is missing from /home/user/.local/bin and SessionStart's
+# bootstrap fallback has to re-fetch from cache.agilebits.com, which
+# is exposed to the same flake the build-time install was supposed
+# to absorb. Surface this loudly so the operator (or a future agent)
+# knows to expect the flake-on-resume failure mode and can /resume
+# rather than wedge.
+if [ "$_op_installed_at_build" = "no" ]; then
+  echo ""
+  echo "  ⚠ op CLI failed to install at build time (op_installed_at_build=false)."
+  echo "    Snapshot is degraded — SessionStart's bootstrap fallback will re-fetch"
+  echo "    op from cache.agilebits.com mid-session, which is exposed to the same"
+  echo "    egress flake the build-time install was supposed to absorb. If bootstrap"
+  echo "    dies at step=ensure_op_cli, /resume rather than wedge — the second"
+  echo "    attempt usually clears."
+fi
 
 echo "───────────────────────────────────────────────────────────────"
 


### PR DESCRIPTION
## Summary

The whole point of `cloud-setup.sh:ensure_op_cli` is to take 1Password egress flake off the SessionStart critical path by pre-installing `op` at snapshot-build time. When the build-time install fails silently (transient `cache.agilebits.com` 5xx — same family as #76), the snapshot is shipped degraded: the binary is missing from `/home/user/.local/bin/op`, but the receipt records nothing about it. The next session's SessionStart bootstrap fallback re-runs `ensure_op_cli` and is exposed to the same flake — this time on the critical path with no upstream absorber.

`run-2026-04-25T182206` compounded exactly this way: `coo_bootstrap_ran=false` was in the receipt with no signal about *why*; the operator had no way to know the snapshot was degraded; the same hiccup defeated the SessionStart-side retry.

This PR makes the failure visible.

## Changes

| File | Change |
|---|---|
| `scripts/cloud-setup.sh` | Capture the result of `ensure_op_cli` into `OP_INSTALLED_AT_BUILD` (boolean); pass it to `build_receipt_write` as `op_installed_at_build`. |
| `scripts/coo-identity-digest.sh` | Extend the existing receipt probe (single `node -e` call) to read `op_installed_at_build` alongside `op_token_visible`. When the field reads `false`, print a warning block explaining the snapshot is degraded and recommending `/resume` on bootstrap failure rather than wedge. The build-receipt section's existing for-loop iterator displays the new field automatically; no edits needed there. |

## Back-compat

Snapshots cut before this PR don't carry `op_installed_at_build`. The node probe distinguishes `true` / `false` / undefined and emits `unknown` for the third case; the warning fires **only on explicit `false`**. Older snapshots show no new behavior.

Verified with stub-JSON inline tests: present-true → `yes`, present-false → `no`, missing → `unknown`.

## Test plan

### Cloud (REQUIRED before merge)
- [x] `bash -n` on both modified scripts: pass.
- [x] Receipt-probe back-compat verified locally with stub JSON for both shapes (with-field and without-field).
- [ ] **Simulated failure rebuild:** trigger a cloud snapshot rebuild with `cache.agilebits.com` blocked (e.g. iptables drop during cloud-setup). Verify:
  - `setup-receipt.json` contains `op_installed_at_build: false`
  - Next SessionStart digest prints the warning block (`⚠ op CLI failed to install at build time...`)
  - `coo-identity-digest` exits 0 (warning is informational, not fatal)
- [ ] **Happy-path no-regression:** healthy snapshot rebuild. Receipt has `op_installed_at_build: true`; digest does not print the new warning; build-receipt section shows the new field with value `true`.

### Mac
Not applicable — Mac doesn't go through the cloud snapshot pipeline. `setup-receipt.json` on Mac is written by `local-setup.sh` under `~/.vade/local-state/` but doesn't model build-time op-install (op comes from brew).

## Sequencing

- [x] After #64 (digest changes overlap, so #77 sequenced after #64). Confirmed conflict-free against current `main` (#64 already merged; this PR's digest edits land in the post-#64 receipt-probe block).
- [x] Independent of #76 (retry-budget): #76 changes the *retry policy* on the same egress flake; this PR makes the *failure visible*. Either can land first; both shipping together gives the most coverage of the failure class.

## References
- Parent epic: #75
- Audit doc: `vade-coo-memory/.vade/plans/bootstrap-cloud-env-hardening-audit-2026-04-25.md`
- Sibling: #76 (retry-budget tuning)

Closes #77
## Handoff prompt for next instance

> Verify vade-runtime#80 (op_installed_at_build receipt field + SessionStart digest warning) after merge. Verification REQUIRES a snapshot rebuild — the field is only written by `cloud-setup.sh` at build time. No Mac verification (Mac doesn't go through the cloud snapshot pipeline).
>
> **Happy-path verification (after a clean snapshot rebuild):**
>
> 1. Confirm the field is in the receipt:
>    `jq . /home/user/.vade-cloud-state/setup-receipt.json | grep op_installed_at_build`
>    Expect: `"op_installed_at_build": true` (the typical case — `cache.agilebits.com` was reachable at build).
>
> 2. SessionStart digest displays the new field automatically:
>    `bash /home/user/vade-runtime/scripts/coo-identity-digest.sh 2>&1 | grep -A2 "Cloud build-time receipt"`
>    Expect: a line `op_installed_at_build:        true`.
>
> 3. The warning block does NOT fire on the happy path:
>    `bash /home/user/vade-runtime/scripts/coo-identity-digest.sh 2>&1 | grep "op CLI failed to install at build time"`
>    Expect: empty output (warning silent).
>
> **Failure-mode repro (REQUIRED before merging):**
>
> 4. Trigger a snapshot rebuild with `cache.agilebits.com` blocked. Easiest path: ask Ven to add an `iptables -A OUTPUT -d cache.agilebits.com -j DROP` rule, then trigger the rebuild via the Anthropic cloud UI's "rebuild snapshot" button (or `bash /home/user/vade-runtime/scripts/cloud-setup.sh` directly while the rule is active). After cloud-setup completes, remove the rule and start a session.
>
> 5. Confirm the receipt records the failure:
>    `jq . /home/user/.vade-cloud-state/setup-receipt.json | grep op_installed_at_build`
>    Expect: `"op_installed_at_build": false`.
>
> 6. Confirm the digest warning fires on the next SessionStart:
>    `bash /home/user/vade-runtime/scripts/coo-identity-digest.sh 2>&1 | grep -A4 "op CLI failed to install at build time"`
>    Expect: the warning block printing the four-line explanation. `coo-identity-digest` itself exits 0 (warning is informational, not fatal).
>
> 7. Back-compat check (older snapshots without the field): manually edit `setup-receipt.json` to remove `op_installed_at_build` (or test against a snapshot built before #80 landed). Confirm digest does NOT print the new warning — it should silently treat the missing field as `unknown` and skip.
>
> **If snapshot rebuild is too involved to set up immediately:** the diff is two-line in cloud-setup.sh + one extended node probe in coo-identity-digest.sh. Visual review + ad-hoc receipt editing per step 7 is sufficient evidence to merge — the worst case is the new field is absent (no behavior change vs pre-PR) and the warning never fires.
>
> **Followup blocked by #80:** none — independent of #78 and #79. Audit's sequencing constraint (#77 sequence after #64) was about the digest changes overlapping with #64; #64 already merged, so this PR was conflict-free against current `main`.
>
> **Greeting:** verify happy path first, then greet with which fields are now in the receipt.
