### PR TITLE
auto-subscribe to PR activity after gh pr create

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,14 @@
           { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" session-lifecycle --end" }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" auto-subscribe-pr" }
+        ]
+      }
     ]
   },
   "env": {

--- a/scripts/auto-subscribe-pr.sh
+++ b/scripts/auto-subscribe-pr.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PostToolUse Bash hook: auto-subscribe to PR activity after `gh pr create`.
+#
+# Reads hook input JSON on stdin, detects whether the bash command was a
+# `gh pr create`, parses the PR URL from the tool response, and emits an
+# additionalContext system reminder instructing the next turn to call
+# mcp__github__subscribe_pr_activity. PR subscriptions are session-scoped
+# to the model, so a shell-side call cannot register one — the model must
+# issue the MCP call itself, hence the context-injection design.
+#
+# Always exits 0; no-ops cleanly on non-matching commands or unparsable
+# output so a misclassification can never block tool execution.
+
+set -uo pipefail
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && exit 0
+
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)"
+case "$cmd" in
+  *"gh pr create"*) ;;
+  *) exit 0 ;;
+esac
+
+blob="$(printf '%s' "$input" | jq -r '.tool_response | tostring' 2>/dev/null || true)"
+url="$(printf '%s' "$blob" | grep -oE 'https://github\.com/[^/[:space:]"\\]+/[^/[:space:]"\\]+/pull/[0-9]+' | head -1 || true)"
+[ -z "$url" ] && exit 0
+
+owner="$(printf '%s' "$url" | sed -E 's|.*github\.com/([^/]+)/.*|\1|')"
+repo="$(printf '%s' "$url" | sed -E 's|.*github\.com/[^/]+/([^/]+)/pull/[0-9]+.*|\1|')"
+pn="$(printf '%s' "$url" | sed -E 's|.*/pull/([0-9]+).*|\1|')"
+
+if [ -z "$owner" ] || [ -z "$repo" ] || [ -z "$pn" ]; then
+  exit 0
+fi
+case "$pn" in *[!0-9]*|'') exit 0 ;; esac
+
+jq -n --arg owner "$owner" --arg repo "$repo" --argjson pn "$pn" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: ("[auto-subscribe-pr] A pull request was just created at " + $owner + "/" + $repo + "#" + ($pn|tostring) + ". Call mcp__github__subscribe_pr_activity with owner=\"" + $owner + "\", repo=\"" + $repo + "\", pullNumber=" + ($pn|tostring) + " now so CI failures, comments, and reviews on this PR are delivered into this session as github-webhook-activity events. Do this silently in your next tool batch — do not narrate it.")
+  }
+}'

--- a/scripts/auto-subscribe-pr.sh
+++ b/scripts/auto-subscribe-pr.sh
@@ -22,7 +22,10 @@ case "$cmd" in
   *) exit 0 ;;
 esac
 
-blob="$(printf '%s' "$input" | jq -r '.tool_response | tostring' 2>/dev/null || true)"
+blob="$(printf '%s' "$input" | jq -r '
+  if (.tool_response | type) == "object"
+  then (.tool_response.stdout // "")
+  else (.tool_response | tostring) end' 2>/dev/null || true)"
 url="$(printf '%s' "$blob" | grep -oE 'https://github\.com/[^/[:space:]"\\]+/[^/[:space:]"\\]+/pull/[0-9]+' | head -1 || true)"
 [ -z "$url" ] && exit 0
 
@@ -38,6 +41,6 @@ case "$pn" in *[!0-9]*|'') exit 0 ;; esac
 jq -n --arg owner "$owner" --arg repo "$repo" --argjson pn "$pn" '{
   hookSpecificOutput: {
     hookEventName: "PostToolUse",
-    additionalContext: ("[auto-subscribe-pr] A pull request was just created at " + $owner + "/" + $repo + "#" + ($pn|tostring) + ". Call mcp__github__subscribe_pr_activity with owner=\"" + $owner + "\", repo=\"" + $repo + "\", pullNumber=" + ($pn|tostring) + " now so CI failures, comments, and reviews on this PR are delivered into this session as github-webhook-activity events. Do this silently in your next tool batch — do not narrate it.")
+    additionalContext: ("[auto-subscribe-pr] A pull request was just created at " + $owner + "/" + $repo + "#" + ($pn|tostring) + ". Call mcp__github__subscribe_pr_activity with owner=\"" + $owner + "\", repo=\"" + $repo + "\", pullNumber=" + ($pn|tostring) + " in your next tool batch so CI failures, comments, and reviews on this PR stream into this session as github-webhook-activity events.")
   }
 }'


### PR DESCRIPTION
## Summary

- New `scripts/auto-subscribe-pr.sh` PostToolUse Bash hook: detects `gh pr create`, parses the PR URL from tool output, and emits a system reminder telling the next turn to call `mcp__github__subscribe_pr_activity`.
- Wired into `.claude/settings.json` via the existing `vade-hooks/dispatch.sh` shim.

## Why this design

PR subscriptions are session-scoped to the model — a shell-side call cannot register one. The hook therefore injects `hookSpecificOutput.additionalContext` so the assistant issues the MCP call itself on the next turn. Removes the manual ritual of clicking "Auto-fix CI & address comments" on every PR.

## Test plan

- [x] Pipe-test (positive): synthetic `gh pr create` payload → emits proper `additionalContext` JSON with parsed `owner`/`repo`/`pullNumber`.
- [x] Pipe-test (negative, unrelated bash): silent no-op, exit 0.
- [x] Pipe-test (negative, `gh pr create --web`, no URL on stdout): silent no-op, exit 0.
- [x] Pipe-test (env-var-prefixed `GH_TOKEN=… gh pr create`): still detected.
- [x] End-to-end through `vade-hooks/dispatch.sh auto-subscribe-pr`: routes via `self_path` rule, returns correct JSON.
- [x] `jq` schema validation on settings.json passes.
- [ ] Post-merge: on a fresh container, run any `gh pr create` and confirm the assistant calls `subscribe_pr_activity` immediately after.

## Notes

- The hook fires on every Bash call but self-filters in ~1ms via a `case` match on the command string before doing any URL parsing.
- Always exits 0; misclassification cannot block the underlying tool.

https://claude.ai/code/session_01LJwyf263wgi2KKigyZ2nRJ