### PR TITLE
persist-permissions: auto-migrate runtime "always allow" decisions to version-controlled settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,8 @@
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" session-lifecycle --end" }
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" session-lifecycle --end" },
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" persist-permissions" }
         ]
       }
     ],

--- a/scripts/persist-permissions.sh
+++ b/scripts/persist-permissions.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Migrate runtime-granted "always allow" permission decisions from
+# .claude/settings.local.json (gitignored, ephemeral on cloud) into
+# vade-runtime/.claude/settings.json (version-controlled), then
+# auto-commit + push on the current branch.
+#
+# Wired as a Stop hook so every turn-end checks for new permission
+# decisions and persists them. Idempotent: when no new entries are
+# present in local-not-in-shared, exits silently.
+#
+# Skips auto-commit on main/master (or detached HEAD); writes
+# settings.json regardless and surfaces a notice. Append-only:
+# does not remove from .local.json (ephemeral) and does not delete
+# from shared.allow when local has the same pattern in deny — in
+# practice the runtime prompt only writes to .allow, so the conflict
+# case is theoretical.
+#
+# Flags:
+#   --dry-run   compute and print delta; do not write, commit, or push.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+boot_log_record "persist-permissions" start dry_run="$DRY_RUN"
+trap '_rc=$?; boot_log_record "persist-permissions" end $([ $_rc -eq 0 ] && echo ok || echo fail) rc=$_rc' EXIT
+
+SHARED="$RUNTIME_ROOT/.claude/settings.json"
+if [ ! -f "$SHARED" ]; then
+  log_err "persist-permissions: no shared settings.json at $SHARED; skip"
+  exit 0
+fi
+
+# Find local settings.local.json. CLAUDE_PROJECT_DIR is most reliable;
+# fall back to $HOME-relative and the cloud /home/user fallback so the
+# hook works regardless of which user the harness runs as.
+LOCAL=""
+for candidate in \
+  "${CLAUDE_PROJECT_DIR:-}/.claude/settings.local.json" \
+  "$HOME/.claude/settings.local.json" \
+  "/root/.claude/settings.local.json" \
+  "/home/user/.claude/settings.local.json"; do
+  if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+    LOCAL="$candidate"
+    break
+  fi
+done
+
+if [ -z "$LOCAL" ]; then
+  exit 0
+fi
+
+# Compute deltas for allow / deny / ask. Missing keys → empty array.
+delta=$(jq -n --slurpfile l "$LOCAL" --slurpfile s "$SHARED" '
+  def arr(p): (($l[0] | getpath(p)) // []) - (($s[0] | getpath(p)) // []) | unique;
+  {
+    allow: arr(["permissions","allow"]),
+    deny:  arr(["permissions","deny"]),
+    ask:   arr(["permissions","ask"])
+  }
+')
+
+new_count=$(jq -r '[.allow,.deny,.ask] | flatten | length' <<< "$delta")
+if [ "$new_count" -eq 0 ]; then
+  exit 0
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "[persist-permissions] would migrate $new_count entry/entries from $LOCAL → $SHARED:"
+  jq . <<< "$delta"
+  exit 0
+fi
+
+# Snapshot whether settings.json has prior uncommitted changes BEFORE
+# we write. If yes, we'll still apply the migration (so the user's
+# session benefits this turn), but skip auto-commit so we don't bundle
+# our diff into their work-in-progress.
+prior_diff=0
+if ! git -C "$RUNTIME_ROOT" diff --quiet HEAD -- .claude/settings.json 2>/dev/null; then
+  prior_diff=1
+fi
+
+# Apply delta to shared. Append at the end of each array (jq array
+# concat preserves existing order; new entries land sorted-unique at
+# the tail). Drop empty optional keys (.ask) so we don't write {} for
+# permission types that were never used.
+tmp=$(mktemp)
+jq --argjson d "$delta" '
+  .permissions.allow = ((.permissions.allow // []) + $d.allow) |
+  .permissions.deny  = ((.permissions.deny  // []) + $d.deny) |
+  (if ($d.ask | length) > 0
+    then .permissions.ask = ((.permissions.ask // []) + $d.ask)
+    else .
+  end)
+' "$SHARED" > "$tmp"
+
+if ! jq -e '.permissions.allow | type == "array"' "$tmp" >/dev/null; then
+  log_err "persist-permissions: sanity-check failed; refusing to overwrite $SHARED"
+  rm -f "$tmp"
+  exit 1
+fi
+
+mv "$tmp" "$SHARED"
+
+# Auto-commit + push when branch is non-main and settings.json had no
+# prior uncommitted changes. Always log what we did.
+cd "$RUNTIME_ROOT"
+branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+if [ -z "$branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  log "persist-permissions: wrote $new_count entry/entries to settings.json on branch '${branch:-detached}'; not auto-committing."
+  exit 0
+fi
+if [ "$prior_diff" = "1" ]; then
+  log "persist-permissions: pre-existing changes to settings.json; wrote $new_count entry/entries but skipping auto-commit (commit manually)."
+  exit 0
+fi
+
+git add .claude/settings.json
+if git diff --cached --quiet; then
+  exit 0
+fi
+
+msg=$(printf 'settings.json: persist %d runtime-granted permission(s)\n\nMigrated from %s by persist-permissions Stop hook.' \
+  "$new_count" "${LOCAL/$HOME/\$HOME}")
+git commit -m "$msg" >/dev/null
+
+# Push with retry per CLAUDE.md guidance (2s, 4s, 8s, 16s).
+pushed=0
+for delay in 0 2 4 8 16; do
+  [ "$delay" -gt 0 ] && sleep "$delay"
+  if git push -u origin "$branch" >/dev/null 2>&1; then
+    pushed=1
+    break
+  fi
+done
+
+if [ "$pushed" = "1" ]; then
+  log "persist-permissions: migrated $new_count entry/entries; committed + pushed to $branch."
+else
+  log_err "persist-permissions: migrated $new_count + committed locally; push failed after 4 retries (will retry next session)."
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/persist-permissions.sh` Stop hook that migrates new entries in `.claude/settings.local.json` (where Claude Code writes runtime "Yes, don't ask again" decisions — gitignored, ephemeral on cloud) into version-controlled `vade-runtime/.claude/settings.json`, then auto-commits + pushes on the current non-main branch so the rule survives container rebuild.
- Wires the new hook into the Stop chain in `.claude/settings.json` after the existing `session-lifecycle --end`. The dispatch shim resolves the name to `scripts/persist-permissions.sh` automatically — no shim edit needed.
- Idempotent (`local - shared` set difference; no-op when nothing new), append-only on `permissions.{allow,deny,ask}`, retries push 4× with exponential backoff.

## Why

Per [code.claude.com/docs/en/permissions.md](https://code.claude.com/docs/en/permissions.md), runtime "always allow" decisions land in the **local-project** scope (`.claude/settings.local.json`), not the shared/version-controlled `settings.json`. There is no built-in setting to redirect this. On the cloud sandbox the local file lives at `/root/.claude/settings.local.json` and is destroyed at session end, so each granted permission re-prompts on every fresh container — friction this hook eliminates.

## Behavior

| Condition | Result |
|---|---|
| New entries in local-not-in-shared | Append to shared; auto-commit + push on `claude/*` branch |
| No new entries (or local entries already in shared) | Silent exit 0 |
| Branch is `main` / `master` / detached | Write migration; skip auto-commit; surface notice |
| `settings.json` has prior uncommitted changes | Write migration; skip auto-commit (don't bundle into user WIP); surface notice |
| `--dry-run` | Print delta as JSON; no writes |

## Trade-offs

1. **Per-Stop firing.** Stop fires every turn, not every session. Most invocations are no-ops because no new permissions were granted. The few that match → one commit per granted permission batch. If the noise becomes annoying we can switch to a SessionEnd batch later.
2. **Auto-commit on `claude/*` branches.** Each grant produces a small commit on whichever feature branch is checked out. This is the price of "version-controlled". `git log --grep "settings.json: persist"` finds them all for squashing.
3. **Append-only on conflicts.** If a pattern is in both `local.allow` and `local.deny`, both get appended to shared. In practice the runtime prompt only writes to `.allow`, so this is theoretical.

## Test plan

- [x] `--dry-run` correctly identifies entries in local-not-in-shared (3 detected; correctly skipped `Bash(jq:*)` already present)
- [x] No-op when local entries are subset of shared (silent exit 0)
- [x] `prior_diff=1` short-circuits auto-commit (verified during dev with the in-progress `.claude/settings.json` edit)
- [ ] **Live cloud run** — next fresh-container session: grant any new "always allow", confirm a `settings.json: persist N runtime-granted permission(s)` commit lands on the active `claude/*` branch
- [ ] **Local Mac run** — grant "always allow" on `~/GitHub/vade-app/vade-runtime`; confirm settings.json gets the entry; no auto-commit because `prior_diff` may be set or branch may be `main`

## Pre-merge gating

Review the diff in `scripts/persist-permissions.sh`. The hook only fires after merge in fresh sessions — the in-PR session can `bash scripts/persist-permissions.sh --dry-run` against any prior `.claude/settings.local.json` to sanity-check.

## Post-merge confirmation

Fresh container from merged `main`:

1. Grant any new "always allow" via the runtime prompt (e.g. accept a `Bash(some-new-cmd)` proposal you wouldn't normally have).
2. Wait for the agent turn to end (Stop hook fires).
3. Run `git -C /home/user/vade-runtime log --oneline -3`.
4. Expect a recent commit titled `settings.json: persist N runtime-granted permission(s)`.
5. If not present, check `~/.vade/boot.log` for `script:"hooks-dispatch","hook":"persist-permissions"` lines and the corresponding outcome.

Failure response:
- Hook didn't dispatch: confirm `~/.claude/vade-hooks/dispatch.sh` symlink resolves to `vade-runtime/scripts/hooks-dispatch.sh`; check `boot.log` for the resolver rule used.
- Hook dispatched but no commit: check `boot.log` for `persist-permissions` end record; check `git status` in `vade-runtime` — likely `prior_diff=1` skipped the auto-commit, surfaced via `[vade-setup] persist-permissions:` log line.

https://claude.ai/code/session_01XoXEaKDk262FhCshLvMaoq