### PR TITLE
common.sh: respect VADE_NO_COO_ENV_AUTOSOURCE opt-out (closes #126)

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -230,8 +230,12 @@ retry() {
 # them from Claude Code's own env (settings.json is read only at
 # Claude Code startup, so the first session after provisioning has
 # a gap that this closes).
+#
+# Caller opt-out: export VADE_NO_COO_ENV_AUTOSOURCE=1 to suppress.
+# Tests that supply their own GITHUB_MCP_PAT / etc. otherwise have
+# the host's real values silently overwrite the fake ones (see #126).
 # shellcheck source=/dev/null
-[ -f "${HOME}/.vade/coo-env" ] && . "${HOME}/.vade/coo-env"
+[ -z "${VADE_NO_COO_ENV_AUTOSOURCE:-}" ] && [ -f "${HOME}/.vade/coo-env" ] && . "${HOME}/.vade/coo-env"
 
 # Block until coo-bootstrap.sh reaches a terminal state (OK/FAIL/SKIP)
 # in this session, then re-source coo-env so vars written during the
@@ -282,7 +286,7 @@ wait_for_coo_bootstrap() {
   done
   VADE_BOOTSTRAP_WAIT_ELAPSED="$elapsed"
   # shellcheck source=/dev/null
-  [ -f "${HOME}/.vade/coo-env" ] && . "${HOME}/.vade/coo-env"
+  [ -z "${VADE_NO_COO_ENV_AUTOSOURCE:-}" ] && [ -f "${HOME}/.vade/coo-env" ] && . "${HOME}/.vade/coo-env"
   return 0
 }
 


### PR DESCRIPTION
## Summary

Adds a caller opt-out (`VADE_NO_COO_ENV_AUTOSOURCE=1`) to the unconditional `~/.vade/coo-env` source on `scripts/lib/common.sh` load. Tests that supply their own `GITHUB_MCP_PAT` / `AGENTMAIL_API_KEY` / `MEM0_API_KEY` via env-prefix were having those values silently overwritten by the host's real values on every `common.sh` import — the surprise that bit `test-git-push-fallback.sh` during #125 (worked around there with a `HOME=` stub).

Two locations updated:
- `scripts/lib/common.sh:234` — the boot-time autosource.
- `scripts/lib/common.sh:289` — the post-`wait_for_coo_bootstrap` re-source.

Production behavior unchanged — variable unset by default. Comment block above the autosource explains the new opt-out and links #126.

## Why this stays a P3 fix

The production path is correct (closes the SessionStart subprocess env-gap that motivated the autosource originally). The fix is purely about test ergonomics — future test authors get a less surprising knob, and there's no longer a quiet path for the host's real PAT to leak into a test fixture (`MOCK_LOG`, etc.).

## Out of scope

- Migrating `test-git-push-fallback.sh` from the `HOME=` stub to the new flag. The workaround is functional; refactoring it is separate scope and not needed for the closure.
- The "respect-pre-existing-values" alternative shape from the issue body (more complex, changes production behavior in edge cases). Opt-out is the lower-risk shape.

## Test plan

- [ ] Bootstrap-regression CI passes (the sourcing path is exercised on every CI run; the new guard is a strict superset of the old one when the env var is unset).
- [ ] Local sanity: `VADE_NO_COO_ENV_AUTOSOURCE=1 bash -c 'source scripts/lib/common.sh; echo $GITHUB_MCP_PAT'` prints empty even when `~/.vade/coo-env` has a value.
- [ ] Default sanity: `bash -c 'source scripts/lib/common.sh; echo ${GITHUB_MCP_PAT:+SET}'` prints `SET` (unchanged behavior).

Closes #126.

https://claude.ai/code/session_01JFxVxvTPp4SFK1vZqxw6ai