### PR TITLE
bootstrap: persist VADE_CLOUD_STATE_DIR + bindir PATH into settings.json env (#83)

### DIFF
--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -70,7 +70,8 @@ _settings_env_complete() {
     try { cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8")) || {}; }
     catch { process.exit(1); }
     const env = cfg.env || {};
-    const required = ["GITHUB_MCP_PAT", "GITHUB_TOKEN", "AGENTMAIL_API_KEY", "MEM0_API_KEY"];
+    const required = ["GITHUB_MCP_PAT", "GITHUB_TOKEN", "AGENTMAIL_API_KEY", "MEM0_API_KEY",
+                      "VADE_CLOUD_STATE_DIR", "PATH"];
     for (const k of required) { if (!env[k]) process.exit(1); }
     process.exit(0);
   ' "$settings" 2>/dev/null
@@ -141,6 +142,12 @@ validate_coo_identity
 
 COO_BOOTSTRAP_STEP="merge_coo_settings_env"
 merge_coo_settings_env
+
+# Persist non-secret path state (VADE_CLOUD_STATE_DIR + PATH with the
+# snapshot user bindir prepended) into ~/.claude/settings.json env so
+# fresh shells inherit it on first try. vade-runtime#83.
+COO_BOOTSTRAP_STEP="merge_coo_settings_paths"
+merge_coo_settings_paths
 
 COO_BOOTSTRAP_STEP="summarize_coo_identity"
 summarize_coo_identity

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -891,6 +891,19 @@ merge_coo_settings_env() {
     "${MEM0_API_KEY:-}"
 }
 
+# Persist non-secret bootstrap-derived path state into ~/.claude/settings.json
+# env so every shell the harness spawns (sub-agents, Bash tool calls,
+# Skill invocations) inherits it on first try. Without this the bootstrap
+# knows VADE_CLOUD_STATE_DIR and the snapshot user bindir during its own
+# run, but they evaporate after exit — leaving CLAUDE.md fallbacks
+# (which assume $HOME == cwd) and `command -v op` to fail in fresh shells.
+# vade-runtime#83.
+merge_coo_settings_paths() {
+  local bindir
+  bindir="$(_snapshot_user_bindir)"
+  _write_claude_settings_paths "$VADE_CLOUD_STATE_DIR" "$bindir"
+}
+
 # Merge COO env vars into ~/.claude/settings.json "env" object. Claude
 # Code reads this at process startup, so ${GITHUB_MCP_PAT} etc. in
 # .mcp.json substitute correctly. Idempotent.
@@ -951,6 +964,61 @@ _write_claude_settings_env() {
   ' "$settings_file"
   chmod 600 "$settings_file"
   log "  merged COO env vars into $settings_file"
+}
+
+# Persist non-secret path state into the same settings.json env block.
+# Split from _write_claude_settings_env because it has no PAT validation
+# dependency — it can run any time after _snapshot_user_bindir is
+# resolvable, including a re-run on cached-PAT skip path. Idempotent.
+#
+# - VADE_CLOUD_STATE_DIR: where integrity-check.json, setup-receipt.json,
+#   and build.log live. Without this in env, CLAUDE.md's documented
+#   ${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state} fallback resolves
+#   to /root/.vade-cloud-state on the cloud harness (HOME=/root) — wrong
+#   tree. vade-runtime#83.
+# - PATH: prepend the snapshot user bindir so `op`, `gh` (when installed
+#   here), and any other ensure_*_cli tooling resolve in shells the
+#   harness spawns after bootstrap exits. ensure_op_cli prepends to its
+#   own shell only; settings.json env is the durable surface.
+_write_claude_settings_paths() {
+  local cloud_state_dir="$1" bindir="$2"
+  if ! check_cmd node; then
+    log "Warning: node missing; skipping ~/.claude/settings.json paths merge"
+    return 0
+  fi
+  local settings_dir="${HOME}/.claude"
+  local settings_file="$settings_dir/settings.json"
+  mkdir -p "$settings_dir"
+  [ -f "$settings_file" ] || echo '{}' > "$settings_file"
+
+  VADE_CLOUD_STATE_DIR="$cloud_state_dir" VADE_BINDIR="$bindir" node -e '
+    const fs = require("fs");
+    const path = process.argv[1];
+    let cfg = {};
+    try { cfg = JSON.parse(fs.readFileSync(path, "utf8")) || {}; }
+    catch (e) {
+      console.error("[vade-setup] " + path + " unparseable; aborting paths merge.");
+      process.exit(1);
+    }
+    const merged = Object.assign({}, cfg.env || {});
+    if (process.env.VADE_CLOUD_STATE_DIR) {
+      merged.VADE_CLOUD_STATE_DIR = process.env.VADE_CLOUD_STATE_DIR;
+    }
+    if (process.env.VADE_BINDIR) {
+      // Prepend bindir to PATH idempotently. Use ${PATH} so bash expands
+      // it at shell init against whatever the harness has set.
+      const bindir = process.env.VADE_BINDIR;
+      const existing = merged.PATH || "${PATH}";
+      // Idempotency: dont prepend if already first-segment.
+      if (!existing.startsWith(bindir + ":")) {
+        merged.PATH = bindir + ":" + existing;
+      }
+    }
+    cfg.env = merged;
+    fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
+  ' "$settings_file"
+  chmod 600 "$settings_file"
+  log "  merged COO path vars into $settings_file"
 }
 
 # Ensure openssh-client is present (provides ssh-keygen + ssh-keyscan).


### PR DESCRIPTION
Fixes #83.

## Summary

- Adds `merge_coo_settings_paths` + `_write_claude_settings_paths` helpers in `scripts/lib/common.sh` that persist `VADE_CLOUD_STATE_DIR` and a `PATH` entry (snapshot user bindir + `\${PATH}` literal) into `~/.claude/settings.json` env.
- Wires the new step into `scripts/coo-bootstrap.sh` immediately after `merge_coo_settings_env`.
- Extends the SKIP-marker env-completeness check (the gate at the top of `coo-bootstrap.sh` that decides whether to use the fast path) to require both new keys, so existing containers re-run the bootstrap on next boot rather than continuing with stale state.
- Companion docs fix in vade-coo-memory#142 (separate PR) makes the CLAUDE.md fallback resilient even before this lands; together they close vade-runtime#83.

## Why

In fresh-container session run-2026-04-25T222249, two path-shape bugs surfaced post-#75:
- `\${VADE_CLOUD_STATE_DIR:-\$HOME/.vade-cloud-state}/integrity-check.json` resolved to `/root/.vade-cloud-state/...` because `HOME=/root` and `VADE_CLOUD_STATE_DIR` wasn't exported.
- `command -v op` returned empty in fresh shells because `/home/user/.local/bin` was only PATH-prepended inside `ensure_op_cli`'s own shell.

Same shape: state the bootstrap had during its run wasn't persisted into the harness env block other shells inherit. This PR persists both.

## Pre-merge gating

REQUIRED before merging: review the diff. No tests fail since the new code only runs at bootstrap time, and we don't have bootstrap regression tests yet (followup-worthy but not blocking).

```bash
gh pr checkout 84   # or whatever # the hub assigns
bash -n scripts/coo-bootstrap.sh && bash -n scripts/lib/common.sh
# Expect: OK (both parse).
bash -c 'source scripts/lib/common.sh && declare -F merge_coo_settings_paths _write_claude_settings_paths'
# Expect: both names print.
```

## Post-merge confirmation

Fresh container from merged `main`, then:

```bash
# 1. Bootstrap actually ran (not just SKIP path):
grep '\(merge_coo_settings_paths\|merged COO path vars\)' /home/user/.vade/coo-bootstrap.log | tail
# Expect: lines from this session showing merge_coo_settings_paths step ran.
# (If marker survived snapshot, this might be from a prior session — that's fine; what matters is settings.json env is populated.)

# 2. settings.json env carries the new keys:
jq '.env | {VADE_CLOUD_STATE_DIR, PATH}' /root/.claude/settings.json
# Expect: VADE_CLOUD_STATE_DIR="/home/user/.vade-cloud-state",
#         PATH starts with "/home/user/.local/bin:" and ends with "\${PATH}"
#         (the literal — bash expands at shell init).

# 3. Fresh shell sees the env on first try:
bash -c 'echo VADE_CLOUD_STATE_DIR=\$VADE_CLOUD_STATE_DIR; command -v op'
# Expect: VADE_CLOUD_STATE_DIR=/home/user/.vade-cloud-state, /home/user/.local/bin/op

# 4. Documented fallback (with companion vade-coo-memory#142 merged) resolves:
jq '.summary.ok' "\${VADE_CLOUD_STATE_DIR:-\$CLAUDE_PROJECT_DIR/.vade-cloud-state}/integrity-check.json"
# Expect: true or false (parses without "No such file").
```

If step 2 fails, the bootstrap took the SKIP path against an old marker — touch `~/.vade/.coo-bootstrap-done` and re-run, or `VADE_FORCE_COO_BOOTSTRAP=1 bash /home/user/vade-runtime/scripts/coo-bootstrap.sh`.

## Followup

The marker SKIP path now requires the two new env keys via the env-completeness check, so the first fresh container after merge will trigger a re-bootstrap. That's the intended behavior. No manual cache bust needed.

Greeting Ven: after.

https://claude.ai/code/session_01Pf9byM7y2K9RnjkxvXVMjc