### PR TITLE
gh-coo-wrap: invoke issue-pr-shape-check.py before forward (#201)

### DIFF
--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -58,6 +58,25 @@ sid="${CLAUDE_CODE_REMOTE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
 SESSION_URL=""
 [ -n "$sid" ] && SESSION_URL="https://claude.ai/code/session_${sid#cse_}"
 
+# Resolve issue/PR shape-check script. Advisory only; missing-tolerant.
+# Source: vade-coo-memory/bin/issue-pr-shape-check.py (lands via
+# vade-coo-memory#226). The wrapper uses the script when present;
+# absence is silent and never affects the gh invocation.
+SHAPE_CHECK="${VADE_COO_MEMORY_DIR:-/home/user/vade-coo-memory}/bin/issue-pr-shape-check.py"
+[ -x "$SHAPE_CHECK" ] || SHAPE_CHECK=""
+
+# shape_check_body <body>: surface advisory body-shape warnings to
+# stderr per MEMO-2026-04-28-4umz. Side-effect only — script's
+# stderr passes through; exit code is intentionally ignored
+# (the check is non-blocking by #201's "no hard gates" constraint).
+shape_check_body() {
+  local body="$1"
+  [ -z "$SHAPE_CHECK" ] && return 0
+  [ -z "$body" ] && return 0
+  printf '%s' "$body" | python3 "$SHAPE_CHECK" || true
+  return 0
+}
+
 # is_covered <argv...>: returns 0 iff the (subcommand, action) pair
 # parsed from argv falls in the augment-eligible set. Skips leading
 # global flags so that e.g. `gh -R repo issue comment` is recognized
@@ -101,8 +120,12 @@ is_covered() {
 #   * no session URL available
 #   * body is empty
 #   * body already contains a claude.ai/code/session_ link
+#
+# Side-effect: invokes shape_check_body before the URL append so
+# the original (un-augmented) body is what's measured.
 augment() {
   local body="$1"
+  shape_check_body "$body"
   if [ -z "$SESSION_URL" ] || [ -z "$body" ]; then
     printf '%s' "$body"
     return


### PR DESCRIPTION
## Summary

Sibling to vade-coo-memory#226. Wires the new \`bin/issue-pr-shape-check.py\` advisory check into \`gh-coo-wrap.sh\` so every attributable \`gh issue create / pr create / *comment / *edit\` write surfaces a soft warning + paired-file refactor suggestion when the body exceeds 600 words or 5 \`### \` sub-headings.

## Behavior

- Path resolution: \`\$VADE_COO_MEMORY_DIR/bin/issue-pr-shape-check.py\` (default \`/home/user/vade-coo-memory/bin/issue-pr-shape-check.py\`).
- Missing-tolerant: if the script isn't present (local checkout without vade-coo-memory beside vade-runtime), the wrapper passes through unchanged.
- Always non-blocking. The script exits 0 unconditionally; the wrapper suppresses any failure path with \`|| true\`. \"No hard gates\" per #201.
- Measurement is on the original body, before the session URL is appended.

## Verification

End-to-end with a stubbed real-gh in this branch:

- 16-word body: silent shape-check, real-gh receives augmented body with session URL ✓
- 700-word body: stderr surfaces \"Body is 700 words ... paired-file pattern ...\", real-gh still receives augmented body unchanged ✓

## Dependency

Requires vade-coo-memory#226 to land first so the script exists at \`/home/user/vade-coo-memory/bin/issue-pr-shape-check.py\` on cloud sessions. Until then the wrapper silently no-ops on the new code path. Safe to merge in either order.

## Test plan

- [x] \`bash -n scripts/gh-coo-wrap.sh\` passes (syntax).
- [x] End-to-end test with stubbed real-gh — short body silent, long body fires advisory.
- [ ] Bootstrap-regression CI pass.
- [ ] Post-merge: next attributable \`gh\` write from a long-body PR/issue surfaces the advisory.

## Refs

- Closes vade-app/vade-runtime#— (no parent runtime issue; tracked under vade-coo-memory#201)
- Sibling: vade-coo-memory#226 (script + memo)
- MEMO-2026-04-28-4umz (binding discipline)

https://claude.ai/code/session_016XRSTh2ZK1nLkL5NrYE11K