### PR TITLE
integrity-check: bump F_CUTOFF_GIT to retire chronic-yellow F4 (MEMO 2026-04-26-01)

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -287,8 +287,19 @@ _add E4 skip "requires-agent: observe tool namespaces"
 # decision-bearing commit of the day; an "adoption moment" captures
 # the adoption boundary cleanly without retroactively flagging a
 # legitimate pre-adoption attribution.
-F_CUTOFF="2026-04-24"          # date form — used for F2 memo-index, F3 essay-filename comparisons
-F_CUTOFF_GIT="2026-04-24 12:00:00 +0000"  # timestamp form — used for F1/F4 git log --since
+#
+# F_CUTOFF_GIT bumped 2026-04-26 per MEMO 2026-04-26-01 to retire
+# 7 chronic-yellow F4 hits (3 nightly-routine, 2 historical Ven-
+# human-action quick-fixes, 1 post-convention quick-fix where the
+# auto-marker workflow did not yet exist, 1 coo-scope refactor where
+# the bootstrap was degraded at PR-open time). The auto-marker workflow
+# in vade-coo-memory/.github/workflows/f4-marker.yml takes effect on
+# PRs opened from this point forward; F4 reflects the post-workflow
+# reality rather than the historical accumulation. F_CUTOFF (date form)
+# stays at 2026-04-24 — F2/F3 are green and the broader memo/essay
+# invariants should keep the wider window.
+F_CUTOFF="2026-04-24"                     # date form — used for F2 memo-index, F3 essay-filename comparisons
+F_CUTOFF_GIT="2026-04-26 00:30:00 +0000"  # timestamp form — used for F1/F4 git log --since
 
 # Resolve the vade-coo-memory repo path. Canonical order: env
 # override, sibling under WORKSPACE_ROOT (works on both cloud and


### PR DESCRIPTION
Companion to vade-app/vade-coo-memory#145 — together they retire F4's chronic-yellow state by adding a working enforcement layer (the auto-marker workflow in vade-coo-memory) and narrowing F4's checked window to start at the moment that workflow takes effect.

Decision: MEMO 2026-04-26-01 (vade-coo-memory).

## Summary

- `scripts/integrity-check.sh`: `F_CUTOFF_GIT` advances from `2026-04-24 12:00:00 +0000` to `2026-04-26 00:30:00 +0000`.
- `F_CUTOFF` (date form, used by F2/F3) stays at `2026-04-24` — F2/F3 are green and the broader memo/essay invariants should keep the wider window. F1 also uses `F_CUTOFF_GIT`; F1 was already 100% green so the bump silences nothing material there.
- The 7 historical F4 mismatches — bucketed in MEMO 2026-04-25-02 (5 commits) and MEMO 2026-04-26-01 (2 new commits since) — drop out of F4's checked window. The historical record remains in those memos, in `coo/memo_index.json`, and in git log. Only F4's read of them retires.

## Why bump rather than rewrite history

MEMO 2026-04-25-02 classified amending merged commits as "rewriting history" and rejected it. Advancing the cutoff is a different operation: narrows the checked window without touching git history.

## Pre-merge gating

REQUIRED before merging: vade-app/vade-coo-memory#145 must merge first AND the post-merge steps in that PR (apply `squash_merge_commit_message=PR_BODY`, create `attribution:on-behalf-of-coo` label) must complete. Otherwise this PR retires the chronic-yellow without an enforcement layer behind it — the next venpopov-opened coo-scope PR would re-yellow F4 with no auto-correction.

```bash
gh pr checkout <PR>
bash -n scripts/integrity-check.sh
# Expect: OK.
grep -nE 'F_CUTOFF(_GIT)?=' scripts/integrity-check.sh
# Expect: F_CUTOFF stays "2026-04-24"; F_CUTOFF_GIT moves to "2026-04-26 00:30:00 +0000".
```

## Post-merge confirmation

```bash
# Fresh container from merged main, then:
jq '.groups.F.F4' "${VADE_CLOUD_STATE_DIR:-$CLAUDE_PROJECT_DIR/.vade-cloud-state}/integrity-check.json"
# Expect: {"ok": true, "detail": "<N>/<N> commits resolve to vade-coo or carry ven-human-action"}
#          where <N> is the count of vade-coo-memory commits since 2026-04-26 00:30:00 +0000.

jq '.summary' "${VADE_CLOUD_STATE_DIR:-$CLAUDE_PROJECT_DIR/.vade-cloud-state}/integrity-check.json"
# Expect: {"ok": true, "passed": 20, "total": 20, "degraded": []}
#          (assuming no other regressions land before this PR's snapshot).
```

If `summary.ok` stays false post-merge, inspect `.summary.degraded` for which invariant — F4 should no longer appear there.

## Followup

If a venpopov-opened PR merges before vade-app/vade-coo-memory#145's auto-marker workflow can fire on it (race window during PR-pair merge), F4 will yellow again on that one commit. Trivial to clear: re-bump `F_CUTOFF_GIT` past it, or accept the one-commit yellow until natural recovery. Watching for this is part of the post-merge confirmation; not a blocker.