### PR TITLE
git-shim: route `git push` through fallback wrapper by default (#67)

### DIFF
--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -138,6 +138,14 @@ fetch_coo_secrets
 COO_BOOTSTRAP_STEP="write_coo_gitconfig"
 write_coo_gitconfig
 
+# Make `git push` route through git-push-with-fallback.sh by default
+# (vade-runtime#67 adoption-as-default). Non-fatal: if the install
+# refuses (e.g. user already has a custom $bindir/git), the bootstrap
+# continues. Pushes still work via system git; they just won't auto-
+# fallback when the cloud git-proxy 403s.
+COO_BOOTSTRAP_STEP="install_coo_git_shim"
+install_coo_git_shim || log "coo-bootstrap: git shim install skipped/failed; continuing"
+
 # Validate BEFORE merging into ~/.claude/settings.json (#66): a
 # wrong-identity PAT must never land in the harness's persistent env
 # block. fetch_coo_secrets stages secrets in ~/.vade/coo-env and exports

--- a/scripts/git-shim.sh
+++ b/scripts/git-shim.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# vade-coo git shim — intercepts `git push` and routes through
+# git-push-with-fallback.sh so the cloud git-proxy 403 wraparound
+# (vade-runtime#67) is the default behavior, not an opt-in.
+#
+# Installed by coo-bootstrap.sh as a symlink at <bindir>/git, where
+# bindir is _snapshot_user_bindir (typically /home/user/.local/bin on
+# cloud, ${HOME}/.local/bin on Mac). PATH already prepends that bindir,
+# so this shim shadows the system git.
+#
+# Behavior:
+#   - First arg "push" → exec git-push-with-fallback.sh with the rest.
+#   - Anything else (status, fetch, commit, push with global flags
+#     before the subcommand, etc.) → exec system git directly.
+#   - VADE_GIT_SHIM_BYPASS=1 in env → unconditionally exec system git.
+#     The shim itself sets this on its own subprocess so the wrapper's
+#     internal `git push` / `git remote get-url` / etc. don't recurse.
+#
+# Removal:
+#   rm "$(command -v git)" if it points to this shim, or unset PATH
+#   prepend in your shell. The shim is fail-soft — if the wrapper or
+#   readlink misbehaves, all paths fall through to system git.
+
+set -uo pipefail
+
+# Resolve the system git: first git in PATH that isn't this shim.
+_resolve_system_git() {
+  if [ -n "${VADE_SYSTEM_GIT:-}" ] && [ -x "$VADE_SYSTEM_GIT" ]; then
+    printf '%s' "$VADE_SYSTEM_GIT"
+    return 0
+  fi
+  local self candidate self_real cand_real
+  self="$(readlink -f -- "$0" 2>/dev/null || printf '%s' "$0")"
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    cand_real="$(readlink -f -- "$candidate" 2>/dev/null || printf '%s' "$candidate")"
+    [ "$cand_real" = "$self" ] && continue
+    printf '%s' "$candidate"
+    return 0
+  done < <(type -ap git 2>/dev/null)
+  printf '/usr/bin/git'
+}
+
+SYSTEM_GIT="$(_resolve_system_git)"
+
+# Bypass cases: env-flag set (recursion / opt-out), no args, or first
+# arg is anything other than the bare subcommand "push". The shim
+# deliberately does NOT try to parse `git -c key=val push` or
+# `git -C dir push` — those invocations bypass to system git, which is
+# the safe default. The wrapper handles the common case (`git push
+# <args>`) which is what agent loops and humans type 99% of the time.
+if [ -n "${VADE_GIT_SHIM_BYPASS:-}" ] || [ "${1:-}" != "push" ]; then
+  exec "$SYSTEM_GIT" "$@"
+fi
+
+# Resolve the wrapper relative to this shim's source. The shim is
+# typically a symlink at <bindir>/git → <runtime>/scripts/git-shim.sh,
+# and the wrapper is its sibling at <runtime>/scripts/git-push-with-fallback.sh.
+# Cloud and Mac paths differ; readlink resolution avoids hard-coding either.
+_shim_real="$(readlink -f -- "$0" 2>/dev/null || printf '%s' "$0")"
+_shim_dir="$(dirname -- "$_shim_real")"
+WRAPPER="${VADE_GIT_PUSH_WRAPPER:-$_shim_dir/git-push-with-fallback.sh}"
+
+if [ ! -x "$WRAPPER" ]; then
+  exec "$SYSTEM_GIT" "$@"
+fi
+
+shift  # drop "push"
+export VADE_GIT_SHIM_BYPASS=1
+exec bash "$WRAPPER" "$@"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1243,6 +1243,59 @@ write_coo_gitconfig() {
   git config --file "$gc" core.sshCommand "ssh -i ${HOME}/.ssh/vade-coo-auth -o IdentitiesOnly=yes -o UserKnownHostsFile=${HOME}/.ssh/known_hosts"
 }
 
+# Install the vade-coo git shim at the snapshot-persistent bindir,
+# making `git push` route through git-push-with-fallback.sh by default
+# (vade-runtime#67 adoption-as-default — the wrapper has been merged
+# since #74, but no path made it the default until this shim).
+#
+# The shim is a symlink to scripts/git-shim.sh in this repo. Removing
+# the symlink restores the system git. Set VADE_DISABLE_GIT_SHIM=1 in
+# the bootstrap env to skip installation entirely (useful for debug
+# sessions where intercepting git push is undesirable).
+#
+# Idempotent: if the symlink already points to the right source, no-op.
+# Fail-soft: refuses to clobber a non-symlink at the install path.
+install_coo_git_shim() {
+  if [ "${VADE_DISABLE_GIT_SHIM:-0}" = "1" ]; then
+    log "git shim install: skipped (VADE_DISABLE_GIT_SHIM=1)"
+    return 0
+  fi
+
+  local bindir shim_src wrapper shim_dst current_target
+  bindir="$(_snapshot_user_bindir)"
+  shim_src="$SCRIPT_DIR/git-shim.sh"
+  wrapper="$SCRIPT_DIR/git-push-with-fallback.sh"
+
+  if [ ! -x "$shim_src" ]; then
+    log_err "git shim install: source not executable at $shim_src; skipping"
+    return 1
+  fi
+  if [ ! -x "$wrapper" ]; then
+    log_err "git shim install: wrapper missing at $wrapper; shim would no-op, skipping"
+    return 1
+  fi
+
+  mkdir -p "$bindir"
+  shim_dst="$bindir/git"
+
+  if [ -e "$shim_dst" ] && [ ! -L "$shim_dst" ]; then
+    log_err "git shim install: $shim_dst exists and is not a symlink; refusing to clobber"
+    log_err "  remove it manually if you want the shim, or set VADE_DISABLE_GIT_SHIM=1"
+    return 1
+  fi
+
+  if [ -L "$shim_dst" ]; then
+    current_target="$(readlink -- "$shim_dst" 2>/dev/null || true)"
+    if [ "$current_target" = "$shim_src" ]; then
+      log "git shim install: already current at $shim_dst → $shim_src"
+      return 0
+    fi
+  fi
+
+  ln -sfn -- "$shim_src" "$shim_dst"
+  log "git shim installed at $shim_dst → $shim_src (intercepts \`git push\`; bypass with VADE_GIT_SHIM_BYPASS=1)"
+}
+
 validate_coo_identity() {
   if [ -z "${GITHUB_MCP_PAT:-}" ]; then
     log "Skipping GitHub PAT validation (GITHUB_MCP_PAT unset; degraded bootstrap)"

--- a/scripts/test-git-shim.sh
+++ b/scripts/test-git-shim.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# test-git-shim: smoke-test the git shim that intercepts `git push`
+# and routes it through git-push-with-fallback.sh (vade-runtime#67).
+#
+# Strategy: install a mock system git that records its argv, plus a
+# mock wrapper that records its argv. Run the shim with various arg
+# shapes and assert the right binary is reached.
+#
+# Run: bash scripts/test-git-shim.sh
+# Exit: 0 if all assertions pass, non-zero otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHIM="$SCRIPT_DIR/git-shim.sh"
+
+[ -x "$SHIM" ] || { echo "FAIL: shim not executable at $SHIM"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Mock system git: dumps argv to a log file.
+cat > "$WORK/git-real" <<'EOF'
+#!/usr/bin/env bash
+log="${MOCK_GIT_LOG:-/dev/null}"
+{
+  printf 'INVOKED: git'
+  for a in "$@"; do printf ' [%s]' "$a"; done
+  printf '\n'
+} >> "$log"
+EOF
+chmod +x "$WORK/git-real"
+
+# Mock wrapper: dumps argv to a separate log file.
+cat > "$WORK/git-push-with-fallback.sh" <<'EOF'
+#!/usr/bin/env bash
+log="${MOCK_WRAPPER_LOG:-/dev/null}"
+{
+  printf 'INVOKED: wrapper'
+  for a in "$@"; do printf ' [%s]' "$a"; done
+  printf '\n'
+} >> "$log"
+EOF
+chmod +x "$WORK/git-push-with-fallback.sh"
+
+# Stage the shim alongside the mock wrapper so readlink-based wrapper
+# resolution finds the mock, not the real one.
+cp "$SHIM" "$WORK/git-shim.sh"
+chmod +x "$WORK/git-shim.sh"
+
+PASS=0
+FAIL=0
+
+assert_log() {
+  local label="$1" log="$2" expected="$3"
+  local actual
+  actual="$(cat "$log" 2>/dev/null || true)"
+  if [ "$actual" = "$expected" ]; then
+    printf '  PASS: %s\n' "$label"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL: %s\n    expected: %s\n    actual:   %s\n' "$label" "$expected" "$actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_shim() {
+  : > "$WORK/git.log"
+  : > "$WORK/wrapper.log"
+  MOCK_GIT_LOG="$WORK/git.log" \
+  MOCK_WRAPPER_LOG="$WORK/wrapper.log" \
+  VADE_SYSTEM_GIT="$WORK/git-real" \
+  VADE_GIT_PUSH_WRAPPER="$WORK/git-push-with-fallback.sh" \
+  unset_bypass=1 \
+  bash "$WORK/git-shim.sh" "$@"
+}
+
+run_shim_with_bypass() {
+  : > "$WORK/git.log"
+  : > "$WORK/wrapper.log"
+  MOCK_GIT_LOG="$WORK/git.log" \
+  MOCK_WRAPPER_LOG="$WORK/wrapper.log" \
+  VADE_SYSTEM_GIT="$WORK/git-real" \
+  VADE_GIT_PUSH_WRAPPER="$WORK/git-push-with-fallback.sh" \
+  VADE_GIT_SHIM_BYPASS=1 \
+  bash "$WORK/git-shim.sh" "$@"
+}
+
+echo "test 1 — non-push subcommand passes through to system git"
+run_shim status -sb
+assert_log "git invoked" "$WORK/git.log" 'INVOKED: git [status] [-sb]'
+assert_log "wrapper not invoked" "$WORK/wrapper.log" ''
+
+echo "test 2 — bare git (no args) passes through"
+run_shim
+assert_log "git invoked with no args" "$WORK/git.log" 'INVOKED: git'
+assert_log "wrapper not invoked" "$WORK/wrapper.log" ''
+
+echo "test 3 — \`git push <args>\` routes to the wrapper"
+run_shim push -u origin main
+assert_log "git not invoked directly" "$WORK/git.log" ''
+assert_log "wrapper invoked with shifted args" "$WORK/wrapper.log" 'INVOKED: wrapper [-u] [origin] [main]'
+
+echo "test 4 — \`git push\` with no further args still routes to wrapper"
+run_shim push
+assert_log "wrapper invoked with no args" "$WORK/wrapper.log" 'INVOKED: wrapper'
+assert_log "git not invoked directly" "$WORK/git.log" ''
+
+echo "test 5 — VADE_GIT_SHIM_BYPASS=1 forces system git even on push"
+run_shim_with_bypass push -u origin main
+assert_log "git invoked under bypass" "$WORK/git.log" 'INVOKED: git [push] [-u] [origin] [main]'
+assert_log "wrapper not invoked under bypass" "$WORK/wrapper.log" ''
+
+echo "test 6 — global flags before push (\`git -c k=v push\`) bypass to system git"
+# This is by design — the shim doesn't parse global flags.
+run_shim -c remote.origin.fetch=foo push -u origin main
+assert_log "git invoked (shim doesn't handle global flags)" "$WORK/git.log" 'INVOKED: git [-c] [remote.origin.fetch=foo] [push] [-u] [origin] [main]'
+assert_log "wrapper not invoked" "$WORK/wrapper.log" ''
+
+echo "test 7 — missing wrapper falls through to system git on push"
+mv "$WORK/git-push-with-fallback.sh" "$WORK/git-push-with-fallback.sh.disabled"
+run_shim push -u origin main
+assert_log "git invoked when wrapper missing" "$WORK/git.log" 'INVOKED: git [push] [-u] [origin] [main]'
+mv "$WORK/git-push-with-fallback.sh.disabled" "$WORK/git-push-with-fallback.sh"
+
+echo
+echo "=== results: ${PASS} passed, ${FAIL} failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Installs a shim at `<bindir>/git` that intercepts `git push <args>` and routes to the existing `scripts/git-push-with-fallback.sh` wrapper from PR #74. Everything else (non-push subcommands, global flags before push, missing wrapper, opt-out flag) passes straight through to system git.
- Closes the adoption gap on #67/#74. Until now, the wrapper was merged but no path made it the default — agents kept hitting the proxy 403 and reaching for manual `git remote add github` workarounds (today's `run-2026-04-26T053652` was the third such session; see the [comment trail on #67](https://github.com/vade-app/vade-runtime/issues/67#issuecomment-4321375246)).
- Wired into `coo-bootstrap.sh` as a non-fatal step: install failures log and continue (system git still works, just without the proxy 403 fallback).

## Files

| Path | Change |
|---|---|
| `scripts/git-shim.sh` | NEW — the shim itself, fail-soft on every edge case |
| `scripts/lib/common.sh` | `install_coo_git_shim()` — idempotent symlink install, refuses to clobber non-symlink, opt-out via `VADE_DISABLE_GIT_SHIM=1` |
| `scripts/coo-bootstrap.sh` | Calls install after `write_coo_gitconfig`, before `validate_coo_identity` |
| `scripts/test-git-shim.sh` | NEW — 13 assertions; all pass |

## Design notes

- **Symlink, not copy.** Shim is a symlink at `<bindir>/git` → `<runtime>/scripts/git-shim.sh`. Updates to shim source travel with the runtime; no re-install needed.
- **`readlink -f` resolves the wrapper sibling**, so the shim finds `git-push-with-fallback.sh` correctly on both cloud (`/home/user/vade-runtime/scripts/`) and Mac (`~/GitHub/vade-app/vade-runtime/scripts/`) without any env-var config.
- **Recursion guard.** Shim sets `VADE_GIT_SHIM_BYPASS=1` before exec'ing the wrapper. The wrapper's internal `git push` / `git remote get-url` calls hit the shim again, see the bypass flag, and route straight to system git. No infinite loop.
- **Edge cases bypass safely.** Anything more complex than `git push <args>` — `git -c k=v push`, `git -C dir push`, `git --git-dir=… push` — bypasses to system git rather than risk misparsing. The 80/20 covers what agents and humans actually type.
- **Opt-out paths:** `VADE_DISABLE_GIT_SHIM=1` to skip install at bootstrap; `VADE_GIT_SHIM_BYPASS=1` to bypass an installed shim per-invocation; remove the symlink to restore system git directly.

## Test plan

- [x] `bash scripts/test-git-shim.sh` → 13 passed, 0 failed.
- [x] Manual install + `git --version` → passthrough to system git.
- [x] Manual install + `git push --dry-run` → wrapper engaged, correctly identified non-fast-forward as not-a-proxy-failure (`no proxy-failure marker; passing through`), no false-fallback retry.
- [x] Manual install + `git fetch` → unaffected.
- [x] This PR's branch was pushed through the shim → wrapper → system git → proxy on the first try, no fallback needed.
- [ ] **Post-merge fresh-container boot** — see handoff comment.
- [ ] **Local Mac fresh shell** — confirm `_snapshot_user_bindir` resolves to `${HOME}/.local/bin` and the install lands there.

## Out of scope

- The two remaining investigation directions in #67 (proxy auth-state decay; per-session token-scope drift). The shim is a mitigation, not a root-cause fix. #67 stays open.
- Adopting the wrapper from `gh` write paths or from any other transport. Scope: `git push` only.

https://claude.ai/code/session_012jEnR7rvV2wVji1zEENKRe