### PR TITLE
session-lifecycle --end: wrap reminder as Stop-hook structured JSON

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -30,6 +30,19 @@ log "Baseline: node=$(node --version 2>/dev/null || echo 'missing') npm=$(npm --
 
 ensure_dirs
 sync_claude_config "$RUNTIME_DIR/.claude"
+# vade-runtime#157 switched settings.json hook commands from
+# $HOME/.claude/vade-hooks/dispatch.sh to
+# $CLAUDE_PROJECT_DIR/.claude/vade-hooks/dispatch.sh. On local those paths
+# coincide because $CLAUDE_PROJECT_DIR resolves to $WORKSPACE_ROOT and the
+# user's personal $HOME is left untouched, but on cloud they diverge:
+# $HOME=/root while $CLAUDE_PROJECT_DIR=/home/user (=$WORKSPACE_ROOT) at
+# hook-fire time (see integrity-check B5). The sync_claude_config above
+# only installs the shim under $HOME/.claude, so without this extra
+# install the first SessionStart on a fresh snapshot would fail to
+# resolve any of the hook chain. Mirror the shim under the workspace
+# .claude as well — session-start-sync's full re-sync to
+# $WORKSPACE_ROOT/.claude takes over once the chain bootstraps.
+ensure_hooks_dispatch_shim "$RUNTIME_DIR/.claude" "$WORKSPACE_ROOT/.claude"
 # Aggregate per-repo primitives from data-owning repos into the
 # user-scope .claude/ via per-file symlinks. Per the data-ownership
 # rule (MEMO 2026-04-25-02), slash commands and skills live in the

--- a/scripts/session-lifecycle.sh
+++ b/scripts/session-lifecycle.sh
@@ -131,6 +131,16 @@ if [ -f "$RUN_ID_FILE" ] && [ -s "$RUN_ID_FILE" ]; then
   RUN_ID="$(cat "$RUN_ID_FILE")"
 fi
 
+# Stop-hook context-injection contract: Claude Code only surfaces a
+# Stop hook's reminder text to the next turn when the hook returns
+# {"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"..."}}.
+# Plain stdout from a Stop hook lands in transcript-mode logs (Ctrl-R)
+# and is invisible to Claude — which is why this reminder silently
+# stopped reaching agents at some point in the harness lifetime,
+# despite the hook firing cleanly. Capture all reminder text into a
+# buffer, then emit it wrapped in the JSON envelope below.
+END_BUF="$(mktemp -t vade-session-end.XXXXXX 2>/dev/null || mktemp)"
+{
 echo "───────────────────────────────────────────────────────────────"
 echo "Session lifecycle — end of session (SOP-MEM-001 §5)"
 echo ""
@@ -226,3 +236,25 @@ fi
 
 echo "Full SOP: vade-coo-memory/coo/mem0_sop.md"
 echo "───────────────────────────────────────────────────────────────"
+} > "$END_BUF"
+
+# Emit captured reminder as Stop-hook structured output so Claude
+# actually sees it on the next turn. Falls back to plain stdout if
+# node is missing — strictly worse than the JSON path (Claude won't
+# see it), but the script must remain a graceful no-op when deps are
+# missing rather than aborting the Stop chain.
+if check_cmd node; then
+  node -e '
+    const fs = require("fs");
+    const text = fs.readFileSync(process.argv[1], "utf8");
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "Stop",
+        additionalContext: text
+      }
+    }) + "\n");
+  ' "$END_BUF"
+else
+  cat "$END_BUF"
+fi
+rm -f "$END_BUF"


### PR DESCRIPTION
## Summary

The end-of-session reminder script (`session-lifecycle.sh --end`) was emitting its four-step SOP-MEM-001 §5 protocol (commit plans, write episodic Mem0 entry, consider Journal, write session log) as plain stdout. Per Claude Code's hook spec, **plain stdout from a Stop hook is captured to transcript-mode logs (Ctrl-R) but is NOT injected back into the agent's context** — Stop hooks only surface output via `{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"..."}}`.

Result: the reminder was firing successfully (boot.log shows `session-lifecycle-end phase=end ok=true rc=0` every Stop event) but never reaching the agent. The end-session protocol was being silently skipped because the agent literally never saw the reminder text.

This was caught when Ven asked why I skipped the protocol on a session end. The hook log proved the script ran correctly; comparing against `SessionStart` output (which DOES inject as `<system-reminder>`) and `PostToolUse` output (which DOES inject as `PostToolUse:Bash hook additional context: ...`) confirmed Stop is the only hook event that requires the JSON wrapper.

## Fix

`scripts/session-lifecycle.sh --end` now captures its existing reminder text into a buffer, then emits the buffer wrapped in the Stop-hook structured-output envelope:

```json
{"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": "<reminder text>"}}
```

Falls back to plain `cat` if node is missing — strictly worse (Claude still won't see it) but better than aborting the Stop chain. Start mode is unchanged: SessionStart plain-stdout *is* surfaced by the harness, so the boot reminder was already reaching agents fine.

## Verification

```bash
bash -n scripts/session-lifecycle.sh                 # syntax OK
bash scripts/session-lifecycle.sh --end | jq .       # parses as valid JSON
bash scripts/session-lifecycle.sh --end \
  | node -e 'const o=JSON.parse(require("fs").readFileSync(0,"utf8")); console.log(o.hookSpecificOutput.hookEventName)'
# Stop
bash scripts/session-lifecycle.sh | head -1          # plain text (start mode unchanged)
```

## Test plan

- [ ] Bootstrap-regression CI passes.
- [ ] On the next session-end on cloud or local, the agent receives a `Stop hook additional context: ...` system-reminder containing the SOP-MEM-001 §5 four-step protocol.
- [ ] Subsequent agent ends sessions per protocol (writes Mem0 episodic entry + vade-agent-logs session log) without a manual prompt from Ven.

## Why this matters

The end-session protocol (Mem0 episodic + session log) is the substrate that makes cross-session continuity work. If the reminder is invisible, sessions silently drop their summary, the next session boots with stale recent-episodic context, and the failure mode is invisible to the operator until the agent visibly drops a thread. Restoring the reminder pipeline closes a class of "the agent forgot X" complaints that aren't actually about agent recall — they're about the harness never asking for X to be saved.

https://claude.ai/code/session_01GtzT8KSUZyExkw51cMc2NW