### PR TITLE
session-idle-watchdog: idle-triggered session-end protocol (closes vade-agent-logs#67)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,8 @@
           { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" coo-bootstrap" },
           { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" memo-index" },
           { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" coo-identity-digest" },
-          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" discussions-digest" }
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" discussions-digest" },
+          { "type": "command", "command": "bash \"$HOME/.claude/vade-hooks/dispatch.sh\" session-idle-watchdog --start" }
         ]
       },
       {

--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -117,3 +117,6 @@ jobs:
 
       - name: Transcript export hook — smoke (dry-run, isolated $HOME)
         run: python3 "$GITHUB_WORKSPACE/scripts/ci/test-transcript-export.py"
+
+      - name: Idle watchdog — close sequence smoke (vade-agent-logs#67)
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/test-session-idle-watchdog.sh"

--- a/scripts/ci/test-session-idle-watchdog.sh
+++ b/scripts/ci/test-session-idle-watchdog.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# CI smoke test for scripts/session-idle-watchdog.sh.
+#
+# Three asserts:
+#
+#   1. cmd_close drops a coo-idle-close-<id>.md stub at the expected
+#      vade-agent-logs sessions path with the documented header shape
+#      (Status / Started / Ended / Idle minutes / Event count).
+#   2. The stub references the meta.json sidecar when one is present.
+#   3. The bootstrap-mode --start path is a clean no-op when
+#      VADE_SESSION_IDLE_DISABLE=1 is set (so CI doesn't fork a
+#      background worker that outlives the test).
+#
+# The test does NOT exercise:
+#   - Real Mem0 writes (no MEM0_API_KEY in the test env).
+#   - Real git commits (no .git in the staged agent-logs dir).
+#   - The transcript-export hook (covered by test-transcript-export.py).
+#
+# vade-app/vade-agent-logs#67.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WATCHDOG="$REPO_ROOT/scripts/session-idle-watchdog.sh"
+
+if [ ! -x "$WATCHDOG" ]; then
+  echo "FAIL: $WATCHDOG not executable" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d -t idle-watchdog-test-XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAKE_HOME="$WORKDIR/home"
+FAKE_AGENT_LOGS="$WORKDIR/vade-agent-logs"
+FAKE_PROJECTS="$FAKE_HOME/.claude/projects/-home-user"
+mkdir -p "$FAKE_HOME/.vade/agent-state" "$FAKE_HOME/.vade/idle-watchdog-logs" \
+  "$FAKE_AGENT_LOGS/sessions" "$FAKE_AGENT_LOGS/transcripts/2026/04/28" \
+  "$FAKE_PROJECTS"
+
+SESSION_ID="testsession-aaaaaaaaaaaaaaaaaaaa"
+JSONL="$FAKE_PROJECTS/${SESSION_ID}.jsonl"
+
+# Synthetic jsonl with two parseable timestamps. Construct via printf
+# to keep the shape clean. No secret-shaped tokens (scanner-clean).
+printf '{"type":"user","timestamp":"2026-04-28T01:00:00.000Z","content":"hello"}\n' > "$JSONL"
+printf '{"type":"assistant","timestamp":"2026-04-28T01:30:42.123Z","content":"world"}\n' >> "$JSONL"
+
+# Synthetic meta.json sidecar (so the stub references it).
+META_PATH="$FAKE_AGENT_LOGS/transcripts/2026/04/28/${SESSION_ID}.meta.json"
+cat > "$META_PATH" <<EOF
+{
+  "schema_version": 1,
+  "parser_version": 1,
+  "session_id": "$SESSION_ID",
+  "exported_at": "2026-04-28T01:30:55Z",
+  "events_processed": 2,
+  "redaction_hits": {}
+}
+EOF
+
+# ---------------------------------------------------------------------------
+# Test 1: --start with VADE_SESSION_IDLE_DISABLE=1 is a clean no-op.
+# ---------------------------------------------------------------------------
+
+env -i HOME="$FAKE_HOME" PATH="$PATH" \
+  VADE_SESSION_IDLE_DISABLE=1 \
+  bash "$WATCHDOG" --start
+
+# No worker should have been forked; no PID file should exist.
+if compgen -G "$FAKE_HOME/.vade/agent-state/idle-watchdog.*.pid" >/dev/null 2>&1; then
+  echo "FAIL: VADE_SESSION_IDLE_DISABLE=1 still forked a worker (pid-file present)" >&2
+  ls -la "$FAKE_HOME/.vade/agent-state/" >&2
+  exit 1
+fi
+echo "ok: --start respects VADE_SESSION_IDLE_DISABLE=1"
+
+# ---------------------------------------------------------------------------
+# Test 2: cmd_close drops the stub log with expected shape and references.
+# ---------------------------------------------------------------------------
+
+# No MEM0_API_KEY in env → mem0 step is a no-op (logged as skipped).
+# No .git in $FAKE_AGENT_LOGS → git step is a no-op (logged as skipped).
+env -i HOME="$FAKE_HOME" PATH="$PATH" \
+  VADE_AGENT_LOGS_DIR="$FAKE_AGENT_LOGS" \
+  bash "$WATCHDOG" --close "$SESSION_ID" "$JSONL"
+
+STUB="$FAKE_AGENT_LOGS/sessions/2026/04/28/coo-idle-close-${SESSION_ID}.md"
+if [ ! -f "$STUB" ]; then
+  echo "FAIL: stub not written at $STUB" >&2
+  echo "tree of $FAKE_AGENT_LOGS:" >&2
+  find "$FAKE_AGENT_LOGS" >&2
+  exit 1
+fi
+echo "ok: stub written at $STUB"
+
+assert_contains() {
+  local needle="$1"
+  if ! grep -qF -- "$needle" "$STUB"; then
+    echo "FAIL: stub missing expected text: $needle" >&2
+    echo "--- stub contents ---" >&2
+    cat "$STUB" >&2
+    exit 1
+  fi
+}
+
+assert_contains 'Status:** incomplete'
+assert_contains "Session ID:** \`${SESSION_ID}\`"
+assert_contains 'Started:** 2026-04-28T01:00:00.000Z'
+assert_contains 'Ended:**   2026-04-28T01:30:42.123Z'
+assert_contains 'Event count:** 2'
+assert_contains "Transcript sidecar:** \`transcripts/2026/04/28/${SESSION_ID}.meta.json\`"
+assert_contains 'vade-app/vade-agent-logs#67'
+
+echo "ok: stub shape matches expected schema"
+
+# ---------------------------------------------------------------------------
+# Test 3: cmd_close on a session_id without a sidecar still drops a stub
+#         (no Transcript-sidecar line; no crash).
+# ---------------------------------------------------------------------------
+
+NO_SIDECAR_ID="testsession-bbbbbbbbbbbbbbbbbbbb"
+NO_SIDECAR_JSONL="$FAKE_PROJECTS/${NO_SIDECAR_ID}.jsonl"
+printf '{"type":"user","timestamp":"2026-04-28T02:00:00.000Z","content":"x"}\n' > "$NO_SIDECAR_JSONL"
+
+env -i HOME="$FAKE_HOME" PATH="$PATH" \
+  VADE_AGENT_LOGS_DIR="$FAKE_AGENT_LOGS" \
+  bash "$WATCHDOG" --close "$NO_SIDECAR_ID" "$NO_SIDECAR_JSONL"
+
+STUB2="$FAKE_AGENT_LOGS/sessions/2026/04/28/coo-idle-close-${NO_SIDECAR_ID}.md"
+if [ ! -f "$STUB2" ]; then
+  echo "FAIL: stub not written for no-sidecar case at $STUB2" >&2
+  exit 1
+fi
+if grep -qF "Transcript sidecar:" "$STUB2"; then
+  echo "FAIL: stub claims a sidecar that doesn't exist" >&2
+  cat "$STUB2" >&2
+  exit 1
+fi
+echo "ok: no-sidecar close case skips the sidecar reference cleanly"
+
+# ---------------------------------------------------------------------------
+# Test 4: --stop is idempotent (no-op when no PID files).
+# ---------------------------------------------------------------------------
+
+env -i HOME="$FAKE_HOME" PATH="$PATH" bash "$WATCHDOG" --stop
+echo "ok: --stop is a clean no-op when nothing is live"
+
+echo
+echo "PASS: scripts/ci/test-session-idle-watchdog.sh"

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -101,13 +101,13 @@ fi
 # B1: re-run the resolver for each expected hook name
 B1_ok=true
 B1_detail=""
-for name in session-start-sync coo-bootstrap coo-identity-digest discussions-digest session-lifecycle; do
+for name in session-start-sync coo-bootstrap coo-identity-digest discussions-digest session-lifecycle session-idle-watchdog; do
   if ! [ -f "$RUNTIME_DIR/scripts/$name.sh" ]; then
     B1_ok=false
     B1_detail="${B1_detail}missing: $name.sh; "
   fi
 done
-[ "$B1_ok" = true ] && B1_detail="all 5 hook scripts present in runtime"
+[ "$B1_ok" = true ] && B1_detail="all 6 hook scripts present in runtime"
 _add B1 "$B1_ok" "$B1_detail"
 
 # B3: hook chain outcomes for the current session in boot.log.

--- a/scripts/session-idle-watchdog.sh
+++ b/scripts/session-idle-watchdog.sh
@@ -1,0 +1,622 @@
+#!/usr/bin/env bash
+# session-idle-watchdog.sh — vade-app/vade-agent-logs#67.
+#
+# Background daemon that fires the mechanical session-end protocol when
+# a Claude Code session goes idle without an explicit Stop. Solves the
+# "I forget to trigger end" failure: without this, a session that goes
+# quiet leaves no exported transcript, no session log, and no episodic
+# Mem0 handoff for the next boot to pick up.
+#
+# Lifecycle:
+#   1. SessionStart launches `session-idle-watchdog.sh --start` (the
+#      bootstrap form). Bootstrap kills any prior watchdog by PID-file,
+#      forks a `--run` worker via nohup, and exits 0 so the hook chain
+#      doesn't block.
+#   2. The `--run` worker polls
+#      `~/.claude/projects/<slug>/<id>.jsonl` mtime every CHECK_SECONDS.
+#      When (now - mtime) >= IDLE_THRESHOLD_MINUTES, it enters a grace
+#      window of GRACE_MINUTES; any mtime advance during grace aborts
+#      grace and resumes polling.
+#   3. If grace passes without activity, the worker fires the close
+#      sequence (--close), then exits 0.
+#
+# Close sequence (mechanical, since no Claude is running):
+#   a. Invoke `session-end-transcript-export.sh` with CLAUDE_SESSION_ID
+#      pinned to the watched jsonl's basename. The export hook already
+#      handles redact + age + R2 upload + meta.json sidecar drop.
+#   b. Write a stub session log at
+#      <vade-agent-logs>/sessions/YYYY/MM/DD/coo-idle-close-<id>.md
+#      with status=incomplete, started_at/ended_at from jsonl event
+#      timestamps, and a pointer to the meta.json sidecar.
+#   c. POST a minimal Mem0 episodic entry (event=session_summary,
+#      idle_close=true, summary_pending=true, artifact_refs=[stub-log,
+#      sidecar]) via the Mem0 REST API with $MEM0_API_KEY from coo-env.
+#      Tier-1 safe text only — no transcript content (MEMO-2026-04-11-10).
+#   d. git add + commit + push the stub-log and any new sidecar files
+#      under `<vade-agent-logs>/transcripts/**/<id>.{meta,export-error}.{json,txt}`.
+#      Identity is the cloud container's vade-coo gitconfig + PAT, so
+#      attribution stays correct.
+#   e. PID-file cleanup, exit 0.
+#
+# SessionStart on the next session reads any prior `coo-idle-close-*.md`
+# files via `session-lifecycle.sh --start` and surfaces a boot reminder
+# so the interactive COO can write the real summary as a sibling
+# `coo-summary-on-<id>.md`.
+#
+# Config (via env, all optional):
+#   VADE_SESSION_IDLE_MINUTES        idle threshold; default 60
+#   VADE_SESSION_IDLE_GRACE_MINUTES  grace window;   default 5
+#   VADE_SESSION_IDLE_CHECK_SECONDS  poll interval;  default 60
+#   VADE_SESSION_IDLE_DISABLE=1      no-op the daemon (CI / local dev)
+#   VADE_AGENT_LOGS_DIR              override agent-logs working tree
+#
+# This script never blocks the session-start hook chain — `--start`
+# always exits 0, even when prerequisites are missing. The integrity-
+# check probe surfaces gaps loudly so ops sees them on next boot.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Constants + paths
+# ---------------------------------------------------------------------------
+
+STATE_DIR="${HOME}/.vade/agent-state"
+LOG_DIR="${HOME}/.vade/idle-watchdog-logs"
+COO_ENV="${HOME}/.vade/coo-env"
+EXPORT_HOOK="$SCRIPT_DIR/session-end-transcript-export.sh"
+
+IDLE_THRESHOLD_MINUTES="${VADE_SESSION_IDLE_MINUTES:-60}"
+GRACE_MINUTES="${VADE_SESSION_IDLE_GRACE_MINUTES:-5}"
+CHECK_SECONDS="${VADE_SESSION_IDLE_CHECK_SECONDS:-60}"
+
+mkdir -p "$STATE_DIR" "$LOG_DIR" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Logging — append-only, per-session log file
+# ---------------------------------------------------------------------------
+
+# Set after session id resolves; logs land in $LOG_DIR/<id>.log.
+WATCHDOG_LOG=""
+
+log() {
+  local ts msg
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  msg="$ts session-idle-watchdog[$$]: $*"
+  if [ -n "$WATCHDOG_LOG" ]; then
+    printf '%s\n' "$msg" >> "$WATCHDOG_LOG" 2>/dev/null || true
+  fi
+  printf '%s\n' "$msg" >&2 || true
+}
+
+# ---------------------------------------------------------------------------
+# jsonl resolution — most-recent under ~/.claude/projects/*/*.jsonl
+# ---------------------------------------------------------------------------
+
+resolve_active_jsonl() {
+  local projects="$HOME/.claude/projects"
+  local sid="${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
+
+  # If an explicit session id was provided and a matching jsonl exists,
+  # prefer that. Otherwise fall back to most-recent mtime — same logic
+  # as session-end-transcript-export.py.
+  if [ -d "$projects" ] && [ -n "$sid" ]; then
+    local match
+    match="$(find "$projects" -maxdepth 2 -type f -name "${sid}.jsonl" 2>/dev/null | head -1)"
+    if [ -n "$match" ]; then
+      printf '%s\n' "$match"
+      return 0
+    fi
+  fi
+
+  if [ -d "$projects" ]; then
+    find "$projects" -maxdepth 2 -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+      | sort -rn | head -1 | cut -d' ' -f2-
+  fi
+}
+
+jsonl_basename_id() {
+  local p="$1"
+  basename "$p" .jsonl
+}
+
+# Cross-platform mtime in seconds.
+mtime_seconds() {
+  local f="$1"
+  if stat -c '%Y' -- "$f" >/dev/null 2>&1; then
+    stat -c '%Y' -- "$f"
+  else
+    stat -f '%m' -- "$f"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Bootstrap mode (--start): kill any prior watchdog, fork --run
+# ---------------------------------------------------------------------------
+
+cmd_start() {
+  if [ "${VADE_SESSION_IDLE_DISABLE:-}" = "1" ]; then
+    log "VADE_SESSION_IDLE_DISABLE=1 — skipping watchdog start"
+    return 0
+  fi
+
+  local jsonl session_id pidfile
+  jsonl="$(resolve_active_jsonl)"
+  if [ -z "$jsonl" ] || [ ! -f "$jsonl" ]; then
+    # No active transcript yet (first hook invocation can race). Don't
+    # error — the watchdog has nothing to bind to. Next session will
+    # find one.
+    log "no active jsonl found under ~/.claude/projects; skipping start"
+    return 0
+  fi
+  session_id="$(jsonl_basename_id "$jsonl")"
+  pidfile="$STATE_DIR/idle-watchdog.${session_id}.pid"
+  WATCHDOG_LOG="$LOG_DIR/${session_id}.log"
+
+  # Kill any prior watchdog for this same session id. Idempotent
+  # SessionStart re-fires (e.g. /resume) shouldn't accumulate workers.
+  if [ -f "$pidfile" ]; then
+    local prior_pid
+    prior_pid="$(cat "$pidfile" 2>/dev/null || true)"
+    if [ -n "$prior_pid" ] && kill -0 "$prior_pid" 2>/dev/null; then
+      kill "$prior_pid" 2>/dev/null || true
+      log "killed prior watchdog pid=$prior_pid"
+    fi
+    rm -f "$pidfile" 2>/dev/null || true
+  fi
+
+  log "starting watchdog for session_id=$session_id jsonl=$jsonl threshold=${IDLE_THRESHOLD_MINUTES}m grace=${GRACE_MINUTES}m"
+
+  # Fork the worker. Pass the resolved jsonl path so the worker doesn't
+  # re-resolve later (and pick a sibling under racy multi-instance use).
+  nohup bash "$SCRIPT_DIR/session-idle-watchdog.sh" --run "$jsonl" \
+    >> "$WATCHDOG_LOG" 2>&1 &
+  disown $! 2>/dev/null || true
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run mode (--run <jsonl>): the polling worker
+# ---------------------------------------------------------------------------
+
+cmd_run() {
+  local jsonl="${1:-}"
+  if [ -z "$jsonl" ] || [ ! -f "$jsonl" ]; then
+    log "cmd_run: missing or unreadable jsonl path: $jsonl"
+    return 0
+  fi
+
+  local session_id pidfile
+  session_id="$(jsonl_basename_id "$jsonl")"
+  pidfile="$STATE_DIR/idle-watchdog.${session_id}.pid"
+  WATCHDOG_LOG="$LOG_DIR/${session_id}.log"
+
+  # Single-writer: refuse if a live PID-file exists.
+  if [ -f "$pidfile" ]; then
+    local prior_pid
+    prior_pid="$(cat "$pidfile" 2>/dev/null || true)"
+    if [ -n "$prior_pid" ] && [ "$prior_pid" != "$$" ] && kill -0 "$prior_pid" 2>/dev/null; then
+      log "another watchdog is live (pid=$prior_pid); refusing to start"
+      return 0
+    fi
+  fi
+  echo "$$" > "$pidfile"
+  trap 'rm -f "$pidfile" 2>/dev/null || true' EXIT
+  trap 'log "SIGTERM received; running best-effort export-only close"; bash "$EXPORT_HOOK" </dev/null >/dev/null 2>&1 || true; rm -f "$pidfile" 2>/dev/null || true; exit 0' TERM
+
+  local idle_sec=$(( IDLE_THRESHOLD_MINUTES * 60 ))
+  local grace_sec=$(( GRACE_MINUTES * 60 ))
+
+  log "worker live pid=$$ idle_sec=$idle_sec grace_sec=$grace_sec check_sec=$CHECK_SECONDS"
+
+  while true; do
+    sleep "$CHECK_SECONDS"
+    if [ ! -f "$jsonl" ]; then
+      log "jsonl disappeared at $jsonl; exiting"
+      return 0
+    fi
+    local mtime now elapsed
+    mtime="$(mtime_seconds "$jsonl")"
+    now="$(date -u +%s)"
+    elapsed=$(( now - mtime ))
+    if [ "$elapsed" -lt "$idle_sec" ]; then
+      continue
+    fi
+
+    # Threshold reached — enter grace.
+    log "idle threshold reached (elapsed=${elapsed}s); entering grace=${grace_sec}s"
+    local grace_start grace_now grace_mtime
+    grace_start="$(date -u +%s)"
+    while true; do
+      sleep "$CHECK_SECONDS"
+      grace_mtime="$(mtime_seconds "$jsonl")"
+      if [ "$grace_mtime" -gt "$mtime" ]; then
+        log "activity during grace (mtime advanced ${mtime} -> ${grace_mtime}); aborting close"
+        break
+      fi
+      grace_now="$(date -u +%s)"
+      if [ $(( grace_now - grace_start )) -ge "$grace_sec" ]; then
+        log "grace expired without activity; firing close sequence"
+        cmd_close "$session_id" "$jsonl" || true
+        return 0
+      fi
+    done
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Close sequence (--close <id> <jsonl>): the mechanical session-end work
+# ---------------------------------------------------------------------------
+
+cmd_close() {
+  local session_id="${1:-}" jsonl="${2:-}"
+  if [ -z "$session_id" ] || [ -z "$jsonl" ]; then
+    log "cmd_close: missing args (session_id=$session_id jsonl=$jsonl)"
+    return 0
+  fi
+  WATCHDOG_LOG="$LOG_DIR/${session_id}.log"
+
+  # Source coo-env so MEM0_API_KEY, GITHUB_MCP_PAT, R2_* are populated.
+  if [ -f "$COO_ENV" ]; then
+    # shellcheck disable=SC1090,SC1091
+    set +u; . "$COO_ENV"; set -u
+    log "sourced coo-env"
+  else
+    log "coo-env not found at $COO_ENV — Mem0/git steps will degrade"
+  fi
+
+  # ---- a. Mechanical export ------------------------------------------------
+  if [ -x "$EXPORT_HOOK" ]; then
+    log "invoking transcript export hook with CLAUDE_SESSION_ID=$session_id"
+    CLAUDE_SESSION_ID="$session_id" bash "$EXPORT_HOOK" </dev/null \
+      >> "$WATCHDOG_LOG" 2>&1 || true
+  else
+    log "export hook missing or non-executable at $EXPORT_HOOK; skipping"
+  fi
+
+  # ---- b. Stub session log -------------------------------------------------
+  local agent_logs_dir
+  agent_logs_dir="$(_resolve_agent_logs_dir)"
+  if [ -z "$agent_logs_dir" ]; then
+    log "vade-agent-logs working tree not found; cannot drop stub log"
+    return 0
+  fi
+
+  local first_ts last_ts ev_count idle_close_ts date_path
+  first_ts="$(_jsonl_first_timestamp "$jsonl")"
+  last_ts="$(_jsonl_last_timestamp "$jsonl")"
+  ev_count="$(_jsonl_event_count "$jsonl")"
+  idle_close_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  # Date for the path comes from the FIRST event so a long-running
+  # session stays in its starting day (matching the export hook).
+  date_path="$(_date_path_from_ts "$first_ts")"
+
+  local sessions_dir stub_path
+  sessions_dir="$agent_logs_dir/sessions/$date_path"
+  mkdir -p "$sessions_dir" 2>/dev/null || true
+  stub_path="$sessions_dir/coo-idle-close-${session_id}.md"
+
+  # Locate the meta.json sidecar (if the export hook wrote one) so we
+  # can reference it in the stub. Search transcripts/ rather than just
+  # the date-path because clock skew or first-event-fallback can land
+  # the sidecar one day off.
+  local meta_path export_error_path
+  meta_path="$(find "$agent_logs_dir/transcripts" -maxdepth 4 -type f -name "${session_id}.meta.json" 2>/dev/null | head -1)"
+  export_error_path="$(find "$agent_logs_dir/transcripts" -maxdepth 4 -type f -name "${session_id}.export-error.txt" 2>/dev/null | head -1)"
+  local idle_minutes
+  idle_minutes=$(( (IDLE_THRESHOLD_MINUTES + GRACE_MINUTES) ))
+
+  {
+    echo "# COO session — idle close (incomplete)"
+    echo
+    echo "**Status:** incomplete — ended on idle timeout, summary deferred"
+    echo "**Session ID:** \`$session_id\`"
+    echo "**Started:** ${first_ts:-unknown}"
+    echo "**Ended:**   ${last_ts:-unknown}"
+    echo "**Idle close fired at:** $idle_close_ts"
+    echo "**Idle minutes at close:** ~${idle_minutes} (threshold=${IDLE_THRESHOLD_MINUTES}m + grace=${GRACE_MINUTES}m)"
+    echo "**Event count:** ${ev_count:-unknown}"
+    echo
+    if [ -n "$meta_path" ]; then
+      echo "**Transcript sidecar:** \`${meta_path#"$agent_logs_dir/"}\`"
+    fi
+    if [ -n "$export_error_path" ]; then
+      echo "**Transcript export error:** \`${export_error_path#"$agent_logs_dir/"}\`"
+    fi
+    echo
+    echo "## How to continue"
+    echo
+    echo "The interactive COO on the next session should append a sibling"
+    echo "\`coo-summary-on-${session_id}.md\` (or amend this file in place)"
+    echo "with the real session summary — what was worked on, decisions made,"
+    echo "open threads — so adoption-tracker grep paths still resolve."
+    echo
+    echo "Authoring this stub: \`vade-runtime/scripts/session-idle-watchdog.sh\`"
+    echo "(vade-app/vade-agent-logs#67)."
+  } > "$stub_path"
+  log "wrote stub session log: $stub_path"
+
+  # ---- c. Mem0 minimal episodic entry --------------------------------------
+  _mem0_post_idle_close "$session_id" "$first_ts" "$last_ts" "$idle_close_ts" \
+    "$stub_path" "$meta_path" "$agent_logs_dir" || true
+
+  # ---- d. git commit + push ------------------------------------------------
+  _git_commit_and_push "$agent_logs_dir" "$stub_path" "$meta_path" "$export_error_path" "$session_id" || true
+
+  log "close sequence complete for session_id=$session_id"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Helpers — agent-logs resolution, jsonl introspection, Mem0 POST, git push
+# ---------------------------------------------------------------------------
+
+_resolve_agent_logs_dir() {
+  if [ -n "${VADE_AGENT_LOGS_DIR:-}" ] && [ -d "$VADE_AGENT_LOGS_DIR" ]; then
+    printf '%s\n' "$VADE_AGENT_LOGS_DIR"; return 0
+  fi
+  for cand in \
+    "$HOME/GitHub/vade-app/vade-agent-logs" \
+    "/home/user/vade-agent-logs" \
+    "$RUNTIME_ROOT/../vade-agent-logs"; do
+    if [ -d "$cand" ]; then printf '%s\n' "$cand"; return 0; fi
+  done
+  return 1
+}
+
+_jsonl_first_timestamp() {
+  local f="$1"
+  awk '
+    /^[[:space:]]*$/ { next }
+    {
+      if (match($0, /"timestamp"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/^"timestamp"[[:space:]]*:[[:space:]]*"/, "", s)
+        sub(/"$/, "", s)
+        print s
+        exit
+      }
+    }
+  ' "$f" 2>/dev/null
+}
+
+_jsonl_last_timestamp() {
+  local f="$1"
+  awk '
+    {
+      if (match($0, /"timestamp"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/^"timestamp"[[:space:]]*:[[:space:]]*"/, "", s)
+        sub(/"$/, "", s)
+        last = s
+      }
+    }
+    END { if (last != "") print last }
+  ' "$f" 2>/dev/null
+}
+
+_jsonl_event_count() {
+  local f="$1"
+  awk 'NF { n++ } END { print n+0 }' "$f" 2>/dev/null
+}
+
+_date_path_from_ts() {
+  local ts="${1:-}"
+  if [ -z "$ts" ]; then
+    date -u +'%Y/%m/%d'
+    return 0
+  fi
+  # ISO-8601 → YYYY/MM/DD. Best-effort string slicing avoids the
+  # platform-dependent `date -d` flag.
+  printf '%s\n' "$ts" | awk -F'[-T]' 'NF>=3 { printf "%s/%s/%s\n", $1, $2, $3; exit } { print "" }'
+}
+
+_mem0_post_idle_close() {
+  local session_id="$1" first_ts="$2" last_ts="$3" close_ts="$4"
+  local stub_path="$5" meta_path="$6" agent_logs_dir="$7"
+
+  if [ -z "${MEM0_API_KEY:-}" ]; then
+    log "MEM0_API_KEY not set; skipping Mem0 episodic write"
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
+    log "jq or curl missing; skipping Mem0 episodic write"
+    return 0
+  fi
+
+  local stub_ref meta_ref refs
+  stub_ref="vade-agent-logs/${stub_path#"$agent_logs_dir/"}"
+  if [ -n "$meta_path" ]; then
+    meta_ref="vade-agent-logs/${meta_path#"$agent_logs_dir/"}"
+    refs="$(jq -nc --arg a "$stub_ref" --arg b "$meta_ref" '[$a,$b]')"
+  else
+    refs="$(jq -nc --arg a "$stub_ref" '[$a]')"
+  fi
+
+  # Tier-1 safe content: structural facts about the session, no
+  # transcript content (MEMO-2026-04-11-10).
+  local message_text expiration
+  message_text="Idle close fired for COO session_id=${session_id}; transcript-export hook ran mechanically. Summary pending — next interactive session owes the real summary. Started=${first_ts:-unknown} ended=${last_ts:-unknown} closed=${close_ts}."
+  # 30 days out (approximate; ISO date only).
+  expiration="$(date -u -d '+30 days' +%Y-%m-%d 2>/dev/null || date -u -v+30d +%Y-%m-%d 2>/dev/null || true)"
+
+  local body
+  body="$(jq -nc \
+    --arg msg "$message_text" \
+    --arg sid "$session_id" \
+    --arg ftt "${first_ts:-}" \
+    --arg ltt "${last_ts:-}" \
+    --arg cts "$close_ts" \
+    --arg exp "$expiration" \
+    --argjson refs "$refs" \
+    '{
+      messages: [{ role: "assistant", content: $msg }],
+      user_id: "ven",
+      agent_id: "claude-code",
+      infer: false,
+      metadata: {
+        memory_type: "episodic",
+        event: "session_summary",
+        idle_close: true,
+        summary_pending: true,
+        created_by: "coo",
+        retention: "ephemeral",
+        source_session: $sid,
+        first_event_ts: $ftt,
+        last_event_ts: $ltt,
+        closed_at: $cts,
+        artifact_refs: $refs,
+        expiration_date: $exp
+      }
+    }')"
+
+  local http_code
+  http_code="$(curl -sS -o "$LOG_DIR/${session_id}.mem0-response.json" -w '%{http_code}' \
+    -X POST "https://api.mem0.ai/v1/memories/" \
+    -H "Authorization: Token ${MEM0_API_KEY}" \
+    -H 'Content-Type: application/json' \
+    --data "$body" 2>>"$WATCHDOG_LOG" || echo '000')"
+  case "$http_code" in
+    2*) log "mem0 episodic write ok (HTTP $http_code)";;
+    *)  log "mem0 episodic write failed (HTTP $http_code); response in $LOG_DIR/${session_id}.mem0-response.json";;
+  esac
+  return 0
+}
+
+_git_commit_and_push() {
+  local repo="$1" stub_path="$2" meta_path="$3" export_error_path="$4" session_id="$5"
+
+  if [ ! -d "$repo/.git" ]; then
+    log "git: $repo is not a git working tree; skipping commit/push"
+    return 0
+  fi
+  if ! command -v git >/dev/null 2>&1; then
+    log "git binary missing; skipping commit/push"
+    return 0
+  fi
+
+  # Pre-flight: are we on a branch we can push? Default expectation is
+  # main; the cloud container's gitconfig + PAT attribute as vade-coo.
+  local branch
+  branch="$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+
+  # Stage the stub log, the meta.json (if present), and an
+  # export-error.txt (if present). Don't stage anything else — the
+  # daemon must not surface unrelated dirty state.
+  local rel
+  for path in "$stub_path" "$meta_path" "$export_error_path"; do
+    [ -z "$path" ] && continue
+    [ ! -e "$path" ] && continue
+    rel="${path#"$repo/"}"
+    git -C "$repo" add -- "$rel" 2>>"$WATCHDOG_LOG" || true
+  done
+
+  if git -C "$repo" diff --cached --quiet 2>/dev/null; then
+    log "git: nothing staged (no stub or sidecar changes); skipping commit"
+    return 0
+  fi
+
+  local msg_subject msg_body commit_rc
+  msg_subject="watchdog: idle close for ${session_id}"
+  msg_body=$'Mechanical session-end protocol fired by\nvade-runtime/scripts/session-idle-watchdog.sh — the interactive COO\ndid not call /end before the idle threshold expired.\n\nNext interactive session owes the real summary; see the\ncoo-idle-close-*.md stub for the handoff.\n\nvade-app/vade-agent-logs#67'
+
+  if git -C "$repo" -c commit.gpgsign=false commit \
+       -m "$msg_subject" -m "$msg_body" >>"$WATCHDOG_LOG" 2>&1; then
+    log "git: committed on branch=$branch"
+  else
+    commit_rc=$?
+    log "git: commit failed rc=$commit_rc; aborting push"
+    return 0
+  fi
+
+  if git -C "$repo" push origin "$branch" >>"$WATCHDOG_LOG" 2>&1; then
+    log "git: pushed to origin/$branch"
+  else
+    log "git: push failed (will retry on next interactive session via normal commit flow)"
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Stop mode — kill the live worker for a given session id (for tests)
+# ---------------------------------------------------------------------------
+
+cmd_stop() {
+  local session_id="${1:-}"
+  if [ -z "$session_id" ]; then
+    # Stop all watchdogs in $STATE_DIR.
+    local pf
+    for pf in "$STATE_DIR"/idle-watchdog.*.pid; do
+      [ -f "$pf" ] || continue
+      local pid
+      pid="$(cat "$pf" 2>/dev/null || true)"
+      [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+      rm -f "$pf" 2>/dev/null || true
+    done
+    return 0
+  fi
+  local pf="$STATE_DIR/idle-watchdog.${session_id}.pid"
+  if [ -f "$pf" ]; then
+    local pid
+    pid="$(cat "$pf" 2>/dev/null || true)"
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+    rm -f "$pf" 2>/dev/null || true
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+main() {
+  local mode="${1:---start}"
+  shift || true
+  case "$mode" in
+    --start|start|"")
+      cmd_start
+      ;;
+    --run|run)
+      cmd_run "$@"
+      ;;
+    --close|close)
+      cmd_close "$@"
+      ;;
+    --stop|stop)
+      cmd_stop "$@"
+      ;;
+    -h|--help|help)
+      cat <<'EOF'
+session-idle-watchdog.sh — vade-app/vade-agent-logs#67.
+
+Usage:
+  session-idle-watchdog.sh --start
+      Bootstrap form (called from SessionStart hook). Kills any prior
+      watchdog by PID-file, forks a --run worker, exits 0.
+  session-idle-watchdog.sh --run <jsonl-path>
+      Internal worker loop. Polls mtime; fires --close on idle.
+  session-idle-watchdog.sh --close <session-id> <jsonl-path>
+      Run the close sequence directly (used by the worker and by CI).
+  session-idle-watchdog.sh --stop [<session-id>]
+      Kill the live worker for a session id (or all, if omitted).
+
+Env:
+  VADE_SESSION_IDLE_MINUTES        idle threshold; default 60
+  VADE_SESSION_IDLE_GRACE_MINUTES  grace window;   default 5
+  VADE_SESSION_IDLE_CHECK_SECONDS  poll interval;  default 60
+  VADE_SESSION_IDLE_DISABLE=1      no-op the daemon (CI / local dev)
+  VADE_AGENT_LOGS_DIR              override agent-logs working tree
+EOF
+      exit 0
+      ;;
+    *)
+      echo "session-idle-watchdog: unknown mode '$mode' (try --help)" >&2
+      exit 0
+      ;;
+  esac
+  return 0
+}
+
+main "$@"

--- a/scripts/session-lifecycle.sh
+++ b/scripts/session-lifecycle.sh
@@ -84,6 +84,41 @@ if [ "$MODE" = "start" ]; then
     echo ""
   fi
 
+  # Prior idle-close stub logs: if the watchdog
+  # (vade-app/vade-agent-logs#67) fired a mechanical close on a recent
+  # session, the next interactive COO owes a real summary. Surface
+  # any unpaired stubs from the last 3 days so the agent doesn't have
+  # to discover them.
+  agent_logs_dir=""
+  for _cand in "$HOME/GitHub/vade-app/vade-agent-logs" "/home/user/vade-agent-logs"; do
+    if [ -d "$_cand" ]; then agent_logs_dir="$_cand"; break; fi
+  done
+  if [ -n "$agent_logs_dir" ] && [ -d "$agent_logs_dir/sessions" ]; then
+    pending_stubs="$(find "$agent_logs_dir/sessions" -type f \
+      -name 'coo-idle-close-*.md' -mtime -3 2>/dev/null | sort)"
+    if [ -n "$pending_stubs" ]; then
+      while IFS= read -r stub; do
+        [ -z "$stub" ] && continue
+        sid="$(basename "$stub" .md)"
+        sid="${sid#coo-idle-close-}"
+        # Skip stubs that already have a paired summary file in the same dir.
+        stub_dir="$(dirname "$stub")"
+        if [ -f "$stub_dir/coo-summary-on-${sid}.md" ]; then continue; fi
+        if [ -z "${idle_close_header_printed:-}" ]; then
+          echo "  • Prior session(s) ended on idle (vade-app/vade-agent-logs#67):"
+          idle_close_header_printed=1
+        fi
+        echo "      - ${stub#"$agent_logs_dir/"}"
+      done <<< "$pending_stubs"
+      if [ -n "${idle_close_header_printed:-}" ]; then
+        echo "    These owe a real session summary. Append a sibling"
+        echo "    coo-summary-on-<sessionId>.md in the same dir, or amend"
+        echo "    the stub in place with what was worked on."
+        echo ""
+      fi
+    fi
+  fi
+
   echo "Full SOP: vade-coo-memory/coo/mem0_sop.md"
   echo "───────────────────────────────────────────────────────────────"
   exit 0


### PR DESCRIPTION
## Summary

Solves vade-app/vade-agent-logs#67 — the "I forget to trigger end" failure that leaves recent sessions without an exported transcript, session log, or episodic Mem0 handoff. Independent of the vade-agent-logs#64 transcript-export arc that closed today; this is the trigger-side companion.

A background daemon launches from the SessionStart startup chain (after `coo-bootstrap` so coo-env is populated). It watches the active jsonl's mtime and fires the mechanical session-end protocol after configurable idle threshold + grace.

## What ships

| File | Status | Purpose |
|---|---|---|
| `scripts/session-idle-watchdog.sh` | new | Polling daemon; modes `--start`, `--run`, `--close`, `--stop` |
| `scripts/session-lifecycle.sh` | edit | `--start` boot reminder surfaces prior idle-close stub logs |
| `.claude/settings.json` | edit | Adds `session-idle-watchdog --start` to SessionStart startup chain |
| `scripts/integrity-check.sh` | edit | B1 enumerates 6 hook scripts (was 5) |
| `scripts/ci/test-session-idle-watchdog.sh` | new | Hermetic close-sequence smoke; ran clean locally |
| `.github/workflows/bootstrap-regression.yml` | edit | Wires the smoke into the `transcript-redaction` job |

## Design defaults (from issue body's Open Questions, vade-coo recommendations)

1. **Stub-log shape:** one stub per close (`coo-idle-close-<sessionId>.md`), alongside regular session logs. Done.
2. **Mem0 entry:** minimal episodic with `idle_close: true`, `summary_pending: true`, `artifact_refs` pointing at stub + sidecar. Tier-1 safe (no transcript content; MEMO-2026-04-11-10). Done.
3. **Multi-instance:** different `sessionId` → different PID-file → no conflict. Documented in script docstring.
4. **Suspend rather than close?** No — session is genuinely done; closing is correct. Done.

## Configurables (env)

- `VADE_SESSION_IDLE_MINUTES` (default 60)
- `VADE_SESSION_IDLE_GRACE_MINUTES` (default 5)
- `VADE_SESSION_IDLE_CHECK_SECONDS` (default 60)
- `VADE_SESSION_IDLE_DISABLE=1` — clean no-op (CI / local dev)
- `VADE_AGENT_LOGS_DIR` — override agent-logs working tree

## Close sequence (mechanical, since no Claude is running)

1. Invoke `session-end-transcript-export.sh` with `CLAUDE_SESSION_ID` pinned to the watched jsonl's basename — the existing Batch-2 hook handles redact + age + R2 + meta.json sidecar.
2. Drop a `coo-idle-close-<id>.md` stub at `vade-agent-logs/sessions/YYYY/MM/DD/` with status=incomplete, started/ended timestamps, event count, sidecar reference.
3. POST a minimal Mem0 episodic entry via curl + `MEM0_API_KEY` from `~/.vade/coo-env`.
4. `git add` + `git commit` + `git push origin <branch>` from the cloud container's vade-coo identity. Stages only the stub + sidecar files (never unrelated dirty state).
5. PID-file cleanup, exit 0.

SIGTERM handler is best-effort export-only (the transcript at least lands on disk before container teardown wins the race).

## Container teardown coverage

Per the issue's explicit scope: out of scope. The watchdog only fires inside a live container. If the container is killed before threshold + grace elapses, the close sequence never runs — covered by a separate teardown hook in a future issue.

## Test plan

- [x] Local: `bash scripts/ci/test-session-idle-watchdog.sh` — 4 asserts pass (stub shape, sidecar reference, no-sidecar fallback, `--start` no-op when disabled).
- [x] Local: `bash scripts/session-lifecycle.sh` with a fixture stub-log under `$HOME/GitHub/vade-app/vade-agent-logs/sessions/2026/04/28/` — surfaces the "Prior session(s) ended on idle" boot reminder with the expected body.
- [x] Local: `bash scripts/integrity-check.sh` — B1 reports `all 6 hook scripts present in runtime`. (B4 degrades on this repo because settings.json sync hasn't run; resolves on next SessionStart.)
- [ ] Post-merge fresh-container ritual (handoff prompt comment below).

## Boot-impact disclosure

Modifies `.claude/settings.json` SessionStart chain + `session-lifecycle.sh` boot output + adds a new hook script. Verification on a fresh container — handoff prompt posted as a separate comment per MEMO-2026-04-25-03.

https://claude.ai/code/session_01N9W7v79dr2XXSdSbfcrsDe