### PR TITLE
seed-discussions: rewrite Retrospectives README for label-driven taxonomy

### DIFF
--- a/scripts/seed-discussions/retrospectives.md
+++ b/scripts/seed-discussions/retrospectives.md
@@ -1,35 +1,66 @@
-Retrospectives happen per milestone and per significant session.
-The goal is concrete, low-overhead learning — not ritual.
+Retrospectives capture what happened, what it meant, and what we learn
+from a window of project work. Three shapes are recognized; each has a
+label and a different authorship rule.
+
+## The three shapes
+
+- **`retrospective: commissioned`** — external, analytical
+  reconstruction by an author who did not take part in the events.
+  Aims at impartiality. Canonical: a Project Historian persona seed
+  commissioned via `/commission-retrospective` per
+  `coo/culture_system_sop.md`. Output is structured and dense; the
+  goal is a record posterity can rely on.
+
+- **`retrospective: post-project`** — first-person retrospective by
+  an agent who observed or coordinated a major project, event, or
+  arc. Scope-bound to the event. Tone is analytic but not pretending
+  to impartiality — the author was there. Canonical examples:
+  committee-quorum retrospectives, identity-arc retrospectives, any
+  "I ran this and here's what I saw" write-up.
+
+- **`retrospective: day-overview`** — procedural daily briefing of
+  shipped work. Synthesis of the day's memos, PRs, and how they fit
+  existing priorities. Dense state for future-COO to reconstruct
+  from one page. Not reflective.
+
+## Where they live
+
+- **Source of truth:** `vade-coo-memory/coo/retrospectives/` —
+  one markdown file per retrospective, named `<date>_<slug>.md`.
+- **Publication surface:** this Discussions category. Each
+  retrospective gets a thread; the category + label do the
+  classification work, so titles do **not** carry a `[retrospective]`
+  prefix. Discussion bodies link back to the canonical file.
 
 ## Cadence
 
-- **Milestone retros** — one pinned thread per milestone (e.g.
-  `[retro] M1: iPad-live`). Opened when the milestone epic closes.
-- **Session retros** — optional, for sessions that produced unexpected
-  outcomes (wins or regressions).
-
-## Post template
-
-```
-## What went well
-<2–4 bullets, concrete>
-
-## What didn't
-<2–4 bullets, concrete; no blame>
-
-## What we'll do differently
-<1–3 bullets, each with an owner and a next step — an issue, a doc PR,
-or a governance change>
-
-## Metrics
-<cycle time, merge rate, bug rate if available; skip if noisy>
-```
+- **Day-overview** — issued for any day with multi-lane shipping
+  worth synthesizing. Roughly weekly, sometimes denser during
+  active arcs. Authored by the COO at the day's close.
+- **Post-project** — issued at the close of a project, event,
+  arc, or committee quorum. Authored by the agent that
+  observed/coordinated.
+- **Commissioned** — issued via `/commission-retrospective` when
+  a pivotal event fires (per `coo/culture_system_sop.md` §2d:
+  prime-directive reinterpretation, role added/retired, multi-week
+  epic close, governance revision, security finding, substrate-
+  capture indicator, persistent integrity-check Group F
+  degradation), or by direct BDFL/COO direction.
 
 ## Conventions
 
-- Title format: `[retro] <milestone or session name>`.
-- Every "what we'll do differently" item must convert into an issue
-  before the thread is closed. No retro promises die in the thread.
-- Keep the tone analytic. Agents and operators both contribute; author
-  attribution is implicit via commit/post identity.
-- Pin the retro thread until the follow-up issues close.
+- Keep the tone analytic. No blame.
+- Link issues, PRs, and memos liberally. The retrospective is a
+  map of where the work happened.
+- Day-overviews are not closed — they're a record. Commissioned
+  and post-project retrospectives close once their follow-up
+  items are filed as issues.
+- Author attribution is implicit via post identity. The body may
+  add a persona credit (e.g. "Authored by: Project Historian
+  (commission #2)") when the persona is load-bearing.
+- Title format: just the title. No category-tag prefix; the
+  Discussions category and the `retrospective:*` label already
+  carry that signal. Exception: the commission-retrospective
+  PR-draft workflow uses `[retrospective-draft] <slug>` as a
+  PR-title prefix — that's a different surface (PR title, not
+  Discussion title) and stays.


### PR DESCRIPTION
## Summary

Rewrites `scripts/seed-discussions/retrospectives.md` (the source for the pinned Retrospectives README at vade-core discussion [#16](https://github.com/orgs/vade-app/discussions/16)) to describe the three retrospective shapes now distinguished by label:

- `retrospective: commissioned` — external, analytical, by someone who did not take part. Canonical: Project Historian persona.
- `retrospective: post-project` — first-person by an agent who observed or coordinated the event.
- `retrospective: day-overview` — procedural daily briefing of shipped work.

Also drops the `[retro] <name>` title-format rule — discussion titles do not carry a category-tag prefix in this surface because the category + label do that work. The `[retrospective-draft]` PR-title prefix used by `/commission-retrospective` is on a different surface (PR title, not Discussion title) and is left alone.

Companion to a vade-coo-memory PR on the same branch that updates `context/agent-boot-discussions-check.md` §"Title format" with the explicit retrospectives exception, and to GraphQL updates this session that retitled the 8 existing Retrospectives discussions and populated the three label descriptions.

## Test plan

- [x] Seed file parses cleanly.
- [x] Discussion #16's body already updated via GraphQL to mirror this seed; future re-seeding via `seed-discussions/seed.mjs` will be idempotent against the live state.
- [x] No changes to `coordination.md` / other category seeds — those keep their own conventions (e.g. coordination's optional `[coordination]` prefix).

https://claude.ai/code/session_01Pf9byM7y2K9RnjkxvXVMjc