### PR TITLE
settings.json: allow all agentmail MCP tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -215,7 +215,10 @@
       "Bash(flyctl logs *)",
       "mcp__vade-canvas__getCanvasState",
       "Bash(xargs -0 cat)",
-      "mcp__claude_ai_Mem0__add_memory"
+      "mcp__claude_ai_Mem0__add_memory",
+      "mcp__agentmail__get_inbox",
+      "mcp__agentmail__list_inboxes",
+      "mcp__agentmail__list_threads"
     ],
     "deny": [
       "Bash(rm -rf /:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -216,7 +216,10 @@
       "mcp__vade-canvas__getCanvasState",
       "Bash(xargs -0 cat)",
       "mcp__claude_ai_Mem0__add_memory",
-      "mcp__agentmail__*"
+      "mcp__agentmail__*",
+      "mcp__agentmail__get_inbox",
+      "mcp__agentmail__list_inboxes",
+      "mcp__agentmail__list_threads"
     ],
     "deny": [
       "Bash(rm -rf /:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -216,9 +216,7 @@
       "mcp__vade-canvas__getCanvasState",
       "Bash(xargs -0 cat)",
       "mcp__claude_ai_Mem0__add_memory",
-      "mcp__agentmail__get_inbox",
-      "mcp__agentmail__list_inboxes",
-      "mcp__agentmail__list_threads"
+      "mcp__agentmail__*"
     ],
     "deny": [
       "Bash(rm -rf /:*)",


### PR DESCRIPTION
## Summary
- Replace three explicit allow entries (`mcp__agentmail__get_inbox`, `mcp__agentmail__list_inboxes`, `mcp__agentmail__list_threads`) with the wildcard `mcp__agentmail__*`.
- Ven archived ~500 overflow GitHub-notification emails from `vade-coo@agentmail.to` and turned the upstream notifications off; he then asked to always allow AgentMail operations going forward.
- Wildcard covers reads + writes (drafts, send/reply/forward, label updates, attachments) without per-tool prompts. Inbox is already scoped to a single agent inbox, so blast radius is contained.

## Test plan
- [x] Wildcard pattern is in the documented permission rule syntax (matches `mcp__agentmail__update_message`, `mcp__agentmail__send_message`, etc.).
- [ ] Next session: confirm `~/.claude/settings.json` synced from this file picks up the wildcard.

https://claude.ai/code/session_015vBKX4kzLQW8L3YTLaYDYw