### PR TITLE
ci: Layer-1 bootstrap regression suite (closes #86)

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -1,0 +1,87 @@
+name: Bootstrap regression
+
+# Layer-1 script-level CI for the cloud bootstrap chain.
+# Tracks vade-app/vade-runtime#86. Layer-2 (SDK-driven harness test)
+# lives at #85 and is out of scope here.
+#
+# What this catches that production currently catches via "open a fresh
+# Claude Code session and watch the digest":
+#   - #66 env-merge before validate
+#   - #72 cached-PAT recheck on marker shortcut
+#   - #73 digest path resolver
+#   - #83 settings.json env injection
+#
+# What it does NOT cover (Layer-2 territory):
+#   - Claude Code reading settings.json + loading skills + MCP startup
+#   - macOS local-setup.sh surface
+#   - Live 1Password / live GitHub PAT round-trips (mocked here)
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - '.claude/**'
+      - '.mcp.json'
+      - 'versions.lock'
+      - 'Dockerfile'
+      - '.github/workflows/bootstrap-regression.yml'
+  workflow_dispatch:
+    inputs:
+      allowlist:
+        description: "Comma-separated invariant ids to tolerate as degraded"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: bootstrap-regression-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run bootstrap-regression suite
+        id: run
+        env:
+          # Empty by default. Today's expected-degraded set:
+          #   - E1–E4: live MCP probes; integrity-check.sh marks them
+          #     "skip" in CI by design — never appear in degraded.
+          #   - F1–F4: culture-substrate invariants; skip cleanly when
+          #     vade-coo-memory is a stub without .git.
+          # Bump this if a new structural-but-known-yellow invariant
+          # lands; cite the reason in the commit message so the next
+          # operator can audit.
+          VADE_CI_ALLOWLIST: ${{ github.event.inputs.allowlist || '' }}
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/run-bootstrap-regression.sh" "$GITHUB_WORKSPACE"
+
+      - name: Post or update PR comment
+        if: always() && github.event.pull_request.number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/post-or-update-pr-comment.sh"
+
+      - name: Upload integrity-check artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bootstrap-regression-${{ github.run_id }}
+          path: |
+            /home/user/.vade-cloud-state/integrity-check.json
+            /home/user/.vade-cloud-state/setup-receipt.json
+            /home/user/.vade-cloud-state/build.log
+            /tmp/bootstrap-regression-summary.md
+            /tmp/bootstrap-regression-result.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,60 @@ See `versions.lock` for pinned tools.
 Next planned additions (deferred until needed): Rust toolchain via
 `rustup` when the first performance module lands, Python 3.12 when a
 canvas artifact needs scientific helpers.
+
+## Bootstrap CI
+
+PRs that touch `scripts/`, `.claude/`, `.mcp.json`, `versions.lock`,
+or `Dockerfile` trigger
+`.github/workflows/bootstrap-regression.yml`, which stages a
+cloud-style workspace under `/home/user`, runs `scripts/cloud-setup.sh`
++ `scripts/session-start-sync.sh` end-to-end in **fake-env mode**
+(PATH-shadowed `op` and `curl`-to-`api.github.com/user` mocks under
+`scripts/ci/mocks/`), then asserts the integrity-check report has no
+degraded invariants modulo the `VADE_CI_ALLOWLIST` env. Catches
+script-level regressions like #66, #72, #73, #83 at PR-open time
+without burning a Claude Code session per check. Tracked at #86.
+
+Layer-2 (SDK-driven harness load test) is sibling work at #85.
+This Layer-1 suite does not exercise Claude Code reading
+`settings.json`, MCP startup, skill loading, or live 1Password / GitHub
+PAT round-trips — those stay in the manual fresh-container ritual
+until #85 closes.
+
+What runs:
+1. `scripts/ci/run-bootstrap-regression.sh` stages
+   `$VADE_CI_WORKSPACE_ROOT/{vade-runtime,vade-coo-memory,vade-core}`
+   from the PR checkout (sibling repos are stubbed).
+2. Generates fixture ed25519 keys per run; their fingerprints are
+   exported as `COO_AUTH_FP_EXPECTED` / `COO_SIGN_FP_EXPECTED` so
+   `install_coo_ssh_keys` validates against the substituted material.
+3. Mocks `op` (returns canned vade-coo-shaped responses) and `curl`
+   (intercepts only `api.github.com/user`; other URLs forward).
+4. Provisions an isolated `$HOME` so the runner's `~/.gitconfig` /
+   `~/.claude` stay untouched.
+5. Runs `cloud-setup.sh` → `session-start-sync.sh` →
+   `integrity-check.sh`; reads `integrity-check.json`, applies
+   `VADE_CI_ALLOWLIST`, fails if anything degraded remains.
+6. Renders a per-group markdown table and posts/updates a sticky PR
+   comment (header marker `<!-- bootstrap-regression-comment -->`).
+
+Allowlist defaults to empty. E1–E4 (live MCP probes) skip in CI by
+design; F1–F4 (culture-substrate invariants) skip cleanly because
+the staged `vade-coo-memory` is a stub without `.git`. Bump the
+allowlist via the workflow's `VADE_CI_ALLOWLIST` env or the
+`workflow_dispatch` input — cite the reason in the commit so the
+next operator can audit.
+
+Local run (from a vade-runtime checkout, against a scratch workspace
+to avoid clobbering production /home/user):
+
+```sh
+VADE_CI_WORKSPACE_ROOT=/tmp/vade-ci-workspace \
+  bash scripts/ci/run-bootstrap-regression.sh "$PWD"
+```
+
+Smoke-test the suite itself by editing `cloud-setup.sh` /
+`session-start-sync.sh` to comment out a call like
+`ensure_workspace_identity_link` or `merge_coo_settings_env` — the
+runner should report the corresponding C1/D4 invariant as degraded
+and exit 1.

--- a/scripts/ci/mocks/curl
+++ b/scripts/ci/mocks/curl
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Mock curl wrapper for the bootstrap-regression suite (issue #86).
+#
+# Intercepts requests to https://api.github.com/user — the endpoint
+# `validate_coo_identity` and `_cached_pat_still_valid` use to confirm
+# the cached PAT resolves to the vade-coo login — and returns a canned
+# vade-coo identity. Every other curl invocation forwards to the real
+# binary (op/gh download paths, ssh-keyscan fallbacks, etc.) so the
+# substrate stays representative.
+set -euo pipefail
+
+REAL_CURL="${VADE_CI_REAL_CURL:-/usr/bin/curl}"
+
+for arg in "$@"; do
+  case "$arg" in
+    https://api.github.com/user|https://api.github.com/user\?*)
+      cat <<'EOF'
+{"login":"vade-coo","id":278229580,"type":"User","name":"VADE COO (CI mock)"}
+EOF
+      exit 0
+      ;;
+  esac
+done
+
+exec "$REAL_CURL" "$@"

--- a/scripts/ci/mocks/op
+++ b/scripts/ci/mocks/op
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Mock 1Password CLI for the bootstrap-regression suite (issue #86).
+#
+# Returns canned vade-coo-shaped responses for the subset of `op` calls
+# made by scripts/coo-bootstrap.sh (whoami + read of the four COO refs).
+# SSH key material is read from $VADE_CI_MOCK_KEYDIR/vade-coo-{auth,sign}{,.pub};
+# the runner generates fresh ed25519 keys per CI invocation and exports
+# their fingerprints as COO_AUTH_FP_EXPECTED / COO_SIGN_FP_EXPECTED so
+# install_coo_ssh_keys' fingerprint check passes.
+#
+# Real op CLI is never installed in the regression job — ensure_op_cli's
+# `check_cmd op` short-circuits because this mock is on PATH first
+# (VADE_BINDIR_OVERRIDE points at the dir holding this binary).
+#
+# Out-of-scope subcommands print a clear "[mock op]" diagnostic and exit
+# non-zero, so a bootstrap change that calls a new op subcommand fails
+# the regression visibly rather than silently passing.
+set -euo pipefail
+
+KEYDIR="${VADE_CI_MOCK_KEYDIR:-/tmp/vade-ci-mocks/keys}"
+
+case "${1:-}" in
+  --version)
+    echo "2.31.0 (vade-ci mock)"
+    exit 0
+    ;;
+  whoami)
+    echo "ServiceAccount: ci-mock-coo-bootstrap"
+    exit 0
+    ;;
+  read)
+    ref="${2:-}"
+    case "$ref" in
+      "op://COO/vade-coo-self-2026-04/token")
+        echo "ghp_CIMOCK00000000000000000000000000000000"
+        ;;
+      "op://COO/agentmail-vade-coo/credential")
+        echo "am_CIMOCK_AGENTMAIL_KEY_DO_NOT_USE"
+        ;;
+      "op://COO/mem0-vade-coo/credential")
+        echo "m0_CIMOCK_MEM0_KEY_DO_NOT_USE"
+        ;;
+      "op://COO/vade-coo-auth/private key")
+        cat "$KEYDIR/vade-coo-auth"
+        ;;
+      "op://COO/vade-coo-auth/public key")
+        cat "$KEYDIR/vade-coo-auth.pub"
+        ;;
+      "op://COO/vade-coo-sign/private key")
+        cat "$KEYDIR/vade-coo-sign"
+        ;;
+      "op://COO/vade-coo-sign/public key")
+        cat "$KEYDIR/vade-coo-sign.pub"
+        ;;
+      *)
+        echo "[mock op] unknown op:// ref: $ref" >&2
+        exit 2
+        ;;
+    esac
+    exit 0
+    ;;
+  *)
+    echo "[mock op] unhandled subcommand: $*" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/ci/post-or-update-pr-comment.sh
+++ b/scripts/ci/post-or-update-pr-comment.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Post or update the bootstrap-regression PR comment.
+#
+# Identifies the prior comment by a magic header marker
+# ("<!-- bootstrap-regression-comment -->") emitted by render-integrity-summary.sh
+# so re-runs replace the previous comment instead of stacking duplicates.
+#
+# Required env (set by the workflow step):
+#   GH_TOKEN         — token with issues:write
+#   PR               — pull request number
+#   REPO             — owner/name
+# Optional env:
+#   VADE_CI_SUMMARY_OUT — path to the rendered markdown summary
+set -euo pipefail
+
+SUMMARY="${VADE_CI_SUMMARY_OUT:-/tmp/bootstrap-regression-summary.md}"
+HEADER='<!-- bootstrap-regression-comment -->'
+
+if [ ! -f "$SUMMARY" ]; then
+  echo "[ci-bootstrap-regression] summary file missing at $SUMMARY; nothing to post" >&2
+  exit 0
+fi
+if [ -z "${PR:-}" ] || [ -z "${REPO:-}" ]; then
+  echo "[ci-bootstrap-regression] PR or REPO unset; skipping comment" >&2
+  exit 0
+fi
+
+EXISTING_ID="$(
+  gh api "/repos/$REPO/issues/$PR/comments" --paginate \
+    --jq ".[] | select(.body | startswith(\"$HEADER\")) | .id" \
+    2>/dev/null | head -1 || true
+)"
+
+PAYLOAD="$(mktemp)"
+trap 'rm -f "$PAYLOAD"' EXIT
+jq -n --rawfile body "$SUMMARY" '{body: $body}' > "$PAYLOAD"
+
+if [ -n "$EXISTING_ID" ]; then
+  echo "[ci-bootstrap-regression] updating existing comment $EXISTING_ID"
+  gh api --method PATCH "/repos/$REPO/issues/comments/$EXISTING_ID" \
+    --input "$PAYLOAD" >/dev/null
+else
+  echo "[ci-bootstrap-regression] posting new comment on PR #$PR"
+  gh api --method POST "/repos/$REPO/issues/$PR/comments" \
+    --input "$PAYLOAD" >/dev/null
+fi

--- a/scripts/ci/render-integrity-summary.sh
+++ b/scripts/ci/render-integrity-summary.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Render integrity-check.json + the runner's pass/fail decision into a
+# markdown summary suitable for a PR comment. Called by
+# run-bootstrap-regression.sh; idempotent and safe to invoke standalone
+# for local previewing.
+#
+# Args:
+#   $1  integrity-check.json path
+#   $2  runner-result JSON (ok/degraded/allowed/passed/total)
+#   $3  output markdown path
+#   $4  allowlist (comma-separated invariant ids; informational only)
+set -euo pipefail
+
+INTEGRITY="$1"
+RESULT="$2"
+OUT="$3"
+ALLOWLIST="${4:-}"
+
+node -e '
+  const fs = require("fs");
+  const [integrityPath, resultPath, outPath, allowlistRaw] = process.argv.slice(1);
+  const data = JSON.parse(fs.readFileSync(integrityPath, "utf8"));
+  const result = JSON.parse(fs.readFileSync(resultPath, "utf8"));
+  const allow = (allowlistRaw || "").split(",").map(s => s.trim()).filter(Boolean);
+  const ok = result.ok;
+  const lines = [];
+  lines.push("<!-- bootstrap-regression-comment -->");
+  lines.push("## Bootstrap regression — " + (ok ? "PASS ✅" : "FAIL ❌"));
+  lines.push("");
+  lines.push(
+    "Ran `scripts/cloud-setup.sh` → `scripts/session-start-sync.sh` → " +
+    "`scripts/integrity-check.sh` in fake-env mode (mock `op` + " +
+    "`curl`-to-github-api)."
+  );
+  lines.push("");
+  lines.push("- **Invariants**: `" + result.passed + "/" + result.total + "` passed");
+  if (result.degraded.length) {
+    lines.push("- **Degraded (failing this PR)**: `" + result.degraded.join("`, `") + "`");
+  }
+  if (result.allowed.length) {
+    lines.push("- **Allowlisted (would-be-degraded but tolerated)**: `" + result.allowed.join("`, `") + "`");
+  }
+  if (allow.length) {
+    lines.push("- **Configured allowlist**: `" + allow.join("`, `") + "`");
+  }
+  lines.push("- **Session id**: `" + (data.session_id || "unknown") + "`");
+  lines.push("- **Checked at**: `" + (data.checked_at || "unknown") + "`");
+  lines.push("");
+
+  // Per-group breakdown.
+  const symbol = (v) => {
+    if (v.info) return ":information_source:";
+    if (v.skipped) return ":fast_forward:";
+    return v.ok ? ":white_check_mark:" : ":x:";
+  };
+  for (const g of Object.keys(data.groups).sort()) {
+    lines.push("### Group " + g);
+    lines.push("");
+    lines.push("| ID | Status | Detail |");
+    lines.push("| --- | --- | --- |");
+    for (const k of Object.keys(data.groups[g]).sort()) {
+      const v = data.groups[g][k];
+      const status = symbol(v) + " " + (v.info ? "info" : v.skipped ? "skip" : v.ok ? "pass" : "fail");
+      const detail = String(v.detail || "")
+        .replace(/\|/g, "\\|")
+        .replace(/\r?\n/g, " ")
+        .slice(0, 240);
+      lines.push("| " + k + " | " + status + " | " + detail + " |");
+    }
+    lines.push("");
+  }
+
+  lines.push("---");
+  lines.push("");
+  lines.push("Workflow: `.github/workflows/bootstrap-regression.yml`. " +
+             "Re-run by pushing to this PR or using the workflow_dispatch trigger. " +
+             "Tracked at vade-app/vade-runtime#86.");
+
+  fs.writeFileSync(outPath, lines.join("\n") + "\n");
+' "$INTEGRITY" "$RESULT" "$OUT" "$ALLOWLIST"
+
+echo "[ci-bootstrap-regression] Wrote markdown summary to $OUT"

--- a/scripts/ci/run-bootstrap-regression.sh
+++ b/scripts/ci/run-bootstrap-regression.sh
@@ -76,6 +76,13 @@ git config --global --add safe.directory "$RUNTIME_DST" 2>/dev/null || true
 
 log "Stubbing sibling repos at $WORKSPACE_ROOT"
 rm -rf "$COO_MEM_DST" "$CORE_DST"
+# Wipe workspace-scope leftovers from prior runs so a regression in
+# cloud-setup or session-start-sync (e.g. a missing
+# ensure_workspace_identity_link call) actually fails C1/C2 instead of
+# being masked by a stale symlink. Production CI on ubuntu-latest gets
+# a fresh runner per job; local re-runs need the explicit clean.
+rm -rf "$WORKSPACE_ROOT/CLAUDE.md" "$WORKSPACE_ROOT/.mcp.json" \
+       "$WORKSPACE_ROOT/.vade-cloud-state"
 mkdir -p "$COO_MEM_DST/coo" "$COO_MEM_DST/identity"
 cat > "$COO_MEM_DST/CLAUDE.md" <<'EOF'
 # vade-coo-memory CLAUDE.md (CI bootstrap-regression stub)
@@ -124,6 +131,14 @@ unset GIT_CONFIG_GLOBAL XDG_CONFIG_HOME
 
 # ── 5. Fake credentials + run cloud-setup ────────────────────────
 export OP_SERVICE_ACCOUNT_TOKEN="ops_FAKE_CI_TOKEN_DO_NOT_USE_FOR_REAL_CALLS"
+
+# Pin cloud-state under WORKSPACE_ROOT so the runner reads the same
+# integrity-check.json that cloud-setup wrote. Without this override the
+# common.sh default (/home/user/.vade-cloud-state) wins when the
+# inherited env doesn't already point there, and a non-/home/user
+# WORKSPACE_ROOT in CI yields a path mismatch (cloud-setup writes to
+# /home/user/, runner reads from /tmp/...).
+export VADE_CLOUD_STATE_DIR="$WORKSPACE_ROOT/.vade-cloud-state"
 
 log "Running scripts/cloud-setup.sh"
 bash "$RUNTIME_DST/scripts/cloud-setup.sh"

--- a/scripts/ci/run-bootstrap-regression.sh
+++ b/scripts/ci/run-bootstrap-regression.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# CI runner for the bootstrap regression suite (vade-runtime#86).
+#
+# Drives the full snapshot-build → session-resume cycle in fake-env mode:
+#
+#   1. Stage a cloud-style workspace at $VADE_CI_WORKSPACE_ROOT/{vade-runtime,
+#      vade-coo-memory,vade-core} from the PR checkout.
+#   2. Generate fixture SSH keys + their fingerprints; export them so
+#      install_coo_ssh_keys' fingerprint check passes.
+#   3. Install PATH-shadowed mocks for `op` and `curl` (latter only
+#      intercepts api.github.com/user, forwards everything else).
+#   4. Provision an isolated $HOME so the runner's gitconfig / ~/.claude
+#      stay untouched.
+#   5. Run scripts/cloud-setup.sh (writes setup-receipt.json + invokes
+#      coo-bootstrap.sh under the mocks).
+#   6. Run scripts/session-start-sync.sh (which calls integrity-check.sh
+#      and emits integrity-check.json).
+#   7. Read integrity-check.json, subtract VADE_CI_ALLOWLIST, fail if any
+#      degraded invariants remain.
+#   8. Render a markdown summary (groups + per-invariant table) to
+#      $VADE_CI_SUMMARY_OUT for the PR-comment step in the workflow.
+#
+# Invariants the suite covers correspond 1:1 to integrity-check.sh
+# Groups A–F. E1–E4 (live MCP probes) skip in CI by design; F1–F4 skip
+# cleanly because the staged vade-coo-memory is a stub without .git.
+#
+# Locally invokable: `bash scripts/ci/run-bootstrap-regression.sh .`
+# from a vade-runtime checkout. Set VADE_CI_WORKSPACE_ROOT to a
+# scratch path (e.g. /tmp/vade-ci-workspace) when running locally to
+# avoid clobbering production /home/user/ working trees. SOURCE_DIR
+# must NOT be the same as $VADE_CI_WORKSPACE_ROOT/vade-runtime — the
+# stage step `rm -rf`s the destination first.
+set -euo pipefail
+
+SOURCE_DIR="${1:-$PWD}"
+SOURCE_DIR="$(cd "$SOURCE_DIR" && pwd)"
+
+WORKSPACE_ROOT="${VADE_CI_WORKSPACE_ROOT:-/home/user}"
+RUNTIME_DST="$WORKSPACE_ROOT/vade-runtime"
+COO_MEM_DST="$WORKSPACE_ROOT/vade-coo-memory"
+CORE_DST="$WORKSPACE_ROOT/vade-core"
+
+TEST_HOME="${VADE_CI_TEST_HOME:-/tmp/vade-ci-home}"
+MOCK_DIR="${VADE_CI_MOCK_DIR:-/tmp/vade-ci-mocks}"
+SUMMARY_OUT="${VADE_CI_SUMMARY_OUT:-/tmp/bootstrap-regression-summary.md}"
+RESULT_OUT="${VADE_CI_RESULT_OUT:-/tmp/bootstrap-regression-result.json}"
+ALLOWLIST="${VADE_CI_ALLOWLIST:-}"
+export SUMMARY_OUT RESULT_OUT ALLOWLIST
+
+log() { printf '[ci-bootstrap-regression] %s\n' "$*"; }
+
+# Self-clobber guard: SOURCE_DIR must not equal the destination, or the
+# rm -rf in the stage step will delete the source mid-run.
+if [ "$SOURCE_DIR" = "$RUNTIME_DST" ]; then
+  log "FATAL: SOURCE_DIR equals RUNTIME_DST ($SOURCE_DIR); set VADE_CI_WORKSPACE_ROOT to a scratch path."
+  exit 2
+fi
+
+# ── 1. Stage workspace ───────────────────────────────────────────
+if [ ! -d "$WORKSPACE_ROOT" ] || [ ! -w "$WORKSPACE_ROOT" ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    sudo mkdir -p "$WORKSPACE_ROOT"
+    sudo chown -R "$(id -u):$(id -g)" "$WORKSPACE_ROOT"
+  else
+    mkdir -p "$WORKSPACE_ROOT"
+  fi
+fi
+
+log "Staging $SOURCE_DIR → $RUNTIME_DST"
+rm -rf "$RUNTIME_DST"
+mkdir -p "$RUNTIME_DST"
+# tar-pipe preserves .git so cloud-setup's `git rev-parse --short HEAD`
+# resolves a real sha into the receipt.
+( cd "$SOURCE_DIR" && tar c . ) | ( cd "$RUNTIME_DST" && tar x )
+git config --global --add safe.directory "$RUNTIME_DST" 2>/dev/null || true
+
+log "Stubbing sibling repos at $WORKSPACE_ROOT"
+rm -rf "$COO_MEM_DST" "$CORE_DST"
+mkdir -p "$COO_MEM_DST/coo" "$COO_MEM_DST/identity"
+cat > "$COO_MEM_DST/CLAUDE.md" <<'EOF'
+# vade-coo-memory CLAUDE.md (CI bootstrap-regression stub)
+
+Placeholder file so ensure_workspace_identity_link has a target and
+integrity-check C1 passes. The real CLAUDE.md lives at
+https://github.com/vade-app/vade-coo-memory/blob/main/CLAUDE.md.
+EOF
+mkdir -p "$CORE_DST/.claude"
+
+# ── 2. Fixture SSH keys + fingerprints ───────────────────────────
+log "Generating fixture SSH keys at $MOCK_DIR/keys"
+rm -rf "$MOCK_DIR"
+mkdir -p "$MOCK_DIR/keys" "$MOCK_DIR/bin"
+ssh-keygen -t ed25519 -N '' -q -f "$MOCK_DIR/keys/vade-coo-auth" -C "ci-mock-auth"
+ssh-keygen -t ed25519 -N '' -q -f "$MOCK_DIR/keys/vade-coo-sign" -C "ci-mock-sign"
+COO_AUTH_FP_EXPECTED="$(ssh-keygen -lf "$MOCK_DIR/keys/vade-coo-auth.pub" | awk '{print $2}')"
+COO_SIGN_FP_EXPECTED="$(ssh-keygen -lf "$MOCK_DIR/keys/vade-coo-sign.pub" | awk '{print $2}')"
+export COO_AUTH_FP_EXPECTED COO_SIGN_FP_EXPECTED
+log "  auth fp: $COO_AUTH_FP_EXPECTED"
+log "  sign fp: $COO_SIGN_FP_EXPECTED"
+
+# ── 3. PATH-shadowed mocks ───────────────────────────────────────
+install -m 0755 "$RUNTIME_DST/scripts/ci/mocks/op"   "$MOCK_DIR/bin/op"
+install -m 0755 "$RUNTIME_DST/scripts/ci/mocks/curl" "$MOCK_DIR/bin/curl"
+export VADE_CI_MOCK_KEYDIR="$MOCK_DIR/keys"
+# Capture the real curl path before our mock shadows it on PATH.
+REAL_CURL="$(command -v curl || echo /usr/bin/curl)"
+export VADE_CI_REAL_CURL="$REAL_CURL"
+export PATH="$MOCK_DIR/bin:$PATH"
+# Force ensure_op_cli / ensure_gh_cli to short-circuit on our mocks
+# instead of trying to install the real binaries into a system bindir.
+# Without this the snapshot-bindir resolver would prepend
+# /home/user/.local/bin (when running as root with that dir present),
+# shadowing our mock op with a real one.
+export VADE_BINDIR_OVERRIDE="$MOCK_DIR/bin"
+log "Mocks on PATH: op=$(command -v op) curl=$(command -v curl) (real curl: $REAL_CURL)"
+log "VADE_BINDIR_OVERRIDE=$VADE_BINDIR_OVERRIDE"
+
+# ── 4. Isolated HOME ─────────────────────────────────────────────
+log "Provisioning isolated HOME at $TEST_HOME"
+rm -rf "$TEST_HOME"
+mkdir -p "$TEST_HOME"
+export HOME="$TEST_HOME"
+unset GIT_CONFIG_GLOBAL XDG_CONFIG_HOME
+
+# ── 5. Fake credentials + run cloud-setup ────────────────────────
+export OP_SERVICE_ACCOUNT_TOKEN="ops_FAKE_CI_TOKEN_DO_NOT_USE_FOR_REAL_CALLS"
+
+log "Running scripts/cloud-setup.sh"
+bash "$RUNTIME_DST/scripts/cloud-setup.sh"
+
+# ── 6. Run session-start-sync ────────────────────────────────────
+log "Running scripts/session-start-sync.sh"
+# Tag the integrity-check report with a CI-flavored session id so any
+# operator triaging the artifact can tell it's not a real session.
+export CLAUDE_CODE_SESSION_ID="ci-bootstrap-regression-${GITHUB_RUN_ID:-local}"
+bash "$RUNTIME_DST/scripts/session-start-sync.sh"
+
+# ── 7. Read integrity-check + apply allowlist ────────────────────
+INTEGRITY="${VADE_CLOUD_STATE_DIR:-$WORKSPACE_ROOT/.vade-cloud-state}/integrity-check.json"
+if [ ! -f "$INTEGRITY" ]; then
+  log "FATAL: integrity-check.json not produced at $INTEGRITY"
+  exit 2
+fi
+
+log "integrity-check.json contents:"
+cat "$INTEGRITY"
+echo
+
+set +e
+node -e '
+  const fs = require("fs");
+  const [path, allowlistRaw] = process.argv.slice(1);
+  const allow = new Set((allowlistRaw || "").split(",").map(s => s.trim()).filter(Boolean));
+  const data = JSON.parse(fs.readFileSync(path, "utf8"));
+  const allDegraded = (data.summary && data.summary.degraded) || [];
+  const degraded = allDegraded.filter(k => !allow.has(k));
+  const allowed  = allDegraded.filter(k =>  allow.has(k));
+  const ok = degraded.length === 0;
+  fs.writeFileSync(process.env.RESULT_OUT, JSON.stringify({
+    ok, degraded, allowed,
+    passed: data.summary && data.summary.passed,
+    total:  data.summary && data.summary.total,
+  }) + "\n");
+  process.exit(ok ? 0 : 1);
+' "$INTEGRITY" "$ALLOWLIST"
+RC=$?
+set -e
+
+# ── 8. Render summary regardless of pass/fail ────────────────────
+bash "$RUNTIME_DST/scripts/ci/render-integrity-summary.sh" \
+  "$INTEGRITY" "$RESULT_OUT" "$SUMMARY_OUT" "$ALLOWLIST"
+
+if [ "$RC" -ne 0 ]; then
+  log "FAIL — degraded invariants (excluding allowlist '$ALLOWLIST')"
+  exit 1
+fi
+log "PASS — all integrity-check invariants ok (allowlist: '$ALLOWLIST')"

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -13,23 +13,32 @@
 # /home/user/ before this runs, so we just point at /home/user/vade-runtime.
 set -euo pipefail
 
-source /home/user/vade-runtime/scripts/lib/common.sh
+# Derive workspace root from script location so the bootstrap-regression
+# CI (.github/workflows/bootstrap-regression.yml) can stage a sandboxed
+# /tmp/<root>/vade-runtime tree without colliding with the production
+# /home/user/ working trees. In production both resolve to /home/user.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_ROOT="$(cd "$RUNTIME_DIR/.." && pwd)"
+
+# shellcheck source=lib/common.sh
+source "$RUNTIME_DIR/scripts/lib/common.sh"
 
 log "Cloud environment setup starting"
 build_log_record START "cloud-setup: begin"
 log "Baseline: node=$(node --version 2>/dev/null || echo 'missing') npm=$(npm --version 2>/dev/null || echo 'missing')"
 
 ensure_dirs
-sync_claude_config /home/user/vade-runtime/.claude
+sync_claude_config "$RUNTIME_DIR/.claude"
 # Aggregate per-repo primitives from data-owning repos into the
 # user-scope .claude/ via per-file symlinks. Per the data-ownership
 # rule (MEMO 2026-04-25-02), slash commands and skills live in the
 # repo whose data they manipulate; the aggregator surfaces them at
 # user-scope so they're invokable from any session cwd.
-aggregate_workspace_claude_config /home/user "$HOME/.claude" \
+aggregate_workspace_claude_config "$WORKSPACE_ROOT" "$HOME/.claude" \
   vade-runtime vade-coo-memory vade-core
-ensure_workspace_mcp_config
-ensure_workspace_identity_link
+ensure_workspace_mcp_config "$RUNTIME_DIR/.mcp.json" "$WORKSPACE_ROOT/.mcp.json"
+ensure_workspace_identity_link "$WORKSPACE_ROOT/vade-coo-memory/CLAUDE.md" "$WORKSPACE_ROOT/CLAUDE.md"
 
 # Validate the synced settings.json actually parses as JSON and has a
 # populated SessionStart:startup hook chain. File-exists alone would
@@ -55,13 +64,13 @@ if [ -f "$HOME/.claude/settings.json" ]; then
 fi
 
 WORKSPACE_MCP_SYMLINKED=false
-[ -L /home/user/.mcp.json ] && \
-  [ "$(readlink -f /home/user/.mcp.json 2>/dev/null)" = "$(readlink -f /home/user/vade-runtime/.mcp.json 2>/dev/null)" ] && \
+[ -L "$WORKSPACE_ROOT/.mcp.json" ] && \
+  [ "$(readlink -f "$WORKSPACE_ROOT/.mcp.json" 2>/dev/null)" = "$(readlink -f "$RUNTIME_DIR/.mcp.json" 2>/dev/null)" ] && \
   WORKSPACE_MCP_SYMLINKED=true
 
 IDENTITY_LINK_OK=false
-[ -L /home/user/CLAUDE.md ] && \
-  [ "$(readlink -f /home/user/CLAUDE.md 2>/dev/null)" = "$(readlink -f /home/user/vade-coo-memory/CLAUDE.md 2>/dev/null)" ] && \
+[ -L "$WORKSPACE_ROOT/CLAUDE.md" ] && \
+  [ "$(readlink -f "$WORKSPACE_ROOT/CLAUDE.md" 2>/dev/null)" = "$(readlink -f "$WORKSPACE_ROOT/vade-coo-memory/CLAUDE.md" 2>/dev/null)" ] && \
   IDENTITY_LINK_OK=true
 
 # Workspace deps (npm install vade-core, install tsx) are opt-in:
@@ -70,7 +79,7 @@ IDENTITY_LINK_OK=false
 # full local toolchain set VADE_BOOT_INSTALL=1.
 if [ "${VADE_BOOT_INSTALL:-0}" = "1" ]; then
   ensure_tsx
-  install_deps /home/user/vade-core
+  install_deps "$WORKSPACE_ROOT/vade-core"
 fi
 
 print_versions
@@ -120,7 +129,7 @@ COO_BOOTSTRAP_RAN=false
 if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
   OP_TOKEN_VISIBLE=true
   build_log_record PROBE "cloud-setup: OP_SERVICE_ACCOUNT_TOKEN visible at setup time (len=${#OP_SERVICE_ACCOUNT_TOKEN})"
-  if bash /home/user/vade-runtime/scripts/coo-bootstrap.sh; then
+  if bash "$RUNTIME_DIR/scripts/coo-bootstrap.sh"; then
     COO_BOOTSTRAP_RAN=true
     build_log_record OK "cloud-setup: coo-bootstrap completed"
   else
@@ -135,7 +144,7 @@ fi
 # Durable receipt so sessions can diagnose build-time state without
 # parsing logs. coo-identity-digest surfaces this in the SessionStart
 # digest block.
-GIT_SHA="$(git -C /home/user/vade-runtime rev-parse --short HEAD 2>/dev/null || echo unknown)"
+GIT_SHA="$(git -C "$RUNTIME_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 build_receipt_write \
   built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   op_token_visible="$OP_TOKEN_VISIBLE" \

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -593,14 +593,27 @@ print_versions() {
 
 OP_VERSION_DEFAULT="2.31.0"
 GH_VERSION_DEFAULT="2.91.0"
-COO_AUTH_FP_EXPECTED="SHA256:9vxJc6c69L8eaR6CvwdZoYDco24W6yN6GkKwnsm8Uys"
-COO_SIGN_FP_EXPECTED="SHA256:pZeA8xycAtIsVGwhMzR3mg4KG05n9ksFuy4F1ZVXn3A"
+# Hardcoded production fingerprints; env-overridable so the bootstrap-
+# regression CI (.github/workflows/bootstrap-regression.yml) can
+# substitute fixture-key fingerprints without forking install_coo_ssh_keys.
+# Production paths leave these unset and fall through to the literals.
+COO_AUTH_FP_EXPECTED="${COO_AUTH_FP_EXPECTED:-SHA256:9vxJc6c69L8eaR6CvwdZoYDco24W6yN6GkKwnsm8Uys}"
+COO_SIGN_FP_EXPECTED="${COO_SIGN_FP_EXPECTED:-SHA256:pZeA8xycAtIsVGwhMzR3mg4KG05n9ksFuy4F1ZVXn3A}"
 
 # Snapshot-persistent user bindir. Cloud harness runs as root and the
 # /home/user/ tree survives snapshot → resume; local Mac has no
 # /home/user/ and runs as the operator's user, so $HOME/.local/bin is
 # the right target. Both ensure_op_cli and ensure_gh_cli install here.
+#
+# Env override: VADE_BINDIR_OVERRIDE lets the bootstrap-regression CI
+# point at a sandbox dir pre-populated with mock op/gh binaries so
+# ensure_*_cli short-circuits without touching /home/user/.local/bin.
+# Production paths leave it unset.
 _snapshot_user_bindir() {
+  if [ -n "${VADE_BINDIR_OVERRIDE:-}" ]; then
+    printf '%s' "$VADE_BINDIR_OVERRIDE"
+    return
+  fi
   if [ "$(id -u)" = "0" ] && [ -d /home/user ]; then
     printf '/home/user/.local/bin'
   else

--- a/scripts/session-start-sync.sh
+++ b/scripts/session-start-sync.sh
@@ -38,8 +38,8 @@ sync_claude_config "$SCRIPT_DIR/../.claude"
 WORKSPACE_ROOT_DERIVED="$(cd "$SCRIPT_DIR/../.." && pwd)"
 aggregate_workspace_claude_config "$WORKSPACE_ROOT_DERIVED" "$HOME/.claude" \
   vade-runtime vade-coo-memory vade-core
-ensure_workspace_mcp_config
-ensure_workspace_identity_link
+ensure_workspace_mcp_config "$SCRIPT_DIR/../.mcp.json" "$WORKSPACE_ROOT_DERIVED/.mcp.json"
+ensure_workspace_identity_link "$WORKSPACE_ROOT_DERIVED/vade-coo-memory/CLAUDE.md" "$WORKSPACE_ROOT_DERIVED/CLAUDE.md"
 # Bridge /home/user/.local/bin/gh (persistent install target) onto
 # /root/.local/bin (already on PATH for Claude's Bash tool) so the
 # MEMO 2026-04-23-02 gh-CLI fallback is callable without the agent


### PR DESCRIPTION
## Summary

Adds `.github/workflows/bootstrap-regression.yml` plus the supporting `scripts/ci/` runner, mocks, and PR-comment glue. On every PR that touches `scripts/`, `.claude/`, `.mcp.json`, `versions.lock`, or `Dockerfile`, the workflow stages a cloud-style workspace under `/home/user`, runs `scripts/cloud-setup.sh` → `scripts/session-start-sync.sh` → `scripts/integrity-check.sh` end-to-end in fake-env mode (PATH-shadowed `op` + `curl`-to-`api.github.com/user` mocks), and asserts no degraded invariants modulo a configurable allowlist. Renders a per-group markdown table and posts a sticky PR comment via header marker.

Closes #86. Layer-2 (SDK-driven harness load test) remains sibling work at #85.

## What this catches at PR-open time
Without burning a Claude Code cloud session per PR:
- #66 — env-merge before validate
- #72 — cached-PAT recheck on marker shortcut
- #73 — digest path resolver
- #83 — settings.json env injection

## Auth strategy

Issue-spec option (a): fake-env, no real secrets. Stubbed `OP_SERVICE_ACCOUNT_TOKEN`; mock `op` returns canned vade-coo-shaped responses; mock `curl` only intercepts `api.github.com/user` (other URLs pass through). Fixture ed25519 keys are generated per run and their fingerprints exported as `COO_AUTH_FP_EXPECTED` / `COO_SIGN_FP_EXPECTED` so `install_coo_ssh_keys`'s fingerprint check validates against the substituted material. E1–E4 (live MCP probes) skip in CI by design; F1–F4 skip cleanly because the staged `vade-coo-memory` is a stub without `.git`.

Option (b) — CI-scoped 1Password service account — stays a follow-up if gaps emerge.

## Production code touched (zero behavioural change)

- `scripts/lib/common.sh`:
  - `COO_AUTH_FP_EXPECTED` / `COO_SIGN_FP_EXPECTED` made env-overridable (`\${VAR:-default}`) so the runner can substitute fixture-key fingerprints without forking `install_coo_ssh_keys`.
  - `_snapshot_user_bindir` honours `VADE_BINDIR_OVERRIDE` so the mock `op` binary is not shadowed by `/home/user/.local/bin` in agent-local re-runs.
- `scripts/cloud-setup.sh` and `scripts/session-start-sync.sh`: derive `RUNTIME_DIR` / `WORKSPACE_ROOT` from script location, pass them explicitly to `ensure_workspace_*`. Production paths still resolve to `/home/user/*`.

## Files added

- `.github/workflows/bootstrap-regression.yml`
- `scripts/ci/run-bootstrap-regression.sh` — stage workspace, generate fixture keys, install mocks, isolate `\$HOME`, drive the chain, assert outcome.
- `scripts/ci/render-integrity-summary.sh` — `integrity-check.json` → markdown table per Group A–F with pass/skip/fail icons.
- `scripts/ci/post-or-update-pr-comment.sh` — sticky comment via `<!-- bootstrap-regression-comment -->` marker.
- `scripts/ci/mocks/{op,curl}` — minimal fake-env binaries.

## Allowlist semantics

Empty by default. Set via `VADE_CI_ALLOWLIST` env (comma-separated) or the `workflow_dispatch` input. Bumping it requires a commit citing the reason so the next operator can audit. Today's expected-degraded set is empty.

## Smoke-test plan ✅ (run locally before opening this PR)

1. **Green path**: clean run reports PASS, 16/16 invariants, exit 0.
2. **Red path**: comment out `ensure_workspace_identity_link` in both `cloud-setup.sh` and `session-start-sync.sh` → runner reports FAIL, C1 degraded, exit 1. Sticky comment renders ❌ and lists C1 as the failing invariant.

The runner cleans `\$WORKSPACE_ROOT/{CLAUDE.md,.mcp.json,.vade-cloud-state}` at start so a regression isn't masked by stale symlinks from prior local runs. Production CI on ubuntu-latest gets a fresh runner per job and doesn't need this.

## Test plan

- [x] Local green run passes 16/16
- [x] Local red run (broken `ensure_workspace_identity_link`) fails C1 with exit 1
- [x] Markdown summary renders per-group invariant tables with status icons
- [ ] On-PR validation: this PR's own check should land green (touches `scripts/`, `.claude/`, `.github/workflows/`)
- [ ] Optional follow-up: deliberately-broken commit on a throwaway branch to confirm red status in CI proper
- [ ] Once green confirmed: close #86 and link to first PR-open run

https://claude.ai/code/session_019gHS9JjBy1HFpnTPoD2hfv