### PR TITLE
discussions-digest: compact boot output (refs #152, vade-coo-memory#258)

### DIFF
--- a/scripts/discussions-digest.sh
+++ b/scripts/discussions-digest.sh
@@ -85,32 +85,19 @@ function humanAgo(t) {
   return Math.floor(s/86400) + "d ago";
 }
 
-console.log("───────────────────────────────────────────────────────────────");
-console.log("Boot check: vade-app org discussions");
-console.log("");
 if (recent.length === 0) {
-  console.log("No new discussions since " + cursor + ".");
+  console.log("Boot: vade-app discussions — no new since " + cursor + ".");
 } else {
-  console.log("New or updated since " + cursor + ":");
-  console.log("");
+  console.log("Boot: vade-app discussions, " + recent.length + " new/updated since " + cursor + ":");
   for (const n of recent) {
     const cat = (n.category || {}).name || "?";
     const author = (n.author || {}).login || "?";
-    console.log("  • [" + cat.toLowerCase() + "] " + n.title);
-    console.log("      " + n.url);
-    console.log("      updated " + humanAgo(Date.parse(n.updatedAt)) +
-                " · " + n.comments.totalCount + " comments · @" + author);
+    console.log("  #" + n.number + " [" + cat.toLowerCase() + "] " + n.title +
+                " (" + humanAgo(Date.parse(n.updatedAt)) + ", @" + author +
+                ", " + n.comments.totalCount + "c)");
   }
+  console.log("URLs: github.com/orgs/vade-app/discussions/<num>; norms: coo/agent-boot-discussions-check.md");
 }
-console.log("");
-console.log("Before you start work:");
-console.log("  • Skim titles. Read in full if it touches your current goals.");
-console.log("  • When in doubt, post in Q&A or Coordination. Asking is cheap.");
-console.log("  • One thread = one topic. Link issues and PRs liberally.");
-console.log("");
-console.log("All discussions: https://github.com/vade-app/vade-core/discussions");
-console.log("Posting norms:   vade-coo-memory/coo/agent-boot-discussions-check.md");
-console.log("───────────────────────────────────────────────────────────────");
 ' "$RESPONSE" "$CURSOR" && PARSE_OK=1
 
 if [ "$PARSE_OK" -eq 1 ]; then


### PR DESCRIPTION
## Summary

Implements the hook-output side of **option (2) — compress/project**
from vade-app/vade-coo-memory#325, on the vade-runtime substrate. Companion docs trim is at
[vade-app/vade-coo-memory#259](https://github.com/vade-app/vade-coo-memory/pull/259).

## What's in this PR

Compacts `scripts/discussions-digest.sh` boot output: per band-A in
`coo/_evidence/2026-04-28_transcript-bloat-audit/`, this hook
produced the largest single `hook_success` blob in boot context
(~1.8 KB / session).

- Drop the box-drawing decoration (─ banner lines).
- Inline per-item meta on a single line (was 4 lines: title / blank /
  URL / meta-line → 1 line: `#<num> [<cat>] <title> (<ago>, @<author>,
  <n>c)`).
- Replace the trailing "Before you start work" bulleted block (already
  in CLAUDE.md and `coo/agent-boot-discussions-check.md`) with a
  one-line URL+norms pointer.
- Drop per-item URLs: every discussion sits at
  `github.com/orgs/vade-app/discussions/<num>`. The pattern is named
  once at the bottom; the agent constructs URLs on need rather than
  paying the byte cost on every boot.

## Measured impact

| State | Bytes |
|---|---|
| Before (10 entries with full layout) | ~1,800 |
| After (10 entries, compact one-line) | ~1,121 |
| **Δ** | **−679 B / session** |

Combined with [#259](https://github.com/vade-app/vade-coo-memory/pull/259)'s
−7.8 KB on `nested_memory` + `skill_listing`: **~8.5 KB / session** total
trim.

## Behavior preserved

Same data fetched (10 most recent, same GraphQL query, same cursor
advancement, same graceful no-op on missing token / network failure).
Only stdout formatting differs.

## Pre-merge gating

- Diff review.
- Local smoke test (validates new format renders correctly with real
  GraphQL data):

  ```sh
  HOME=/tmp/digest-fakehome bash -c 'mkdir -p \$HOME/.vade/agent-state \
    && node -e "console.log(new Date(Date.now()-7*24*3600*1000).toISOString())" \
       > \$HOME/.vade/agent-state/discussions-cursor; \
    bash scripts/discussions-digest.sh'
  ```

  Expect ~1.1 KB output with 10 entries, one line each.

## Post-merge confirmation

A handoff comment will be posted on this PR with the post-merge
verification steps (per MEMO-2026-04-25-03 — this PR modifies a
SessionStart hook).

Refs vade-app/vade-coo-memory#325, vade-app/vade-coo-memory#258.
Companion: [vade-app/vade-coo-memory#259](https://github.com/vade-app/vade-coo-memory/pull/259).
Follow-up research issue: vade-app/vade-coo-memory#324.

https://claude.ai/code/session_01FPDAAuEgUXf2NeXAMGmpza