### PR TITLE
mcp: add 1Password MCP server (eliminate rotated-PAT restart class) (#164)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -18,6 +18,16 @@
       "env": {
         "AGENTMAIL_API_KEY": "${AGENTMAIL_API_KEY}"
       }
+    },
+    "1password": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@takescake/1password-mcp@2.4.2"
+      ],
+      "env": {
+        "OP_SERVICE_ACCOUNT_TOKEN": "${OP_SERVICE_ACCOUNT_TOKEN}"
+      }
     }
   }
 }

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -179,6 +179,24 @@ else
   log "Warning: mem0-mcp-server install failed at build time; first session will boot with Mem0 MCP dark."
 fi
 
+# Pre-fetch the 1Password MCP server (@takescake/1password-mcp) into the
+# global npm cache so first-session `npx -y` resolves offline. Same
+# snapshot-persistence rationale as op + gh + mem0 — paying the npm
+# fetch cost at build time keeps the SessionStart MCP spawn off the
+# egress proxy. The MCP exists to close the rotated-PAT → restart
+# failure class (vade-runtime#164): when 1Password rotates a credential
+# mid-session, an in-process MCP path can re-read the secret without
+# the harness restart that the cached `op` CLI bootstrap requires.
+# Read-only is enforced by the COO service account's vault permissions
+# (1Password's own recommendation per their MCP security guidance);
+# .mcp.json scopes credentials to OP_SERVICE_ACCOUNT_TOKEN only.
+if npm install -g "@takescake/1password-mcp@2.4.2" --no-audit --no-fund >/dev/null 2>&1; then
+  build_log_record OK "cloud-setup: @takescake/1password-mcp installed at build time"
+else
+  build_log_record WARN "cloud-setup: @takescake/1password-mcp install failed at build time; first-session npx will fetch on demand"
+  log "Warning: @takescake/1password-mcp install failed at build time; first session will pay an npx-on-demand fetch."
+fi
+
 # COO identity bootstrap runs only when OP_SERVICE_ACCOUNT_TOKEN is set
 # in the cloud environment config. Non-fatal on failure — the base VADE
 # env should still come up even if 1Password is unreachable.


### PR DESCRIPTION
## Summary

Adds `@takescake/1password-mcp@2.4.2` to `.mcp.json` so an in-process MCP path can re-read 1Password secrets when they rotate mid-session — closing the failure class where the `op` CLI's cached bootstrap (single-shot at `coo-bootstrap`) leaves Claude Code holding a stale `GITHUB_MCP_PAT` until a fresh-container restart.

Closes #164.

## Server choice

| Option | npx? | OP_SERVICE_ACCOUNT_TOKEN? | Read-only flag? | Verdict |
| --- | --- | --- | --- | --- |
| `@takescake/1password-mcp` | yes | yes | no runtime flag, but service-account vault permissions enforce it | **chosen** |
| `goodwokdev/op-mcp` | no (`cargo install`) | unclear | exposes 66 tools incl. user/vault management | rejected — too broad, build-from-source |
| `dkvdm/onepassword-mcp-server` | unclear | unverified | n/a | rejected — repo unreachable / 404 at evaluation time |

Rationale (≤2 sentences): `@takescake/1password-mcp` is the only mature npm-published option that natively reads `OP_SERVICE_ACCOUNT_TOKEN` and installs via `npx -y` (matches the existing `agentmail-mcp` pattern, no cargo / build-from-source). Read-only enforcement is delegated to the COO service account's vault-level permissions per 1Password's own MCP security guidance — the package itself doesn't expose a runtime read-only switch, so vault-side permissioning is the durable gate.

## Files changed

- `.mcp.json` — added `1password` server entry; credentials scoped to `${OP_SERVICE_ACCOUNT_TOKEN}` only.
- `scripts/cloud-setup.sh` — added `npm install -g @takescake/1password-mcp@2.4.2` block alongside the existing op/gh/mem0 install steps so the snapshot carries the package and first SessionStart spawn doesn't hit the egress proxy.

## Test plan

- [x] `.mcp.json` parses as valid JSON (`python3 -m json.tool`).
- [x] `bash -n scripts/cloud-setup.sh` returns 0.
- [x] No write paths granted in `.mcp.json` beyond `OP_SERVICE_ACCOUNT_TOKEN` env injection; no path arguments passed at the MCP layer (vault-side permissioning is the gate).
- [ ] Fresh-container smoke test deferred per MEMO-2026-04-25-03 — see handoff prompt comment.

## Boot impact

YES. Touches `.mcp.json` and `scripts/cloud-setup.sh`. Handoff prompt with pre-merge gating + post-merge confirmation steps posted as a separate comment (per MEMO-2026-04-25-03).

https://claude.ai/code/session_011kVUN36ZGfhqbJTtU7gsyY