### PR TITLE
Stream 1 (#112): pull github-coo MCP wire; route GitHub through gh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,8 +30,6 @@
   },
   "permissions": {
     "allow": [
-      "mcp__github-coo__*",
-
       "mcp__mem0__get_memories",
       "mcp__mem0__search_memories",
       "mcp__mem0__add_memory",
@@ -89,6 +87,8 @@
       "Bash(git config --get:*)",
       "Bash(git ls-files:*)",
 
+      "Bash(gh:*)",
+
       "Bash(ls:*)",
       "Bash(find:*)",
       "Bash(grep:*)",
@@ -144,10 +144,30 @@
       "Bash(git reset --hard:*)",
       "Bash(git clean -fd:*)",
       "Bash(git clean -fdx:*)",
-      "mcp__github-coo__merge_pull_request",
-      "mcp__github-coo__delete_file",
-      "mcp__github-coo__create_repository",
-      "mcp__github-coo__fork_repository"
+      "mcp__github-coo__*",
+      "mcp__github__create_pull_request",
+      "mcp__github__create_pull_request_with_copilot",
+      "mcp__github__create_branch",
+      "mcp__github__create_repository",
+      "mcp__github__create_or_update_file",
+      "mcp__github__delete_file",
+      "mcp__github__fork_repository",
+      "mcp__github__merge_pull_request",
+      "mcp__github__update_pull_request",
+      "mcp__github__update_pull_request_branch",
+      "mcp__github__push_files",
+      "mcp__github__add_issue_comment",
+      "mcp__github__add_comment_to_pending_review",
+      "mcp__github__add_reply_to_pull_request_comment",
+      "mcp__github__issue_write",
+      "mcp__github__sub_issue_write",
+      "mcp__github__pull_request_review_write",
+      "mcp__github__assign_copilot_to_issue",
+      "mcp__github__request_copilot_review",
+      "mcp__github__resolve_review_thread",
+      "mcp__github__unresolve_review_thread",
+      "mcp__github__enable_pr_auto_merge",
+      "mcp__github__disable_pr_auto_merge"
     ]
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -15,13 +15,6 @@
       "env": {
         "AGENTMAIL_API_KEY": "${AGENTMAIL_API_KEY}"
       }
-    },
-    "github-coo": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "headers": {
-        "Authorization": "Bearer ${GITHUB_MCP_PAT}"
-      }
     }
   }
 }

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -100,11 +100,11 @@ else
 fi
 
 # Install the gh CLI for the same reason: snapshot-persistent, no
-# per-resume fetch. Primary purpose is to give the COO a durable fallback
-# write path to GitHub under vade-coo attribution when mcp__github-coo__*
-# is degraded (see #36). Non-fatal: gh is not required for the base VADE
-# env to come up, only for degraded-MCP sessions to keep attribution
-# clean instead of falling through to venpopov.
+# per-resume fetch. Per Epic #112 Stream 1 (closing the cloud-boot
+# flake chapter), `gh` is now the canonical GitHub write path under
+# vade-coo attribution — the github-coo MCP transport was retired
+# because its `type: "http"` channel kept hitting Node `undici` DNS-
+# cache overflow (see #36, #109, MEMO-2026-04-24-08).
 if ensure_gh_cli; then
   build_log_record OK "cloud-setup: gh CLI installed at build time"
 else

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -343,8 +343,8 @@ else
   printf "  %-25s %s\n" "gh auth token:" "GITHUB_MCP_PAT unset — /resume or check coo-bootstrap"
 fi
 echo "  gh write path:            GH_TOKEN=\$GITHUB_MCP_PAT gh <cmd>  (attributes as vade-coo)."
-echo "                            Harness github MCP is NOT for attributable writes —"
-echo "                            resolves inconsistently. See CLAUDE.md, MEMO 2026-04-24-08."
+echo "                            Sole GitHub write path. github-coo MCP retired by"
+echo "                            Epic #112 Stream 1; harness github MCP writes deny-listed."
 echo "───────────────────────────────────────────────────────────────"
 
 # Mem0 read/write surface — same banner pattern as "GitHub write surface"

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -268,8 +268,8 @@ fi
 # JSON afterwards. CI skips E1-E4 entirely. E5 is a script-level probe
 # that doesn't require an agent — it spawns the stdio Mem0 MCP and
 # confirms the JSON-RPC handshake.
-_add E1 skip "requires-agent: call mcp__github__get_me"
-_add E2 skip "requires-agent: call mcp__github-coo__get_me"
+_add E1 skip "requires-agent: call mcp__github__get_me (note: harness github MCP writes deny-listed in #112; reads only)"
+_add E2 skip "github-coo MCP retired by Epic #112 Stream 1; vade-coo identity check is now \`gh auth status\` via Bash"
 _add E3 skip "requires-agent: inspect mcp-needs-auth-cache.json"
 _add E4 skip "requires-agent: observe tool namespaces"
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -727,14 +727,13 @@ ensure_op_cli() {
 # into ${HOME}/.local/bin. Bindir resolution is shared with ensure_op_cli
 # via _snapshot_user_bindir.
 #
-# Rationale: vade-app/vade-runtime#36 documents the mcp__github-coo__*
-# streamable-HTTP transport failure ("DNS cache overflow") that forces
-# attribution to fall through to venpopov via mcp__github__* when the
-# MCP is degraded. `gh` authenticated with $GITHUB_MCP_PAT preserves
-# vade-coo opener attribution under the same PAT, via short-lived HTTPS
-# request/response cycles that bypass the failing transport. Same token,
-# same identity, different wire — MEMO 2026-04-22-04 attribution
-# invariant stays load-bearing even when the primary MCP is down.
+# Rationale: vade-runtime#36 documented the streamable-HTTP transport
+# failure ("DNS cache overflow") that motivated `gh` as a parallel path.
+# Epic #112 Stream 1 retired the github-coo MCP entirely; `gh` is now
+# the sole GitHub write path under vade-coo attribution. Authenticated
+# with $GITHUB_MCP_PAT via short-lived HTTPS request/response cycles —
+# same token, same identity, immune to the undici DNS-cache class.
+# MEMO-2026-04-22-04 attribution invariant remains load-bearing.
 ensure_gh_cli() {
   local bindir
   bindir="$(_snapshot_user_bindir)"


### PR DESCRIPTION
## Summary

Stream 1 of the zero-egress boot epic (#112). Pulls the wire that #36 was supposed to pull but didn't: the `github-coo` MCP entry in `.mcp.json` was still on `type: "http"`, spawning the `undici` DNS-cache-vulnerable transport on every boot. The closing comment on #36 substituted "use `gh` as fallback" but the `.mcp.json` was never updated — that's why the same class kept recurring all week (#109 in mem0 form via #110's resolution; this PR is the long-overdue sibling for github-coo).

## Why now

This session reproduced the same `Streamable HTTP error: Error POSTing to endpoint: DNS cache overflow` failure on `mcp__github-coo__search_issues` mid-session. Combined with the multi-issue history (#36, #75, #76, #77, #109, #110, #111), the BDFL directed an architectural close: end the chapter by structurally retiring `type: "http"` MCPs entirely.

## Changes

**Core (commit 1):**
- `.mcp.json:19-25` — delete the `github-coo` entry. Every read/write use case has a `gh` CLI equivalent per MEMO-2026-04-24-08; the residual MCP transport was duplicative and undici-vulnerable.
- `.claude/settings.json` — remove the `mcp__github-coo__*` wildcard from `permissions.allow`; add `Bash(gh:*)` (gh is canonical now); expand `permissions.deny` to wildcard `mcp__github-coo__*` plus explicit denies on every harness `mcp__github__*`-write-class tool. If any future agent tries to reintroduce MCP-based GitHub writes, it fails loudly at the permission layer rather than silently regressing.

**Sweep (commit 2 — per BDFL request "no stray old command propagates"):**
- `scripts/integrity-check.sh:271-272` — E1/E2 skip-detail strings reflect post-#112 reality; E2 directs agents to `gh auth status` rather than the retired `mcp__github-coo__get_me`.
- `scripts/cloud-setup.sh:102-107` — gh CLI install rationale comment reframed as canonical (not fallback).
- `scripts/lib/common.sh:725-737` — same reframing for `ensure_gh_cli`. Historical context referencing #36, MEMO-2026-04-22-04 preserved.
- `scripts/coo-identity-digest.sh:345-347` — SessionStart digest banner now states "Sole GitHub write path. github-coo MCP retired by Epic #112 Stream 1; harness github MCP writes deny-listed."

Historical references in `coo/_archive/`, `coo/_evidence/`, `coo/foundations/`, `coo/retrospectives/`, `coo/_nightly_log/`, `coo/memos.md`, and `vade-agent-logs/sessions/` are deliberately preserved (CLAUDE.md "every pivot earns a transcript").

## Out of scope (deferred to subsequent streams in #112)

- Disabling the harness-injected `github` MCP transport at the spawn layer (still spawns; this PR only blocks its writes via deny list — read tools still in allow).
- Vendoring `op` / `gh` / `mem0-mcp-server` into the Docker image (Stream 2).
- Single-call credential bootstrap + MCP lifecycle workaround (Stream 3).
- Observability hardening: new integrity-check invariants `A4` / `E6` / `D7` (Stream 4).
- Doctrine memo + companion essay (Stream 5).

## Sibling PR

Companion in `vade-coo-memory`: strips `mcp__github-coo__*` declarations from 5 agent prompts and `coo/nightly_review_task.md`, deletes the divergent `vade-coo-memory/.mcp.json`. Must merge as a pair for consistency.

## Test plan

- [ ] Pre-merge: PR-branch `jq . .mcp.json && jq . .claude/settings.json` parse cleanly (verified locally).
- [ ] Pre-merge: `grep -rn 'type.*http' .mcp.json` returns empty (verified locally).
- [ ] Pre-merge: bootstrap-regression CI passes.
- [ ] Post-merge (fresh container): SessionStart digest no longer lists `github-coo` MCP under deferred tools; `mcp__github-coo__*` calls fail with explicit deny rather than `DNS cache overflow`; `gh` calls succeed without permission prompt.

Refs: Epic #112 · #36 (closed but transport switch never landed; this is the actual landing) · MEMO-2026-04-24-08 (gh-canonical doctrine) · #109/#110 (sibling stdio migration for mem0)

https://claude.ai/code/session_01C4TArs12b6bNa9RH7GXczP