### PR TITLE
hotfix: revert op-install FATAL → WARN so sessions can boot degraded

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -111,20 +111,17 @@ if ensure_op_cli; then
   OP_INSTALLED_AT_BUILD=true
   build_log_record OK "cloud-setup: op CLI installed at build time"
 else
-  build_log_record FAIL "cloud-setup: op CLI install failed at build time; failing build per vade-runtime#111 acceptance (a)"
-  log "FATAL: op CLI install failed at build time."
-  log "  Per vade-runtime#111 acceptance (a): a snapshot without op ships degraded;"
-  log "  SessionStart fallback would re-fetch the same flaky origin and likely fail"
-  log "  under the same egress window. Failing the build instead so the receipt is"
-  log "  never written with op_installed_at_build=false."
-  log "  Remediation: retry the build (cache.agilebits.com may have recovered),"
-  log "  or rebuild from a runtime image with op pre-baked (vade-runtime/Dockerfile,"
-  log "  epic #112 Stream 2)."
-  # Deliberately not writing setup-receipt.json — acceptance (a) is
-  # "receipt is never written with op_installed_at_build=false". The
-  # build.log FAIL line above is the diagnostic; the absent receipt
-  # signals the build did not land.
-  exit 1
+  build_log_record WARN "cloud-setup: op CLI install failed at build time; receipt will record op_installed_at_build=false"
+  log "Warning: op CLI install failed at build time; snapshot ships degraded."
+  log "  coo-identity-digest renders a ⚠ block at SessionStart when the receipt"
+  log "  shows op_installed_at_build=false, so the operator sees the degradation"
+  log "  loudly instead of mid-task. coo-bootstrap.sh re-runs ensure_op_cli at"
+  log "  SessionStart — different egress window than build time, may recover."
+  log "  Reverses #116's FATAL flip per BDFL: failing the build was over-strict"
+  log "  given that #119 showed the cloud sandbox doesn't actually use the"
+  log "  Dockerfile-baked /usr/local/bin/op, so the bake doesn't backstop a"
+  log "  cache.agilebits.com flake at snapshot-build time. Bootable-but-degraded"
+  log "  is strictly better than unbootable for diagnostic purposes."
 fi
 
 # Install the gh CLI for the same reason: snapshot-persistent, no


### PR DESCRIPTION
## Summary

Hotfix: PR #116 made `cloud-setup.sh` exit 1 when `ensure_op_cli` fails. cache.agilebits.com is currently flaking, so the cloud snapshot build hard-fails and no fresh session can launch ("Setup script failed with exit code 1"). This PR reverts that single block to WARN-and-continue, matching the `gh` and `mem0-mcp-server` blocks immediately below it. The session boots degraded; the operator can investigate from inside it.

## Why the FATAL flip was over-strict

#116's safety case rested on the Dockerfile-baked `/usr/local/bin/op` layer making `ensure_op_cli` a no-op when the runtime image was in use. **#119 (filed 14 minutes after #116 merged) confirmed the cloud sandbox does not use our Dockerfile** — only local devcontainers do. So in production every snapshot build still hits `cache.agilebits.com`, fully exposed to the same egress flake the bake was supposed to absorb. The FATAL net catches the flake, but the upside (no-fetch on bake) was never wired.

Result: cache flake → unbootable build → no diagnostic session. Strictly worse than the prior degraded-but-bootable behavior.

## What still surfaces the degradation

Already wired, no new code needed:

- `coo-identity-digest.sh:252-260` renders a prominent `⚠` block at SessionStart when `receipt.op_installed_at_build=false`, with remediation hint.
- `integrity-check.sh` D-group invariants flag the cascading effects (D1 OP token, D3 coo-bootstrap log) when op is missing.
- `coo-bootstrap.sh` re-runs `ensure_op_cli` at SessionStart — different egress window than build time, often recovers on its own.

## Test plan

- [x] `bash -n cloud-setup.sh` passes.
- [x] Diff is one block (lines 113-127), exact mirror of the WARN-and-continue pattern used 24 lines below for `ensure_gh_cli`.
- [ ] bootstrap-regression CI (PR-open) passes — should, mocks satisfy `ensure_op_cli` regardless of fail/warn semantics.
- [ ] Post-merge: a snapshot build that hits a cache.agilebits.com 5xx should now ship with `op_installed_at_build=false` in the receipt and a working session that boots into the `⚠` digest block. Hard to dry-run without the upstream actually flaking.

## Related

- Reverts the FATAL behavior introduced in #116 (keeps the Dockerfile bake + the docker-bake-check workflow).
- Doesn't touch #119's underlying gap (cloud sandbox doesn't use our Dockerfile) — that's the proper long-term fix and stays open.
- Doesn't preclude #111 acceptance (b) — alternate origin / local mirror — which would obviate this entirely.

## Followup

Worth re-reading #116's "what fail-build buys you" argument with #119's finding folded in. The doctrine memo (Stream 5 of epic #112) should reflect that fail-build only buys safety when the bake actually no-ops the fetch in the build environment that's failing.

https://claude.ai/code/session_01LJwyf263wgi2KKigyZ2nRJ