### PR TITLE
fix: drop FHS PATH floor; remove stale UUID MCP entry; wire VADE_AUTH_TOKEN (#141 + #142 + vade-core#93)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,8 +75,6 @@
       "mcp__github__search_repositories",
       "mcp__github__search_users",
 
-      "mcp__2f248645-8699-4e80-a5b1-5b991f64fb8c__*",
-
       "Bash(git status:*)",
       "Bash(git diff:*)",
       "Bash(git log:*)",

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ no-op and the cloud env comes up in plain VADE mode.
 ### 1Password vault contract
 
 The service account must have **read** access to a vault named `COO`
-containing five items:
+containing the following items. Items marked *best-effort* may be
+absent — their absence warns and disables the corresponding feature
+without blocking boot.
 
 | Item reference | Type | What it holds |
 |---|---|---|
@@ -143,6 +145,7 @@ containing five items:
 | `op://COO/mem0-vade-coo` | API Credential | Mem0 Platform API key (`credential` field; prefix `m0-`) — powers the `mem0-rest.sh` break-glass fallback when the Mem0 MCP OAuth transport is degraded |
 | `op://COO/vade-coo-auth` | SSH Key | GitHub auth key (`ed25519`) |
 | `op://COO/vade-coo-sign` | SSH Key | GitHub signing key (`ed25519`) |
+| `op://COO/vade-canvas-coo` | API Credential | *Best-effort.* vade-canvas MCP bearer (`credential` field) — resolves the `${VADE_AUTH_TOKEN}` placeholder in `vade-core/.mcp.json`. Bearer must also appear in Fly's `VADE_AUTH_TOKENS.agents[]` for vade-canvas to accept it (see vade-core `docs/auth.md`). Absent until vade-core#93 follow-up creates it. |
 
 Fingerprints validated at boot:
 

--- a/scripts/ci/mocks/op
+++ b/scripts/ci/mocks/op
@@ -56,6 +56,14 @@ case "${1:-}" in
         # and never decrypts a real ciphertext.
         echo "AGE-SECRET-KEY-1CIMOCK000000000000000000000000000000000000000000000000"
         ;;
+      "op://COO/vade-canvas-coo/credential")
+        # Mocked vade-canvas MCP bearer (vade-core#93). Real value is the
+        # operator-shaped opaque bearer that vade-canvas MCP accepts via
+        # Fly's VADE_AUTH_TOKENS.agents[]; mock returns a non-shape
+        # placeholder so the CI integrity-check passes without a real
+        # canvas roundtrip.
+        echo "vat_CIMOCK_VADE_AUTH_TOKEN_DO_NOT_USE"
+        ;;
       "op://COO/vade-coo-auth/private key")
         cat "$KEYDIR/vade-coo-auth"
         ;;

--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -77,8 +77,12 @@ _settings_env_complete() {
     // so a literal "${PATH}" in this position is the broken-output of an
     // earlier bootstrap (vade-runtime#83 first-cut bug). Force re-run so
     // _write_claude_settings_paths overwrites with the expanded form.
-    // Also require /usr/bin in the value as a basic sanity floor.
-    if (env.PATH.includes("${PATH}") || !env.PATH.includes("/usr/bin")) {
+    // No FHS-layout floor (vade-runtime#141): hard-coding /usr/bin
+    // overfit to the Debian base image and would re-trigger the
+    // bootstrap on every boot if the image family ever changes
+    // (Alpine/musl, Nix-style /nix/store, etc.). The literal-${PATH}
+    // check above is the load-bearing one.
+    if (env.PATH.includes("${PATH}")) {
       process.exit(1);
     }
     process.exit(0);

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1110,6 +1110,7 @@ fetch_coo_secrets() {
   log "Fetching COO secrets from 1Password vault COO"
   local github_pat="" agentmail_key="" mem0_key=""
   local r2_access_key_id="" r2_secret_access_key="" age_identity=""
+  local vade_auth_token=""
   local got=0
 
   if github_pat="$(retry 3 op read 'op://COO/vade-coo-self-2026-04/token')" && [ -n "$github_pat" ]; then
@@ -1163,6 +1164,21 @@ fetch_coo_secrets() {
     log "  WARN: op://COO/transcripts-age-key/credential unavailable; transcript decryption (Stage-1 analyzer) disabled — encryption still works (recipient pubkey is committed at scripts/lib/transcripts-recipient.age)"
   fi
 
+  # vade-canvas MCP bearer (vade-core#93). Resolves the ${VADE_AUTH_TOKEN}
+  # placeholder in vade-core/.mcp.json so COO sessions that cwd into
+  # vade-core/ can talk to mcp.vade-app.dev/sse. Best-effort: missing
+  # vault item warns and leaves VADE_AUTH_TOKEN unset (the .mcp.json
+  # then resolves to "Bearer " and the SSE handshake 401s with a clear
+  # cause in coo-bootstrap.log). Bearer must also appear in Fly's
+  # VADE_AUTH_TOKENS.agents[] for the canvas MCP to accept it.
+  if vade_auth_token="$(retry 3 op read 'op://COO/vade-canvas-coo/credential')" && [ -n "$vade_auth_token" ]; then
+    log "  read vade-canvas COO bearer (len=${#vade_auth_token})"
+    got=$((got+1))
+  else
+    vade_auth_token=""
+    log "  WARN: op://COO/vade-canvas-coo/credential unavailable; VADE_AUTH_TOKEN will be unset (vade-core/.mcp.json placeholder resolves empty; vade-canvas MCP unreachable from vade-core/ cwd)"
+  fi
+
   if [ "$got" -eq 0 ]; then
     log "  no COO secrets could be fetched; skipping env file write"
     return 1
@@ -1186,6 +1202,7 @@ fetch_coo_secrets() {
       if [ -n "$r2_access_key_id" ];     then echo "export R2_TRANSCRIPTS_ACCESS_KEY_ID='$r2_access_key_id'"; fi
       if [ -n "$r2_secret_access_key" ]; then echo "export R2_TRANSCRIPTS_SECRET_ACCESS_KEY='$r2_secret_access_key'"; fi
       if [ -n "$age_identity" ];         then echo "export TRANSCRIPTS_AGE_IDENTITY='$age_identity'"; fi
+      if [ -n "$vade_auth_token" ];      then echo "export VADE_AUTH_TOKEN='$vade_auth_token'"; fi
     } > "$env_file"
   )
   chmod 600 "$env_file"
@@ -1202,6 +1219,7 @@ fetch_coo_secrets() {
   if [ -n "$r2_access_key_id" ];     then export R2_TRANSCRIPTS_ACCESS_KEY_ID="$r2_access_key_id"; fi
   if [ -n "$r2_secret_access_key" ]; then export R2_TRANSCRIPTS_SECRET_ACCESS_KEY="$r2_secret_access_key"; fi
   if [ -n "$age_identity" ];         then export TRANSCRIPTS_AGE_IDENTITY="$age_identity"; fi
+  if [ -n "$vade_auth_token" ];      then export VADE_AUTH_TOKEN="$vade_auth_token"; fi
   return 0
 }
 
@@ -1215,7 +1233,8 @@ merge_coo_settings_env() {
   _write_claude_settings_env \
     "${GITHUB_MCP_PAT:-}" \
     "${AGENTMAIL_API_KEY:-}" \
-    "${MEM0_API_KEY:-}"
+    "${MEM0_API_KEY:-}" \
+    "${VADE_AUTH_TOKEN:-}"
 }
 
 # Persist non-secret bootstrap-derived path state into ~/.claude/settings.json
@@ -1244,7 +1263,7 @@ merge_coo_settings_paths() {
 # Both are only exported when the corresponding filesystem path
 # exists, so this is a no-op outside the Claude cloud image.
 _write_claude_settings_env() {
-  local pat="$1" agentmail="$2" mem0="$3"
+  local pat="$1" agentmail="$2" mem0="$3" vade_auth_token="${4:-}"
   if ! check_cmd node; then
     log "Warning: node missing; skipping ~/.claude/settings.json env merge"
     return 0
@@ -1260,6 +1279,7 @@ _write_claude_settings_env() {
   [ -d "/opt/pw-browsers" ] && pw_browsers="/opt/pw-browsers"
 
   GITHUB_MCP_PAT="$pat" AGENTMAIL_API_KEY="$agentmail" MEM0_API_KEY="$mem0" \
+  VADE_AUTH_TOKEN="$vade_auth_token" \
   NODE_PATH="$node_path" PLAYWRIGHT_BROWSERS_PATH="$pw_browsers" node -e '
     const fs = require("fs");
     const path = process.argv[1];
@@ -1279,6 +1299,9 @@ _write_claude_settings_env() {
     }
     if (process.env.MEM0_API_KEY) {
       merged.MEM0_API_KEY = process.env.MEM0_API_KEY;
+    }
+    if (process.env.VADE_AUTH_TOKEN) {
+      merged.VADE_AUTH_TOKEN = process.env.VADE_AUTH_TOKEN;
     }
     if (process.env.NODE_PATH) {
       merged.NODE_PATH = process.env.NODE_PATH;

--- a/scripts/lib/transcript-redaction.json
+++ b/scripts/lib/transcript-redaction.json
@@ -178,6 +178,13 @@
       "notes": "Cloudflare R2 secret access key — 64-char hex (SHA-256-derived). Same kv-anchoring rationale as r2-access-key-id; the existing aws-secret pattern (40-char base64) does not cover R2."
     },
     {
+      "id": "vade-auth-token",
+      "regex": "(?i)(VADE_AUTH_TOKEN\\s*[=:]\\s*['\"]?)[A-Za-z0-9_\\-+/=]{16,}",
+      "replacement": "\\g<1>[REDACTED:vade-auth-token]",
+      "secret_var": "VADE_AUTH_TOKEN",
+      "notes": "vade-canvas MCP bearer (vade-core#93). Opaque shape — bearer is operator-chosen (typically random hex >= 32 chars), so kv-anchored to its env-var name. The entropy fallback also catches it as defense-in-depth."
+    },
+    {
       "id": "auth-header",
       "regex": "(?i)(authorization:\\s*(?:bearer|basic|token)\\s+)[A-Za-z0-9._\\-+/=]{20,}",
       "replacement": "\\g<1>[REDACTED:auth-header]",


### PR DESCRIPTION
## Summary

Three audit-derived changes from the 2026-04-28 architecture audit (parent session \`01G4N99vxb2YbBm1agfWhhx3\`):

- **vade-runtime#141** — \`_settings_env_complete\` no longer requires \`/usr/bin\` in \`PATH\`. The literal-\`\${PATH}\` check above (which catches the unexpanded-PATH bug from #83) is the load-bearing one; the FHS floor was defense-in-depth that overfit to the Debian base image.
- **vade-runtime#142** — Removed the stale \`mcp__2f248645-8699-4e80-a5b1-5b991f64fb8c__*\` allow-list entry. That UUID belonged to the hosted Mem0 MCP server before the 2026-04-26 transport switch to local stdio (MEMO-2026-04-26-16); current Mem0 tools are \`mcp__mem0__*\`.
- **vade-core#93** — Wired the bootstrap to read \`op://COO/vade-canvas-coo/credential\` and export \`VADE_AUTH_TOKEN\` into both \`~/.vade/coo-env\` and \`~/.claude/settings.json\` env. Resolves the \`\${VADE_AUTH_TOKEN}\` placeholder in \`vade-core/.mcp.json\` so COO sessions that cwd into \`vade-core/\` can authenticate against \`mcp.vade-app.dev/sse\`. Best-effort slot (mirrors R2/age pattern): missing vault item warns and leaves \`VADE_AUTH_TOKEN\` unset, never blocks boot.

The first two are purely conservative (looser precondition / removed dead allow-list entry). The third adds plumbing that's a no-op until Ven creates the vault item — see *Follow-up* below.

## Test plan

- [ ] PR diff review.
- [ ] Bootstrap-regression CI passes (it will — \`scripts/ci/mocks/op\` got a matching fake response for the new \`op://\` ref).
- [ ] Post-merge: fresh container boot, integrity-check \`summary.ok=true\`.
- [ ] Post-merge: confirm Mem0 MCP still resolves under \`mcp__mem0__*\`.
- [ ] Post-merge (when vault item exists): \`grep VADE_AUTH_TOKEN ~/.claude/settings.json\` → present; \`grep VADE_AUTH_TOKEN ~/.vade/coo-env\` → present.

## Follow-up (Ven action)

To make vade-core#93 *operationally* live, two manual steps:

1. Create 1Password item \`op://COO/vade-canvas-coo/credential\` holding an opaque bearer (any random hex string ≥ 32 chars).
2. Add the same bearer to Fly's \`VADE_AUTH_TOKENS.agents[]\` array so vade-canvas accepts it. See \`vade-core/docs/auth.md\` for the rotation procedure.

Until both land, \`coo-bootstrap.log\` will show \`WARN: op://COO/vade-canvas-coo/credential unavailable\` and vade-core/ sessions will still 401 against vade-canvas — but with a clearly-named cause. No code change needed once the vault item is populated; next bootstrap picks it up.

Closes vade-runtime#141, closes vade-runtime#142, closes vade-core#93.

https://claude.ai/code/session_0173pp51CB7g8hLYzdgqWrq2