### PR TITLE
Dockerfile: pin uv 0.11.7; harden gh + uv install layers (PR #116 follow-up)

### DIFF
--- a/.github/workflows/docker-bake-check.yml
+++ b/.github/workflows/docker-bake-check.yml
@@ -51,7 +51,7 @@ jobs:
           # making the Dockerfile bake the substitute origin for `op`
           # (and applying the same pattern to `gh` + `mem0-mcp-server`).
           missing=0
-          for binary in op gh mem0-mcp-server; do
+          for binary in op gh uv mem0-mcp-server; do
             if ! docker run --rm "$IMG" sh -c "command -v $binary >/dev/null"; then
               echo "::error::$binary missing from runtime image" >&2
               missing=$((missing + 1))
@@ -60,10 +60,12 @@ jobs:
           if [ "$missing" -gt 0 ]; then
             exit 1
           fi
-          # Version round-trip — `--version` for op and gh; mem0-mcp-server
-          # has no --version flag (we trust the install path test instead).
+          # Version round-trip — `--version` for op, gh, uv;
+          # mem0-mcp-server has no --version flag (we trust the install
+          # path test instead).
           docker run --rm "$IMG" op --version
           docker run --rm "$IMG" gh --version | head -1
+          docker run --rm "$IMG" uv --version
           docker run --rm "$IMG" sh -c "test -x /usr/local/bin/mem0-mcp-server"
 
       - name: Verify pinned versions match versions.lock
@@ -76,7 +78,10 @@ jobs:
           # what the image actually ships.
           op_pin="$(awk '/^op[[:space:]]+/ {print $2; exit}' versions.lock)"
           gh_pin="$(awk '/^gh[[:space:]]+/ {print $2; exit}' versions.lock)"
+          uv_pin="$(awk '/^uv[[:space:]]+/ {print $2; exit}' versions.lock)"
           op_actual="$(docker run --rm "$IMG" op --version 2>&1 | awk '{print $1}')"
           gh_actual="$(docker run --rm "$IMG" gh --version 2>&1 | head -1 | awk '{print $3}')"
+          uv_actual="$(docker run --rm "$IMG" uv --version 2>&1 | awk '{print $2}')"
           [ "$op_pin" = "$op_actual" ] || { echo "::error::op version drift: pin=$op_pin actual=$op_actual" >&2; exit 1; }
           [ "$gh_pin" = "$gh_actual" ] || { echo "::error::gh version drift: pin=$gh_pin actual=$gh_actual" >&2; exit 1; }
+          [ "$uv_pin" = "$uv_actual" ] || { echo "::error::uv version drift: pin=$uv_pin actual=$uv_actual" >&2; exit 1; }

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
 ARG GH_VERSION=2.91.0
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
+    case "$arch" in amd64|arm64) ;; *) echo "Unsupported arch: $arch" >&2; exit 1 ;; esac; \
     tmp="$(mktemp -d)"; \
     curl -fsSL --retry 5 --retry-delay 2 \
       "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${arch}.tar.gz" \
@@ -60,6 +61,30 @@ RUN set -eux; \
     rm -rf "$tmp"; \
     gh --version
 
+# uv (Python package/tool installer) — pinned in versions.lock. Used
+# only as the installer for mem0-mcp-server below. Pulled from the
+# astral-sh GitHub release tarball (not `curl … | sh` from astral.sh)
+# so the version is reproducible and the build doesn't shell-pipe
+# whatever uv is current at image-build time. Same retry budget as op
+# and gh.
+ARG UV_VERSION=0.11.7
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) uv_arch="x86_64-unknown-linux-gnu" ;; \
+      arm64) uv_arch="aarch64-unknown-linux-gnu" ;; \
+      *) echo "Unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    tmp="$(mktemp -d)"; \
+    curl -fsSL --retry 5 --retry-delay 2 \
+      "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${uv_arch}.tar.gz" \
+      -o "$tmp/uv.tgz"; \
+    tar -xzf "$tmp/uv.tgz" -C "$tmp"; \
+    install -m 0755 "$tmp/uv-${uv_arch}/uv" /usr/local/bin/uv; \
+    install -m 0755 "$tmp/uv-${uv_arch}/uvx" /usr/local/bin/uvx; \
+    rm -rf "$tmp"; \
+    uv --version
+
 # mem0-mcp-server stdio binary — pinned in versions.lock. uv-installed
 # globally so the .mcp.json command path resolves at /usr/local/bin
 # without a per-session uvx round-trip. Required for Mem0 MCP
@@ -67,8 +92,6 @@ RUN set -eux; \
 # entry points at a missing binary and Mem0 surface stays dark.
 ARG MEM0_MCP_VERSION=0.2.1
 RUN set -eux; \
-    curl -fsSL https://astral.sh/uv/install.sh \
-      | env UV_INSTALL_DIR=/usr/local/bin sh; \
     UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv-tools \
       /usr/local/bin/uv tool install --python python3 \
       "mem0-mcp-server==${MEM0_MCP_VERSION}"; \

--- a/versions.lock
+++ b/versions.lock
@@ -37,6 +37,13 @@ mem0-mcp-server     0.2.1     # Mem0 stdio MCP server. Required by
                               # baked into the Dockerfile at
                               # /usr/local/bin/mem0-mcp-server in epic
                               # #112 Stream 2.
+uv                  0.11.7    # Python package/tool installer. Used
+                              # only as the bootstrap for
+                              # mem0-mcp-server above. Pinned to the
+                              # release tarball (not the install.sh
+                              # pipe) so image builds are reproducible.
+                              # Bump when a new mem0-mcp-server release
+                              # needs a newer uv, otherwise leave alone.
 
 # Globally installed via npm
 @anthropic-ai/claude-code 1.0.120  # Claude Code CLI. Pinned to the


### PR DESCRIPTION
## Summary

Follow-up to PR #116 (review concerns 1–3). The mem0-mcp-server install layer was piping `curl https://astral.sh/uv/install.sh | sh` — the only unpinned binary in the entire image, which defeats the rest of the version-pin discipline and makes builds non-reproducible / bisect-hostile if a future uv ships a regression.

Three coordinated changes:

1. **Dockerfile (uv layer):** replace the `curl … | sh` install with a pinned release-tarball download from `astral-sh/uv`. Same `--retry 5 --retry-delay 2` budget as op + gh. Arch guard (amd64 → `x86_64-unknown-linux-gnu`, arm64 → `aarch64-unknown-linux-gnu`) plus an explicit `case` for unsupported arches. Closes review concerns **1** (pin) and **2** (retry).
2. **Dockerfile (gh layer):** add the same `case "$arch" in amd64|arm64) ;; *) exit 1 ;; esac` guard already present on op. Today the gh layer would silently 404 on an unsupported arch. Closes review concern **3** (symmetry).
3. **versions.lock + docker-bake-check.yml:** add `uv 0.11.7` entry; extend the binary-presence loop and version-drift check in CI to cover uv with the same shape as op + gh.

`uv 0.11.7` was picked one minor back from the latest release — `0.11.8` was published 2026-04-27 (same day as PR #116 merge), so 0.11.7 gets ~12 days of soak time.

## Why 0.11.7 specifically

The docker-bake-check on PR #116 was green with whatever uv shipped at build time. The unpinned `install.sh` would have resolved to either 0.11.7 (if the cache ran before today) or 0.11.8 (after today's release). Either way, 0.11.7 is known-working with `mem0-mcp-server==0.2.1`, and it's not the same-day release.

## Trade-offs

- **Build SLA:** uv's GitHub release CDN replaces astral.sh's redirect. Same-tier reliability, no expected change in flake rate.
- **Bump cadence:** versions.lock now carries a `uv` pin. Bump it when a new mem0-mcp-server release needs newer uv; otherwise leave alone. Commented inline.
- **CI cost:** docker-bake-check gains one `docker run --rm $IMG uv --version` invocation. Negligible (image is already built, container start is sub-second).

## Test plan

- [x] Local syntax: each `RUN set -eux` block parses under `bash -n`.
- [ ] `docker-bake-check` CI on PR open: builds image, asserts `op gh uv mem0-mcp-server` all present, and pinned versions match versions.lock.
- [ ] `bootstrap-regression` CI on PR open: continues to pass (no script-level changes; the workflow shouldn't even fire under the path filter, but if it does the mocks still satisfy `ensure_*_cli`).

## Out of scope

- Symmetric fail-build for gh and mem0-mcp-server (degraded-not-fatal per PR #116 doctrine; defer).
- mem0-mcp-server version-drift check via `pip show -V` (review concern 5; out of scope here).
- buildx caching for docker-bake-check (review concern 4; out of scope here).

## Post-merge confirmation

This PR does not modify SessionStart hooks, `.mcp.json`, or `coo-bootstrap.sh`. Verification can happen entirely in CI; no fresh-container handoff needed. The vendored `uv` is exercised on the next snapshot rebuild that consumes this Dockerfile.

https://claude.ai/code/session_01WoRB67PbAC3KJWYNVzt2Zj