### PR TITLE
versions.lock: pin binary_vendor_bundle to bb9cf2c3 (binary-vendor-3c08804)

### DIFF
--- a/versions.lock
+++ b/versions.lock
@@ -57,7 +57,7 @@ uv                  0.11.7    # Python package/tool installer. Used
 # Empty until the first publish-binary-vendor workflow run lands a
 # bundle; bump on each Dockerfile/versions.lock change that
 # regenerates the bundle.
-binary_vendor_bundle  -         # SHA256 of binary-vendor.tar.gz; '-' = unset.
+binary_vendor_bundle  bb9cf2c35a86f7d558f6f3dd3a8da3e0b5d7dd30880a33d80e4320c28036f0c3  # SHA256 of binary-vendor.tar.gz published as binary-vendor-3c08804 from merge of #128.
 
 # Globally installed via npm
 @anthropic-ai/claude-code 1.0.120  # Claude Code CLI. Pinned to the


### PR DESCRIPTION
## Summary

Pins `binary_vendor_bundle` in `versions.lock` to the SHA256 of the first bundle published by [`publish-binary-vendor.yml`](https://github.com/vade-app/vade-runtime/actions/runs/25027727952) on the merge commit of #128. This activates `ensure_binaries_from_vendor`'s sha256-verify path; until this lands the function's no-pin branch fires and proceeds without verification.

## Verification trail

Workflow run [25027727952](https://github.com/vade-app/vade-runtime/actions/runs/25027727952) → release `binary-vendor-3c08804` (+ moving tag `binary-vendor-latest`):

```json
{
  "tag": "binary-vendor-3c08804",
  "git_sha": "3c088047f6988fabaca552669787e3c84457d7f3",
  "built_at": "2026-04-28T00:51:20Z",
  "bundle_sha256": "bb9cf2c35a86f7d558f6f3dd3a8da3e0b5d7dd30880a33d80e4320c28036f0c3",
  "bundle_size": 89741628,
  "binaries": {
    "op": "2.31.0",
    "gh": "2.91.0",
    "uv": "0.11.7",
    "mem0-mcp-server": "0.2.1"
  },
  "untar_target": "/home/user",
  "schema_version": "1.0"
}
```

Bundle structure verified locally: `.local/bin/{op,gh,uv,uvx}` are real executables; `.local/bin/mem0-mcp-server` is a symlink to `/home/user/.local/share/uv-tools/mem0-mcp-server/bin/mem0-mcp-server` (absolute production path); the underlying script's shebang `#!/home/user/.local/share/uv-tools/mem0-mcp-server/bin/python` references the same path. All venv references resolve when untarred to `/home/user/` on cloud.

## Test plan

- [x] Workflow run completed (success) — [run 25027727952](https://github.com/vade-app/vade-runtime/actions/runs/25027727952)
- [x] Release published with three assets (`binary-vendor.tar.gz`, `binary-vendor-manifest.json`, `binary-vendor.sha256`) — `gh release view binary-vendor-latest --repo vade-app/vade-runtime`
- [x] Local sha256 of `binary-vendor.tar.gz` matches manifest's `bundle_sha256`
- [x] Bundle structure inspected (real binaries + symlink-to-absolute-path for mem0-mcp-server + venv shebangs intact)
- [ ] Post-merge: next cloud cache rebuild fetches via `ensure_binaries_from_vendor` and the digest shows `[vade-setup] binary vendor: sha256 verified` + `[vade-setup] binary vendor: installed op gh uv mem0-mcp-server to /home/user/.local/bin`

## Refs

- [MEMO-2026-04-28-01](https://github.com/vade-app/vade-coo-memory/pull/218) — adoption ruling + paired evidence file
- vade-runtime#128 — B1 implementation (merged)
- vade-runtime#119 — close once one cloud session boots through this path successfully

https://claude.ai/code/session_01YTWGG6nkTvXmTmqatM7Q4Z