### PR TITLE
repo-reorg Round 4: scripts/ + skill-creator READMEs + F1 regex

### DIFF
--- a/.claude/skills/skill-creator/VENDORED.md
+++ b/.claude/skills/skill-creator/VENDORED.md
@@ -1,0 +1,30 @@
+# Vendored: skill-creator
+
+This skill is vendored from upstream Anthropic. Distributed under the
+Apache License 2.0 (see `LICENSE.txt` in this directory).
+
+## Maintenance rule
+
+**Do not modify in-place.** If a fix or enhancement is needed,
+either:
+
+1. Open an upstream PR and re-vendor once it lands; or
+2. Fork into a sibling skill (e.g. `.claude/skills/skill-creator-vade/`)
+   that depends on the vendored version, leaving the vendored copy
+   pristine.
+
+Inline edits make future re-vendoring expensive and silently desync
+this copy from upstream.
+
+## Origin
+
+See git history for the vendoring commit. Upstream: Anthropic
+skill-creator (search the public skill-creator repository for the
+canonical source).
+
+## Why a separate file
+
+`.claude/skills/skill-creator/` mixes Anthropic-authored content with
+project-local files (e.g. anything VADE adds alongside). This banner
+makes the vendored boundary explicit so future maintainers know which
+files are upstream and which are ours.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,58 @@
+# `scripts/`
+
+Hook-driven per-session scripts plus shared utilities and probes for
+the VADE development environment. The flat top-level layout is
+intentional under ~25 entries; sub-grouping is deferred until the
+count justifies the cost of breaking references in `CLAUDE.md`,
+`hooks-dispatch.sh`, `integrity-check.sh`, several memos, and
+`cloud-setup.sh` itself.
+
+## Inventory by role
+
+**Boot (4)**
+- `bootstrap.sh` — local bootstrap entry point.
+- `cloud-setup.sh` — cloud bootstrap orchestrator (1Password fetch,
+  identity install, settings.json merge).
+- `coo-bootstrap.sh` — COO-identity-specific stage of the bootstrap
+  pipeline; idempotent with a per-container epoch marker.
+- `local-setup.sh` — local-machine bootstrap (Mac CLI surface).
+
+**Session lifecycle (6)**
+- `session-start-sync.sh` — re-syncs `~/.claude/` config from
+  vade-runtime on every SessionStart.
+- `session-lifecycle.sh` — boot/end-of-session reminders
+  (`--end` flag selects mode).
+- `coo-identity-digest.sh` — prints CLAUDE.md + recent memo headers
+  into session context.
+- `discussions-digest.sh` — prints new vade-app org discussions.
+- `memo-index.sh` — thin wrapper that delegates to
+  `vade-coo-memory/.claude/commands/_lib/memo-index.sh`.
+- `hooks-dispatch.sh` — central dispatcher resolving hook names to
+  the canonical script via the five resolver rules (MEMO-2026-04-22-12).
+
+**Wrappers / shims (3)**
+- `gh-coo-wrap.sh` — `gh` wrapper attributing writes to `vade-coo`.
+- `git-shim.sh` — git proxy + auth interceptor.
+- `git-push-with-fallback.sh` — push with HTTPS-proxy 403 fallback.
+
+**Probes (2)**
+- `healthcheck.sh` — fast smoke-test of the bootstrap pipeline.
+- `integrity-check.sh` — full invariant probe (Groups A–F).
+
+**Cross-repo (1)**
+- `sync-repos.sh` — bulk-pull / bulk-fetch across the vade-app repos.
+
+## Sub-folders
+
+- `lib/` — sourced common functions; not entry points.
+- `ci/` — CI runners (`run-bootstrap-regression.sh`, test scripts)
+  and mocks under `ci/mocks/`.
+- `seed-discussions/` — one-shot seed scripts for the org's GitHub
+  Discussions categories; kept after first-run for re-seeding.
+
+## Sub-grouping defer note
+
+When the top-level `.sh` count exceeds ~25, restructure into
+sub-folders by role. At that point document the break-points (which
+references in CLAUDE.md, hooks-dispatch, integrity-check, memos, and
+cloud-setup need updating).

--- a/scripts/ci/mocks/README.md
+++ b/scripts/ci/mocks/README.md
@@ -1,0 +1,30 @@
+# `ci/mocks/`
+
+Drop-in PATH-replacement mocks for `curl` and `op` used by
+`scripts/ci/run-bootstrap-regression.sh` to exercise the bootstrap
+pipeline in CI without real network or 1Password access.
+
+## Contracts
+
+- **`curl`** — intercepts requests to
+  `https://api.github.com/user` (returns a canned `vade-coo`
+  identity, used by `validate_coo_identity` and the cached-PAT
+  recheck). Every other URL forwards to the real `curl` so the
+  substrate stays representative.
+- **`op`** — returns canned vade-coo-shaped responses for the
+  1Password lookups the bootstrap exercises (PAT, SSH keys,
+  AgentMail key, Mem0 API key).
+
+## Invocation
+
+The CI runner places this directory at the head of `$PATH`. Real
+`curl` is preserved at `$VADE_CI_REAL_CURL` (default
+`/usr/bin/curl`).
+
+## Maintenance
+
+Each mock honors specific input shapes documented in the script
+headers. Deviations from those shapes are CI bugs (the mock is
+load-bearing for the bootstrap-regression invariant). Update mocks
+in lockstep with bootstrap-script changes that introduce new HTTP
+endpoints or 1Password lookups.

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -330,7 +330,7 @@ if [ -d "$F_REPO/.git" ] && check_cmd git; then
     # Paths this commit touched that are in scope.
     touched=$(git -C "$F_REPO" show --name-only --format= "$sha" 2>/dev/null \
       | grep -E '^(coo/|identity/|context/|CLAUDE\.md$)' \
-      | grep -vE '^coo/_drafts/|^coo/_archive/|^coo/retrospectives/|^coo/foundations/.*_transcript\.md$' \
+      | grep -vE '^coo/_drafts/|^coo/_archive/|^coo/_evidence/|^coo/retrospectives/|^coo/foundations/.*_transcript\.md$' \
       || true)
     [ -n "$touched" ] || continue
     f1_total=$((f1_total + 1))

--- a/scripts/seed-discussions/README.md
+++ b/scripts/seed-discussions/README.md
@@ -1,0 +1,22 @@
+# `seed-discussions/`
+
+One-shot seed scripts for the `vade-app/vade-core` GitHub Discussions
+categories. Kept after first-run for re-seeding if categories are
+ever reset or new categories are added.
+
+## Invocation
+
+```sh
+node scripts/seed-discussions/seed.mjs
+```
+
+The script is idempotent: it skips creation for any discussion whose
+title already exists in the target category, and the pin attempt is
+best-effort.
+
+## Contents
+
+- `seed.mjs` — main entry point. Iterates over the category README
+  files and posts each to the matching category, then pins it.
+- `announcements.md`, `coordination.md`, `qa.md`, `retrospectives.md`,
+  `rfcs.md` — per-category README content sources.


### PR DESCRIPTION
## Summary

Round 4 of 5 implementing Quorum-6's repo organization sweep
(vade-coo-memory `coo/repo_organization_sweep.md` §"Round 4 — vade-runtime cleanup",
ratified by MEMO-2026-04-26-09). **vade-runtime cleanup** —
4 READMEs + a one-line regex extension.

## Changes

### New READMEs

- **`scripts/README.md`** — role inventory of the 16 top-level
  scripts grouped into 5 conceptual roles (Boot 4, Session-lifecycle 6,
  Wrappers/shims 3, Probes 2, Cross-repo 1) plus the 3 sub-folders
  (`lib/`, `ci/`, `seed-discussions/`). Documents the deferred
  sub-grouping decision (defer until ~25 files; restructuring breaks
  references in CLAUDE.md, hooks-dispatch, integrity-check, several
  memos, and cloud-setup).
- **`scripts/seed-discussions/README.md`** — one-shot seed scripts for
  `vade-app/vade-core` Discussions categories. Kept after first-run
  for re-seeding. Idempotent.
- **`scripts/ci/mocks/README.md`** — drop-in PATH-replacement mocks
  for `curl` + `op` used by `run-bootstrap-regression.sh`. Documents
  the input-shape contracts and the maintenance rule that mock fixes
  must land in lockstep with bootstrap-script changes.
- **`.claude/skills/skill-creator/VENDORED.md`** — marks the skill as
  vendored from upstream Anthropic (Apache-2.0). Codifies the
  do-not-modify-in-place rule and re-vendor convention so future
  maintainers don't silently desync the local copy from upstream.

### F1 exclusion regex (scripts/integrity-check.sh:333)

Add `^coo/_evidence/` to the F1 "decision-bearing commits" filter:

```diff
- | grep -vE '^coo/_drafts/|^coo/_archive/|^coo/retrospectives/|^coo/foundations/.*_transcript\.md$' \
+ | grep -vE '^coo/_drafts/|^coo/_archive/|^coo/_evidence/|^coo/retrospectives/|^coo/foundations/.*_transcript\.md$' \
```

Evidence files added in Round 2 (sub-agent outputs supporting parent
artifacts) are derived; their commits are not decision-bearing on
their own. Without this, Round-2 `_evidence/` commits would
false-positive on the next integrity probe and degrade Group F.

The regex change is monotone-safe: including `_evidence/` in the
exclusion can only suppress false positives. Commits that touch
`_evidence/` AND a non-excluded path remain captured by the broader
`^(coo/|identity/|context/|CLAUDE\.md$)` match.

## Boot impact

This PR modifies `scripts/integrity-check.sh`, which fires from the
SessionStart `session-start-sync` hook. **Pre-merge gating:** the
regex is verifiable by inspection (the diff above). **Post-merge
confirmation:** on the next fresh container session, the integrity
probe should run F1 cleanly against the post-Round-2 state. If
Round 2's vade-coo-memory PR (#186) hasn't merged, F1 still operates
correctly because no `_evidence/` paths exist in the corpus yet —
the new exclusion is harmless.

## Test plan

- [x] No remaining live references to `coo/_drafts/` in vade-runtime tooling that the plan named (handled in Round 3 PR #107).
- [x] F1 regex exclusion is additive and matches Round-2 `_evidence/<topic>/` paths (verified by inspection).
- [x] No new dependencies; no new env vars; no new MCPs.

## Out of scope

- Round 5 — `coo/draft_lifecycle.md` SOP + per-folder READMEs in vade-coo-memory.

Ratification: vade-coo-memory MEMO-2026-04-26-09. Commission: vade-coo-memory#174.

https://claude.ai/code/session_01UHjLdyRxcyFXKNYg7vnjbE