### PR TITLE
fix(hooks): bind session-end pipeline to SessionEnd, not Stop

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,7 +41,7 @@
         ]
       }
     ],
-    "Stop": [
+    "SessionEnd": [
       {
         "hooks": [
           {

--- a/scripts/hooks-dispatch.sh
+++ b/scripts/hooks-dispatch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SessionStart/Stop hook dispatcher.
+# SessionStart/SessionEnd hook dispatcher.
 #
 # Installed as $HOME/.claude/vade-hooks/dispatch.sh (symlink, maintained
 # by sync_claude_config → ensure_hooks_dispatch_shim). Every hook command


### PR DESCRIPTION
Closes #172.

## Summary

Move `session-end-transcript-export`, `session-lifecycle --end`, and `persist-permissions` from the `Stop` hook event to `SessionEnd` in `.claude/settings.json`. `Stop` fires after every assistant turn; `SessionEnd` fires once at actual session termination — which is what these hooks were always meant to wire to.

## Why

Surfaced today during the W18b weekly run. Three downstream symptoms, all rooted in the per-turn refire:

1. **`ciphertext_integrity_mismatch` on `transcript-analyzer` dispatches.** Each turn re-uploads a now-larger ciphertext to the same R2 key with a new sha256. Meanwhile only one of the many per-fire `meta.json` snapshots typically lands on `main`. The sha256 in `main`'s meta.json no longer matches R2's object, and the analyzer hard-stops. Empirical: 6 of 8 sessions sampled today failed; 2 succeeded (both single-fire short sessions).

2. **Auto-commit double-landing.** 23 of 24 open PRs on `vade-agent-logs` cleared today as redundant duplicates (file content identical to main). Same root cause: the per-turn refire commits a `meta.json` and opens a PR per fire.

3. **SOP-MEM-001 §5 reminder block injected per turn** — the `session-lifecycle --end` script's stdout becomes `additionalContext` on every Stop event, bloating agent context and habituating agents to ignore the reminder. The W18b briefing's `skipped-session-log-write` finding (12 of 25 sessions) is partly an artifact of this design.

PR #139 evidence on `vade-agent-logs` independently confirms the multi-fire signature: two `meta.json` versions for the same session differing in `events_processed` (367 vs 185) and `ciphertext_sha256`.

## Diff scope

```
 .claude/settings.json          | 2 +-   ("Stop" -> "SessionEnd")
 scripts/hooks-dispatch.sh      | 2 +-   (docstring header, cosmetic)
 2 files changed, 2 insertions(+), 2 deletions(-)
```

The dispatch shim is event-agnostic (routes by argv, not by Claude Code event name) — no script changes required. Docstring updated for consistency.

## Caveats

- Removes the per-turn `additionalContext` reminder. If a pre-session-end discipline reminder is still wanted, the right channel is `UserPromptSubmit` or an explicit `/end-session` skill (proposed as W18b §5 item 1).
- If `persist-permissions` actually requires per-turn flushes, this PR over-rotates it; the conservative split would keep that one on `Stop`. Mark for review.
- Existing meta.json files on `main` whose ciphertext_sha256 doesn't match R2 are not retroactively repaired by this fix. Either accept partial coverage on the historical corpus, or backfill from local `~/.claude/projects/<slug>/<id>.jsonl` where still on disk.

## Test plan

- [x] JSON validates (`python3 -c 'json.load(open(...))'`)
- [x] Diff is minimal — no script behavior change, no permission/env changes
- [ ] Bootstrap regression CI passes (this PR touches `.claude/settings.json`, so the workflow auto-fires)
- [ ] Post-merge: a fresh-cloud session shows the §5 reminder fires once (not per turn) and `vade-agent-logs/transcripts/<...>.meta.json` is written exactly once per session

## Pre-merge gating

Bootstrap regression CI green.

## Post-merge confirmation

Fresh container session:
1. Run a multi-turn session (≥3 assistant turns).
2. After session ends, check `vade-agent-logs/transcripts/YYYY/MM/DD/` — exactly one meta.json per session_id; commit history shows one auto-commit, not many.
3. Check that no SOP-MEM-001 §5 reminder block appeared in the agent's user-facing context during the session.
4. Re-run `transcript-analyzer` against the new session_id — should succeed (no `ciphertext_integrity_mismatch`).

https://claude.ai/code/session_01LzYHaZjejTMqHJzfH4rpnq