### PR TITLE
F4: SHA allowlist for f4-marker workflow race past fast merges

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -571,6 +571,18 @@ fi
 # Every commit since F_CUTOFF in $F_REPO must resolve to vade-coo
 # (author email coo@vade-app.dev) or carry 'ven-human-action:' in body.
 # Silent venpopov-authored commits on coo-scope paths are F4-relevant.
+#
+# F4_ALLOWLIST_SHA — explicit per-commit carve-outs where the marker
+# was present in the PR body at merge time but the f4-marker workflow
+# raced past a fast manual merge, leaving the commit body without the
+# marker. Each entry must cite the originating PR + tracking issue.
+# Tracked structurally at vade-coo-memory#271.
+F4_ALLOWLIST_SHA=(
+  # 0fd421a198 — vade-coo-memory#262 "add insight analysis" (Ven-
+  # authored doc-add); PR body carries ven-human-action marker but
+  # the merge stripped it. See vade-coo-memory#271 for the race fix.
+  "0fd421a198"
+)
 if [ -d "$F_REPO/.git" ] && check_cmd git; then
   f4_total=0
   f4_bad=()
@@ -586,6 +598,11 @@ if [ -d "$F_REPO/.git" ] && check_cmd git; then
     if printf '%s' "$body" | grep -q 'ven-human-action:'; then
       continue
     fi
+    allowed=0
+    for allow_sha in "${F4_ALLOWLIST_SHA[@]}"; do
+      case "$sha" in "$allow_sha"*) allowed=1; break ;; esac
+    done
+    [ "$allowed" -eq 1 ] && continue
     f4_bad+=("${sha:0:10}($email)")
   done < <(git -C "$F_REPO" log --since="$F_CUTOFF_GIT" --format='%H|%ae|%B%x00' 2>/dev/null | awk 'BEGIN{RS="\0"} { sub(/^\n/, ""); if (NF) { gsub(/\n/,"\\n"); print } }')
 


### PR DESCRIPTION
Surgical unblock for the working-milestone tag gate (MEMO-2026-04-24-11). vade-coo-memory#262 ("add insight analysis") was merged faster than the f4-marker workflow could inject `ven-human-action:` into the PR body, so the merge commit body lacks the marker even though the live PR body now carries it. F4 flags `0fd421a198` on every integrity-check run.

This PR adds a per-commit SHA allowlist to F4 with explicit citation. Each entry must reference the originating PR + tracking issue. The structural race condition is tracked at vade-coo-memory#271 (three candidate fixes: branch-protection gate, F4 PR-body fallback, commit-side marker injection).

## Verification

```
pre-edit  : summary.ok=false, F4=1/50 mismatch (0fd421a198)
post-edit : summary.ok=true,  F4=50/50 pass
```

## Refs

- vade-coo-memory#268 — Briefing 007 disposition (where the F4 hit surfaced)
- vade-coo-memory#271 — f4-marker race condition tracker

## Post-merge confirmation

After merge, in a fresh container:

1. `bash "$HOME/.claude/vade-hooks/dispatch.sh" session-start-sync`
2. Inspect `${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state}/integrity-check.json`; expect `summary.ok=true`.
3. Optionally run `/tag-milestone <nickname>` per MEMO-2026-04-24-11.

https://claude.ai/code/session_01L9BrMpY5ik8uAxWbfuvWBp