### PR TITLE
integrity-check: F2 reads per-memo files via memo_index.file_path (closes #132)

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -503,20 +503,26 @@ else
 fi
 
 # ── F2 — Memo retirement invariant ───────────────────────────
-# Every memo with date >= F_CUTOFF in coo/memo_index.json must carry a
-# 'Retirement condition' clause or `retention: "permanent"` in its body
-# slice of coo/memos.md. Absence = case-law violation per memo_protocol.md.
-if [ -f "$F_REPO/coo/memo_index.json" ] && [ -f "$F_REPO/coo/memos.md" ] && check_cmd jq; then
+# Every memo dated >= F_CUTOFF in coo/memo_index.json must carry a
+# 'Retirement condition' clause or `retention: "permanent"` in the body of
+# its per-memo file at $entry.file_path (post-#210 layout, MEMO-2026-04-27-5kaq;
+# canonical spec: coo/culture_system_sop.md F2 row).
+# Absence = case-law violation per memo_protocol.md.
+if [ -f "$F_REPO/coo/memo_index.json" ] && check_cmd jq; then
   f2_total=0
   f2_bad=()
-  while IFS='|' read -r id ls le; do
+  while IFS='|' read -r id fp; do
     [ -n "$id" ] || continue
     f2_total=$((f2_total + 1))
-    block=$(sed -n "${ls},${le}p" "$F_REPO/coo/memos.md" 2>/dev/null || echo '')
-    if ! printf '%s' "$block" | grep -qE 'Retirement condition|retention: "permanent"'; then
+    body_path="$F_REPO/$fp"
+    if [ ! -f "$body_path" ]; then
+      f2_bad+=("$id(missing-file)")
+      continue
+    fi
+    if ! grep -qE 'Retirement condition|retention: "permanent"' "$body_path"; then
       f2_bad+=("$id")
     fi
-  done < <(jq -r --arg c "$F_CUTOFF" '.[] | select(.date >= $c) | "\(.id)|\(.line_start)|\(.line_end)"' "$F_REPO/coo/memo_index.json" 2>/dev/null)
+  done < <(jq -r --arg c "$F_CUTOFF" '.[] | select(.date >= $c) | "\(.id)|\(.file_path)"' "$F_REPO/coo/memo_index.json" 2>/dev/null)
 
   if [ "$f2_total" -eq 0 ]; then
     _add F2 true "no post-cutoff memos to check"
@@ -526,7 +532,7 @@ if [ -f "$F_REPO/coo/memo_index.json" ] && [ -f "$F_REPO/coo/memos.md" ] && chec
     _add F2 false "missing retirement clause: $(IFS=,; echo "${f2_bad[*]}")"
   fi
 else
-  _add F2 skip "requires memo_index.json, memos.md, and jq"
+  _add F2 skip "requires coo/memo_index.json and jq"
 fi
 
 # ── F3 — Essay companion invariant ───────────────────────────


### PR DESCRIPTION
## Summary

- F2 falsifier in \`scripts/integrity-check.sh\` switches from line-slice walk over the retired \`coo/memos.md\` (post-issue-#210, MEMO-2026-04-27-5kaq) to per-file grep at \`entry.file_path\` from \`coo/memo_index.json\`.
- Spec is faithful to the SOP: \`Retirement condition\` or \`retention: \"permanent\"\` (\`coo/culture_system_sop.md\` F2 row, updated in vade-coo-memory#220). No regex broadening here.
- Adds a missing-file failure mode (index references a stale \`file_path\`).

## Behavior change

F2 was returning \`skipped\` (memos.md prereq absent); now grades every fresh boot.

On current main + current memo state, F2 fires on 5 post-cutoff memos:
- **2026-04-27-02** — no retirement clause at all (true authorship omission).
- **2026-04-28-01, 2026-04-27-5kaq, 2026-04-27-03, 2026-04-27-01** — phrasing drift (\"Retirement triggers\", \"**Retirement:**\", \"Retires when\").

That's the falsifier doing its job. Convention-drift + omission disposition is tracked separately on the memo side; this PR doesn't try to silence the alarm by amending memos or broadening the regex.

## Test plan

- [x] Locally edited \`integrity-check.sh\`, ran \`session-start-sync\` against /home/user — F2 grades (was \"skip\"); fires \"missing retirement clause: 2026-04-28-01,2026-04-27-5kaq,2026-04-27-03,2026-04-27-02,2026-04-27-01\" against current memo state.
- [x] D3/D4 (bootstrap-rerun race FNs) cleared on the same probe; \`summary.passed=20/21\`, \`degraded=[F2]\`.
- [ ] Bootstrap-regression CI on this PR (Layer-1) — F1–F4 skip cleanly in CI per workflow design (stub vade-coo-memory has no .git), so this PR shouldn't trip the suite.
- [ ] Post-merge integrity-check on a fresh container reproduces the same F2 detail (5 violations) until the memo-side follow-up lands.

## Refs

- Closes vade-app/vade-runtime#132
- vade-app/vade-coo-memory#210 (per-memo refactor), #212 (post-merge cleanup), #220 (SOP F2 row update)
- MEMO-2026-04-27-5kaq

https://claude.ai/code/session_016XRSTh2ZK1nLkL5NrYE11K