### PR TITLE
hotfix: capture live PATH instead of literal ${PATH} (#84 regression)

### DIFF
--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -73,6 +73,14 @@ _settings_env_complete() {
     const required = ["GITHUB_MCP_PAT", "GITHUB_TOKEN", "AGENTMAIL_API_KEY", "MEM0_API_KEY",
                       "VADE_CLOUD_STATE_DIR", "PATH"];
     for (const k of required) { if (!env[k]) process.exit(1); }
+    // PATH content sanity: Claude Code does not shell-expand env values,
+    // so a literal "${PATH}" in this position is the broken-output of an
+    // earlier bootstrap (vade-runtime#83 first-cut bug). Force re-run so
+    // _write_claude_settings_paths overwrites with the expanded form.
+    // Also require /usr/bin in the value as a basic sanity floor.
+    if (env.PATH.includes("${PATH}") || !env.PATH.includes("/usr/bin")) {
+      process.exit(1);
+    }
     process.exit(0);
   ' "$settings" 2>/dev/null
 }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -980,6 +980,15 @@ _write_claude_settings_env() {
 #   here), and any other ensure_*_cli tooling resolve in shells the
 #   harness spawns after bootstrap exits. ensure_op_cli prepends to its
 #   own shell only; settings.json env is the durable surface.
+#
+#   Critical: Claude Code does NOT shell-expand env values from
+#   settings.json — it passes them as-is to subprocesses. So we must
+#   write the *literal expanded* PATH at bootstrap time, not a
+#   "${PATH}" placeholder. The first cut of vade-runtime#83 wrote
+#   the literal string "/home/user/.local/bin:${PATH}" and broke fresh
+#   sessions (ls/which/bash all "command not found" because ${PATH}
+#   was treated as a directory name). This pass captures the actual
+#   bootstrap-shell PATH and serializes it.
 _write_claude_settings_paths() {
   local cloud_state_dir="$1" bindir="$2"
   if ! check_cmd node; then
@@ -991,7 +1000,18 @@ _write_claude_settings_paths() {
   mkdir -p "$settings_dir"
   [ -f "$settings_file" ] || echo '{}' > "$settings_file"
 
-  VADE_CLOUD_STATE_DIR="$cloud_state_dir" VADE_BINDIR="$bindir" node -e '
+  # Capture the live PATH for the node child to embed verbatim. Strip
+  # any pre-existing bindir prefix so we don't double-prepend across
+  # bootstrap re-runs (e.g., after marker invalidation).
+  local live_path="${PATH}"
+  case ":${live_path}:" in
+    ":${bindir}:"*) live_path="${live_path#${bindir}:}" ;;
+    *":${bindir}:"*) live_path="${live_path//:${bindir}:/:}" ;;
+    *":${bindir}") live_path="${live_path%:${bindir}}" ;;
+  esac
+
+  VADE_CLOUD_STATE_DIR="$cloud_state_dir" VADE_BINDIR="$bindir" \
+  VADE_LIVE_PATH="$live_path" node -e '
     const fs = require("fs");
     const path = process.argv[1];
     let cfg = {};
@@ -1004,15 +1024,14 @@ _write_claude_settings_paths() {
     if (process.env.VADE_CLOUD_STATE_DIR) {
       merged.VADE_CLOUD_STATE_DIR = process.env.VADE_CLOUD_STATE_DIR;
     }
-    if (process.env.VADE_BINDIR) {
-      // Prepend bindir to PATH idempotently. Use ${PATH} so bash expands
-      // it at shell init against whatever the harness has set.
+    if (process.env.VADE_BINDIR && process.env.VADE_LIVE_PATH !== undefined) {
+      // Always rewrite from a known-good base (the captured shell PATH
+      // with our bindir stripped) — never inherit a prior settings.json
+      // PATH value, because that value may itself be the broken
+      // "${PATH}"-literal output of a previous bootstrap run.
       const bindir = process.env.VADE_BINDIR;
-      const existing = merged.PATH || "${PATH}";
-      // Idempotency: dont prepend if already first-segment.
-      if (!existing.startsWith(bindir + ":")) {
-        merged.PATH = bindir + ":" + existing;
-      }
+      const live = process.env.VADE_LIVE_PATH;
+      merged.PATH = live ? bindir + ":" + live : bindir;
     }
     cfg.env = merged;
     fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");


### PR DESCRIPTION
Fixes #88.

**Hotfix for the PATH regression introduced by #84.**

## Symptom

Fresh sessions booting from any snapshot built post-#84 merge see:

```
$ ls
bash: ls: command not found
$ which bash
bash: which: command not found
$ echo $PATH
/home/user/.local/bin:${PATH}
```

`${PATH}` is the literal four-character string, not an expansion. Claude Code Web does not shell-interpolate env values from `settings.json` — it passes them verbatim to subprocesses. So the harness's actual PATH (`/usr/bin`, `/bin`, etc.) is gone, and only `/home/user/.local/bin` is visible.

Witnessed: Ven's session at run-2026-04-25T231221 (boot snapshot post-#84).

## Root cause

In `_write_claude_settings_paths` (added in #84), the fallback when `merged.PATH` is undefined was `"${PATH}"` — chosen on the assumption bash would expand at shell init. That assumption is wrong for this surface.

Compounding bug: my own local verification of #84 only checked `declare -F` resolved the function names; I never inspected the writer's *output*. If vade-runtime#86 (script-level bootstrap CI) had been in place, the actual emitted JSON would have been asserted and this would have been caught at PR-open.

## Fix (two-pronged)

**1. `_write_claude_settings_paths` (`scripts/lib/common.sh`):** capture the live `$PATH` from the bootstrap shell, strip any pre-existing bindir prefix, then write `bindir + ":" + stripped_live` as a fully-expanded literal. Always rewrites from a known-good base — never inherits a prior settings.json `PATH` value, so a broken-state output of an earlier run gets overwritten correctly on the next run.

**2. `_settings_env_complete` (`scripts/coo-bootstrap.sh`):** the SKIP-marker fast-path gate now also rejects `PATH` values containing the literal `${PATH}` or missing `/usr/bin`. Without this, existing snapshots with the broken value would hit the SKIP path and never re-run the writer. The reject forces a full re-bootstrap, which heals the state.

## Local verification

```bash
# 1. Fresh write produces expanded PATH:
bash -c 'source scripts/lib/common.sh && _write_claude_settings_paths /home/user/.vade-cloud-state /home/user/.local/bin && jq .env.PATH /root/.claude/settings.json'
# Expect: "/home/user/.local/bin:/root/.local/bin:...:/usr/bin:..." (expanded)

# 2. Idempotent (running twice doesn't double-prepend) — verified.

# 3. Self-heals from broken-state — verified (input "/home/user/.local/bin:\${PATH}" rewrites to expanded form).

# 4. SKIP-check rejects broken state — verified (broken-state JSON returns exit 1, forces re-bootstrap).
```

## Pre-merge gating

REQUIRED before merging: review the diff. The new code only runs at bootstrap time so unit tests don't help here; the local verification above is the floor.

## Post-merge confirmation

Fresh container from merged `main`, then:

```bash
# 1. settings.json env carries an expanded PATH:
jq '.env.PATH' /root/.claude/settings.json
# Expect: literal expanded path containing "/home/user/.local/bin:" prefix
# AND "/usr/bin" somewhere in the body. NOT containing "${PATH}".

# 2. Fresh shell finds basic binaries on first try:
bash -c 'command -v ls; command -v bash; command -v op'
# Expect: all three resolve.

# 3. Self-heal property: deliberately corrupt settings.json and force re-bootstrap:
node -e 'const fs=require("fs"),p="/root/.claude/settings.json";const c=JSON.parse(fs.readFileSync(p));c.env.PATH="/home/user/.local/bin:${PATH}";fs.writeFileSync(p,JSON.stringify(c,null,2))'
VADE_FORCE_COO_BOOTSTRAP=1 bash /home/user/vade-runtime/scripts/coo-bootstrap.sh
jq '.env.PATH' /root/.claude/settings.json
# Expect: rewritten to the expanded form, NOT containing "${PATH}".
```

## Recovery for an active broken session (no merge required)

Ven (or anyone) caught in a broken session can heal it inline without waiting for this PR to merge:

```bash
# Use absolute paths since PATH is broken:
/usr/bin/jq '.env.PATH' /root/.claude/settings.json   # confirm broken
HARNESS_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
/usr/bin/node -e "
  const fs=require('fs'),p='/root/.claude/settings.json';
  const c=JSON.parse(fs.readFileSync(p,'utf8'));
  c.env.PATH='/home/user/.local/bin:'+process.env.HARNESS_PATH;
  fs.writeFileSync(p,JSON.stringify(c,null,2)+'\n');
" 
```

Then start a new session (settings.json is read at session start) — bash will work again.

## Followup

Layer 1 of the bootstrap CI (#86) would have caught this. Bumping its priority is the right move; the fix is real, but the regression should never have shipped.

Greeting Ven: after.

https://claude.ai/code/session_01Pf9byM7y2K9RnjkxvXVMjc
