### PR TITLE
mem0 MCP: switch to local stdio + add E5 integrity probe (#109)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,12 @@
 {
   "mcpServers": {
     "mem0": {
-      "type": "http",
-      "url": "https://mcp.mem0.ai/mcp",
-      "headers": {
-        "Authorization": "Bearer ${MEM0_API_KEY}"
+      "type": "stdio",
+      "command": "/home/user/.local/bin/mem0-mcp-server",
+      "args": [],
+      "env": {
+        "MEM0_API_KEY": "${MEM0_API_KEY}",
+        "MEM0_DEFAULT_USER_ID": "ven"
       }
     },
     "agentmail": {

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -112,6 +112,20 @@ else
   log "Warning: gh CLI install failed at build time; degraded-MCP sessions will fall through to venpopov attribution."
 fi
 
+# Install the mem0-mcp-server stdio binary. Same snapshot-persistence
+# rationale as op + gh — paying the install cost at build time means
+# the SessionStart hook chain never has to fetch through the egress
+# proxy, and Claude Code can spawn the MCP at process start without a
+# uvx-on-demand round-trip. Required for mem0 MCP availability per
+# vade-runtime#109; without it the .mcp.json stdio entry points at a
+# missing binary and Mem0 surface stays dark.
+if ensure_mem0_mcp_server; then
+  build_log_record OK "cloud-setup: mem0-mcp-server installed at build time"
+else
+  build_log_record WARN "cloud-setup: mem0-mcp-server install failed at build time; SessionStart hook will retry"
+  log "Warning: mem0-mcp-server install failed at build time; first session will boot with Mem0 MCP dark."
+fi
+
 # COO identity bootstrap runs only when OP_SERVICE_ACCOUNT_TOKEN is set
 # in the cloud environment config. Non-fatal on failure — the base VADE
 # env should still come up even if 1Password is unreachable.

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -347,6 +347,75 @@ echo "                            Harness github MCP is NOT for attributable wri
 echo "                            resolves inconsistently. See CLAUDE.md, MEMO 2026-04-24-08."
 echo "───────────────────────────────────────────────────────────────"
 
+# Mem0 read/write surface — same banner pattern as "GitHub write surface"
+# above. Per vade-runtime#109, the hosted Mem0 MCP at mcp.mem0.ai hits
+# the same Node `undici` DNS-cache-overflow class that kills github-coo,
+# so we run the official stdio server (`mem0-mcp-server`) as a local
+# subprocess instead. This block always prints — green when healthy,
+# loud ⚠ when degraded — so the agent sees Mem0 posture at turn zero
+# rather than only when integrity-check enumerates degraded invariants.
+# E5 in integrity-check.json is the canonical pass/fail signal.
+INTEGRITY_CHECK="${VADE_CLOUD_STATE_DIR}/integrity-check.json"
+
+echo ""
+echo "───────────────────────────────────────────────────────────────"
+echo "Mem0 read/write surface"
+echo "───────────────────────────────────────────────────────────────"
+mem0_bin=""
+for cand in "/home/user/.local/bin/mem0-mcp-server" "$HOME/.local/bin/mem0-mcp-server"; do
+  if [ -x "$cand" ]; then mem0_bin="$cand"; break; fi
+done
+mem0_key="no"
+if [ -f "$SETTINGS_FILE" ] && check_cmd node; then
+  mem0_key="$(node -e '
+    try {
+      const cfg = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+      console.log((cfg.env && cfg.env.MEM0_API_KEY) ? "yes" : "no");
+    } catch { console.log("no"); }
+  ' "$SETTINGS_FILE" 2>/dev/null || echo "no")"
+fi
+e5_status="unknown"
+e5_detail=""
+if [ -f "$INTEGRITY_CHECK" ] && check_cmd node; then
+  read -r e5_status e5_detail < <(node -e '
+    try {
+      const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+      const e = (r.groups && r.groups.E && r.groups.E.E5) || {};
+      let s = "unknown";
+      if (e.ok === true) s = "ok";
+      else if (e.ok === false) s = "degraded";
+      else if (e.skipped === true) s = "skip";
+      console.log(s + " " + (e.detail || "").replace(/\n/g, " "));
+    } catch { console.log("unknown"); }
+  ' "$INTEGRITY_CHECK" 2>/dev/null || echo "unknown")
+fi
+if [ -n "$mem0_bin" ]; then
+  printf "  %-25s %s\n" "stdio MCP binary:" "$mem0_bin"
+else
+  printf "  %-25s %s\n" "stdio MCP binary:" "MISSING (run ensure_mem0_mcp_server; cloud-setup.sh installs at build)"
+fi
+printf "  %-25s %s\n" "MEM0_API_KEY:" "settings.json env=$mem0_key"
+printf "  %-25s %s\n" "integrity-check E5:" "$e5_status"
+echo "  REST fallback (writes):   bin/mem0-rest.sh; canonical for memo_pointer (MEMO 2026-04-24-07)"
+case "$e5_status" in
+  degraded)
+    echo ""
+    echo "  ⚠ Mem0 MCP is degraded. CLAUDE.md §4 + §12 boot rituals (CB-* / OG-* identity"
+    echo "    load, recent-episodic handoff) cannot run via MCP this session. Fall back to"
+    echo "    durable file layer (coo/episodic_memory.md + memo_index.json) per CLAUDE.md §6"
+    echo "    graceful-degradation clause; for writes route through bin/mem0-rest.sh."
+    echo "    Detail: $e5_detail"
+    ;;
+  skip)
+    echo ""
+    echo "  Note: E5 probe was skipped — see detail above. Most common cause: MEM0_API_KEY"
+    echo "  not in this hook's process env even though settings.json carries it (MCP server"
+    echo "  spawn picks it up; the probe subprocess does not). Not a degradation; verify"
+    echo "  by listing mcp__mem0__* tools in your first agent turn."
+    ;;
+esac
+echo "───────────────────────────────────────────────────────────────"
+
 # Integrity check summary — the authoritative "did this session's boot
 # pipeline land correctly" verdict. session-start-sync.sh writes this
 # to $VADE_CLOUD_STATE_DIR/integrity-check.json on every boot. The file
@@ -356,7 +425,6 @@ echo "────────────────────────�
 # file themselves. Quorum-automation context: without this, routine
 # instances operated with less situational awareness than interactive
 # COO sessions (observed during quorum #3, PR #90).
-INTEGRITY_CHECK="${VADE_CLOUD_STATE_DIR}/integrity-check.json"
 echo ""
 echo "───────────────────────────────────────────────────────────────"
 echo "Integrity check"

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -265,11 +265,111 @@ fi
 # ── Group E: MCP surface ─────────────────────────────────────
 # Requires MCP tool calls (get_me on github and github-coo namespaces).
 # An agent invoking this directly should fill E1/E2/E3/E4 into the
-# JSON afterwards. CI skips E entirely.
+# JSON afterwards. CI skips E1-E4 entirely. E5 is a script-level probe
+# that doesn't require an agent — it spawns the stdio Mem0 MCP and
+# confirms the JSON-RPC handshake.
 _add E1 skip "requires-agent: call mcp__github__get_me"
 _add E2 skip "requires-agent: call mcp__github-coo__get_me"
 _add E3 skip "requires-agent: inspect mcp-needs-auth-cache.json"
 _add E4 skip "requires-agent: observe tool namespaces"
+
+# E5: stdio Mem0 MCP server is installed and answers initialize.
+# The hosted https://mcp.mem0.ai endpoint hits a Node `undici` DNS-cache
+# overflow inside Claude Code's MCP HTTP transport on cloud-harness
+# boots (vade-runtime#36/#109), leaving the agent with no Mem0 surface
+# for the rest of the session. We bypass that by running the official
+# stdio MCP server (`mem0-mcp-server`, pinned via common.sh) as a
+# subprocess. This probe is the on-disk + handshake gate: if the binary
+# is missing OR the JSON-RPC initialize fails OR the tool list is
+# missing the read/write surface we depend on, mark E5 false. The
+# coo-identity-digest banner highlights any E* failure in the degraded
+# block, so a degraded Mem0 surface is loud at SessionStart.
+#
+# Skip on CI (VADE_CI_ALLOWLIST will absorb it via the existing E*
+# allowlist convention) or when the binary truly cannot be tested
+# (no MEM0_API_KEY in env — the server won't accept initialize without
+# auth). Live-only invariant; not part of the bootstrap-regression
+# Layer-1 gate.
+E5_ok=skip
+E5_detail="requires mem0-mcp-server binary + MEM0_API_KEY"
+_mem0_bin=""
+for _candidate in "/home/user/.local/bin/mem0-mcp-server" "$HOME/.local/bin/mem0-mcp-server" "${VADE_BINDIR_OVERRIDE:-}/mem0-mcp-server"; do
+  if [ -n "$_candidate" ] && [ -x "$_candidate" ]; then
+    _mem0_bin="$_candidate"
+    break
+  fi
+done
+
+if [ -z "$_mem0_bin" ]; then
+  E5_ok=false
+  E5_detail="mem0-mcp-server binary missing; run ensure_mem0_mcp_server (cloud-setup.sh installs at build; session-start-sync.sh retries on resume)"
+elif [ -z "${MEM0_API_KEY:-}" ]; then
+  # Binary present but no key in process env. settings.json env will
+  # populate it for Claude's MCP spawn, but the script itself runs in
+  # a hook subprocess that may not have inherited yet. Treat as skip
+  # rather than fail to avoid false negatives.
+  E5_ok=skip
+  E5_detail="mem0-mcp-server present at $_mem0_bin; MEM0_API_KEY not in hook env (cannot probe; settings.json env will populate at MCP spawn)"
+elif ! check_cmd timeout || ! check_cmd node; then
+  E5_ok=skip
+  E5_detail="timeout or node missing; cannot probe"
+else
+  # Send initialize + initialized notification + tools/list, then read
+  # responses with a tight timeout. The server emits one JSON-RPC line
+  # per response on stdout. Success criteria: line 1 has
+  # result.serverInfo.name == "mem0", and tools list contains
+  # get_memories + search_memories + add_memory.
+  E5_probe_out="$(
+    {
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"integrity-check","version":"1.0"}}}'
+      sleep 0.2
+      printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
+      sleep 0.1
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+      sleep 1.5
+    } | MEM0_API_KEY="$MEM0_API_KEY" timeout 6 "$_mem0_bin" 2>/dev/null \
+      | head -3
+  )"
+  E5_verdict="$(printf '%s' "$E5_probe_out" | node -e '
+    let data = "";
+    process.stdin.on("data", c => data += c);
+    process.stdin.on("end", () => {
+      const lines = data.split("\n").filter(Boolean);
+      let serverName = null;
+      let toolNames = [];
+      for (const l of lines) {
+        try {
+          const m = JSON.parse(l);
+          if (m.id === 1 && m.result?.serverInfo?.name) serverName = m.result.serverInfo.name;
+          if (m.id === 2 && Array.isArray(m.result?.tools)) toolNames = m.result.tools.map(t => t.name);
+        } catch {}
+      }
+      const required = ["get_memories", "search_memories", "add_memory"];
+      const missing = required.filter(n => !toolNames.includes(n));
+      const out = {
+        serverName,
+        toolCount: toolNames.length,
+        missing,
+        ok: serverName === "mem0" && missing.length === 0,
+      };
+      process.stdout.write(JSON.stringify(out));
+    });
+  ' 2>/dev/null)"
+
+  if [ -n "$E5_verdict" ] && printf '%s' "$E5_verdict" | grep -q '"ok":true'; then
+    E5_ok=true
+    E5_tools="$(printf '%s' "$E5_verdict" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const o=JSON.parse(d);process.stdout.write(o.toolCount+"")}catch{process.stdout.write("?")}})' 2>/dev/null || echo "?")"
+    E5_detail="stdio Mem0 MCP healthy: $_mem0_bin (initialize ok, $E5_tools tools)"
+  else
+    E5_ok=false
+    if [ -z "$E5_probe_out" ]; then
+      E5_detail="$_mem0_bin spawned but produced no JSON-RPC output in 6s; check MEM0_API_KEY validity, network egress to api.mem0.ai, and 'cat \$E5_probe_out_path' for any stderr"
+    else
+      E5_detail="$_mem0_bin handshake failed: $(printf '%s' "$E5_verdict" | head -c 240)"
+    fi
+  fi
+fi
+_add E5 "$E5_ok" "$E5_detail"
 
 # ── Group F: Culture-system substrate discipline ─────────────
 # Implements E1–E4 from coo/foundations/2026-04-22_we-can-claim-a-record.md

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -285,11 +285,11 @@ _add E4 skip "requires-agent: observe tool namespaces"
 # coo-identity-digest banner highlights any E* failure in the degraded
 # block, so a degraded Mem0 surface is loud at SessionStart.
 #
-# Skip on CI (VADE_CI_ALLOWLIST will absorb it via the existing E*
-# allowlist convention) or when the binary truly cannot be tested
-# (no MEM0_API_KEY in env — the server won't accept initialize without
-# auth). Live-only invariant; not part of the bootstrap-regression
-# Layer-1 gate.
+# Skip on CI (bootstrap-regression runs in fake-env mode against a
+# mock workspace; live MCP probes can't validate there) and when the
+# binary truly cannot be tested (no MEM0_API_KEY in env — the server
+# won't accept initialize without auth). Live-only invariant; not part
+# of the bootstrap-regression Layer-1 gate.
 E5_ok=skip
 E5_detail="requires mem0-mcp-server binary + MEM0_API_KEY"
 _mem0_bin=""
@@ -300,7 +300,15 @@ for _candidate in "/home/user/.local/bin/mem0-mcp-server" "$HOME/.local/bin/mem0
   fi
 done
 
-if [ -z "$_mem0_bin" ]; then
+if [ -n "${VADE_CI_WORKSPACE_ROOT:-}" ] || [ -n "${VADE_BINDIR_OVERRIDE:-}" ]; then
+  # CI mode: bootstrap-regression stages a fake-env workspace and the
+  # live MCP install path is intentionally not exercised (would mean
+  # a 50-package uv install on every PR run for a probe that can't
+  # validate against the real api.mem0.ai anyway). Same shape as
+  # E1-E4 above; skip cleanly.
+  E5_ok=skip
+  E5_detail="skipped in CI fake-env (VADE_CI_WORKSPACE_ROOT or VADE_BINDIR_OVERRIDE set); live-only probe"
+elif [ -z "$_mem0_bin" ]; then
   E5_ok=false
   E5_detail="mem0-mcp-server binary missing; run ensure_mem0_mcp_server (cloud-setup.sh installs at build; session-start-sync.sh retries on resume)"
 elif [ -z "${MEM0_API_KEY:-}" ]; then

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -593,6 +593,11 @@ print_versions() {
 
 OP_VERSION_DEFAULT="2.31.0"
 GH_VERSION_DEFAULT="2.91.0"
+# Mem0 stdio MCP server. Bypasses the Node `undici` DNS-cache-overflow
+# failure that kills Claude Code's MCP HTTP transport against
+# api.mem0.ai (vade-runtime#36/#109). Pinned because the upstream repo
+# (mem0ai/mem0-mcp) was archived in 2025-12 — bump deliberately.
+MEM0_MCP_SERVER_VERSION_DEFAULT="0.2.1"
 # Hardcoded production fingerprints; env-overridable so the bootstrap-
 # regression CI (.github/workflows/bootstrap-regression.yml) can
 # substitute fixture-key fingerprints without forking install_coo_ssh_keys.
@@ -799,6 +804,76 @@ ensure_gh_cli() {
     return 1
   fi
   log "Installed gh CLI: $(gh --version 2>&1 | head -1)"
+}
+
+# Durable Mem0 MCP read/write surface for COO identity & episodic recall.
+#
+# Installs the `mem0-mcp-server` Python package (PyPI) into a
+# snapshot-persistent path under the user's .local tree via `uv tool
+# install`, exposing the binary at <bindir>/mem0-mcp-server. The .mcp.json
+# stdio entry points at this binary directly so Claude Code spawns it
+# as a subprocess at process start — bypassing the Node `undici`
+# DNS-cache-overflow failure that kills the streamable-HTTP transport
+# against api.mem0.ai (vade-runtime#36 class extended to non-MCP egress
+# in #109). Same egress as the failing transport, different wire: the
+# stdio server uses Python `httpx` for its REST hop, which is not
+# subject to undici's bug.
+#
+# Linux + macOS auto-install (uv is cross-platform). uv is required;
+# this function refuses if it can't find uv on PATH after the install
+# attempt. The Anthropic cloud image already has uv at
+# /root/.local/bin/uv; for local dev install via `curl -LsSf
+# https://astral.sh/uv/install.sh | sh` first.
+#
+# Tool dir is pinned to <bindir>/.. so the venv lives under the same
+# snapshot-persistent path as the binary symlink. Without an explicit
+# UV_TOOL_DIR, uv puts the venv under $XDG_DATA_HOME (typically
+# ~/.local/share/uv/) which on the cloud harness lives under /root/
+# and gets erased per resume.
+ensure_mem0_mcp_server() {
+  local bindir
+  bindir="$(_snapshot_user_bindir)"
+  case ":$PATH:" in
+    *":$bindir:"*) ;;
+    *) export PATH="$bindir:$PATH" ;;
+  esac
+
+  local version="${MEM0_MCP_SERVER_VERSION:-$MEM0_MCP_SERVER_VERSION_DEFAULT}"
+  local target="$bindir/mem0-mcp-server"
+
+  # Idempotent short-circuit. Don't re-install if the binary is already
+  # in place — uv tool install is non-trivial (resolves a ~50-package
+  # dep tree) and the snapshot has already paid that cost. Version-pin
+  # check is best-effort: there's no --version flag on this server, so
+  # we trust the symlink target.
+  if [ -x "$target" ]; then
+    log "mem0-mcp-server present: $target"
+    return 0
+  fi
+
+  if ! check_cmd uv; then
+    log "mem0-mcp-server: uv not on PATH; install it first (https://astral.sh/uv)"
+    return 1
+  fi
+
+  # uv tool install resolves and installs into UV_TOOL_DIR/<package>/
+  # and links console_scripts into UV_TOOL_BIN_DIR. Both must point at
+  # the snapshot-persistent tree.
+  local tool_dir="${bindir%/bin}/share/uv-tools"
+  mkdir -p "$tool_dir" "$bindir"
+
+  log "Installing mem0-mcp-server v${version} via uv tool → $target"
+  if ! UV_TOOL_DIR="$tool_dir" UV_TOOL_BIN_DIR="$bindir" \
+       uv tool install "mem0-mcp-server==${version}" >/dev/null 2>&1; then
+    log "mem0-mcp-server: uv tool install failed"
+    return 1
+  fi
+
+  if [ ! -x "$target" ]; then
+    log "mem0-mcp-server: install reported success but $target missing"
+    return 1
+  fi
+  log "Installed mem0-mcp-server v${version}"
 }
 
 # Expose gh on Claude Code's Bash-tool PATH every session.

--- a/scripts/session-start-sync.sh
+++ b/scripts/session-start-sync.sh
@@ -40,6 +40,14 @@ aggregate_workspace_claude_config "$WORKSPACE_ROOT_DERIVED" "$HOME/.claude" \
   vade-runtime vade-coo-memory vade-core
 ensure_workspace_mcp_config "$SCRIPT_DIR/../.mcp.json" "$WORKSPACE_ROOT_DERIVED/.mcp.json"
 ensure_workspace_identity_link "$WORKSPACE_ROOT_DERIVED/vade-coo-memory/CLAUDE.md" "$WORKSPACE_ROOT_DERIVED/CLAUDE.md"
+# Stale-snapshot fallback for the mem0 stdio MCP (vade-runtime#109).
+# cloud-setup.sh is the canonical installer; this catches snapshots
+# built before that change, or local dev environments where build-time
+# setup doesn't run. Idempotent — short-circuits when the binary is
+# already present. Failure is non-fatal: integrity-check E5 will
+# surface the gap loudly via the coo-identity-digest banner so the
+# next session triggers a /resume rather than wedging silently.
+ensure_mem0_mcp_server || true
 # Bridge /home/user/.local/bin/gh (persistent install target) onto
 # /root/.local/bin (already on PATH for Claude's Bash tool) so the
 # MEMO 2026-04-23-02 gh-CLI fallback is callable without the agent


### PR DESCRIPTION
## Summary

Closes the recurring `Streamable HTTP error: Error POSTing to endpoint: DNS cache overflow` failure on the Mem0 MCP at session boot — same `undici` DNS-cache class that closed #36 for github-coo, extended to `api.mem0.ai` by #109. Three recurrences in 4 days; past the threshold #109 flagged.

Same-token-different-wire fix:
- `.mcp.json` mem0 entry: `type: "http"` → `type: "stdio"`, pointing at `mem0-mcp-server==0.2.1` (PyPI, pinned).
- `lib/common.sh::ensure_mem0_mcp_server` installs via `uv tool install` into a snapshot-persistent path, mirroring `ensure_op_cli` / `ensure_gh_cli`.
- `cloud-setup.sh` calls it at build time; `session-start-sync.sh` retries idempotently on resume.

Loud surface (CLAUDE.md §14):
- `integrity-check.sh::E5` probes the binary + JSON-RPC handshake + tool list at every boot. Failure flips `summary.ok=false`, `degraded=["E5"]`.
- `coo-identity-digest.sh`: dedicated **Mem0 read/write surface** banner — always prints binary path + key state + E5 verdict; ⚠ banner with fallback path when degraded.

Full rationale + trade-offs in MEMO-2026-04-26-16 (paired vade-coo-memory PR).

Trade-offs accepted with eyes open:
- `list_events` / `get_event_status` disappear (last actively used 2026-04-15 → 2026-04-20 nightlies; Night's Watch v2 doesn't depend on them; `bin/mem0-rest.sh` covers the read fallback if a future need arises).
- `infer=false` still not exposed; MEMO-2026-04-24-07's REST-canonical-for-`memo_pointer`-writes rule unchanged.
- Upstream repo (`mem0ai/mem0-mcp`) archived 2025-12; pinned deliberately.

## Test plan

Local smoke-test passed: stdio MCP boots, `initialize` + `tools/list` round-trip <1s, exposes the 9-tool surface (`add_memory`, `search_memories`, `get_memories`, `get_memory`, `update_memory`, `delete_memory`, `list_entities`, `delete_all_memories`, `delete_entities`). E5 passes when binary present (21/21 OK), trips to `false` with actionable detail when binary moved aside (20/21 DEGRADED).

Full verification needs a fresh container — see handoff comment.

- [ ] Pre-merge: PR-branch `bash scripts/integrity-check.sh` returns 21/21 OK
- [ ] Pre-merge: `bash scripts/coo-identity-digest.sh | grep -A2 "Mem0 read/write surface"` shows binary path + E5=ok
- [ ] Post-merge (fresh container): `mcp__mem0__get_memories` callable from agent's first turn — proves the boot-time DNS-cache class no longer kills the surface
- [ ] Post-merge: bootstrap-regression CI passes (E5 will skip in CI as expected; no allowlist bump needed)

Refs: #36 (closed; same class for github-coo) · #109 (open; #109 will close on merge per the recurrence threshold)

https://claude.ai/code/session_01JneHPjBjEmaUuY8qUDwCXD