### PR TITLE
transcript-redaction: ship engine, 24-class pattern table, registration rule

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -85,3 +85,22 @@ jobs:
             /tmp/bootstrap-regression-result.json
           if-no-files-found: warn
           retention-days: 14
+
+  transcript-redaction:
+    # Fast standalone job for the redaction engine + Secret Registration
+    # Rule. Independent of the heavy bootstrap-regression job above
+    # because it doesn't need a staged workspace — just python3 + jq.
+    # Origin: vade-app/vade-agent-logs#64.
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Redaction engine — corpus + thinking + negative tests
+        run: python3 "$GITHUB_WORKSPACE/scripts/ci/test-transcript-redaction.py"
+
+      - name: Secret Registration Rule — common.sh ↔ redaction config parity
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/check-secret-registration.sh"

--- a/scripts/ci/check-secret-registration.sh
+++ b/scripts/ci/check-secret-registration.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Enforces the **Secret Registration Rule**:
+#
+# Every secret env var exported inside `fetch_coo_secrets`
+# (scripts/lib/common.sh) MUST have a matching entry in
+# scripts/lib/transcript-redaction.json with `secret_var` == the var
+# name. This rule is the linchpin of the redaction pipeline's
+# future-proofing posture: when a new MCP / integration adds a secret,
+# CI fails until a redaction pattern is registered alongside it.
+#
+# Origin: vade-app/vade-agent-logs#64 security review §3.
+#
+# Exits 0 when the two sides agree, 1 with a diff on divergence.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMMON_SH="$RUNTIME_ROOT/scripts/lib/common.sh"
+REDACT_JSON="$RUNTIME_ROOT/scripts/lib/transcript-redaction.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required" >&2
+  exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required" >&2
+  exit 2
+fi
+
+# Extract the body of fetch_coo_secrets. Use Python to slice between
+# the `^fetch_coo_secrets()` line and the matching `^}` at column 0,
+# so changes elsewhere in common.sh don't bleed in.
+common_exports=$(
+  python3 - <<PY
+import re, sys
+src = open("$COMMON_SH").read()
+m = re.search(r"(?ms)^fetch_coo_secrets\s*\(\s*\)\s*\{(.*?)^\}\s*$", src)
+if not m:
+    print("ERROR: could not locate fetch_coo_secrets in $COMMON_SH", file=sys.stderr)
+    sys.exit(2)
+body = m.group(1)
+seen = set()
+# Match `export FOO=` or `export FOO="..."` or `export FOO FOO2=...`
+for em in re.finditer(r"\bexport\s+([A-Z][A-Z0-9_]+)\b", body):
+    seen.add(em.group(1))
+# Filter out non-secret exports: derivatives like GITHUB_TOKEN that
+# carry the same value as a registered secret should still be listed,
+# but ones that aren't credential material can be excluded by name.
+# Today there are no such exclusions; if a future export is non-secret
+# (e.g. RUN_ID-style), add an annotation comment in common.sh and
+# extend this filter. Conservative default: every exported var must
+# be registered.
+for v in sorted(seen):
+    print(v)
+PY
+)
+
+# Extract registered secret_vars from JSON. Skip null entries (those
+# are patterns for shapes that aren't tied to a coo-env secret).
+# secret_var may be a string OR an array of aliases (e.g. GITHUB_MCP_PAT
+# and GITHUB_TOKEN both carry the same fine-grained-PAT shape).
+registered_vars=$(jq -r '
+  .patterns[] | select(.secret_var != null) |
+  (if (.secret_var | type) == "array" then .secret_var[] else .secret_var end)
+' "$REDACT_JSON" | sort -u)
+
+unregistered=$(comm -23 <(printf '%s\n' "$common_exports" | sort -u) <(printf '%s\n' "$registered_vars"))
+orphaned=$(comm -13   <(printf '%s\n' "$common_exports" | sort -u) <(printf '%s\n' "$registered_vars"))
+
+fail=0
+if [ -n "$unregistered" ]; then
+  echo "FAIL: secrets exported by fetch_coo_secrets but with no transcript-redaction.json pattern:"
+  while IFS= read -r v; do echo "       - $v"; done <<< "$unregistered"
+  echo
+  echo "Action: add a pattern entry to scripts/lib/transcript-redaction.json"
+  echo "with \"secret_var\": \"<NAME>\" matching each line above. The Secret"
+  echo "Registration Rule (vade-app/vade-agent-logs#64) requires this."
+  fail=1
+fi
+if [ -n "$orphaned" ]; then
+  echo "WARN: transcript-redaction.json registers secret_var that is no longer"
+  echo "      exported by fetch_coo_secrets:"
+  while IFS= read -r v; do echo "       - $v"; done <<< "$orphaned"
+  echo
+  echo "Action: either (a) the secret was retired and the pattern entry's"
+  echo "secret_var should be set to null (keep the pattern in case the shape"
+  echo "still appears in transcripts from third-party tool output), or"
+  echo "(b) the pattern entry should be removed."
+  # Orphaned entries are a warning, not an error. Stale patterns don't
+  # leak secrets — they just clutter the table.
+fi
+
+if [ "$fail" -eq 0 ] && [ -z "$orphaned" ]; then
+  echo "secret-registration parity OK: $(echo "$common_exports" | wc -l | tr -d ' ') exports, all registered"
+fi
+
+exit "$fail"

--- a/scripts/ci/test-transcript-redaction.py
+++ b/scripts/ci/test-transcript-redaction.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+CI test for the transcript-redaction engine.
+
+Asserts:
+  1. Positive corpus — every synthesized token of every pattern shape
+     is redacted with its expected REDACTED:<id> label.
+  2. Negative corpus — strings that resemble secrets but don't match
+     any pattern pass through unchanged (no over-redaction; no entropy
+     false-positives on common short / low-entropy strings).
+  3. Thinking blocks — JSON events with {type:"thinking",text:"..."}
+     have their text wholesale-replaced (preserving structure +
+     signature); embedded secrets-inside-thinking are gone via defense
+     in depth; hits summary reports thinking-block count.
+
+Why Python instead of TSV fixtures + bash:
+  GitHub secret-scanning push protection blocks any commit whose disk
+  content matches partner patterns (real PAT shapes, Stripe keys,
+  Slack tokens, etc.). Storing literal-shape synthetic tokens on disk
+  trips the scanner. Building tokens via string concatenation at test
+  runtime keeps the disk content scanner-clean while still exercising
+  the redactor against canonical shapes. The corpus *contents* never
+  exist as literal strings in the repo — only as concatenation
+  expressions.
+
+Exits 0 on full pass, 1 on any failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Iterable
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+REDACT = os.path.join(REPO_ROOT, "scripts", "lib", "transcript-redact.sh")
+
+
+# Synthetic-token builders. Each returns a string whose shape matches
+# the named pattern but whose content is never-real (high-entropy
+# patterns use 'A' fillers; structured patterns use trivial fixed
+# content). Build at runtime — never write these literal strings to
+# any committed file.
+def _A(n: int) -> str:
+    return "A" * n
+
+
+def _gh_classic_pat() -> str:
+    return "ghp" + "_" + _A(36)
+
+
+def _gh_fine_pat() -> str:
+    # Spec: 11-char prefix + 82 chars (verified at length 93).
+    return "github" + "_pat_" + _A(82)
+
+
+def _gh_oauth(prefix: str) -> str:
+    return prefix + "_" + _A(36)
+
+
+def _anthropic_key() -> str:
+    return "sk" + "-ant-" + "api01" + "-" + _A(95)
+
+
+def _openai_key() -> str:
+    return "sk" + "-proj-" + _A(60)
+
+
+def _mem0_key() -> str:
+    return "m0" + "-" + _A(43)
+
+
+def _agentmail_key() -> str:
+    return "agentmail" + "-" + _A(76)
+
+
+def _op_token() -> str:
+    # Realistic shape: ops_ prefix + base64-shaped JWT body. We use a
+    # short structurally-valid base64 fragment so the regex matches but
+    # secret-scanning doesn't fingerprint it as a real op token.
+    return "ops" + "_" + "eyJ" + ("a" * 30) + "." + ("a" * 30)
+
+
+def _generic_jwt() -> str:
+    return "eyJ" + ("a" * 20) + "." + ("a" * 20) + "." + ("a" * 20)
+
+
+def _aws_akid() -> str:
+    return "AKIA" + ("A" * 16)
+
+
+def _aws_secret() -> str:
+    return "aws_secret_access_key=" + ("A" * 40)
+
+
+def _auth_header() -> str:
+    return "Authorization: " + "Bearer " + ("a" * 30)
+
+
+def _gcp_refresh() -> str:
+    return "1" + "//0" + ("A" * 60)
+
+
+def _gcp_pem() -> str:
+    return (
+        "-----BEGIN PRIVATE KEY-----\n"
+        + "MIIEvQ" + ("A" * 30) + "\n"
+        + "-----END PRIVATE KEY-----"
+    )
+
+
+def _ssh_private() -> str:
+    return (
+        "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+        + "b3Blbn" + ("A" * 30) + "\n"
+        + "-----END OPENSSH PRIVATE KEY-----"
+    )
+
+
+def _slack_token() -> str:
+    return "xox" + "b" + "-1234567890-1234567890-1234567890-" + ("a" * 32)
+
+
+def _slack_webhook() -> str:
+    return "https://hooks.slack" + ".com/services/T" + ("0" * 9) + "/B" + ("0" * 9) + "/" + ("a" * 24)
+
+
+def _discord_webhook() -> str:
+    return "https://discord" + ".com/api/webhooks/" + ("0" * 18) + "/" + ("a" * 24)
+
+
+def _stripe_key() -> str:
+    return "sk_" + "live_" + ("A" * 24)
+
+
+def _hf_token() -> str:
+    return "hf" + "_" + ("a" * 36)
+
+
+def _npm_token() -> str:
+    return "npm" + "_" + _A(36)
+
+
+def _pypi_token() -> str:
+    # Macaroon-shape: pypi-AgEIcHlwaS5vcmc + base64ish run.
+    return "pypi-Ag" + "EIcHlwaS5vcmc" + ("A" * 60)
+
+
+# (pattern_id, token-builder, surrounding-context)
+POSITIVE_CASES: list[tuple[str, callable, str]] = [
+    ("gh-classic-pat", _gh_classic_pat, "stdout: gh auth status"),
+    ("gh-fine-pat", _gh_fine_pat, "embedded in env="),
+    ("gh-oauth-u2s", lambda: _gh_oauth("ghu"), "from a hypothetical OAuth flow"),
+    ("gh-oauth-s2s", lambda: _gh_oauth("ghs"), "server-to-server"),
+    ("gh-oauth-refresh", lambda: _gh_oauth("ghr"), "refresh"),
+    ("anthropic-key", _anthropic_key, "leaked into a stray printenv"),
+    ("openai-key", _openai_key, "leaked into Bash output"),
+    ("mem0-key", _mem0_key, "in env-snapshot"),
+    ("agentmail-key", _agentmail_key, "agentmail key dump"),
+    ("op-token", _op_token, "1Password service token"),
+    ("jwt", _generic_jwt, "a JWT in a tool result"),
+    ("aws-akid", _aws_akid, "AWS access key in stdout"),
+    ("aws-secret", _aws_secret, "in a credentials file paste"),
+    ("auth-header", _auth_header, "curl -v output line"),
+    ("gcp-refresh", _gcp_refresh, "Google OAuth refresh token"),
+    ("gcp-pem", _gcp_pem, "GCP service-account JSON"),
+    ("ssh-private", _ssh_private, "An SSH key block"),
+    ("slack-token", _slack_token, "Slack bot token"),
+    ("slack-webhook", _slack_webhook, "Slack webhook URL"),
+    ("discord-webhook", _discord_webhook, "Discord webhook URL"),
+    ("stripe-key", _stripe_key, "Stripe live secret"),
+    ("hf-token", _hf_token, "HuggingFace user token"),
+    ("npm-token", _npm_token, "npm publish token"),
+    ("pypi-token", _pypi_token, "PyPI Macaroon token"),
+]
+
+
+# Strings that should NOT trigger any redaction.
+NEGATIVE_CASES: list[tuple[str, str]] = [
+    ("short-id", "abc123"),
+    ("common-word", "hello"),
+    ("common-phrase", "The quick brown fox"),
+    ("short-numeric", "12345"),
+    ("date-iso", "2026-04-27T22:33:08.589Z"),
+    ("sha-prefix", "08849f6"),
+    ("git-shim-path", "/home/user/.local/bin/git"),
+    ("ghp-not-pat", "ghp" + "_short"),
+    ("github-pat-too-short", "github" + "_pat_" + _A(6)),
+    ("m0-too-short", "m0" + "-" + _A(4)),
+    ("ops-without-eyJ", "ops" + "_" + _A(28)),
+    ("low-entropy-long", "a" * 37),
+    ("session-id-uuid", "a3ff2b79-14b0-43e2-b167-63782e72a4f1"),
+]
+
+
+def _run_redact(payload: str) -> str:
+    """Pipe `payload` through the redact wrapper, return redacted output."""
+    proc = subprocess.run(
+        ["bash", REDACT],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def _run_redact_with_hits(input_path: str) -> tuple[str, dict]:
+    """Run redact on a file path; return (redacted_text, hits_summary)."""
+    import tempfile
+    out = tempfile.NamedTemporaryFile(mode="w+", delete=False, suffix=".jsonl")
+    hits = tempfile.NamedTemporaryFile(mode="w+", delete=False, suffix=".json")
+    out.close()
+    hits.close()
+    subprocess.run(
+        ["bash", REDACT, "--input", input_path, "--output", out.name, "--hits", hits.name],
+        check=True,
+    )
+    with open(out.name) as f:
+        redacted = f.read()
+    with open(hits.name) as f:
+        summary = json.load(f)
+    os.unlink(out.name)
+    os.unlink(hits.name)
+    return redacted, summary
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    print("[1/3] Positive corpus: every shape must redact with its expected label")
+    for pid, builder, ctx in POSITIVE_CASES:
+        token = builder()
+        payload = json.dumps({"type": "user", "content": f"{ctx} {token} extra-suffix"}) + "\n"
+        out = _run_redact(payload)
+        if token in out:
+            failures.append(f"pattern={pid} token survived (first 50 chars): {token[:50]!r}")
+        if f"REDACTED:{pid}" not in out:
+            failures.append(f"pattern={pid} expected label REDACTED:{pid} not in output: {out[:200]!r}")
+
+    print("[2/3] Negative corpus: strings must pass through unchanged")
+    for label, s in NEGATIVE_CASES:
+        payload = json.dumps({"type": "user", "content": s}) + "\n"
+        out = _run_redact(payload)
+        if s not in out:
+            failures.append(f"negative={label} string was modified: {s!r}")
+        if "REDACTED:" in out:
+            failures.append(f"negative={label} triggered redaction: {s!r}")
+
+    print("[3/3] Thinking blocks: text replaced + signature preserved + embedded secrets gone")
+    # Build a thinking-block fixture at runtime.
+    embedded_secret_1 = _gh_classic_pat()
+    embedded_secret_2 = _gh_fine_pat()
+    fixture_lines = [
+        json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "thinking",
+                    "text": f"This reasoning re-states a secret like {embedded_secret_1} that the model decided not to print to user-visible output.",
+                    "signature": "sig123",
+                }]
+            },
+        }),
+        json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Public output line."},
+                    {
+                        "type": "thinking",
+                        "text": f"More thinking, mentioning {embedded_secret_2} which is also embedded.",
+                        "signature": "sig456",
+                    },
+                ],
+            },
+        }),
+    ]
+    import tempfile
+    fixture_path = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl")
+    fixture_path.write("\n".join(fixture_lines) + "\n")
+    fixture_path.close()
+    try:
+        redacted, summary = _run_redact_with_hits(fixture_path.name)
+    finally:
+        os.unlink(fixture_path.name)
+
+    if "This reasoning re-states a secret" in redacted:
+        failures.append("thinking text 'This reasoning re-states a secret' survived")
+    if '"signature": "sig123"' not in redacted and '"signature":"sig123"' not in redacted:
+        failures.append("signature 'sig123' not preserved in event 1")
+    if "REDACTED:thinking-block:" not in redacted:
+        failures.append("thinking-block redaction marker not present")
+    if embedded_secret_1 in redacted:
+        failures.append(f"embedded secret 1 survived thinking redaction (defense-in-depth fail): {embedded_secret_1[:30]!r}")
+    if embedded_secret_2 in redacted:
+        failures.append(f"embedded secret 2 survived thinking redaction (defense-in-depth fail): {embedded_secret_2[:30]!r}")
+    thinking_count = summary.get("redaction_hits", {}).get("thinking-block", 0)
+    if thinking_count < 2:
+        failures.append(f"hits summary reported thinking-block={thinking_count}, expected >=2; full hits: {summary.get('redaction_hits')}")
+
+    if failures:
+        print("")
+        print(f"FAIL ({len(failures)} failure(s)):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("")
+    print("all transcript-redaction tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/transcript-redact.py
+++ b/scripts/lib/transcript-redact.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+Redact a Claude Code session transcript jsonl in preparation for
+commit/upload. Streams line-by-line; emits redacted jsonl on stdout
+and a hit-count summary JSON on stderr (readable by the export hook
+for inclusion in the meta.json sidecar).
+
+Usage:
+    transcript-redact.py [--config PATH] < input.jsonl > output.jsonl 2> hits.json
+
+Design notes:
+  - Order of operations per line:
+      1. Parse as JSON; on parse failure, fall back to raw-text regex
+         pipeline (defensive).
+      2. Walk the JSON tree and replace any {type: "thinking", text: ...}
+         text field with the configured placeholder; preserves the
+         event structure and any signature field.
+      3. Re-serialize and run the regex pipeline (in config order) over
+         the serialized string. This catches secrets in any field —
+         tool-result bodies, env-var dumps, Bash stdout, etc.
+      4. Apply the entropy fallback last, but only outside replacement
+         markers we just inserted (so we don't re-redact our own
+         REDACTED tokens).
+  - Hit counts are per-pattern + entropy + thinking; surface non-zero
+    entropy hits in the next morning's Watch briefing as 24h-leak
+    detection.
+  - Failure mode: if the engine itself raises, exit non-zero with no
+    output written. The export hook is expected to detect this and
+    write {sessionId}.export-error.txt rather than fall back to
+    unredacted output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+from collections import Counter
+from typing import Any
+
+
+DEFAULT_CONFIG = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "transcript-redaction.json",
+)
+
+
+def load_config(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def compile_patterns(cfg: dict) -> list[tuple[str, re.Pattern, str]]:
+    out = []
+    for entry in cfg.get("patterns", []):
+        out.append((entry["id"], re.compile(entry["regex"]), entry["replacement"]))
+    return out
+
+
+def shannon_entropy_bits_per_char(s: str) -> float:
+    if not s:
+        return 0.0
+    counts = Counter(s)
+    n = len(s)
+    return -sum((c / n) * math.log2(c / n) for c in counts.values())
+
+
+def redact_thinking_in_place(node: Any, hits: Counter, replacement_template: str) -> None:
+    """Walk a parsed JSON tree, replace text in {type: 'thinking', text: ...}."""
+    if isinstance(node, dict):
+        if node.get("type") == "thinking" and isinstance(node.get("text"), str):
+            length = len(node["text"])
+            node["text"] = replacement_template.format(length=length)
+            hits["thinking-block"] += 1
+        for v in node.values():
+            redact_thinking_in_place(v, hits, replacement_template)
+    elif isinstance(node, list):
+        for v in node:
+            redact_thinking_in_place(v, hits, replacement_template)
+
+
+def apply_regex_pipeline(text: str, patterns: list[tuple[str, re.Pattern, str]], hits: Counter) -> str:
+    for pid, regex, replacement in patterns:
+        # Use subn to count hits per pattern.
+        text, n = regex.subn(replacement, text)
+        if n:
+            hits[pid] += n
+    return text
+
+
+# A redaction marker we will not re-redact: [REDACTED:<label>...]
+_MARKER_RE = re.compile(r"\[REDACTED:[^\]]+\]")
+# Char classes inside an entropy-eligible run.
+def _entropy_substitute(text: str, cfg: dict, hits: Counter) -> str:
+    if not cfg.get("enabled", False):
+        return text
+    min_len = int(cfg.get("min_length", 32))
+    min_ent = float(cfg.get("min_entropy_bits_per_char", 4.5))
+    charset = cfg.get("charset", "A-Za-z0-9_/+=.\\-")
+    replacement = cfg.get("replacement", "[REDACTED:high-entropy]")
+    run_re = re.compile(rf"[{charset}]{{{min_len},}}")
+
+    # Carve out marker spans we must not touch.
+    spans: list[tuple[int, int, str | None]] = []
+    cursor = 0
+    for m in _MARKER_RE.finditer(text):
+        if cursor < m.start():
+            spans.append((cursor, m.start(), None))
+        spans.append((m.start(), m.end(), text[m.start():m.end()]))
+        cursor = m.end()
+    if cursor < len(text):
+        spans.append((cursor, len(text), None))
+
+    out_parts: list[str] = []
+    for start, end, marker in spans:
+        if marker is not None:
+            out_parts.append(marker)
+            continue
+        segment = text[start:end]
+
+        def repl(m: re.Match) -> str:
+            run = m.group(0)
+            ent = shannon_entropy_bits_per_char(run)
+            if ent >= min_ent:
+                hits["high-entropy"] += 1
+                return replacement
+            return run
+
+        out_parts.append(run_re.sub(repl, segment))
+    return "".join(out_parts)
+
+
+def redact_line(line: str, patterns: list, cfg: dict, hits: Counter, parser_warnings: list) -> str:
+    line_stripped = line.rstrip("\n")
+    if not line_stripped:
+        return line
+
+    # Stage 1: parse JSON, redact thinking blocks structurally.
+    parsed = None
+    try:
+        parsed = json.loads(line_stripped)
+    except json.JSONDecodeError as e:
+        parser_warnings.append({"error": "json-decode", "detail": str(e)[:200]})
+
+    if parsed is not None and cfg.get("thinking_block", {}).get("enabled", False):
+        tpl = cfg["thinking_block"]["replacement_template"]
+        redact_thinking_in_place(parsed, hits, tpl)
+        serialized = json.dumps(parsed, ensure_ascii=False, separators=(",", ":"))
+    else:
+        serialized = line_stripped
+
+    # Stage 2: regex pipeline.
+    serialized = apply_regex_pipeline(serialized, patterns, hits)
+
+    # Stage 3: entropy fallback.
+    serialized = _entropy_substitute(serialized, cfg.get("entropy_fallback", {}), hits)
+
+    return serialized + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default=DEFAULT_CONFIG)
+    ap.add_argument("--input", default=None, help="path to jsonl (default: stdin)")
+    ap.add_argument("--output", default=None, help="path to redacted jsonl (default: stdout)")
+    ap.add_argument("--hits", default=None, help="path to hit-count JSON (default: stderr)")
+    args = ap.parse_args()
+
+    cfg = load_config(args.config)
+    patterns = compile_patterns(cfg)
+    hits: Counter = Counter()
+    parser_warnings: list = []
+
+    in_stream = open(args.input, "r") if args.input else sys.stdin
+    out_stream = open(args.output, "w") if args.output else sys.stdout
+
+    bytes_pre = 0
+    bytes_post = 0
+    events = 0
+    try:
+        for line in in_stream:
+            bytes_pre += len(line.encode("utf-8"))
+            redacted = redact_line(line, patterns, cfg, hits, parser_warnings)
+            bytes_post += len(redacted.encode("utf-8"))
+            events += 1
+            out_stream.write(redacted)
+    finally:
+        if args.input:
+            in_stream.close()
+        if args.output:
+            out_stream.close()
+
+    summary = {
+        "redaction_hits": dict(hits),
+        "events_processed": events,
+        "events_with_unparseable_json": len(parser_warnings),
+        "parser_warnings_sample": parser_warnings[:5],
+        "bytes_pre": bytes_pre,
+        "bytes_post": bytes_post,
+        "engine_version": 1,
+    }
+    summary_text = json.dumps(summary, indent=2) + "\n"
+    if args.hits:
+        with open(args.hits, "w") as f:
+            f.write(summary_text)
+    else:
+        sys.stderr.write(summary_text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/transcript-redact.sh
+++ b/scripts/lib/transcript-redact.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Bash wrapper around transcript-redact.py for callsite consistency
+# with other scripts in scripts/lib (which are predominantly bash).
+# The Python engine carries the actual logic.
+#
+# Usage:
+#   transcript-redact.sh < input.jsonl > redacted.jsonl 2> hits.json
+#   transcript-redact.sh --input X --output Y --hits Z
+#
+# Exit codes:
+#   0 — redaction completed
+#   non-zero — engine crashed; caller should NOT fall back to writing
+#              the unredacted file. Drop {sessionId}.export-error.txt
+#              instead.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/transcript-redact.py" "$@"

--- a/scripts/lib/transcript-redaction.json
+++ b/scripts/lib/transcript-redaction.json
@@ -1,0 +1,187 @@
+{
+  "_comment": "Redaction patterns applied to Claude Code session transcripts before commit/upload. Order matters — longer/more-structured shapes first, prefixed shapes next, generic JWT, then entropy fallback. See vade-app/vade-agent-logs#64 design comment + security review.",
+  "version": 1,
+  "patterns": [
+    {
+      "id": "gcp-pem",
+      "regex": "-----BEGIN PRIVATE KEY-----[\\s\\S]*?-----END PRIVATE KEY-----",
+      "replacement": "[REDACTED:gcp-pem]",
+      "secret_var": null,
+      "notes": "GCP service-account private-key block. Apply before generic SSH/PEM."
+    },
+    {
+      "id": "ssh-private",
+      "regex": "-----BEGIN (?:RSA |OPENSSH |EC |DSA |ENCRYPTED |)PRIVATE KEY-----[\\s\\S]*?-----END [^-]+PRIVATE KEY-----",
+      "replacement": "[REDACTED:ssh-private]",
+      "secret_var": null,
+      "notes": "Catches OpenSSH and PEM variants. Multiline non-greedy."
+    },
+    {
+      "id": "op-token",
+      "regex": "\\bops_eyJ[A-Za-z0-9_-]+(?:\\.[A-Za-z0-9_-]+){0,3}\\b",
+      "replacement": "[REDACTED:op-token]",
+      "secret_var": null,
+      "notes": "1Password service-account token. Defensive: the harness env carries OP_SERVICE_ACCOUNT_TOKEN at boot but fetch_coo_secrets does not re-export it (the harness owns it directly). Apply before generic JWT — ops_ prefix carries an embedded JWT-shaped payload that would otherwise match the JWT pattern."
+    },
+    {
+      "id": "anthropic-key",
+      "regex": "\\bsk-ant-(?:api|admin|sid)\\d{2}-[A-Za-z0-9_-]{86,}\\b",
+      "replacement": "[REDACTED:anthropic-key]",
+      "secret_var": null,
+      "notes": "Anthropic API keys. Critical class for a Claude-running shop. Pattern covers api/admin/sid variants with 2-digit version. Defensive: not currently in fetch_coo_secrets, but lands in transcripts via stray Bash output / WebFetch / colleague-paste paths."
+    },
+    {
+      "id": "openai-key",
+      "regex": "\\bsk-(?:proj-)?[A-Za-z0-9_-]{40,}\\b",
+      "replacement": "[REDACTED:openai-key]",
+      "secret_var": null,
+      "notes": "OpenAI API keys, current and project-scoped formats."
+    },
+    {
+      "id": "gh-fine-pat",
+      "regex": "\\bgithub_pat_[A-Za-z0-9_]{82,}\\b",
+      "replacement": "[REDACTED:gh-fine-pat]",
+      "secret_var": ["GITHUB_MCP_PAT", "GITHUB_TOKEN"],
+      "notes": "GitHub fine-grained PAT. 11-char prefix + 82 chars (verified against live PAT length 93). Spec is exact 82, but using {82,} so over-long anomalous strings (e.g. corpus typos, future format extensions) still redact rather than slip through into commit."
+    },
+    {
+      "id": "gh-classic-pat",
+      "regex": "\\bghp_[A-Za-z0-9]{36}\\b",
+      "replacement": "[REDACTED:gh-classic-pat]",
+      "secret_var": null,
+      "notes": "GitHub classic PAT, 40 chars total."
+    },
+    {
+      "id": "gh-oauth-u2s",
+      "regex": "\\bghu_[A-Za-z0-9]{36}\\b",
+      "replacement": "[REDACTED:gh-oauth-u2s]",
+      "secret_var": null,
+      "notes": "GitHub OAuth user-to-server token."
+    },
+    {
+      "id": "gh-oauth-s2s",
+      "regex": "\\bghs_[A-Za-z0-9]{36}\\b",
+      "replacement": "[REDACTED:gh-oauth-s2s]",
+      "secret_var": null,
+      "notes": "GitHub OAuth server-to-server token."
+    },
+    {
+      "id": "gh-oauth-refresh",
+      "regex": "\\bghr_[A-Za-z0-9]{36}\\b",
+      "replacement": "[REDACTED:gh-oauth-refresh]",
+      "secret_var": null,
+      "notes": "GitHub OAuth refresh token."
+    },
+    {
+      "id": "mem0-key",
+      "regex": "\\bm0-[A-Za-z0-9]{40,}\\b",
+      "replacement": "[REDACTED:mem0-key]",
+      "secret_var": "MEM0_API_KEY",
+      "notes": "Mem0 API key. Live key length observed at 43 chars."
+    },
+    {
+      "id": "agentmail-key",
+      "regex": "\\bagentmail[_-]?[A-Za-z0-9_-]{60,}\\b",
+      "replacement": "[REDACTED:agentmail-key]",
+      "secret_var": "AGENTMAIL_API_KEY",
+      "notes": "AgentMail API key (length 76 per coo-bootstrap.sh). Prefix unverified — refine when shape known."
+    },
+    {
+      "id": "stripe-key",
+      "regex": "\\b(?:sk|rk)_live_[A-Za-z0-9]{24,}\\b",
+      "replacement": "[REDACTED:stripe-key]",
+      "secret_var": null,
+      "notes": "Stripe secret + restricted live keys."
+    },
+    {
+      "id": "slack-token",
+      "regex": "\\bxox[abprs]-\\d+-\\d+-\\d+-[a-fA-F0-9]+\\b",
+      "replacement": "[REDACTED:slack-token]",
+      "secret_var": null,
+      "notes": "Slack bot/user/workspace tokens."
+    },
+    {
+      "id": "slack-webhook",
+      "regex": "https://hooks\\.slack\\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+",
+      "replacement": "[REDACTED:slack-webhook]",
+      "secret_var": null,
+      "notes": "Slack incoming-webhook URLs."
+    },
+    {
+      "id": "discord-webhook",
+      "regex": "https://discord(?:app)?\\.com/api/webhooks/\\d+/[\\w-]+",
+      "replacement": "[REDACTED:discord-webhook]",
+      "secret_var": null,
+      "notes": "Discord incoming-webhook URLs."
+    },
+    {
+      "id": "hf-token",
+      "regex": "\\bhf_[A-Za-z0-9]{34,}\\b",
+      "replacement": "[REDACTED:hf-token]",
+      "secret_var": null,
+      "notes": "HuggingFace user/access token."
+    },
+    {
+      "id": "npm-token",
+      "regex": "\\bnpm_[A-Za-z0-9]{36}\\b",
+      "replacement": "[REDACTED:npm-token]",
+      "secret_var": null,
+      "notes": "npm publish token."
+    },
+    {
+      "id": "pypi-token",
+      "regex": "\\bpypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{50,}\\b",
+      "replacement": "[REDACTED:pypi-token]",
+      "secret_var": null,
+      "notes": "PyPI API token (Macaroon-shape)."
+    },
+    {
+      "id": "gcp-refresh",
+      "regex": "\\b1//[A-Za-z0-9_-]{60,}\\b",
+      "replacement": "[REDACTED:gcp-refresh]",
+      "secret_var": null,
+      "notes": "GCP OAuth refresh token shape."
+    },
+    {
+      "id": "aws-akid",
+      "regex": "\\bAKIA[A-Z0-9]{16}\\b",
+      "replacement": "[REDACTED:aws-akid]",
+      "secret_var": null,
+      "notes": "AWS access-key id, 20 chars."
+    },
+    {
+      "id": "aws-secret",
+      "regex": "(?i)(aws_secret_access_key\\s*[=:]\\s*)[A-Za-z0-9/+]{40}",
+      "replacement": "\\g<1>[REDACTED:aws-secret]",
+      "secret_var": null,
+      "notes": "AWS secret access key, kv-anchored to avoid the over-broad raw-40-char-base64 false-positive class."
+    },
+    {
+      "id": "auth-header",
+      "regex": "(?i)(authorization:\\s*(?:bearer|basic|token)\\s+)[A-Za-z0-9._\\-+/=]{20,}",
+      "replacement": "\\g<1>[REDACTED:auth-header]",
+      "secret_var": null,
+      "notes": "Generic Authorization header, kv-anchored. Catches anything tokenized over HTTP that hits a transcript via curl -v."
+    },
+    {
+      "id": "jwt",
+      "regex": "\\beyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\b",
+      "replacement": "[REDACTED:jwt]",
+      "secret_var": null,
+      "notes": "Generic JWT. Apply AFTER op-token (which has a JWT-shaped payload after ops_ prefix)."
+    }
+  ],
+  "entropy_fallback": {
+    "enabled": true,
+    "min_length": 32,
+    "min_entropy_bits_per_char": 4.5,
+    "charset": "A-Za-z0-9_/+=.\\-",
+    "replacement": "[REDACTED:high-entropy]",
+    "notes": "Shannon-entropy safety net for unknown-shape tokens (third-party-emitted secrets that don't go through fetch_coo_secrets and aren't covered by a registered pattern). Tolerates false positives — they are a redaction-pipeline-safe failure mode."
+  },
+  "thinking_block": {
+    "enabled": true,
+    "replacement_template": "[REDACTED:thinking-block:{length}-chars]",
+    "notes": "Wholesale redaction of <thinking> block content. Reasoning often re-states secrets the model decided not to print to user-visible output, and adoption analysis only needs the *fact* of thinking + its length. Targets JSON objects shaped {type: 'thinking', text: '...'} in assistant.message.content[]; preserves event structure and signature field."
+  }
+}


### PR DESCRIPTION
## Summary

First PR of the [vade-app/vade-agent-logs#64](https://github.com/vade-app/vade-agent-logs/issues/64) implementation arc — the testable redaction core that the export hook + Night's Watch analyzer will sit on top of in subsequent PRs. Ships:

- **`scripts/lib/transcript-redact.py`** — streaming jsonl redaction engine. Three-stage per-line: parse JSON → wholesale-redact `<thinking>` blocks (preserve structure + signature) → regex pipeline in config order → Shannon-entropy fallback (≥4.5 bits/char over 32+ char runs) for unknown shapes. Marker-protected so REDACTED labels don't get re-redacted. Emits hits summary for the export hook's `meta.json` sidecar.
- **`scripts/lib/transcript-redaction.json`** — 24-class pattern table covering Anthropic / OpenAI / GitHub PATs (classic + fine-grained + 3 OAuth variants) / Mem0 / AgentMail / 1Password / generic JWT / AWS / GCP refresh + service-account PEM / SSH-PEM / Slack / Discord / Stripe / HuggingFace / npm / PyPI / generic Authorization headers. Pattern order is load-bearing.
- **`scripts/ci/check-secret-registration.sh`** — enforces the **Secret Registration Rule**: every `export FOO=` in `fetch_coo_secrets` (`scripts/lib/common.sh`) MUST have a matching pattern entry. Future-proofs against new MCPs / integrations adding secrets without adding redaction patterns.
- **`scripts/ci/test-transcript-redaction.py`** — three-corpus test (positive / negative / thinking-block). Synthetic tokens are built at test runtime via string concatenation, not stored as literal-shape strings on disk, so GitHub secret-scanning push protection doesn't fingerprint the fixtures as real PATs.
- **CI wiring** — new fast `transcript-redaction` job in `bootstrap-regression.yml` (3-min timeout, no workspace staging). Triggers via existing `scripts/**` paths filter.

Smoke-tested on a live 338-event 1.1 MB session transcript: zero secret-shape survivors via Python regex verification; full pattern table exercised by real input (159 entropy hits, 143 fine-grained-PAT, 19 GCP-PEM, 11 SSH/PEM, 13 each AWS-secret + Authorization-header).

## Test plan

- [x] `python3 scripts/ci/test-transcript-redaction.py` passes locally
- [x] `bash scripts/ci/check-secret-registration.sh` passes locally (4 exports, all registered; `GITHUB_TOKEN` recognized as alias of `GITHUB_MCP_PAT`)
- [x] Smoke test on live `~/.claude/projects/.../session.jsonl` — zero secret-shape survivors
- [ ] CI `transcript-redaction` job green
- [ ] Existing `bootstrap` job remains green

## Subsequent PRs in this arc

- export hook + R2 upload + age encryption + new R2 token registered per the rule (ships the runtime)
- `.claude/agents/transcript-analyzer.md` in vade-coo-memory (Stage 1 analyzer)
- Night's Watch §1 + §1.5 updates folding sidecars into `adoption_tracker.md`
- vade-agent-logs README + CLAUDE.md publication-posture update + memos (Secret Registration Rule, raw-transcripts-never-publishable)
- [vade-app/vade-agent-logs#67](https://github.com/vade-app/vade-agent-logs/issues/67) idle watchdog (independent track)

https://claude.ai/code/session_012M2ibHx7mu5oeeF2T8mqbT