### PR TITLE
git-push-with-fallback: redact PAT from -u fallback path (closes #124)

### DIFF
--- a/scripts/ci/test-git-push-fallback.sh
+++ b/scripts/ci/test-git-push-fallback.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# test-git-push-fallback: unit-test the credential-leak hardening in
+# scripts/git-push-with-fallback.sh (vade-app/vade-runtime#124).
+#
+# Strategy: source the wrapper's helper functions in isolation and
+# pipe-test their behavior on representative arg shapes. Also exercise
+# the redaction sed against a stream containing a credential URL, and
+# end-to-end the .git/config tracking restoration via a mock-git repo
+# that pretends the fallback push succeeded.
+#
+# Run: bash scripts/ci/test-git-push-fallback.sh
+# Exit: 0 if all assertions pass, non-zero otherwise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/../git-push-with-fallback.sh"
+
+[ -f "$WRAPPER" ] || { echo "FAIL: wrapper not found at $WRAPPER"; exit 1; }
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS: %s\n' "$label"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL: %s\n    expected: %q\n    actual:   %q\n' "$label" "$expected" "$actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_no_match() {
+  local label="$1" pattern="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qE "$pattern"; then
+    printf '  FAIL: %s\n    pattern %q matched in: %q\n' "$label" "$pattern" "$haystack"
+    FAIL=$((FAIL + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_match() {
+  local label="$1" pattern="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qE "$pattern"; then
+    printf '  PASS: %s\n' "$label"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL: %s\n    pattern %q did not match in: %q\n' "$label" "$pattern" "$haystack"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Source the wrapper for direct access to helper functions. The wrapper
+# guards `main "$@"` behind a BASH_SOURCE/0 check so sourcing is safe.
+# shellcheck disable=SC1090
+source "$WRAPPER"
+
+echo "== parse_push_refspec =="
+
+out="$(parse_push_refspec origin -u origin claude/foo)"
+assert_eq "simple: -u origin claude/foo" "$(printf 'claude/foo\nclaude/foo\n')" "$out"
+
+out="$(parse_push_refspec origin --set-upstream origin claude/foo:claude/bar)"
+assert_eq "split refspec: --set-upstream origin claude/foo:claude/bar" \
+  "$(printf 'claude/foo\nclaude/bar\n')" "$out"
+
+out="$(parse_push_refspec origin -u origin +claude/foo)"
+assert_eq "force prefix: -u origin +claude/foo" "$(printf 'claude/foo\nclaude/foo\n')" "$out"
+
+out="$(parse_push_refspec origin -u origin claude/foo:refs/heads/claude/bar)"
+assert_eq "explicit refs/heads/ in dst" \
+  "$(printf 'claude/foo\nrefs/heads/claude/bar\n')" "$out"
+
+echo "== PAT_REDACT_SED =="
+
+leak_input='branch claude/foo set up to track '"'"'https://vade-coo:github_pat_AAAA1234@github.com/vade-app/vade-runtime.git/claude/foo'"'"'.'
+redacted="$(printf '%s' "$leak_input" | sed -E "$PAT_REDACT_SED")"
+assert_no_match "PAT redacted from git tracking-set line" 'github_pat_' "$redacted"
+assert_eq "redacted URL has *** placeholder" \
+  "branch claude/foo set up to track 'https://vade-coo:***@github.com/vade-app/vade-runtime.git/claude/foo'." \
+  "$redacted"
+
+multi_input='https://octocat:ghp_BBBB5678@github.com/foo/bar.git'
+redacted_multi="$(printf '%s' "$multi_input" | sed -E "$PAT_REDACT_SED")"
+assert_eq "redaction is user-agnostic" "https://octocat:***@github.com/foo/bar.git" "$redacted_multi"
+
+clean_input='https://github.com/vade-app/vade-runtime.git'
+clean_out="$(printf '%s' "$clean_input" | sed -E "$PAT_REDACT_SED")"
+assert_eq "redaction leaves clean URLs alone" "$clean_input" "$clean_out"
+
+echo "== end-to-end: -u flag does not leak PAT into .git/config =="
+
+# Stage a scratch repo whose `origin` remote points at a non-github proxy
+# stand-in. The wrapper will detect the proxy URL pattern, fall back to
+# the credential-bearing direct URL, and call `git push` against it. We
+# intercept that call with a mock `git` that fails the first push (to
+# trigger the fallback) and succeeds the second — bypassing the actual
+# network — then verify the resulting .git/config.
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+REAL_GIT="/usr/bin/git"
+[ -x "$REAL_GIT" ] || { echo "FAIL: real git not at $REAL_GIT"; exit 1; }
+
+MOCK_LOG="$WORK/git-mock.log"
+STATE="$WORK/state"
+cat > "$WORK/git" <<MOCKEOF
+#!/usr/bin/env bash
+# Forward read-only ops to the real git so the wrapper's setup calls
+# (remote get-url, symbolic-ref, config write) work in this test.
+case "\$1" in
+  push)
+    {
+      printf 'MOCK PUSH ARGS:'
+      for a in "\$@"; do printf ' [%s]' "\$a"; done
+      printf '\n'
+    } >> "$MOCK_LOG"
+    if [ -f "$STATE" ]; then
+      # Second-and-onward push: succeed.
+      exit 0
+    fi
+    # First push: emit a proxy-failure marker and fail.
+    : > "$STATE"
+    printf 'remote: HTTP 403\n' >&2
+    exit 1
+    ;;
+  *)
+    exec $REAL_GIT "\$@"
+    ;;
+esac
+MOCKEOF
+chmod +x "$WORK/git"
+
+REPO="$WORK/repo"
+mkdir -p "$REPO"
+(
+  cd "$REPO"
+  $REAL_GIT init -q -b main >/dev/null 2>&1
+  $REAL_GIT -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
+  $REAL_GIT checkout -q -b claude/test-branch
+  $REAL_GIT remote add origin "http://local_proxy@127.0.0.1:8080/git/vade-app/vade-runtime"
+)
+
+# Isolate HOME so the wrapper's `lib/common.sh` doesn't source the
+# host's ~/.vade/coo-env and overwrite our test PAT (common.sh:234).
+STUB_HOME="$WORK/stub-home"
+mkdir -p "$STUB_HOME"
+
+(
+  cd "$REPO"
+  PATH="$WORK:$PATH"
+  HOME="$STUB_HOME" \
+  GITHUB_MCP_PAT="test_pat_DO_NOT_LEAK_2222" \
+    bash "$WRAPPER" -u origin claude/test-branch
+) > "$WORK/wrapper.out" 2>&1
+
+wrapper_out="$(cat "$WORK/wrapper.out")"
+mock_log="$(cat "$MOCK_LOG" 2>/dev/null || true)"
+
+assert_no_match "wrapper stdout/stderr does not contain PAT" \
+  'test_pat_DO_NOT_LEAK_2222' "$wrapper_out"
+
+config_remote="$($REAL_GIT -C "$REPO" config --get branch.claude/test-branch.remote || true)"
+assert_eq ".git/config branch tracking remote = symbolic origin" "origin" "$config_remote"
+
+config_merge="$($REAL_GIT -C "$REPO" config --get branch.claude/test-branch.merge || true)"
+assert_eq ".git/config branch merge ref = refs/heads/claude/test-branch" \
+  "refs/heads/claude/test-branch" "$config_merge"
+
+# Two MOCK pushes recorded: first proxy attempt + fallback.
+push_count="$(grep -c '^MOCK PUSH ARGS:' "$MOCK_LOG" 2>/dev/null || echo 0)"
+assert_eq "mock saw two push attempts (proxy + fallback)" "2" "$push_count"
+
+# First-attempt push (line 1): contains -u, contains [origin] (symbolic).
+first_line="$(sed -n '1p' "$MOCK_LOG")"
+assert_match "first push contains [-u]" '\[-u\]' "$first_line"
+assert_match "first push contains [origin]" '\[origin\]' "$first_line"
+
+# Fallback push (line 2): no -u, no --set-upstream, contains the direct URL.
+second_line="$(sed -n '2p' "$MOCK_LOG")"
+assert_no_match "fallback push args do not contain -u" '\[-u\]' "$second_line"
+assert_no_match "fallback push args do not contain --set-upstream" '\[--set-upstream\]' "$second_line"
+assert_match "fallback push args contain direct vade-coo URL" 'vade-coo:test_pat_DO_NOT_LEAK_2222@github.com' "$second_line"
+
+# .git/config must NOT contain the PAT anywhere.
+assert_no_match ".git/config contains no PAT" 'test_pat_DO_NOT_LEAK_2222' \
+  "$(cat "$REPO/.git/config")"
+
+echo
+printf 'Results: %d pass, %d fail\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/git-push-with-fallback.sh
+++ b/scripts/git-push-with-fallback.sh
@@ -23,6 +23,16 @@
 # Requires GITHUB_MCP_PAT in the environment for the fallback path. If
 # unset, the wrapper passes the original failure through with a
 # pointer at coo-bootstrap.sh.
+#
+# Credential-leak hardening (vade-app/vade-runtime#124):
+#   The fallback push targets a credential-bearing URL. To prevent the
+#   PAT from leaking into stdout or .git/config when `-u` /
+#   `--set-upstream` is present, the wrapper:
+#     · strips upstream flags from the fallback args and re-establishes
+#       tracking via `git config branch.<X>.remote=<symbolic remote>`
+#       after the push lands;
+#     · pipes fallback push output through a sed redactor that masks
+#       any `<user>:<password>@` URL.
 
 set -uo pipefail
 
@@ -34,6 +44,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Anything matching is eligible for the direct-URL fallback. Keep this
 # list narrow — we don't want to retry genuine permission errors.
 readonly PROXY_FAILURE_PATTERNS='HTTP 403|send-pack: unexpected disconnect|the remote end hung up unexpectedly|refusing to allow an OAuth App|workflow.*scope'
+
+# Sed expression that masks any `<user>:<password>@` segment of a URL.
+# Defensive against the wrapper's own credential URL leaking from any
+# git-emitted line we don't otherwise control.
+readonly PAT_REDACT_SED='s|(https?://[^:/[:space:]]+:)[^@[:space:]]+@|\1***@|g'
 
 resolve_remote_from_args() {
   local a
@@ -52,6 +67,41 @@ extract_repo_path() {
   # Proxy form: http(s)://[user@]host[:port]/git/owner/repo[.git]
   path="$(printf '%s' "$url" | sed -nE 's#^https?://[^/]+/git/(.+)$#\1#p')"
   printf '%s' "${path%.git}"
+}
+
+# Parse the push refspec out of a git push arg list. Prints two lines —
+# <local-branch> and <remote-ref-name> — used to restore upstream
+# tracking after a fallback push that had `-u` stripped. Empty output
+# when a refspec can't be determined.
+parse_push_refspec() {
+  local remote="$1"; shift
+  local seen_remote=0 a
+  for a in "$@"; do
+    case "$a" in
+      -u|--set-upstream) continue ;;
+      -*) continue ;;
+    esac
+    if [ "$seen_remote" -eq 0 ] && [ "$a" = "$remote" ]; then
+      seen_remote=1
+      continue
+    fi
+    local raw="${a#+}"  # strip force-push prefix
+    local src dst
+    if [[ "$raw" == *:* ]]; then
+      src="${raw%%:*}"
+      dst="${raw#*:}"
+    else
+      src="$raw"
+      dst="$raw"
+    fi
+    printf '%s\n%s\n' "$src" "$dst"
+    return 0
+  done
+  local cur
+  cur="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+  if [ -n "$cur" ]; then
+    printf '%s\n%s\n' "$cur" "$cur"
+  fi
 }
 
 PUSH_OUT_TMP=""
@@ -105,17 +155,23 @@ main() {
   local masked_url="https://vade-coo:***@github.com/${repo_path}.git"
   log_err "git proxy push failed; retrying via $masked_url"
 
+  # Build fallback args: substitute direct_url for the remote token, and
+  # drop -u / --set-upstream (the upstream-tracking config gets written
+  # explicitly post-push, see #124).
   local -a new_args=()
-  local seen=0 a
+  local seen_remote=0 has_upstream=0 a
   for a in "$@"; do
-    if [ "$seen" -eq 0 ] && [ "$a" = "$remote" ]; then
+    case "$a" in
+      -u|--set-upstream) has_upstream=1; continue ;;
+    esac
+    if [ "$seen_remote" -eq 0 ] && [ "$a" = "$remote" ]; then
       new_args+=("$direct_url")
-      seen=1
+      seen_remote=1
     else
       new_args+=("$a")
     fi
   done
-  if [ "$seen" -eq 0 ]; then
+  if [ "$seen_remote" -eq 0 ]; then
     local current_branch
     current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
     if [ -z "$current_branch" ]; then
@@ -125,7 +181,37 @@ main() {
     new_args+=("$direct_url" "HEAD:refs/heads/$current_branch")
   fi
 
-  git push "${new_args[@]}"
+  # Pipe push output through a redactor as belt-and-suspenders against
+  # any URL leak from git itself. PIPESTATUS preserves git's exit code.
+  local fallback_rc
+  git push "${new_args[@]}" 2>&1 | sed -E "$PAT_REDACT_SED"
+  fallback_rc="${PIPESTATUS[0]}"
+  if [ "$fallback_rc" -ne 0 ]; then
+    return "$fallback_rc"
+  fi
+
+  # Restore upstream tracking via the symbolic remote so .git/config
+  # stays free of the credential URL. Skip silently if the user didn't
+  # ask for upstream-setting.
+  if [ "$has_upstream" -eq 1 ]; then
+    local refs local_branch remote_ref merge_ref
+    refs="$(parse_push_refspec "$remote" "$@")"
+    local_branch="$(printf '%s' "$refs" | sed -n '1p')"
+    remote_ref="$(printf '%s' "$refs" | sed -n '2p')"
+    if [ -n "$local_branch" ] && [ -n "$remote_ref" ]; then
+      case "$remote_ref" in
+        refs/*) merge_ref="$remote_ref" ;;
+        *) merge_ref="refs/heads/$remote_ref" ;;
+      esac
+      git config "branch.${local_branch}.remote" "$remote"
+      git config "branch.${local_branch}.merge" "$merge_ref"
+    else
+      log_err "fallback push succeeded but could not parse refspec; upstream not restored — run 'git push -u $remote <branch>' manually if needed"
+    fi
+  fi
 }
 
-main "$@"
+# Run main only when invoked as a script (not when sourced for testing).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary

Closes #124. The fallback path in `scripts/git-push-with-fallback.sh` constructs a credential-bearing direct URL (`https://vade-coo:${GITHUB_MCP_PAT}@github.com/...`) and runs `git push` against it. When the user's args included `-u` / `--set-upstream`, git itself emitted the credential URL in two places the wrapper's existing `masked_url` log line did not control:

1. **stdout** — git's "branch X set up to track 'Y'" announcement printed the URL verbatim.
2. **`.git/config`** — `branch.<name>.remote = <credential URL>` got persisted to disk and stayed there until manually cleaned.

Two-layer fix per the issue's proposal:

- Strip `-u` / `--set-upstream` from the fallback push args. After the push lands, set `branch.<X>.remote` to the symbolic remote name and `branch.<X>.merge` to the parsed dst ref directly via `git config` — credential URL never enters the persisted tracking config.
- Pipe fallback push output through a `sed` redactor that masks any `<user>:<password>@` URL. Belt-and-suspenders against future cases where git emits the URL on a path the wrapper doesn't otherwise control.

Added `parse_push_refspec` helper (handles `+force` prefix, `src:dst` split, explicit `refs/heads/` dst, no-refspec / current-branch case) and a `BASH_SOURCE/0` guard around `main` so unit tests can `source` the wrapper directly.

## Test plan

New `scripts/ci/test-git-push-fallback.sh` — 18 assertions, all passing:

- `parse_push_refspec`: simple `-u origin <branch>`, split `src:dst`, force-prefix `+ref`, explicit `refs/heads/<ref>` dst.
- `PAT_REDACT_SED`: redacts a credential URL inside a typical "set up to track" line; user-agnostic (also masks `octocat:ghp_*@`); leaves clean URLs untouched.
- End-to-end with a mock `git`:
  - mock saw two pushes (proxy attempt + fallback)
  - first push received `-u` and `[origin]` verbatim
  - fallback push received neither `-u` nor `--set-upstream`, but did receive the direct URL
  - `.git/config` has `branch.<X>.remote=origin` (symbolic) and `merge=refs/heads/<X>`
  - `.git/config` contains no PAT substring anywhere
  - wrapper stdout/stderr never contained the test PAT

Run: `bash scripts/ci/test-git-push-fallback.sh` — `Results: 18 pass, 0 fail`.

The new test isolates `HOME` to a stub directory because `lib/common.sh` line 234 unconditionally sources `~/.vade/coo-env` on import, which would otherwise re-export the host's real `GITHUB_MCP_PAT` over the test value. (Worth noting in case other future tests trip over the same thing.)

## Severity recap

P1 — credential-class leak. PAT exposure was contained to (a) the local workspace `.git/config` and (b) any session transcript that observed the leak. Remote git history is unaffected. Cleanup of an already-leaked workspace: `git config branch.<name>.remote origin`.

## Out of scope

- Replacing the URL-embedded credential with `git -c http.extraheader=...` or a credential helper. That's the cleaner architectural fix but a larger surface change; this PR closes the immediate leak. File a follow-up if desired.
- Wiring `test-git-push-fallback.sh` into a CI workflow. The two existing test scripts (`test-git-shim.sh`, `test-gh-coo-wrap.sh`) are also standalone manual smoke-tests; the new one matches that convention.

https://claude.ai/code/session_01MYvNUp5mAhVsnxZQkZQDVH