### PR TITLE
cloud-setup: install dispatch shim under $WORKSPACE_ROOT/.claude (cloud-compat for #157)

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -30,6 +30,19 @@ log "Baseline: node=$(node --version 2>/dev/null || echo 'missing') npm=$(npm --
 
 ensure_dirs
 sync_claude_config "$RUNTIME_DIR/.claude"
+# vade-runtime#157 switched settings.json hook commands from
+# $HOME/.claude/vade-hooks/dispatch.sh to
+# $CLAUDE_PROJECT_DIR/.claude/vade-hooks/dispatch.sh. On local those paths
+# coincide because $CLAUDE_PROJECT_DIR resolves to $WORKSPACE_ROOT and the
+# user's personal $HOME is left untouched, but on cloud they diverge:
+# $HOME=/root while $CLAUDE_PROJECT_DIR=/home/user (=$WORKSPACE_ROOT) at
+# hook-fire time (see integrity-check B5). The sync_claude_config above
+# only installs the shim under $HOME/.claude, so without this extra
+# install the first SessionStart on a fresh snapshot would fail to
+# resolve any of the hook chain. Mirror the shim under the workspace
+# .claude as well — session-start-sync's full re-sync to
+# $WORKSPACE_ROOT/.claude takes over once the chain bootstraps.
+ensure_hooks_dispatch_shim "$RUNTIME_DIR/.claude" "$WORKSPACE_ROOT/.claude"
 # Aggregate per-repo primitives from data-owning repos into the
 # user-scope .claude/ via per-file symlinks. Per the data-ownership
 # rule (MEMO 2026-04-25-02), slash commands and skills live in the


### PR DESCRIPTION
## Summary

vade-runtime#157 changes `.claude/settings.json` hook commands from `$HOME/.claude/vade-hooks/dispatch.sh` to `$CLAUDE_PROJECT_DIR/.claude/vade-hooks/dispatch.sh`. Its "Cloud impact: None" claim rests on `$HOME == $WORKSPACE_ROOT == /home/user` on cloud, but that's not what the cloud harness actually does. Per integrity-check B5 in this very session:

```
CLAUDE_PROJECT_DIR=/home/user cwd=/home/user HOME=/root
```

So at hook-fire time on cloud, `$HOME` and `$CLAUDE_PROJECT_DIR` resolve to **different** directories. `cloud-setup.sh` installs the dispatch shim only at `$HOME/.claude/vade-hooks/dispatch.sh` (`/root/.claude/...`). After #157 lands, hook commands would look for `/home/user/.claude/vade-hooks/dispatch.sh` — which doesn't exist on a fresh snapshot — and every `SessionStart` hook (including `session-start-sync`, which would otherwise self-heal) would fail `file-not-found`.

The bootstrap-regression CI doesn't catch this because in CI `CLAUDE_PROJECT_DIR=<unset>` (per the bot comment on #157), and the B4 invariant only checks settings.json shape, not whether the referenced shim path resolves at hook-fire time.

## Fix

Add a single `ensure_hooks_dispatch_shim "\$RUNTIME_DIR/.claude" "\$WORKSPACE_ROOT/.claude"` call alongside the existing `\$HOME/.claude` install in `cloud-setup.sh`. The shim now exists at both `/root/.claude/vade-hooks/dispatch.sh` (existing — keeps integrity-check B2 happy and Claude Code's user-scope settings.json read path intact) and `/home/user/.claude/vade-hooks/dispatch.sh` (new — what `\$CLAUDE_PROJECT_DIR/.claude/vade-hooks/dispatch.sh` resolves to). Once the chain bootstraps, `session-start-sync` (which #157 redirects to `\$WORKSPACE_ROOT/.claude`) takes over the full re-sync.

This is additive and a no-op pre-#157 (nothing references the new path on cloud today); it becomes load-bearing the moment #157 lands.

## Sequencing

- This PR does not depend on #157 and can merge first.
- After merge: the next cloud snapshot rebuild produces a snapshot that has the shim at both paths. #157 is then safe to merge — its hook-command path change resolves correctly on cloud.
- If #157 merges first, snapshots built between #157 and this PR are broken on cloud (no SessionStart hooks fire). Recommend merging this PR first or merging both within the same snapshot-rebuild window.

## Changes

- `scripts/cloud-setup.sh`: one extra `ensure_hooks_dispatch_shim` call after `sync_claude_config`, mirrored under `\$WORKSPACE_ROOT/.claude`. 13 lines (mostly comment explaining why).

## Test plan

- [ ] Bootstrap-regression CI passes (no behavior change in CI's fake-env mode — the new install is idempotent).
- [ ] After merge + snapshot rebuild: a fresh cloud session shows `/home/user/.claude/vade-hooks/dispatch.sh` symlinked to `/home/user/vade-runtime/scripts/hooks-dispatch.sh`.
- [ ] After #157 merges on top of this: SessionStart hooks fire on cloud (boot.log shows session-start-sync entries) and `integrity-check.json` `summary.ok=true`.

## Post-merge confirmation

After merging (BEFORE #157 lands), on a fresh cloud snapshot:

```bash
ls -la /home/user/.claude/vade-hooks/dispatch.sh
# Expected: symlink → /home/user/vade-runtime/scripts/hooks-dispatch.sh
ls -la /root/.claude/vade-hooks/dispatch.sh
# Expected: symlink → /home/user/vade-runtime/scripts/hooks-dispatch.sh
```

Both paths should resolve. After #157 then merges, re-verify on a subsequent snapshot rebuild that `boot.log` shows the SessionStart-hook chain firing without `file-not-found` errors.

https://claude.ai/code/session_01GtzT8KSUZyExkw51cMc2NW