### PR TITLE
gh-coo-wrap: auto-inject session URL on COO gh writes (#150)

### DIFF
--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# gh-coo-wrap: append the Claude Code session URL to --body on
+# COO-attributed `gh` writes, then run the real gh.
+#
+# Substrate enforcement of the rule in
+# vade-coo-memory MEMO 2026-04-26-02 (issue #150). Carved out so the
+# COO does not have to add the trail manually each turn — every
+# attributable write that flows through `gh` carries the link back
+# to the originating session.
+#
+# Marker (DO NOT REMOVE): COO-GH-COO-WRAP-MARKER-v1
+#
+# Behavior:
+#   * Covered subcommands: `gh pr {create,edit,comment,review}` and
+#     `gh issue {create,edit,comment}` — only when --body / -b /
+#     --body-file is present (editor-flow and approve-only invocations
+#     pass through unchanged).
+#   * Source of URL: $CLAUDE_CODE_REMOTE_SESSION_ID (fallback
+#     $CLAUDE_CODE_SESSION_ID), with `cse_` prefix stripped.
+#   * Idempotent: bodies that already contain `claude.ai/code/session_`
+#     are not re-augmented.
+#   * Silent pass-through if no session URL is available (running
+#     outside Claude Code) or the body is empty.
+#   * Real gh located at $COO_GH_REAL (default
+#     /home/user/.local/bin/gh-real). If absent, falls back to the
+#     first `gh` on PATH whose directory differs from this wrapper's
+#     and which does not itself carry the wrapper marker.
+
+set -eu
+
+WRAPPER_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+WRAPPER_DIR="$(dirname "$WRAPPER_PATH")"
+
+# Resolve the real gh binary.
+REAL_GH="${COO_GH_REAL:-/home/user/.local/bin/gh-real}"
+if [ ! -x "$REAL_GH" ]; then
+  REAL_GH=""
+  oldifs="$IFS"; IFS=:
+  for d in $PATH; do
+    IFS="$oldifs"
+    [ "$d" = "$WRAPPER_DIR" ] && { IFS=:; continue; }
+    if [ -x "$d/gh" ] && ! grep -q 'COO-GH-COO-WRAP-MARKER-v1' "$d/gh" 2>/dev/null; then
+      REAL_GH="$d/gh"
+      break
+    fi
+    IFS=:
+  done
+  IFS="$oldifs"
+fi
+
+if [ -z "$REAL_GH" ] || [ ! -x "$REAL_GH" ]; then
+  printf 'gh-coo-wrap: real gh binary not found (COO_GH_REAL=%s); refusing to run.\n' "${COO_GH_REAL:-unset}" >&2
+  exit 127
+fi
+
+# Compute session URL once. Empty if outside Claude Code.
+sid="${CLAUDE_CODE_REMOTE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
+SESSION_URL=""
+[ -n "$sid" ] && SESSION_URL="https://claude.ai/code/session_${sid#cse_}"
+
+is_covered() {
+  case "${1:-}" in
+    pr)
+      case "${2:-}" in create|edit|comment|review) return 0 ;; esac
+      ;;
+    issue)
+      case "${2:-}" in create|edit|comment) return 0 ;; esac
+      ;;
+  esac
+  return 1
+}
+
+# augment <body>: prints body with session URL appended on a
+# blank-line-separated trailing line. Returns body unchanged if:
+#   * no session URL available
+#   * body is empty
+#   * body already contains a claude.ai/code/session_ link
+augment() {
+  local body="$1"
+  if [ -z "$SESSION_URL" ] || [ -z "$body" ]; then
+    printf '%s' "$body"
+    return
+  fi
+  case "$body" in
+    *"claude.ai/code/session_"*) printf '%s' "$body"; return ;;
+  esac
+  printf '%s\n\n%s' "$body" "$SESSION_URL"
+}
+
+# Pass-through: no session URL OR not a covered subcommand.
+if [ -z "$SESSION_URL" ] || ! is_covered "${1:-}" "${2:-}"; then
+  exec "$REAL_GH" "$@"
+fi
+
+# Walk args, augmenting --body / --body-file values.
+declare -a new_args=()
+declare -a tmp_files=()
+cleanup() {
+  if [ "${#tmp_files[@]}" -gt 0 ]; then
+    rm -f "${tmp_files[@]}"
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+while [ $# -gt 0 ]; do
+  a="$1"
+  case "$a" in
+    --body|-b)
+      shift
+      body="${1:-}"
+      new_args+=("$a" "$(augment "$body")")
+      ;;
+    --body=*)
+      body="${a#--body=}"
+      new_args+=("--body=$(augment "$body")")
+      ;;
+    -b=*)
+      body="${a#-b=}"
+      new_args+=("-b=$(augment "$body")")
+      ;;
+    --body-file)
+      shift
+      bf="${1:-}"
+      if [ "$bf" = "-" ]; then
+        body="$(cat)"
+        new_args+=("--body" "$(augment "$body")")
+      elif [ -f "$bf" ]; then
+        body="$(cat "$bf")"
+        tmp="$(mktemp)"
+        tmp_files+=("$tmp")
+        printf '%s' "$(augment "$body")" > "$tmp"
+        new_args+=("--body-file" "$tmp")
+      else
+        new_args+=("--body-file" "$bf")
+      fi
+      ;;
+    --body-file=*)
+      bf="${a#--body-file=}"
+      if [ "$bf" = "-" ]; then
+        body="$(cat)"
+        new_args+=("--body" "$(augment "$body")")
+      elif [ -f "$bf" ]; then
+        body="$(cat "$bf")"
+        tmp="$(mktemp)"
+        tmp_files+=("$tmp")
+        printf '%s' "$(augment "$body")" > "$tmp"
+        new_args+=("--body-file=$tmp")
+      else
+        new_args+=("$a")
+      fi
+      ;;
+    *)
+      new_args+=("$a")
+      ;;
+  esac
+  shift
+done
+
+# Run real gh. Don't exec — we need the EXIT trap to clean up
+# tmp files. gh reads --body-file synchronously, so the file is
+# safe to remove after it returns.
+"$REAL_GH" "${new_args[@]}"
+exit $?

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -810,6 +810,46 @@ ensure_gh_symlink_on_path() {
   ln -sfn "$target" "$link"
 }
 
+# Install the gh-coo-wrap wrapper at /home/user/.local/bin/gh so every
+# attributable `gh` write auto-carries the Claude Code session URL.
+# Substrate enforcement of vade-coo-memory MEMO 2026-04-26-02 (issue
+# #150). The real gh binary moves to /home/user/.local/bin/gh-real;
+# the wrapper exec's it after augmenting --body / --body-file.
+#
+# Idempotent: subsequent runs detect the wrapper marker and only
+# refresh the wrapper content (in case the source script has been
+# updated). Cloud-only path guard (root + /home/user); macOS/local
+# uses brew gh and is left untouched.
+ensure_gh_coo_wrap() {
+  [ "$(id -u)" = "0" ] && [ -d /home/user ] || return 0
+  local gh_path="/home/user/.local/bin/gh"
+  local real_path="/home/user/.local/bin/gh-real"
+  local wrapper_src="${1:-}"
+  if [ -z "$wrapper_src" ] || [ ! -f "$wrapper_src" ]; then
+    log "gh-coo-wrap: source script missing; skipping"
+    return 0
+  fi
+  if [ ! -x "$gh_path" ]; then
+    log "gh-coo-wrap: $gh_path missing; skipping (ensure_gh_cli installs gh)"
+    return 0
+  fi
+  if grep -q 'COO-GH-COO-WRAP-MARKER-v1' "$gh_path" 2>/dev/null; then
+    # Wrapper already installed — refresh content in case the source has changed.
+    install -m 0755 "$wrapper_src" "$gh_path"
+    return 0
+  fi
+  # First-time install: rename real binary and place wrapper.
+  if [ ! -x "$real_path" ]; then
+    mv "$gh_path" "$real_path"
+  else
+    # Real binary already present (recovery from a partial state):
+    # back up whatever is at gh_path and replace with the wrapper.
+    rm -f "$gh_path"
+  fi
+  install -m 0755 "$wrapper_src" "$gh_path"
+  log "gh-coo-wrap: installed (wrapper at $gh_path, real binary at $real_path)"
+}
+
 # Fetch COO secrets from 1Password and write ~/.vade/coo-env plus a
 # merged env block in ~/.claude/settings.json so Claude Code resolves
 # ${GITHUB_MCP_PAT} / ${AGENTMAIL_API_KEY} at startup. Each read is

--- a/scripts/session-start-sync.sh
+++ b/scripts/session-start-sync.sh
@@ -45,6 +45,10 @@ ensure_workspace_identity_link
 # MEMO 2026-04-23-02 gh-CLI fallback is callable without the agent
 # having to rediscover the install path every session.
 ensure_gh_symlink_on_path
+# Install the gh-coo-wrap wrapper so every attributable `gh` write
+# auto-carries the Claude Code session URL. MEMO 2026-04-26-02
+# (issue #150). Idempotent via marker grep.
+ensure_gh_coo_wrap "$SCRIPT_DIR/gh-coo-wrap.sh"
 # Emit integrity-check.json so its snapshot is on disk before the
 # digest hook runs (which may surface a one-line summary). Non-fatal.
 bash "$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true

--- a/scripts/test-gh-coo-wrap.sh
+++ b/scripts/test-gh-coo-wrap.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# test-gh-coo-wrap: smoke-test the gh wrapper that auto-injects the
+# Claude Code session URL onto --body for covered `gh` subcommands.
+#
+# Strategy: install a mock `gh-real` that prints its JSON-encoded
+# argv (and stdin) to stdout, then run the wrapper with various arg
+# shapes and assert the augmented body appears (or doesn't, for
+# pass-through cases) where expected.
+#
+# Run: bash scripts/test-gh-coo-wrap.sh
+# Exit: 0 if all assertions pass, non-zero otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/gh-coo-wrap.sh"
+
+[ -x "$WRAPPER" ] || { echo "FAIL: wrapper not executable at $WRAPPER"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Mock gh-real: dump its argv, one per line, to stdout. For
+# --body-file we also dump the file contents marked with FILE-CONTENT:.
+cat > "$WORK/gh-real" <<'EOF'
+#!/usr/bin/env bash
+i=0
+for a in "$@"; do
+  i=$((i+1))
+  printf 'ARG[%d]=%s\n' "$i" "$a"
+done
+# If a body-file path was given, dump its contents too.
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--body-file" ]; then
+    if [ -f "$a" ]; then
+      printf 'FILE-CONTENT-START\n'
+      cat "$a"
+      printf '\nFILE-CONTENT-END\n'
+    fi
+  fi
+  case "$a" in
+    --body-file=*)
+      bf="${a#--body-file=}"
+      if [ -f "$bf" ]; then
+        printf 'FILE-CONTENT-START\n'
+        cat "$bf"
+        printf '\nFILE-CONTENT-END\n'
+      fi
+      ;;
+  esac
+  prev="$a"
+done
+EOF
+chmod 0755 "$WORK/gh-real"
+
+# Synthetic session env for tests.
+export CLAUDE_CODE_REMOTE_SESSION_ID="cse_TESTID123"
+export COO_GH_REAL="$WORK/gh-real"
+EXPECTED_URL="https://claude.ai/code/session_TESTID123"
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS+1))
+    printf '  PASS  %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+    printf '         expected to contain: %s\n' "$needle"
+    printf '         got:\n'
+    printf '%s\n' "$haystack" | sed 's/^/           /'
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+    printf '         expected NOT to contain: %s\n' "$needle"
+    printf '         got:\n'
+    printf '%s\n' "$haystack" | sed 's/^/           /'
+  else
+    PASS=$((PASS+1))
+    printf '  PASS  %s\n' "$name"
+  fi
+}
+
+# ---- TEST 1: gh pr create --body "X" augments body ----
+out="$("$WRAPPER" pr create --title t --body "hello world")"
+assert_contains "pr create --body augments" "$out" "$EXPECTED_URL"
+assert_contains "pr create --body preserves original" "$out" "hello world"
+
+# ---- TEST 2: gh pr comment --body "X" augments ----
+out="$("$WRAPPER" pr comment 123 --body "ack")"
+assert_contains "pr comment --body augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 3: gh issue create --body "X" augments ----
+out="$("$WRAPPER" issue create --title t --body "report")"
+assert_contains "issue create --body augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 4: gh issue comment --body "X" augments ----
+out="$("$WRAPPER" issue comment 1 --body "thanks")"
+assert_contains "issue comment --body augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 5: gh pr review --body "X" augments ----
+out="$("$WRAPPER" pr review 9 --request-changes --body "needs fix")"
+assert_contains "pr review --body augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 6: --body= form (single token) augments ----
+out="$("$WRAPPER" pr create --title t --body="long body text")"
+assert_contains "--body= form augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 7: -b short form augments ----
+out="$("$WRAPPER" pr create --title t -b "short")"
+assert_contains "-b short form augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 8: idempotent (body already has URL) ----
+existing_url="https://claude.ai/code/session_OLDID"
+out="$("$WRAPPER" pr create --title t --body "preexisting $existing_url")"
+assert_contains "idempotent: preexisting URL preserved" "$out" "$existing_url"
+assert_not_contains "idempotent: new URL not appended" "$out" "$EXPECTED_URL"
+
+# ---- TEST 9: empty body — no augmentation ----
+out="$("$WRAPPER" pr create --title t --body "")"
+assert_not_contains "empty body: not augmented" "$out" "$EXPECTED_URL"
+
+# ---- TEST 10: pass-through — pr review --approve (no body) ----
+out="$("$WRAPPER" pr review 9 --approve)"
+assert_not_contains "pr review --approve: pass-through" "$out" "$EXPECTED_URL"
+
+# ---- TEST 11: pass-through — non-covered subcommand (pr list) ----
+out="$("$WRAPPER" pr list --state open)"
+assert_not_contains "pr list: pass-through" "$out" "$EXPECTED_URL"
+
+# ---- TEST 12: pass-through — gh api (uncovered) ----
+out="$("$WRAPPER" api '/repos/foo/bar' -f body="x")"
+assert_not_contains "gh api: pass-through" "$out" "$EXPECTED_URL"
+
+# ---- TEST 13: --body-file augments (file contents written augmented) ----
+echo "from a file" > "$WORK/body.txt"
+out="$("$WRAPPER" pr create --title t --body-file "$WORK/body.txt")"
+assert_contains "--body-file augments file content" "$out" "$EXPECTED_URL"
+assert_contains "--body-file preserves original content" "$out" "from a file"
+
+# ---- TEST 14: --body-file=- reads stdin and augments ----
+out="$(printf 'from stdin' | "$WRAPPER" pr create --title t --body-file -)"
+assert_contains "--body-file=stdin augments" "$out" "$EXPECTED_URL"
+assert_contains "--body-file=stdin preserves" "$out" "from stdin"
+
+# ---- TEST 15: outside-Claude (no session env) — pass-through ----
+out="$(env -u CLAUDE_CODE_REMOTE_SESSION_ID -u CLAUDE_CODE_SESSION_ID \
+       COO_GH_REAL="$WORK/gh-real" "$WRAPPER" pr create --title t --body "hi")"
+assert_not_contains "no session env: not augmented" "$out" "claude.ai/code/session_"
+
+# ---- TEST 16: real binary missing AND none on PATH — exit 127 ----
+# Set PATH to dirs that don't contain gh so the fallback also fails.
+ec=0
+err="$(env -i PATH=/usr/bin:/bin HOME="$HOME" COO_GH_REAL=/nonexistent/path \
+       "$WRAPPER" pr create --body "x" 2>&1 >/dev/null)" || ec=$?
+if [ "$ec" = "127" ]; then
+  PASS=$((PASS+1))
+  printf '  PASS  missing real binary: exit 127\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("missing real binary exit code")
+  printf '  FAIL  missing real binary: exit %s, expected 127\n' "$ec"
+  printf '         stderr: %s\n' "$err"
+fi
+
+printf '\n'
+printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed tests:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Substrate enforcement for vade-coo-memory#150 / **MEMO 2026-04-26-02**: every COO-attributed `gh` write (PR / issue / comment / review) auto-carries the originating Claude Code session URL on its body.

- `scripts/gh-coo-wrap.sh` — wrapper script. Augments `--body` / `-b` / `--body=…` / `-b=…` / `--body-file <path>` / `--body-file=<path>` (including `-` for stdin) on `gh pr {create,edit,comment,review}` and `gh issue {create,edit,comment}`. Idempotent on bodies that already contain a session URL. Pass-through for: `pr review --approve` (no body), empty body strings, non-covered subcommands (`pr list`, `pr checkout`, `api`, …), bodies with an existing `claude.ai/code/session_` link, and outside Claude Code (no session env).
- `scripts/test-gh-coo-wrap.sh` — 20-assertion smoke test against a mock `gh-real`. Covers every augmentation path and pass-through carve-out.
- `scripts/lib/common.sh` — adds `ensure_gh_coo_wrap`. First run renames `/home/user/.local/bin/gh` → `gh-real` and places the wrapper at the original path. Subsequent runs detect the wrapper marker (`COO-GH-COO-WRAP-MARKER-v1`) and refresh the wrapper content from source. Cloud-only path guard (`id -u == 0 && /home/user`); macOS / brew gh untouched.
- `scripts/session-start-sync.sh` — invokes `ensure_gh_coo_wrap` after `ensure_gh_symlink_on_path` so the wrapper is in place by the time the agent issues its first `gh` call.

Companion PR vade-coo-memory#152 ships the helper script (`bin/coo-session-url.sh`), the memo, and the `CLAUDE.md` reflective rule.

## Test plan

### Pre-merge gating
- [x] `bash scripts/test-gh-coo-wrap.sh` — 20/20 pass.
- [x] `bash -n` syntax check on `gh-coo-wrap.sh`, `session-start-sync.sh`, `lib/common.sh`.
- [x] Reviewer skim of `ensure_gh_coo_wrap` for the rename-and-replace install logic (the only non-idempotent step).

### Post-merge confirmation (fresh container)
- [ ] `which gh` → `/home/user/.local/bin/gh` (still). `file /home/user/.local/bin/gh` → ASCII text (the wrapper script). `file /home/user/.local/bin/gh-real` → ELF executable (the real binary).
- [ ] `grep COO-GH-COO-WRAP-MARKER-v1 /home/user/.local/bin/gh` → matches.
- [ ] `gh --version` → prints the gh CLI version (pass-through to real).
- [ ] Open a throwaway test PR via `gh pr create --title test --body "hello"`; confirm the created PR body ends with a blank line then `https://claude.ai/code/session_<this-session>`.
- [ ] Post a comment via `gh pr comment <test-pr> --body "ack"`; confirm trailing URL.
- [ ] Re-run `bash scripts/test-gh-coo-wrap.sh` against the deployed wrapper → 20/20.

## Boot-impact

This PR modifies `session-start-sync.sh` and `scripts/lib/common.sh` — both are SessionStart-critical. Per **MEMO 2026-04-25-03** this PR is boot-impacting; the handoff prompt for the next instance is posted as a standalone PR comment after this PR is opened.

## What this does NOT change

- Commit messages (already carry the URL via the manual heredoc convention).
- The `mcp__github*` write paths (out of scope; MEMO 2026-04-24-08 forbids those for attributable writes).
- Attribution wiring (`GH_TOKEN=$GITHUB_MCP_PAT` is unchanged; the wrapper passes env through verbatim).
- macOS / local dev (path-guard skips when not running as root in /home/user).

Refs vade-coo-memory#150, vade-coo-memory#152.

https://claude.ai/code/session_0141X1eedpNLeNXcYX7YuCmp