### PR TITLE
issue-comments: bounded gh wrapper + dispatch convention (#153)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,10 +30,14 @@ count justifies the cost of breaking references in `CLAUDE.md`,
 - `hooks-dispatch.sh` — central dispatcher resolving hook names to
   the canonical script via the five resolver rules (MEMO-2026-04-22-12).
 
-**Wrappers / shims (3)**
+**Wrappers / shims (4)**
 - `gh-coo-wrap.sh` — `gh` wrapper attributing writes to `vade-coo`.
 - `git-shim.sh` — git proxy + auth interceptor.
 - `git-push-with-fallback.sh` — push with HTTPS-proxy 403 fallback.
+- `issue-comments.sh` — bounded fetch of an issue comment thread
+  (compact projection, default 10 KB ceiling, `--full` escape hatch).
+  Substitute for unbounded `mcp__github__issue_read get_comments`
+  (vade-runtime#153, transcript-bloat-audit Tier 1).
 
 **Probes (2)**
 - `healthcheck.sh` — fast smoke-test of the bootstrap pipeline.

--- a/scripts/ci/test-issue-comments.sh
+++ b/scripts/ci/test-issue-comments.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# test-issue-comments: smoke-test scripts/issue-comments.sh.
+#
+# Strategy: install a mock `gh` binary that returns a canned JSON
+# array for the `api repos/.../issues/N/comments` call, then assert
+# the wrapper's outputs (default projection, --full passthrough,
+# --limit, --max-bytes truncation, footer messaging).
+#
+# Run: bash scripts/ci/test-issue-comments.sh
+# Exit: 0 if all assertions pass, non-zero otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/../issue-comments.sh"
+
+[ -x "$WRAPPER" ] || { echo "FAIL: wrapper not executable at $WRAPPER"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Fixture: 5 comments, mixed authors, varying body lengths. Two have
+# reactions; one has multi-line body to verify newline collapsing.
+cat > "$WORK/fixture.json" <<'EOF'
+[
+  {
+    "id": 1001,
+    "user": {"login": "alice"},
+    "created_at": "2026-04-20T10:00:00Z",
+    "body": "First comment. Short.",
+    "reactions": {"+1": 2, "heart": 1, "rocket": 0}
+  },
+  {
+    "id": 1002,
+    "user": {"login": "bob"},
+    "created_at": "2026-04-21T11:00:00Z",
+    "body": "Second comment with a very very very very very very very very very very very very very very very very very long body that exceeds 120 chars by a comfortable margin so we can verify the truncation suffix.",
+    "reactions": {}
+  },
+  {
+    "id": 1003,
+    "user": {"login": "alice"},
+    "created_at": "2026-04-22T12:00:00Z",
+    "body": "Multi\nline\nbody\nshould\ncollapse",
+    "reactions": {"laugh": 3}
+  },
+  {
+    "id": 1004,
+    "user": {"login": "carol"},
+    "created_at": "2026-04-23T13:00:00Z",
+    "body": "Fourth.",
+    "reactions": {}
+  },
+  {
+    "id": 1005,
+    "user": {"login": "dave"},
+    "created_at": "2026-04-24T14:00:00Z",
+    "body": "Fifth and final.",
+    "reactions": {}
+  }
+]
+EOF
+
+# Mock gh: respond to `api repos/.../comments...` by dumping the
+# fixture. Anything else exits non-zero so we catch unexpected calls.
+cat > "$WORK/gh" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "api" ] && [[ "\$2" == repos/*/issues/*/comments* ]]; then
+  cat "$WORK/fixture.json"
+  exit 0
+fi
+echo "mock gh: unexpected call: \$*" >&2
+exit 99
+EOF
+chmod 0755 "$WORK/gh"
+
+# Point the wrapper at the mock via COO_GH_REAL.
+export COO_GH_REAL="$WORK/gh"
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS+1))
+    printf '  PASS  %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+    printf '         expected to contain: %s\n' "$needle"
+    printf '         got:\n'
+    printf '%s\n' "$haystack" | sed 's/^/           /'
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+    printf '         expected NOT to contain: %s\n' "$needle"
+    printf '         got:\n'
+    printf '%s\n' "$haystack" | sed 's/^/           /'
+  else
+    PASS=$((PASS+1))
+    printf '  PASS  %s\n' "$name"
+  fi
+}
+
+assert_le() {
+  local name="$1" actual="$2" max="$3"
+  if [ "$actual" -le "$max" ]; then
+    PASS=$((PASS+1))
+    printf '  PASS  %s (%d <= %d)\n' "$name" "$actual" "$max"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name")
+    printf '  FAIL  %s (%d > %d)\n' "$name" "$actual" "$max"
+  fi
+}
+
+# ---- TEST 1: default projection contains all 5 comments ----
+out="$("$WRAPPER" foo/bar 1)"
+assert_contains "default projection: comment 1 header" "$out" "## comment 1 (alice, 2026-04-20)"
+assert_contains "default projection: comment 5 header" "$out" "## comment 5 (dave, 2026-04-24)"
+assert_contains "default projection: footer present" "$out" "5 of 5 comments shown"
+
+# ---- TEST 2: reactions sum is rendered ----
+assert_contains "reactions: alice +3 (2 thumbs + 1 heart)" "$out" "[+3 reactions]"
+assert_contains "reactions: laugh counts" "$out" "[+3 reactions]"
+
+# ---- TEST 3: multi-line body collapses to ' / ' ----
+assert_contains "multi-line collapses" "$out" "Multi / line / body / should / collapse"
+
+# ---- TEST 4: long body gets truncated with ... suffix ----
+assert_contains "long body has ellipsis" "$out" "..."
+assert_not_contains "long body does NOT contain final phrase" "$out" "comfortable margin"
+
+# ---- TEST 5: byte-ceiling default keeps result well under 10 KB ----
+n="$(printf '%s' "$out" | wc -c)"
+assert_le "default output under 10 KB" "$n" 10240
+
+# ---- TEST 6: --full returns the raw JSON unmodified ----
+out_full="$("$WRAPPER" foo/bar 1 --full)"
+assert_contains "--full has raw JSON marker" "$out_full" '"id": 1001'
+assert_contains "--full has full long body" "$out_full" "comfortable margin"
+assert_not_contains "--full has no projection footer" "$out_full" "comments shown"
+
+# ---- TEST 7: --limit 2 returns the most recent 2 comments ----
+out_limit="$("$WRAPPER" foo/bar 1 --limit 2)"
+assert_contains "--limit: includes comment 4" "$out_limit" "carol, 2026-04-23"
+assert_contains "--limit: includes comment 5" "$out_limit" "dave, 2026-04-24"
+assert_not_contains "--limit: excludes comment 1" "$out_limit" "alice, 2026-04-20"
+assert_contains "--limit: footer reports limit" "$out_limit" "limited to 2 of 5"
+
+# ---- TEST 8: --max-bytes truncates and reports ----
+out_small="$("$WRAPPER" foo/bar 1 --max-bytes 200)"
+assert_contains "--max-bytes: truncated footer" "$out_small" "truncated to"
+assert_contains "--max-bytes: footer says 'pass --full'" "$out_small" "pass --full to retrieve all"
+
+# ---- TEST 9: --body-chars overrides projection length ----
+out_long="$("$WRAPPER" foo/bar 1 --body-chars 200)"
+assert_contains "--body-chars 200: long body present" "$out_long" "comfortable margin"
+
+# ---- TEST 10: bad arg (non-numeric issue) exits 2 ----
+ec=0
+"$WRAPPER" foo/bar abc >/dev/null 2>&1 || ec=$?
+if [ "$ec" = "2" ]; then
+  PASS=$((PASS+1))
+  printf '  PASS  bad issue number: exit 2\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("bad issue number exit code")
+  printf '  FAIL  bad issue number: exit %s, expected 2\n' "$ec"
+fi
+
+# ---- TEST 11: missing repo exits 2 ----
+ec=0
+"$WRAPPER" 1 >/dev/null 2>&1 || ec=$?
+if [ "$ec" = "2" ]; then
+  PASS=$((PASS+1))
+  printf '  PASS  missing args: exit 2\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("missing args exit code")
+  printf '  FAIL  missing args: exit %s, expected 2\n' "$ec"
+fi
+
+printf '\n'
+printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed tests:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/issue-comments.sh
+++ b/scripts/issue-comments.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# issue-comments: bounded fetch of an issue's comment thread.
+#
+# Substitute for `mcp__github__issue_read method=get_comments`, which
+# is unbounded — vade-app/vade-agent-logs#64 returns ~30 KB on a
+# single read across multiple analyst groups in the
+# 2026-04-28 transcript-bloat-audit. Substrate fix: vade-runtime#153
+# (Tier 1 close-out of vade-coo-memory#258).
+#
+# Default behavior is a compact projection of the form
+#
+#   ## comment N (login, ISO-date) [+R reactions]
+#   <first 120 chars of body, single-line>...
+#   <repo>#<n> comment <id>
+#
+# repeated up to a soft byte ceiling (default 10240 bytes). Output
+# closes with a footer that reports truncation:
+#
+#   # truncated to K of M comments — pass --full to retrieve all
+#
+# When --full is passed, the entire raw thread is dumped (no
+# projection, no ceiling) — caller is asserting they need it.
+#
+# Usage:
+#   bash scripts/issue-comments.sh <owner/repo> <issue-number>
+#   bash scripts/issue-comments.sh <owner/repo> <issue-number> --full
+#   bash scripts/issue-comments.sh <owner/repo> <issue-number> --limit 5
+#   bash scripts/issue-comments.sh <owner/repo> <issue-number> --since 2026-04-20
+#
+# Authentication: relies on GH_TOKEN being set by the caller (the
+# canonical pattern is `GH_TOKEN="$GITHUB_MCP_PAT"`).
+#
+# Exit codes:
+#   0  success
+#   2  argument error
+#   *  upstream gh / jq failure (propagated)
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: issue-comments.sh <owner/repo> <issue-number> [options]
+
+Bounded fetch of an issue comment thread; default-truncates to a soft
+10 KB ceiling with a compact projection.
+
+Options:
+  --full              Return the full raw thread (no projection, no ceiling).
+  --limit N           Cap the number of comments to N (most recent).
+  --since ISO8601     Only return comments since this date (RFC 3339).
+  --max-bytes N       Override the default 10240-byte soft ceiling.
+  --body-chars N      Per-comment body excerpt length (default 120).
+  -h, --help          Print this message.
+
+Examples:
+  issue-comments.sh vade-app/vade-agent-logs 64
+  issue-comments.sh vade-app/vade-agent-logs 64 --full
+  issue-comments.sh vade-app/vade-agent-logs 64 --limit 3
+EOF
+}
+
+REPO=""
+NUM=""
+FULL=0
+LIMIT=""
+SINCE=""
+MAX_BYTES=10240
+BODY_CHARS=120
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)        usage; exit 0 ;;
+    --full)           FULL=1; shift ;;
+    --limit)          LIMIT="$2"; shift 2 ;;
+    --since)          SINCE="$2"; shift 2 ;;
+    --max-bytes)      MAX_BYTES="$2"; shift 2 ;;
+    --body-chars)     BODY_CHARS="$2"; shift 2 ;;
+    --)               shift; break ;;
+    -*)               echo "issue-comments: unknown flag: $1" >&2; usage >&2; exit 2 ;;
+    *)
+      if [ -z "$REPO" ]; then REPO="$1"
+      elif [ -z "$NUM" ]; then NUM="$1"
+      else echo "issue-comments: unexpected positional: $1" >&2; exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$REPO" ] || [ -z "$NUM" ]; then
+  usage >&2
+  exit 2
+fi
+
+case "$REPO" in
+  */*) ;;
+  *) echo "issue-comments: <owner/repo> must contain a slash, got: $REPO" >&2; exit 2 ;;
+esac
+case "$NUM" in
+  ''|*[!0-9]*) echo "issue-comments: <issue-number> must be numeric, got: $NUM" >&2; exit 2 ;;
+esac
+
+GH="${COO_GH_REAL:-gh}"
+command -v "$GH" >/dev/null 2>&1 || { echo "issue-comments: $GH not found on PATH" >&2; exit 2; }
+
+API_PATH="repos/${REPO}/issues/${NUM}/comments?per_page=100"
+if [ -n "$SINCE" ]; then
+  API_PATH="${API_PATH}&since=${SINCE}"
+fi
+
+# Fetch raw JSON array. --paginate concatenates pages into a single
+# array via gh's built-in handling.
+RAW="$("$GH" api "$API_PATH" --paginate)"
+
+if [ "$FULL" -eq 1 ]; then
+  printf '%s\n' "$RAW"
+  exit 0
+fi
+
+# Apply LIMIT (most recent N) post-fetch. The jq filter:
+#   * trims body to BODY_CHARS, single-lines it (collapse newlines to
+#     ' / '), strips trailing whitespace
+#   * sums non-zero reactions
+#   * emits one paragraph per comment (terminated by a blank line)
+#   * emits a final '__META total=<n> shown=<m>' line
+#
+# Output is text, not JSON, because we're optimizing for byte-cost
+# in a model context window.
+
+LIMIT_EXPR=".[-${LIMIT}:]"
+[ -z "$LIMIT" ] && LIMIT_EXPR="."
+
+PROJECTION="$(printf '%s' "$RAW" | jq -r \
+  --argjson body_chars "$BODY_CHARS" \
+  --arg repo "$REPO" \
+  --arg num "$NUM" "
+  ${LIMIT_EXPR} as \$slice
+  | length as \$total
+  | (\$slice | length) as \$shown
+  | (\$slice | to_entries[] |
+      .key as \$i |
+      .value as \$c |
+      (\$c.reactions // {}) as \$r |
+      (((\$r.\"+1\"//0) + (\$r.\"-1\"//0) + (\$r.laugh//0) + (\$r.confused//0)
+        + (\$r.heart//0) + (\$r.hooray//0) + (\$r.rocket//0) + (\$r.eyes//0))) as \$rsum |
+      (\$c.body // \"\" | gsub(\"\\\\r\"; \"\") | gsub(\"\\\\n+\"; \" / \") | gsub(\"  +\"; \" \") | .[0:\$body_chars]) as \$snippet |
+      \"## comment \(\$i + 1) (\(\$c.user.login // \"?\"), \(\$c.created_at[0:10]))\(if \$rsum > 0 then \" [+\(\$rsum) reactions]\" else \"\" end)\\n\(\$snippet)\(if (\$c.body // \"\" | length) > \$body_chars then \"...\" else \"\" end)\\n\(\$repo)#\(\$num) comment \(\$c.id)\\n\"
+    ),
+    \"__META total=\(\$total) shown=\(\$shown)\"
+")"
+
+# Split off the trailer (last line is the META marker).
+META="$(printf '%s' "$PROJECTION" | tail -n 1)"
+# Body is everything except the final META line.
+BODY="$(printf '%s\n' "$PROJECTION" | sed '$d')"
+TOTAL="$(printf '%s' "$META" | sed -n 's/^__META total=\([0-9]*\) shown=.*$/\1/p')"
+SHOWN_LIMIT="$(printf '%s' "$META" | sed -n 's/^__META total=[0-9]* shown=\([0-9]*\)$/\1/p')"
+TOTAL="${TOTAL:-0}"
+SHOWN_LIMIT="${SHOWN_LIMIT:-0}"
+
+# Apply byte ceiling: walk projection paragraph-by-paragraph and stop
+# when the cumulative size would exceed MAX_BYTES.
+KEPT_FILE="$(mktemp)"
+OUT="$(printf '%s' "$BODY" | awk -v max="$MAX_BYTES" -v keptfile="$KEPT_FILE" '
+  BEGIN { RS = ""; buf = ""; total = 0; kept = 0 }
+  {
+    block = $0 "\n\n"
+    if (total + length(block) > max && kept > 0) { exit }
+    buf = buf block
+    total += length(block)
+    kept++
+  }
+  END {
+    printf "%s", buf
+    print kept > keptfile
+  }
+')"
+KEPT="$(cat "$KEPT_FILE")"
+rm -f "$KEPT_FILE"
+
+printf '%s\n' "$OUT"
+
+# Footer: report truncation if either the byte ceiling or the --limit
+# dropped comments. Always emit something so the reader knows the
+# default-truncate is in effect.
+if [ "$KEPT" -lt "$SHOWN_LIMIT" ]; then
+  printf '# truncated to %d of %d comments — pass --full to retrieve all\n' "$KEPT" "$TOTAL"
+elif [ "$SHOWN_LIMIT" -lt "$TOTAL" ]; then
+  printf '# limited to %d of %d comments (--limit) — pass --full to retrieve all\n' "$SHOWN_LIMIT" "$TOTAL"
+else
+  printf '# %d of %d comments shown (default projection — pass --full for raw bodies)\n' "$KEPT" "$TOTAL"
+fi


### PR DESCRIPTION
## Summary

Bounds the byte cost of fetching long issue comment threads, the
worst-offender pattern flagged by the 2026-04-28 transcript-bloat-audit
(vade-coo-memory#258, Tier 1).

`mcp__github__issue_read` with `method=get_comments` returns the
**entire** thread unbounded. Concrete evidence in the audit
synthesis:

- `vade-app/vade-agent-logs#64` get_comments → 32,061 / 30,618 / 31,268
  bytes across 3 of 5 analyst groups (need was usually ≤2 KB).
- `mcp__github__issue_read` corpus avg per-call cost ≈12,118 bytes,
  ~10× `pull_request_read`'s ~1,259.

The MCP wrapper is harness-injected (Anthropic-side) and not editable
from this repo, so the substrate fix is a wrapper script + agent
dispatch convention rather than a wrapper-side fix. The discipline
cue lands in `vade-coo-memory/CLAUDE.md` (separate PR, see footer).

## Approach

- `scripts/issue-comments.sh` — bounded fetch with a compact projection
  (`[author, date, first_120_chars, reaction_sum]`) and a soft 10 KB
  ceiling. Footer line is **always** present:
    - `# truncated to K of M comments — pass --full to retrieve all`
    - `# limited to N of M comments (--limit) — pass --full to retrieve all`
    - `# K of M comments shown (default projection — pass --full for raw bodies)`
- Escape hatches: `--full` (raw paginated JSON, no ceiling), `--limit N`,
  `--since YYYY-MM-DD`, `--max-bytes N`, `--body-chars N`.
- `scripts/ci/test-issue-comments.sh` — 21 assertions over a mocked
  `gh` binary (mirrors the `test-gh-coo-wrap.sh` style).
- `scripts/README.md` inventory updated (Wrappers/shims 3→4).

## Measured byte savings

Reference call: `vade-app/vade-agent-logs#64` (6 comments).

| Mode | Bytes | Δ vs raw |
| --- | ---: | ---: |
| Raw `gh api ... --paginate` | 49,888 | (baseline) |
| `issue-comments.sh` default | 1,332 | **−97.3%** (≈37×) |
| `issue-comments.sh --full` | 49,889 | parity |
| `issue-comments.sh --limit 2` | 543 | −98.9% |

Default output well under the 10 KB target.

## Coordination

- No `.mcp.json` modifications (Track B's #154 owns that file). Stayed
  in `scripts/`.
- No hook touches (Track C's #155 owns those). Not boot-impacting.
- Slim CLAUDE.md cue lands in companion PR on `vade-app/vade-coo-memory`
  (one-line pointer to `coo/operations/issue-comments-bounded.md`).

## Test plan

- [x] `bash scripts/ci/test-issue-comments.sh` → 21 / 21 pass
- [x] Live reference call: `GH_TOKEN="$GITHUB_MCP_PAT" bash scripts/issue-comments.sh vade-app/vade-agent-logs 64 | wc -c` → 1332
- [x] `--full` parity: `... --full | wc -c` → 49889 (matches raw `gh api --paginate`)
- [x] Truncation footer visible on `--max-bytes 600`
- [x] Bad-arg paths exit 2

Closes vade-app/vade-runtime#153
Refs vade-app/vade-coo-memory#258

https://claude.ai/code/session_01Y28MnZRYqpsSJvnpzz838n