### PR TITLE
session-lifecycle: update briefing path comment (MEMO-2026-04-27-02)

### DIFF
--- a/scripts/session-lifecycle.sh
+++ b/scripts/session-lifecycle.sh
@@ -10,8 +10,9 @@
 # does the work via MCP tools.
 #
 # See vade-coo-memory/coo/mem0_sop.md for the full SOP.
-# See docs/briefings/003-claude-code-cross-session-state.md in
-# vade-core for the design rationale.
+# See vade-coo-memory/coo/briefings/003-claude-code-cross-session-state.md
+# for the design rationale (relocated from vade-core/docs/briefings/
+# per MEMO-2026-04-27-02).
 #
 # Graceful no-op if sourced libraries or node are missing; never
 # breaks session start or stop.


### PR DESCRIPTION
## Summary

Comment-only update at `scripts/session-lifecycle.sh:13-14`. The briefings procedure relocated from `vade-core/docs/briefings/` to `vade-coo-memory/coo/briefings/` per MEMO-2026-04-27-02; this PR updates the design-rationale pointer in the script header to point at the new path.

No runtime behavior change. No invariant change.

## Why

Per `vade-coo-memory/coo/draft_lifecycle.md` §7 disposition (iii) — inline edit at relocation. The reference survey identified this as the only path-string cite outside the briefings bucket itself.

## Sibling PRs (merge in this order)

1. vade-coo-memory — adds `coo/briefings/` + memo. (Must merge first.)
2. **This PR** — updates the comment to point at the new location.
3. vade-core — clean-cut deletion of `docs/briefings/`.

## Test plan

- [ ] Bootstrap-regression CI passes (fires on `scripts/**`; comment-only change should be null relative to integrity-check).
- [ ] Comment renders correctly on github.com.

https://claude.ai/code/session_01XC1AF7LecoDXt5gMQAHhCf