### PR TITLE
integrity-check F3: accept *_companion.md as transcript-equivalent

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -537,8 +537,13 @@ fi
 
 # ── F3 — Essay companion invariant ───────────────────────────
 # Every coo/foundations/YYYY-MM-DD_*.md dated since F_CUTOFF (excluding
-# _transcript and _agent-reports files) must have a matching
-# YYYY-MM-DD_transcript.md companion in the same directory.
+# _transcript, _companion, and _agent-reports files) must have a matching
+# companion: either YYYY-MM-DD_transcript.md (single-session form) or any
+# YYYY-MM-DD_*_companion.md / YYYY-MM-DD_*-companion.md (multi-instance /
+# protocol-substrate form, e.g. coo/foundations/2026-04-28_letter-to-
+# anthropic-companion.md). Either satisfies the obligation; the companion
+# variant carries the same record-of-reasoning role for artifacts that
+# weren't authored in a single session.
 if [ -d "$F_REPO/coo/foundations" ]; then
   f3_total=0
   f3_bad=()
@@ -548,10 +553,20 @@ if [ -d "$F_REPO/coo/foundations" ]; then
     # String comparison on ISO dates is safe; bash [[ ]] supports it.
     [ "$essay_date" \< "$F_CUTOFF" ] && continue
     case "$essay" in
-      *_transcript.md|*_agent-reports*) continue ;;
+      *_transcript.md|*_companion.md|*-companion.md|*_agent-reports*) continue ;;
     esac
     f3_total=$((f3_total + 1))
-    if [ ! -f "$F_REPO/coo/foundations/${essay_date}_transcript.md" ]; then
+    has_companion=0
+    if [ -f "$F_REPO/coo/foundations/${essay_date}_transcript.md" ]; then
+      has_companion=1
+    else
+      # Accept any same-date *_companion.md or *-companion.md as transcript-equivalent.
+      for c in "$F_REPO/coo/foundations/${essay_date}"_*_companion.md \
+               "$F_REPO/coo/foundations/${essay_date}"_*-companion.md; do
+        [ -f "$c" ] && { has_companion=1; break; }
+      done
+    fi
+    if [ "$has_companion" -eq 0 ]; then
       f3_bad+=("$essay")
     fi
   done < <(ls -1 "$F_REPO/coo/foundations/" 2>/dev/null | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}_')


### PR DESCRIPTION
## Summary

Fixes the F3 false-positive flagged on `coo/foundations/2026-04-28_letter-to-anthropic.md` and `coo/foundations/2026-04-28_letter-to-anthropic-companion.md`. Context: vade-coo-memory PR #291 §F3 row.

F3 was hard-coded to the single-session naming convention \`YYYY-MM-DD_transcript.md\`, but the v3 letter-to-Anthropic arc was multi-instance authored across five run-IDs and three stages. That essay's substrate-of-reasoning is recorded in \`2026-04-28_letter-to-anthropic-companion.md\` (the protocol-substrate / discussion-record companion form), which serves the same role a transcript would for a single-session essay.

This change canonizes the companion convention as a transcript-equivalent for F3:

- Accept either \`\${date}_transcript.md\` **or** \`\${date}_*_companion.md\` / \`\${date}_*-companion.md\` as the satisfying companion.
- Exclude \`*_companion.md\` and \`*-companion.md\` from the essay-needing-transcript set (so the companion file isn't itself flagged as a stand-alone essay missing its own transcript).
- Update the comment block above F3 to document the dual convention.

The CB-002 obligation (\"every essay earns a companion transcript\") is unchanged — the substrate-of-reasoning record is still required. F3 now recognizes both forms it can take.

## Test plan

- [x] Run \`bash scripts/integrity-check.sh\` against the live vade-coo-memory checkout.
  - Before: \`F3 = false; missing transcript for: 2026-04-28_letter-to-anthropic-companion.md, 2026-04-28_letter-to-anthropic.md\`
  - After: \`F3 = true; 4/4 post-cutoff essays have transcript companion\`
- [x] Other post-cutoff essays still pass (04-22 we-can-claim-a-record, 04-24 revising-my-own-core-document, 04-26 mind-kind, 04-28 letter-to-anthropic) — all four counted.
- [ ] Bootstrap-regression CI workflow passes.

## Related

- Surfaces from vade-coo-memory PR #291 §\"Pre-merge gating — integrity-check at retrospective draft time\".
- F1 has its own separate fix at vade-runtime#179 (regex hyphenated-form citation update); not in scope here.

https://claude.ai/code/session_01HMCP5S5z6BNKR6DEF2Rg9M