### PR TITLE
Stream 2: bake op + gh + mem0-mcp-server into Dockerfile; fail build on op flake (closes #111)

### DIFF
--- a/.github/workflows/docker-bake-check.yml
+++ b/.github/workflows/docker-bake-check.yml
@@ -1,0 +1,82 @@
+name: Docker bake check
+
+# Layer-1 image-level CI for the vendored-binaries gate added by epic
+# vade-runtime#112 Stream 2. Builds the runtime Docker image from the
+# PR checkout and asserts the binaries that close vade-runtime#111 (op)
+# and that surface Mem0 + GitHub write paths (mem0-mcp-server, gh) are
+# baked into the image at /usr/local/bin. Catches Dockerfile drift like
+# "the layer was deleted" or "the version pin disagrees with versions.lock"
+# before merge, instead of catching it via a fresh-container boot
+# failure post-merge.
+#
+# Cheap path filter — only triggers when the Dockerfile or its pin
+# layer is actually touched. The bootstrap-regression workflow handles
+# script-level changes; this one handles image-level changes.
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'versions.lock'
+      - '.github/workflows/docker-bake-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-bake-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Build runtime image
+        run: docker build -t vade-runtime-test:${{ github.sha }} .
+
+      - name: Verify vendored binaries baked into the image
+        env:
+          IMG: vade-runtime-test:${{ github.sha }}
+        run: |
+          set -euxo pipefail
+          # Each binary must be present at a PATH location and runnable
+          # in the image. Closes vade-runtime#111 acceptance (a) by
+          # making the Dockerfile bake the substitute origin for `op`
+          # (and applying the same pattern to `gh` + `mem0-mcp-server`).
+          missing=0
+          for binary in op gh mem0-mcp-server; do
+            if ! docker run --rm "$IMG" sh -c "command -v $binary >/dev/null"; then
+              echo "::error::$binary missing from runtime image" >&2
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "$missing" -gt 0 ]; then
+            exit 1
+          fi
+          # Version round-trip — `--version` for op and gh; mem0-mcp-server
+          # has no --version flag (we trust the install path test instead).
+          docker run --rm "$IMG" op --version
+          docker run --rm "$IMG" gh --version | head -1
+          docker run --rm "$IMG" sh -c "test -x /usr/local/bin/mem0-mcp-server"
+
+      - name: Verify pinned versions match versions.lock
+        env:
+          IMG: vade-runtime-test:${{ github.sha }}
+        run: |
+          set -euxo pipefail
+          # Read the pins from versions.lock (cheap inline parse — the
+          # file is short and the format is fixed). Compare against
+          # what the image actually ships.
+          op_pin="$(awk '/^op[[:space:]]+/ {print $2; exit}' versions.lock)"
+          gh_pin="$(awk '/^gh[[:space:]]+/ {print $2; exit}' versions.lock)"
+          op_actual="$(docker run --rm "$IMG" op --version 2>&1 | awk '{print $1}')"
+          gh_actual="$(docker run --rm "$IMG" gh --version 2>&1 | head -1 | awk '{print $3}')"
+          [ "$op_pin" = "$op_actual" ] || { echo "::error::op version drift: pin=$op_pin actual=$op_actual" >&2; exit 1; }
+          [ "$gh_pin" = "$gh_actual" ] || { echo "::error::gh version drift: pin=$gh_pin actual=$gh_actual" >&2; exit 1; }

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ARG USERNAME=node
 # build tools for any native npm deps, curl for debugging, procps for
 # tools like `ps` used by dev servers, openssh-client for git-over-ssh
 # and ssh-keygen fingerprint validation, unzip for the 1Password CLI
-# install path used by the COO identity bootstrap.
+# install path used by the COO identity bootstrap, python3 / python3-venv
+# for the uv-managed mem0-mcp-server install below.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git \
       ca-certificates \
@@ -20,7 +21,58 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       procps \
       openssh-client \
       unzip \
+      python3 \
+      python3-venv \
     && rm -rf /var/lib/apt/lists/*
+
+# 1Password CLI — pinned in versions.lock. Baked at image-build time so
+# the cloud snapshot-build path (cloud-setup.sh ensure_op_cli) and the
+# SessionStart fallback never have to fetch from cache.agilebits.com
+# mid-boot. Closes vade-runtime#111; advances epic #112 Stream 2
+# (zero-egress boot). cloud-setup.sh's existing presence-check
+# short-circuits when /usr/local/bin/op is on PATH.
+ARG OP_VERSION=2.31.0
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in amd64|arm64) ;; *) echo "Unsupported arch: $arch" >&2; exit 1 ;; esac; \
+    tmp="$(mktemp -d)"; \
+    curl -fsSL --retry 5 --retry-delay 2 \
+      "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_VERSION}/op_linux_${arch}_v${OP_VERSION}.zip" \
+      -o "$tmp/op.zip"; \
+    unzip -qo "$tmp/op.zip" -d "$tmp"; \
+    install -m 0755 "$tmp/op" /usr/local/bin/op; \
+    rm -rf "$tmp"; \
+    op --version
+
+# GitHub CLI — pinned in versions.lock. Same rationale as op:
+# image-build-time once, no per-snapshot or per-session fetch.
+# Required for COO attribution (`gh` is the canonical write path
+# under vade-coo since github-coo MCP retired in epic #112 Stream 1).
+ARG GH_VERSION=2.91.0
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    tmp="$(mktemp -d)"; \
+    curl -fsSL --retry 5 --retry-delay 2 \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${arch}.tar.gz" \
+      -o "$tmp/gh.tgz"; \
+    tar -xzf "$tmp/gh.tgz" -C "$tmp"; \
+    install -m 0755 "$tmp/gh_${GH_VERSION}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
+    rm -rf "$tmp"; \
+    gh --version
+
+# mem0-mcp-server stdio binary — pinned in versions.lock. uv-installed
+# globally so the .mcp.json command path resolves at /usr/local/bin
+# without a per-session uvx round-trip. Required for Mem0 MCP
+# availability per vade-runtime#109; without it the .mcp.json stdio
+# entry points at a missing binary and Mem0 surface stays dark.
+ARG MEM0_MCP_VERSION=0.2.1
+RUN set -eux; \
+    curl -fsSL https://astral.sh/uv/install.sh \
+      | env UV_INSTALL_DIR=/usr/local/bin sh; \
+    UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv-tools \
+      /usr/local/bin/uv tool install --python python3 \
+      "mem0-mcp-server==${MEM0_MCP_VERSION}"; \
+    test -x /usr/local/bin/mem0-mcp-server
 
 # Claude Code CLI (global install). Pinned in versions.lock.
 # Install as root into /usr/local so all users can use it.

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -88,15 +88,43 @@ print_versions
 # bootstrap fallback never has to fetch it through the egress proxy
 # mid-session. The binary lands in /home/user/.local/bin/op which
 # survives the snapshot → resume transition. Idempotent: if a prior
-# build already installed it, this is a no-op. Non-fatal: a failure
-# here just means the SessionStart hook will retry (same as before).
+# build (or the runtime Dockerfile, per epic #112 Stream 2) already
+# installed it, ensure_op_cli's presence-check short-circuits.
+#
+# FATAL on failure (closes vade-runtime#111). A snapshot without op is
+# degraded by definition: every session that resumes from it has to
+# re-fetch op from cache.agilebits.com mid-SessionStart, exposed to
+# the same egress flake the build-time install was supposed to absorb,
+# AND the COO identity load (op read … from the COO vault) cannot
+# proceed without it. Failing the build forces an immediate rebuild
+# rather than producing a session that's structurally guaranteed to
+# fail D-group invariants.
+#
+# Trade-off: cloud build SLA — if cache.agilebits.com is flapping,
+# build-fail-rate goes up. Mitigations: the 5-attempt retry budget in
+# ensure_op_cli (vade-runtime#76); the Dockerfile-baked /usr/local/bin/op
+# layer (epic #112 Stream 2) which makes ensure_op_cli a no-op when the
+# runtime image is in use. If neither is enough, follow-up work is
+# vade-runtime#111 option (b) — alternate origin / local mirror.
 OP_INSTALLED_AT_BUILD=false
 if ensure_op_cli; then
   OP_INSTALLED_AT_BUILD=true
   build_log_record OK "cloud-setup: op CLI installed at build time"
 else
-  build_log_record WARN "cloud-setup: op CLI install failed at build time; SessionStart hook will retry"
-  log "Warning: op CLI install failed at build time; SessionStart hook will retry."
+  build_log_record FAIL "cloud-setup: op CLI install failed at build time; failing build per vade-runtime#111 acceptance (a)"
+  log "FATAL: op CLI install failed at build time."
+  log "  Per vade-runtime#111 acceptance (a): a snapshot without op ships degraded;"
+  log "  SessionStart fallback would re-fetch the same flaky origin and likely fail"
+  log "  under the same egress window. Failing the build instead so the receipt is"
+  log "  never written with op_installed_at_build=false."
+  log "  Remediation: retry the build (cache.agilebits.com may have recovered),"
+  log "  or rebuild from a runtime image with op pre-baked (vade-runtime/Dockerfile,"
+  log "  epic #112 Stream 2)."
+  # Deliberately not writing setup-receipt.json — acceptance (a) is
+  # "receipt is never written with op_installed_at_build=false". The
+  # build.log FAIL line above is the diagnostic; the absent receipt
+  # signals the build did not land.
+  exit 1
 fi
 
 # Install the gh CLI for the same reason: snapshot-persistent, no

--- a/versions.lock
+++ b/versions.lock
@@ -28,6 +28,15 @@ gh                  2.91.0    # GitHub CLI. Fallback write path under
                               # fine-grained PAT as the MCP, via
                               # $GITHUB_MCP_PAT in GH_TOKEN. Pinned via
                               # GH_VERSION_DEFAULT in lib/common.sh.
+mem0-mcp-server     0.2.1     # Mem0 stdio MCP server. Required by
+                              # .mcp.json for Mem0 read/write surface
+                              # availability (vade-runtime#109,
+                              # MEMO-2026-04-26-16). Pinned via
+                              # MEM0_MCP_SERVER_VERSION_DEFAULT in
+                              # lib/common.sh. Installed via `uv tool`;
+                              # baked into the Dockerfile at
+                              # /usr/local/bin/mem0-mcp-server in epic
+                              # #112 Stream 2.
 
 # Globally installed via npm
 @anthropic-ai/claude-code 1.0.120  # Claude Code CLI. Pinned to the


### PR DESCRIPTION
## Summary

Three coordinated changes that close vade-runtime#111 and start epic vade-runtime#112 Stream 2.

1. **Dockerfile** bakes `op v2.31.0`, `gh v2.91.0`, and `mem0-mcp-server v0.2.1` into `/usr/local/bin` at image-build time. `cloud-setup.sh` ensure_*_cli functions already short-circuit on presence, so a runtime image using this Dockerfile pays the install cost once at image build instead of every snapshot rebuild. python3 + python3-venv added to the system-package layer for uv-managed mem0-mcp-server install.
2. **cloud-setup.sh** flips from WARN-and-continue to FATAL when `ensure_op_cli` fails. Closes #111 acceptance (a): the receipt is never written with `op_installed_at_build=false` because we exit before reaching the receipt-write step. The build.log FAIL line + absent receipt is the diagnostic.
3. **New CI workflow** `.github/workflows/docker-bake-check.yml` builds the Dockerfile and asserts the three binaries are present at `/usr/local/bin` and that pinned versions match `versions.lock`. Path filter is narrow (Dockerfile + versions.lock + the workflow file) so the docker-build cost only fires on image-level changes.

`versions.lock` adds the `mem0-mcp-server 0.2.1` entry for symmetry.

Closes #111. Advances #112 Stream 2.

## Why fail-build for op specifically (not gh / mem0-mcp-server)

`op` is a hard requirement: the COO identity load (`op read \"op://COO/vade-coo/credential\"`) cannot proceed without it, and Group D integrity-check invariants flip red without those credentials in `settings.json`. A snapshot without op is structurally guaranteed to fail the boot pipeline.

`gh` and `mem0-mcp-server` are degraded-not-fatal:
- Without `gh`, attribution falls through to venpopov (still works, just wrong identity on writes).
- Without `mem0-mcp-server`, the Mem0 surface goes dark (read-only fallback to `coo/memo_index.json` per CLAUDE.md §6).

Stream 2 can flip those to fail-build later if the BDFL wants symmetry, but the conservative interpretation of #111's acceptance is op-only.

## Trade-off (documented inline in cloud-setup.sh)

Cloud-build SLA goes down if cache.agilebits.com is flapping at snapshot-build time — today the snapshot ships degraded; with this PR the build fails. Two mitigations stack:

- The 5-attempt retry budget in `ensure_op_cli` (vade-runtime#76) absorbs short windows.
- The Dockerfile-baked `/usr/local/bin/op` layer in change (1) makes `ensure_op_cli` a no-op when the runtime image is in use — no fetch, no flake.

If neither is enough, the follow-up is #111 option (b) — alternate origin / local mirror.

## Honest scoping note

The cloud sandbox's base image is Anthropic-managed (the harness clones our repos in and runs `cloud-setup.sh` on top). Whether the cloud uses our `Dockerfile` directly is outside this PR's surface. Two interpretations:

- **If the cloud uses our Dockerfile**: changes (1) + (2) close #111 cleanly — the bake makes the fetch a no-op; fail-build is a safety net that should rarely fire.
- **If the cloud doesn't use our Dockerfile**: change (2) alone closes #111 by preventing degraded snapshots from shipping (at the cost of build-fail rate matching the cache.agilebits.com flake rate). The Dockerfile bake is groundwork for a future ops-level move.

Either way, change (3)'s Docker-bake CI catches Dockerfile drift on PR open.

## Test plan

- [x] Local syntax check: `bash -n cloud-setup.sh` passes; each Dockerfile RUN block parses under `bash -n`.
- [ ] `docker-bake-check` CI on PR open: builds image, verifies `op`, `gh`, `mem0-mcp-server` present at `/usr/local/bin` with pinned versions.
- [ ] `bootstrap-regression` CI on PR open: continues to pass (mocks satisfy `ensure_op_cli` regardless of fail-build flip).
- [ ] Fresh-container post-merge confirmation (handoff comment to follow): integrity-check 21/21 OK, `op_installed_at_build=true` in receipt, `op --version` matches pin.

## Out of scope

- Streams 3 (single-call credential bootstrap), 4 (full observability invariants A4/D7/E6 — PR #115 ships the E5 deepening separately), and 5 (doctrine memo).
- Symmetric fail-build for `gh` and `mem0-mcp-server` — degraded-not-fatal; defer.
- Self-host Mem0 — researched and filed as a sibling sub-epic under #112.
- Anthropic harness using our Dockerfile directly — ops-level coordination.

https://claude.ai/code/session_01XC1AF7LecoDXt5gMQAHhCf