### PR TITLE
DO NOT MERGE: validate #86 red path (will be closed without merge)

### DIFF
--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -157,7 +157,10 @@ COO_BOOTSTRAP_STEP="validate_coo_identity"
 validate_coo_identity
 
 COO_BOOTSTRAP_STEP="merge_coo_settings_env"
-merge_coo_settings_env
+# DELIBERATELY-BROKEN (validation of #99 red path; do NOT merge): skip
+# the env merge so settings.json never gets GITHUB_MCP_PAT et al.
+# Bootstrap-regression CI should report D4 degraded and exit red.
+# merge_coo_settings_env
 
 # Persist non-secret path state (VADE_CLOUD_STATE_DIR + PATH with the
 # snapshot user bindir prepended) into ~/.claude/settings.json env so


### PR DESCRIPTION
## Purpose

Validate that the bootstrap-regression workflow shipped in #99 actually turns red end-to-end on a real PR — closes the only unchecked checkbox on the #99 test plan. This PR will be **closed without merging** once we observe the red status.

## Deliberate breakage

`scripts/coo-bootstrap.sh`: `merge_coo_settings_env` call commented out.

Expected runner outcome:
- `bootstrap-regression` check: ❌ FAIL
- Sticky comment: D4 listed under **Degraded (failing this PR)**
- Reason: settings.json env block never gets `GITHUB_MCP_PAT`, `GITHUB_TOKEN`, `AGENTMAIL_API_KEY`, `MEM0_API_KEY` because the merge step is skipped.

## Test plan

- [ ] Workflow runs (paths filter matches `scripts/**`)
- [ ] Conclusion is `failure`, not `success`
- [ ] PR comment renders with FAIL ❌ header and lists D4 in degraded
- [ ] Close this PR without merging
- [ ] Delete `claude/validate-bootstrap-regression-red` branch

Tracks #86 acceptance criterion: "Smoke-tested by pushing a deliberately-broken bootstrap change and confirming red status."

https://claude.ai/code/session_019gHS9JjBy1HFpnTPoD2hfv