### PR TITLE
gh-coo-wrap: handle global flags before subcommand (fix #95)

### DIFF
--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -58,13 +58,39 @@ sid="${CLAUDE_CODE_REMOTE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
 SESSION_URL=""
 [ -n "$sid" ] && SESSION_URL="https://claude.ai/code/session_${sid#cse_}"
 
+# is_covered <argv...>: returns 0 iff the (subcommand, action) pair
+# parsed from argv falls in the augment-eligible set. Skips leading
+# global flags so that e.g. `gh -R repo issue comment` is recognized
+# the same as `gh issue comment -R repo`. Value-taking global flags
+# in their separate-token form (`-R repo`, `--repo repo`,
+# `--hostname host`) consume the following arg; `--flag=value` and
+# boolean flags consume only themselves.
 is_covered() {
-  case "${1:-}" in
+  local sub="" act=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --) shift ;;
+      --*=*) shift ;;
+      -R|--repo|--hostname)
+        shift
+        [ $# -gt 0 ] && shift
+        ;;
+      -*) shift ;;
+      *)
+        if [ -z "$sub" ]; then
+          sub="$1"; shift
+        else
+          act="$1"; break
+        fi
+        ;;
+    esac
+  done
+  case "$sub" in
     pr)
-      case "${2:-}" in create|edit|comment|review) return 0 ;; esac
+      case "$act" in create|edit|comment|review) return 0 ;; esac
       ;;
     issue)
-      case "${2:-}" in create|edit|comment) return 0 ;; esac
+      case "$act" in create|edit|comment) return 0 ;; esac
       ;;
   esac
   return 1
@@ -88,7 +114,7 @@ augment() {
 }
 
 # Pass-through: no session URL OR not a covered subcommand.
-if [ -z "$SESSION_URL" ] || ! is_covered "${1:-}" "${2:-}"; then
+if [ -z "$SESSION_URL" ] || ! is_covered "$@"; then
   exec "$REAL_GH" "$@"
 fi
 

--- a/scripts/test-gh-coo-wrap.sh
+++ b/scripts/test-gh-coo-wrap.sh
@@ -160,7 +160,46 @@ out="$(env -u CLAUDE_CODE_REMOTE_SESSION_ID -u CLAUDE_CODE_SESSION_ID \
        COO_GH_REAL="$WORK/gh-real" "$WRAPPER" pr create --title t --body "hi")"
 assert_not_contains "no session env: not augmented" "$out" "claude.ai/code/session_"
 
-# ---- TEST 16: real binary missing AND none on PATH — exit 127 ----
+# ---- TEST 16: -R <repo> before subcommand — augments ----
+out="$("$WRAPPER" -R vade-app/vade-coo-memory issue comment 1 --body "with -R")"
+assert_contains "-R before subcommand: issue comment augments" "$out" "$EXPECTED_URL"
+assert_contains "-R before subcommand: body preserved" "$out" "with -R"
+
+# ---- TEST 17: --repo <repo> before subcommand — augments ----
+out="$("$WRAPPER" --repo vade-app/vade-runtime pr comment 2 --body "with --repo")"
+assert_contains "--repo before subcommand: pr comment augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 18: --repo=<repo> (=value form) before subcommand — augments ----
+out="$("$WRAPPER" --repo=vade-app/vade-core issue create --title t --body "with --repo=")"
+assert_contains "--repo=value before subcommand: issue create augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 19: -R then pr review --body — augments ----
+out="$("$WRAPPER" -R vade-app/vade-runtime pr review 9 --request-changes --body "needs work")"
+assert_contains "-R before pr review --body: augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 20: -R then pr list — pass-through (uncovered subcommand) ----
+out="$("$WRAPPER" -R vade-app/vade-runtime pr list --state open)"
+assert_not_contains "-R before pr list: pass-through" "$out" "$EXPECTED_URL"
+
+# ---- TEST 21: -R then pr review --approve (no body) — pass-through ----
+out="$("$WRAPPER" -R vade-app/vade-runtime pr review 9 --approve)"
+assert_not_contains "-R before pr review --approve: no augmentation" "$out" "$EXPECTED_URL"
+
+# ---- TEST 22: -R interleaved (subcommand then -R then action) — augments ----
+out="$("$WRAPPER" issue -R vade-app/vade-runtime comment 1 --body "interleaved")"
+assert_contains "-R interleaved: issue comment augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 23: --hostname before subcommand — augments ----
+out="$("$WRAPPER" --hostname github.com issue comment 1 --body "with hostname")"
+assert_contains "--hostname before subcommand: augments" "$out" "$EXPECTED_URL"
+
+# ---- TEST 24: -R then --body-file — augments file content ----
+echo "from a file (with -R)" > "$WORK/body2.txt"
+out="$("$WRAPPER" -R vade-app/vade-coo-memory issue comment 1 --body-file "$WORK/body2.txt")"
+assert_contains "-R before --body-file: file content augmented" "$out" "$EXPECTED_URL"
+assert_contains "-R before --body-file: original content preserved" "$out" "from a file (with -R)"
+
+# ---- TEST 25: real binary missing AND none on PATH — exit 127 ----
 # Set PATH to dirs that don't contain gh so the fallback also fails.
 ec=0
 err="$(env -i PATH=/usr/bin:/bin HOME="$HOME" COO_GH_REAL=/nonexistent/path \


### PR DESCRIPTION
## Summary

- Fixes #95: `gh-coo-wrap` was misclassifying invocations of the form `gh -R <repo> issue comment --body "x"` as non-covered, so no session URL was appended. Caught in fresh-container post-merge verification of #94 (handoff step 6).
- The defect: `is_covered()` only inspected `$1` and `$2`. With global flags before the subcommand, the subcommand isn't at `$1`. The cover check now walks past leading global flags (boolean `-*`, `--*=*`, and the value-taking trio `-R`/`--repo`/`--hostname`).
- Test gap closed: added 11 cases covering global-flags-before-subcommand for every covered subcommand, plus pass-through cases (`pr list`, `pr review --approve`), the `--repo=value` form, the `--hostname` global, interleaved `-R` between subcommand and action, and `-R` before `--body-file`. The previous suite had zero coverage for this shape.

## Test plan

- [x] `bash scripts/test-gh-coo-wrap.sh` — 31 pass, 0 fail (was 20/20 pre-patch, all preserved).
- [x] Live end-to-end on this container: `GH_TOKEN=$GITHUB_MCP_PAT gh -R vade-app/vade-coo-memory issue comment 150 --body "..."` now produces a comment with the session URL appended. Evidence: vade-coo-memory#150 comment 4321109524.
- [x] Pass-through unchanged for non-covered subcommands and bodyless covered subcommands.
- [x] Existing edge cases (idempotent body, empty body, missing real binary, no session env) still pass.

## Pre-merge gating

(none — local test suite + live verification on this container both pass; no SessionStart-critical changes beyond the wrapper itself, which session-start-sync re-installs from `scripts/gh-coo-wrap.sh` per the existing flow.)

## Post-merge confirmation (fresh container)

Same as #94 step 5/6, in a fresh container after this lands on main:

1. `bash /home/user/vade-runtime/scripts/test-gh-coo-wrap.sh` — expect `Total: 31 pass, 0 fail`.
2. `GH_TOKEN="$GITHUB_MCP_PAT" gh -R vade-app/vade-coo-memory issue comment 150 --body "post-fix smoke from <run-id>"` — then fetch the comment via `gh api repos/vade-app/vade-coo-memory/issues/comments/<id> --jq .body` and confirm the body ends with `https://claude.ai/code/session_<your-current-session>`.
3. If both pass, close vade-coo-memory#150.

## Followup

- vade-coo-memory#150 stays open; close it once post-merge step 2 above passes in a fresh session.
- `/memo-sync` for MEMO 2026-04-26-02 still pending — independent of this fix.