### PR TITLE
settings: default model opusplan + effortLevel high (MEMO-2026-04-28-7yi7)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,6 @@
 {
+  "model": "opusplan",
+  "effortLevel": "high",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

- Adds two top-level keys to `.claude/settings.json` so cloud sessions start on `opusplan` (Opus during plan mode, Sonnet for execution) at `high` effort instead of the v2.1.117 built-in default of Opus 4.7 [1m] at `xhigh`.
- Per-session `/model` and `/effort` overrides remain available for sessions that genuinely need Opus + 1M or `xhigh`.

## Why

Diagnosis and full rationale in [MEMO-2026-04-28-7yi7](https://github.com/vade-app/vade-coo-memory/blob/claude/evaluate-rtk-tool-DnI3w/coo/memos/2026-04-28-7yi7.md). Short version: parent on Opus + built-in \`Plan\`/\`general-purpose\` subagents inheriting Opus + Phase 3 routine subagent dispatch = $200 of overage in a single day after the cap raise to $500. Plausible 50-60% reduction on heavy-use days from this single change.

## Test plan

- [ ] Confirm the diff is exactly two added top-level keys; the rest of `settings.json` (hooks, env, permissions) is untouched.
- [ ] CI bootstrap-regression suite (`.github/workflows/bootstrap-regression.yml`) should pass — it stages `settings.json` and runs `session-start-sync.sh`. Adding `model` + `effortLevel` does not interact with hooks or env validation.

## Post-merge confirmation

In a fresh container after merge:

- [ ] \`jq '.model, .effortLevel' /root/.claude/settings.json\` returns \`"opusplan"\` and \`"high"\`.
- [ ] On Claude Code session start, \`/status\` reports the active model is \`opusplan\` and the effort level is \`high\`. If the harness shows the v2.1.117 \`xhigh\` default instead, the settings sync hook regressed — check \`session-start-sync.sh\` \`merge_coo_settings_env\` path.
- [ ] If a session needs Opus + 1M for a memo-grade decision, override with \`/model opus[1m]\` and \`/effort xhigh\`; this is now the explicit exception, not the default.

https://claude.ai/code/session_01Rj1nFQTkhNcotfnjff1K7e