### PR TITLE
transcript pipeline: backfill + Stop hook auto-commit + closer dispatch (#148, refs vade-coo-memory#243)

### DIFF
--- a/scripts/lib/transcript-meta-backfill.py
+++ b/scripts/lib/transcript-meta-backfill.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["boto3>=1.34,<2"]
+# ///
+"""
+transcript-meta-backfill.py — vade-coo-memory#243.
+
+Stub-meta generator. The Stop hook (session-end-transcript-export.py)
+writes <id>.meta.json locally but doesn't commit it; until vade-runtime#148
+Part A lands and is reliable, sessions can leave R2 ciphertext orphaned
+from any sidecar in the agent-logs working tree. This script enumerates
+R2 directly, finds session_ids without a sibling meta.json in
+vade-agent-logs/transcripts/<date>/, and drops a stub <id>.meta.json
+that the transcript-analyzer agent accepts.
+
+Pipeline per session_id:
+  1. boto3 list_objects_v2 against the configured R2 prefix.
+  2. For each ciphertext key transcripts/YYYY/MM/DD/<id>.jsonl.gz.age:
+     - If the agent-logs working tree already holds a real meta.json
+       at the same date-path, skip.
+     - If a stub meta.json already exists (carrying _stub: true), skip.
+     - Otherwise download the ciphertext to a temp file, compute
+       sha256, write a stub meta.json with the fields the analyzer
+       reads.
+
+The stub is intentionally shallow — the analyzer doesn't need
+events_processed or bytes_post_redaction; it computes those itself
+when it parses the redacted jsonl. The fields the analyzer DOES rely
+on are r2.bucket / r2.key / r2.endpoint / r2.uploaded /
+ciphertext_sha256 / age_recipient_pubkey, all populated here.
+
+CLI:
+  --date YYYY/MM/DD              process one R2 date prefix
+  --session-id <id>              process exactly one session (locates
+                                 R2 key by walking the prefix)
+  --dry-run                      report what would be written without
+                                 writing
+  --agent-logs-dir <path>        override resolution (else ENV
+                                 VADE_AGENT_LOGS_DIR or default candidates)
+
+Env (sourced from ~/.vade/coo-env, mirroring the export hook):
+  R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY
+Read at run time via `op read`:
+  op://COO/r2-transcripts/endpoint
+  op://COO/r2-transcripts/bucket
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PARSER_VERSION = 1
+SCHEMA_VERSION = 1
+SCRIPT_DIR = Path(__file__).resolve().parent
+RUNTIME_ROOT = SCRIPT_DIR.parent.parent
+RECIPIENT_FILE = RUNTIME_ROOT / "scripts" / "lib" / "transcripts-recipient.age"
+
+R2_KEY_PATTERN = re.compile(
+    r"^transcripts/(?P<date>\d{4}/\d{2}/\d{2})/(?P<sid>[A-Za-z0-9_\-]+)\.jsonl\.gz\.age$"
+)
+
+
+def _stderr(msg: str) -> None:
+    sys.stderr.write(f"[transcript-meta-backfill] {msg}\n")
+
+
+def _resolve_agent_logs_dir(explicit: str | None) -> Path:
+    if explicit:
+        p = Path(explicit).expanduser()
+        if p.is_dir():
+            return p
+        raise FileNotFoundError(f"--agent-logs-dir={p} does not exist")
+    env = os.environ.get("VADE_AGENT_LOGS_DIR", "").strip()
+    if env:
+        p = Path(env)
+        if p.is_dir():
+            return p
+        raise FileNotFoundError(f"VADE_AGENT_LOGS_DIR={p} does not exist")
+    candidates = [
+        Path.home() / "GitHub" / "vade-app" / "vade-agent-logs",
+        Path("/home/user/vade-agent-logs"),
+        RUNTIME_ROOT.parent / "vade-agent-logs",
+    ]
+    for c in candidates:
+        if c.is_dir():
+            return c
+    raise FileNotFoundError(
+        "vade-agent-logs working tree not found; tried "
+        + ", ".join(str(c) for c in candidates)
+    )
+
+
+def _op_read(ref: str) -> str:
+    if not shutil.which("op"):
+        return ""
+    try:
+        out = subprocess.run(
+            ["op", "read", ref],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return out.stdout.strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return ""
+
+
+def _r2_creds() -> tuple[str, str, str, str]:
+    access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
+    secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
+    if not access_key or not secret_key:
+        raise RuntimeError(
+            "R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY "
+            "missing — source ~/.vade/coo-env first"
+        )
+    endpoint = _op_read("op://COO/r2-transcripts/endpoint")
+    bucket = _op_read("op://COO/r2-transcripts/bucket")
+    if not endpoint or not bucket:
+        raise RuntimeError(
+            "op://COO/r2-transcripts/{endpoint,bucket} unreadable — "
+            "verify OP_SERVICE_ACCOUNT_TOKEN and 1Password provisioning"
+        )
+    return access_key, secret_key, endpoint, bucket
+
+
+def _r2_client(access_key: str, secret_key: str, endpoint: str):
+    import boto3
+    from botocore.config import Config
+
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="auto",
+        config=Config(
+            signature_version="s3v4",
+            retries={"max_attempts": 3, "mode": "standard"},
+        ),
+    )
+
+
+def _list_r2_keys(s3, bucket: str, prefix: str) -> list[dict]:
+    """Return [{key, size, last_modified}, ...] under prefix."""
+    out: list[dict] = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            out.append(
+                {
+                    "key": obj["Key"],
+                    "size": obj["Size"],
+                    "last_modified": obj["LastModified"],
+                }
+            )
+    return out
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(64 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _read_recipient_pubkey() -> str:
+    """Mirror of session-end-transcript-export._read_recipient_pubkey."""
+    try:
+        for line in reversed(RECIPIENT_FILE.read_text().splitlines()):
+            s = line.strip()
+            if s and not s.startswith("#"):
+                return s
+    except OSError:
+        pass
+    return ""
+
+
+def _meta_already_present(sidecar_dir: Path, session_id: str) -> tuple[bool, str]:
+    """Returns (skip, reason). Skip when a real or stub meta is already on disk."""
+    meta_path = sidecar_dir / f"{session_id}.meta.json"
+    if not meta_path.exists():
+        return False, ""
+    try:
+        existing = json.loads(meta_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return True, "existing meta.json unparseable; refusing to overwrite"
+    if existing.get("_stub") is True:
+        return True, "stub already present"
+    return True, "real meta.json already present"
+
+
+def _r2_iter(date_filter: str | None, session_id_filter: str | None):
+    """Yield (key, size, last_modified, date_path, sid) tuples that match
+    the requested scope. `date_filter` is YYYY/MM/DD; `session_id_filter`
+    is the bare session id (we walk the bucket and grep by sid)."""
+    access_key, secret_key, endpoint, bucket = _r2_creds()
+    s3 = _r2_client(access_key, secret_key, endpoint)
+
+    if date_filter:
+        prefix = f"transcripts/{date_filter}/"
+    else:
+        # Single-session search: walk the whole transcripts/ tree.
+        # Bucket lifecycle keeps this small; if it grows we can add a
+        # --window-days bound.
+        prefix = "transcripts/"
+
+    for entry in _list_r2_keys(s3, bucket, prefix):
+        m = R2_KEY_PATTERN.match(entry["key"])
+        if not m:
+            continue
+        date_path = m.group("date")
+        sid = m.group("sid")
+        if session_id_filter and sid != session_id_filter:
+            continue
+        yield (entry, date_path, sid, bucket, endpoint)
+
+
+def _write_stub(
+    sidecar_dir: Path,
+    session_id: str,
+    bucket: str,
+    endpoint: str,
+    r2_key: str,
+    ciphertext_size: int,
+    ciphertext_sha256: str,
+    last_modified: datetime.datetime,
+) -> Path:
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    sidecar_path = sidecar_dir / f"{session_id}.meta.json"
+    stub = {
+        "_stub": True,
+        "schema_version": SCHEMA_VERSION,
+        "parser_version": PARSER_VERSION,
+        "session_id": session_id,
+        "exported_at": last_modified.astimezone(datetime.timezone.utc).isoformat(),
+        "source_jsonl": None,
+        "events_processed": None,
+        "events_with_unparseable_json": None,
+        "bytes_pre_redaction": None,
+        "bytes_post_redaction": None,
+        "bytes_post_gzip": None,
+        "bytes_ciphertext": ciphertext_size,
+        "ciphertext_sha256": ciphertext_sha256,
+        "redaction_hits": None,
+        "r2": {
+            "bucket": bucket,
+            "key": r2_key,
+            "endpoint": endpoint,
+            "uploaded": True,
+        },
+        "age_recipient_file": str(RECIPIENT_FILE.relative_to(RUNTIME_ROOT))
+        if RECIPIENT_FILE.exists()
+        else None,
+        "age_recipient_pubkey": _read_recipient_pubkey(),
+        "stub_generator": "vade-runtime/scripts/lib/transcript-meta-backfill.py",
+        "stub_generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    with open(sidecar_path, "w") as f:
+        json.dump(stub, f, indent=2)
+        f.write("\n")
+    return sidecar_path
+
+
+def _backfill_one(
+    entry: dict,
+    date_path: str,
+    session_id: str,
+    bucket: str,
+    endpoint: str,
+    sidecar_dir: Path,
+    s3,
+    dry_run: bool,
+) -> str:
+    """Returns a one-line status string for the report."""
+    skip, reason = _meta_already_present(sidecar_dir, session_id)
+    if skip:
+        return f"SKIP {date_path}/{session_id} ({reason})"
+
+    if dry_run:
+        return f"DRY  {date_path}/{session_id} would write stub ({entry['size']} bytes)"
+
+    with tempfile.TemporaryDirectory(prefix=f"meta-backfill-{session_id}-") as tmp:
+        ciphertext = Path(tmp) / f"{session_id}.jsonl.gz.age"
+        s3.download_file(bucket, entry["key"], str(ciphertext))
+        sha = _sha256(ciphertext)
+        size = ciphertext.stat().st_size
+
+    sidecar = _write_stub(
+        sidecar_dir,
+        session_id,
+        bucket,
+        endpoint,
+        entry["key"],
+        size,
+        sha,
+        entry["last_modified"],
+    )
+    return f"WROTE {date_path}/{session_id} ({sidecar})"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="R2-first stub meta.json generator (vade-coo-memory#243).",
+    )
+    parser.add_argument(
+        "--date",
+        help="R2 date prefix to process (YYYY/MM/DD).",
+    )
+    parser.add_argument(
+        "--session-id",
+        help="Process exactly one session_id (search the bucket for its key).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report would-write actions without writing.",
+    )
+    parser.add_argument(
+        "--agent-logs-dir",
+        help="Override vade-agent-logs working tree resolution.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.date and not args.session_id:
+        parser.error("either --date or --session-id is required")
+
+    agent_logs_dir = _resolve_agent_logs_dir(args.agent_logs_dir)
+    transcripts_root = agent_logs_dir / "transcripts"
+
+    access_key, secret_key, endpoint, bucket = _r2_creds()
+    s3 = _r2_client(access_key, secret_key, endpoint)
+
+    seen = 0
+    written = 0
+    skipped = 0
+    for entry, date_path, sid, _, _ in _r2_iter(args.date, args.session_id):
+        seen += 1
+        sidecar_dir = transcripts_root / date_path
+        line = _backfill_one(
+            entry, date_path, sid, bucket, endpoint, sidecar_dir, s3, args.dry_run
+        )
+        if line.startswith("WROTE"):
+            written += 1
+        elif line.startswith("DRY"):
+            written += 1  # would-have-written
+        else:
+            skipped += 1
+        print(line)
+
+    print(
+        f"\nsummary: seen={seen} written={written} skipped={skipped} "
+        f"dry_run={args.dry_run}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/session-end-transcript-export.py
+++ b/scripts/session-end-transcript-export.py
@@ -48,9 +48,18 @@ Read at run time via `op read` (no env exposure):
   op://COO/r2-transcripts/endpoint  — R2 S3-compat URL
   op://COO/r2-transcripts/bucket    — bucket name
 Optional:
-  CLAUDE_SESSION_ID  — override session-id resolution
-  VADE_AGENT_LOGS_DIR  — override vade-agent-logs working tree resolution
-  VADE_TRANSCRIPT_EXPORT_DRY_RUN=1  — skip R2 upload (CI / smoke-test)
+  CLAUDE_SESSION_ID                  — override session-id resolution
+  VADE_AGENT_LOGS_DIR                — override vade-agent-logs working
+                                       tree resolution
+  VADE_TRANSCRIPT_EXPORT_DRY_RUN=1   — skip R2 upload AND skip auto-PR
+                                       (CI / smoke-test)
+  VADE_TRANSCRIPT_EXPORT_NO_PR=1     — skip auto-PR open only (still
+                                       upload + write sidecar; useful
+                                       when running locally without a
+                                       network or PAT)
+  GITHUB_MCP_PAT                     — required for auto-PR-on-meta;
+                                       absence is a soft skip, not an
+                                       error (per vade-runtime#148 A)
 """
 
 from __future__ import annotations
@@ -304,6 +313,180 @@ def _emit_export_error(sidecar_dir: Path, session_id: str, exc: BaseException) -
     _stderr(f"wrote export-error: {err_path}")
 
 
+def _open_meta_pr(
+    agent_logs_dir: Path,
+    sidecar_path: Path,
+    session_id: str,
+) -> str | None:
+    """Open a single-file pure-add PR carrying just the new meta.json.
+
+    Auto-merge happens via the Night's Watch §4 pure-add gate
+    (MEMO-2026-04-26-04 §4 carve-out for own-author log PRs in
+    vade-agent-logs).
+
+    Best-effort: any failure is logged via export-error.txt and we
+    return None. Never raises, never blocks session end.
+
+    Returns the PR URL on success, None otherwise.
+
+    Skipped (no error) when:
+      - VADE_TRANSCRIPT_EXPORT_DRY_RUN=1 or VADE_TRANSCRIPT_EXPORT_NO_PR=1
+      - GITHUB_MCP_PAT not set
+      - `gh` binary not on PATH
+      - agent_logs_dir is not a git working tree
+      - the auto-meta branch already exists upstream (idempotent re-fire)
+    """
+    if os.environ.get("VADE_TRANSCRIPT_EXPORT_DRY_RUN", "").strip() == "1":
+        _stderr("auto-PR skipped (DRY_RUN=1)")
+        return None
+    if os.environ.get("VADE_TRANSCRIPT_EXPORT_NO_PR", "").strip() == "1":
+        _stderr("auto-PR skipped (NO_PR=1)")
+        return None
+
+    pat = os.environ.get("GITHUB_MCP_PAT", "").strip()
+    if not pat:
+        _stderr("auto-PR skipped (GITHUB_MCP_PAT not set)")
+        return None
+    if not shutil.which("gh"):
+        _stderr("auto-PR skipped (gh binary not on PATH)")
+        return None
+    if not (agent_logs_dir / ".git").exists():
+        _stderr(f"auto-PR skipped ({agent_logs_dir} is not a git tree)")
+        return None
+    if not sidecar_path.is_file():
+        _stderr(f"auto-PR skipped (sidecar missing: {sidecar_path})")
+        return None
+
+    short_sid = session_id[:12]
+    branch = f"claude/auto-meta-{short_sid}"
+    rel_sidecar = str(sidecar_path.relative_to(agent_logs_dir))
+
+    git_env = {**os.environ, "GH_TOKEN": pat}
+
+    def _git(*args: str, capture: bool = False) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", "-C", str(agent_logs_dir), *args],
+            check=False,
+            env=git_env,
+            capture_output=capture,
+            text=capture,
+            timeout=30,
+        )
+
+    # Idempotent guard: if the branch exists on origin already, abort.
+    ls_remote = _git("ls-remote", "--heads", "origin", branch, capture=True)
+    if ls_remote.returncode == 0 and ls_remote.stdout.strip():
+        _stderr(f"auto-PR skipped (branch {branch} exists on origin)")
+        return None
+
+    # Capture current HEAD so we can restore it after the auto-PR work.
+    head_proc = _git("rev-parse", "HEAD", capture=True)
+    if head_proc.returncode != 0:
+        _stderr(f"auto-PR skipped (HEAD unresolvable: {head_proc.stderr.strip()})")
+        return None
+    original_ref_proc = _git("rev-parse", "--abbrev-ref", "HEAD", capture=True)
+    original_ref = (
+        original_ref_proc.stdout.strip() if original_ref_proc.returncode == 0 else ""
+    )
+
+    try:
+        # Fetch origin/main and create the auto-meta branch from it. Use
+        # a worktree-free flow: stash, switch, commit, switch back.
+        fetch = _git("fetch", "origin", "main", capture=True)
+        if fetch.returncode != 0:
+            _stderr(f"auto-PR fetch origin/main failed: {fetch.stderr.strip()}")
+            return None
+
+        # Stage just the new meta.json against the index AT origin/main
+        # by doing the work on the new branch.
+        switch = _git("switch", "-c", branch, "origin/main", capture=True)
+        if switch.returncode != 0:
+            _stderr(f"auto-PR switch -c {branch} failed: {switch.stderr.strip()}")
+            return None
+
+        # Re-write the sidecar at the same relative path on the new
+        # branch (the file may not exist on origin/main yet).
+        target = agent_logs_dir / rel_sidecar
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(sidecar_path.read_text())
+
+        add = _git("add", "--", rel_sidecar, capture=True)
+        if add.returncode != 0:
+            _stderr(f"auto-PR git add failed: {add.stderr.strip()}")
+            return None
+
+        commit_msg = (
+            f"meta: auto-commit sidecar for {session_id}\n\n"
+            "Stop hook auto-commit per vade-runtime#148 Part A.\n"
+            "Pure-add (single file) — eligible for the Night's Watch\n"
+            "§4 pure-add merge gate (MEMO-2026-04-26-04 §4)."
+        )
+        commit = _git(
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            commit_msg,
+            capture=True,
+        )
+        if commit.returncode != 0:
+            _stderr(f"auto-PR git commit failed: {commit.stderr.strip()}")
+            return None
+
+        push = _git("push", "-u", "origin", branch, capture=True)
+        if push.returncode != 0:
+            _stderr(f"auto-PR git push failed: {push.stderr.strip()}")
+            return None
+
+        body = (
+            "## Summary\n\n"
+            f"Auto-commit of `{rel_sidecar}` for session `{session_id}`.\n"
+            "Written by `vade-runtime/scripts/session-end-transcript-export.py`\n"
+            "per vade-runtime#148 Part A. The encrypted ciphertext is\n"
+            "already in R2; this PR makes the sidecar visible to the\n"
+            "transcript-analyzer pipeline.\n\n"
+            "## Test plan\n\n"
+            "- [x] Single-file pure-add (`status == \"added\"`).\n"
+            "- [ ] Auto-merges via the Night's Watch §4 pure-add gate.\n"
+        )
+        pr = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "-R",
+                "vade-app/vade-agent-logs",
+                "--base",
+                "main",
+                "--head",
+                branch,
+                "--title",
+                f"meta: auto-commit sidecar for {session_id}",
+                "--body",
+                body,
+            ],
+            check=False,
+            env=git_env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if pr.returncode != 0:
+            _stderr(f"auto-PR gh pr create failed: {pr.stderr.strip()}")
+            return None
+        url = pr.stdout.strip().splitlines()[-1] if pr.stdout.strip() else ""
+        _stderr(f"auto-PR opened: {url}")
+        return url or None
+    finally:
+        # Restore the working tree to whatever was checked out before.
+        # Stop hooks fire from the active session; leaving the agent-logs
+        # repo on a half-detached branch surprises the operator.
+        if original_ref and original_ref != "HEAD":
+            _git("switch", original_ref)
+        else:
+            _git("switch", "--detach", head_proc.stdout.strip())
+
+
 def main() -> int:
     session_id = "unknown"
     sidecar_dir_for_error: Path | None = None
@@ -382,6 +565,15 @@ def main() -> int:
                 json.dump(sidecar, f, indent=2)
                 f.write("\n")
             _stderr(f"wrote sidecar: {sidecar_path}")
+
+        # Best-effort: open a single-file pure-add PR carrying just the
+        # sidecar. Per vade-runtime#148 Part A — closes the structural
+        # gap where 78% of sessions skipped committing meta.json.
+        # Failures here are logged via export-error, never raised.
+        try:
+            _open_meta_pr(agent_logs_dir, sidecar_path, session_id)
+        except BaseException as e:
+            _stderr(f"auto-PR raised unexpectedly: {e!r}; ignored")
 
         return 0
     except BaseException as e:

--- a/scripts/session-idle-watchdog.sh
+++ b/scripts/session-idle-watchdog.sh
@@ -276,13 +276,26 @@ cmd_close() {
     log "export hook missing or non-executable at $EXPORT_HOOK; skipping"
   fi
 
-  # ---- b. Stub session log -------------------------------------------------
+  # Resolve agent-logs working tree once — both the closer-spawn path
+  # and the stub-fallback path need it.
   local agent_logs_dir
   agent_logs_dir="$(_resolve_agent_logs_dir)"
   if [ -z "$agent_logs_dir" ]; then
     log "vade-agent-logs working tree not found; cannot drop stub log"
     return 0
   fi
+
+  # ---- a.5 Try the session-closer agent (vade-runtime#148 Part B) ---------
+  # If the closer succeeds, it writes a real session-log .md, the Mem0
+  # episodic entry, and opens a PR — return early. If it fails or is
+  # unavailable, fall through to the stub-write path (steps b/c/d).
+  if _try_spawn_session_closer "$session_id" "$agent_logs_dir"; then
+    log "session-closer succeeded; skipping stub fallback"
+    return 0
+  fi
+  log "session-closer unavailable or failed; falling back to stub-write path"
+
+  # ---- b. Stub session log -------------------------------------------------
 
   local first_ts last_ts ev_count idle_close_ts date_path
   first_ts="$(_jsonl_first_timestamp "$jsonl")"
@@ -350,8 +363,76 @@ cmd_close() {
 }
 
 # ---------------------------------------------------------------------------
-# Helpers — agent-logs resolution, jsonl introspection, Mem0 POST, git push
+# Helpers — closer-agent spawn, agent-logs resolution, jsonl
+#          introspection, Mem0 POST, git push
 # ---------------------------------------------------------------------------
+
+# vade-runtime#148 Part B: try to elevate from stub to real synthesized
+# log by spawning the session-closer sub-agent. Returns 0 on success
+# (closer wrote log + Mem0 + PR; caller should skip the stub path);
+# returns 1 on any failure or unavailability (caller falls back to
+# stub-write).
+#
+# Budget cap is bounded explicitly to avoid the closer running away —
+# Sonnet at $3/Mtok input + max ~30 turns worth of work for a session
+# log keeps each fire under ~$0.50 in the worst case.
+_try_spawn_session_closer() {
+  local session_id="${1:-}" agent_logs_dir="${2:-}"
+  if [ -z "$session_id" ] || [ -z "$agent_logs_dir" ]; then
+    log "_try_spawn_session_closer: missing args"
+    return 1
+  fi
+
+  if [ "${VADE_SESSION_CLOSER_DISABLE:-}" = "1" ]; then
+    log "session-closer disabled by VADE_SESSION_CLOSER_DISABLE=1"
+    return 1
+  fi
+
+  if ! command -v claude >/dev/null 2>&1; then
+    log "claude binary not on PATH; closer unavailable"
+    return 1
+  fi
+
+  # Locate the meta.json the closer needs as input. Search transcripts/
+  # rather than just the date-path because the export hook's date-path
+  # is derived from first-event timestamp, not now.
+  local meta_path
+  meta_path="$(find "$agent_logs_dir/transcripts" -maxdepth 4 -type f \
+    -name "${session_id}.meta.json" 2>/dev/null | head -1)"
+  if [ -z "$meta_path" ]; then
+    log "no meta.json for session_id=$session_id; closer cannot synthesize"
+    return 1
+  fi
+
+  local prompt closer_log timeout_seconds
+  closer_log="$LOG_DIR/${session_id}.closer.log"
+  timeout_seconds="${VADE_SESSION_CLOSER_TIMEOUT_SECONDS:-900}"  # 15 min
+  prompt="Synthesize a closer session log for session_id ${session_id}.
+
+The meta.json is at ${meta_path}.
+
+Follow your standard pipeline. Return the session-log path + PR URL."
+
+  log "spawning session-closer (timeout=${timeout_seconds}s, log=$closer_log)"
+
+  # Use --print for non-interactive mode + --max-budget-usd as a
+  # belt-and-braces safety net. PAT is already in env from coo-env;
+  # the closer reads MEM0_API_KEY + GITHUB_MCP_PAT directly.
+  local rc=0
+  timeout "${timeout_seconds}" claude \
+      --agent session-closer \
+      --print \
+      --max-budget-usd "${VADE_SESSION_CLOSER_BUDGET_USD:-1.00}" \
+      "$prompt" \
+      >> "$closer_log" 2>&1 || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    log "session-closer returned rc=0; treating as success"
+    return 0
+  fi
+  log "session-closer rc=$rc — falling back to stub-write path"
+  return 1
+}
 
 _resolve_agent_logs_dir() {
   if [ -n "${VADE_AGENT_LOGS_DIR:-}" ] && [ -d "$VADE_AGENT_LOGS_DIR" ]; then


### PR DESCRIPTION
## Summary

Three runtime changes addressing the transcript-pipeline gaps surfaced by Night's Watch 2026-04-28b (22 of 25 R2 ciphertexts orphaned from any committed sidecar; 78% of sessions skipped the meta.json commit step):

- `bbf4fe0` — **scripts/lib: transcript-meta-backfill — R2-first stub generator (refs vade-coo-memory#243)**
  Promotes the manual backfill from 2026-04-28b into a committed library script. Enumerates R2 via `boto3 list_objects_v2`, finds session_ids without a sibling meta.json in `vade-agent-logs/transcripts/<date>/`, downloads the ciphertext, computes sha256, writes a stub meta.json carrying `_stub: true` plus the fields the transcript-analyzer agent reads. CLI: `--date YYYY/MM/DD` or `--session-id <id>` (mutually-exclusive required); `--dry-run` reports without writing. Idempotent — refuses to overwrite real or stub meta.json on disk. Reuses the same `_resolve_agent_logs_dir`, `_op_read`, `_sha256`, and `_read_recipient_pubkey` patterns from `session-end-transcript-export.py`.

- `0bd4a6d` — **session-end-transcript-export: auto-commit meta.json via PR (refs vade-runtime#148 Part A)**
  After the sidecar is written locally, open a single-file pure-add PR against vade-app/vade-agent-logs on a fresh `claude/auto-meta-<short-sid>` branch. The Night's Watch §4 pure-add gate (MEMO-2026-04-26-04 §4 carve-out) auto-merges this nightly. Best-effort by design — never blocks session end. Skip paths: `VADE_TRANSCRIPT_EXPORT_DRY_RUN=1` (skips R2 + PR), `VADE_TRANSCRIPT_EXPORT_NO_PR=1` (PR only), `GITHUB_MCP_PAT` absent (soft skip), `gh` missing (soft skip), branch already on origin (idempotent). Restores original HEAD/branch in a `finally` clause so the agent-logs working tree is left as-found.

- `4b62a1b` — **session-idle-watchdog: spawn session-closer on idle (closes vade-runtime#148)**
  Adds step (a.5) between mechanical export and stub-write: try to spawn the session-closer sub-agent (defined at vade-coo-memory/.claude/agents/session-closer.md, shipped in vade-coo-memory#248). On success, the closer writes a real synthesized session log + Mem0 episodic + PR; \`cmd_close\` returns early. On failure, falls through to the existing stub-write path — graceful degradation. Spawn shape: \`claude --agent session-closer --print --max-budget-usd 1.00 <prompt>\` under a 15min timeout. New env switches: \`VADE_SESSION_CLOSER_DISABLE\`, \`VADE_SESSION_CLOSER_TIMEOUT_SECONDS\`, \`VADE_SESSION_CLOSER_BUDGET_USD\`.

## Boot-impact

**Both PR commits modify SessionStart-adjacent infrastructure:**
- The Stop hook (`session-end-transcript-export.py`) fires on every session end. The auto-PR step is best-effort and gracefully degrades on missing PAT / missing gh / missing network, but the integration only verifies on a fresh container with a real session ending and the agent-logs working tree available.
- The idle watchdog daemon is launched by SessionStart and runs in the background. The closer-spawn fires when the watchdog detects an idle session, which only happens with no active agent.

Handoff comment posted as a reply to this PR per MEMO-2026-04-25-03.

## Test plan

### Pre-merge gating
- [ ] Read all three atomic commits.
- [ ] `python3 scripts/lib/transcript-meta-backfill.py --help` parses; `--date` and `--session-id` are mutually exclusive (one required).
- [ ] DRY_RUN smoke test: `VADE_TRANSCRIPT_EXPORT_DRY_RUN=1 python3 scripts/session-end-transcript-export.py` — both R2 upload AND auto-PR should be skipped (this PR's commit confirms via three test calls in the commit's stderr).
- [ ] Watchdog syntax: `bash -n scripts/session-idle-watchdog.sh` (passes locally).

### Post-merge confirmation (fresh container)

Required because Stop hook + watchdog only fire on a fresh session. See standalone handoff comment on this PR.

## Companion PRs

- `vade-app/vade-coo-memory#248` — docs disambiguation, mem0_sop §5 schema literal, Night's Watch §1 R2-first rewrite, session-closer agent definition.
- `vade-app/vade-agent-logs` — Sidecars-not-session-logs disambiguation in CLAUDE.md.

https://claude.ai/code/session_01KQFAF2djEgVfRQmUgcbzTs