### PR TITLE
session-end-transcript-export: detach via setsid -f to survive hook teardown (closes #181)

### DIFF
--- a/scripts/ci/test-transcript-export.py
+++ b/scripts/ci/test-transcript-export.py
@@ -142,14 +142,34 @@ def main() -> int:
         if result.returncode != 0:
             fail(f"hook returned rc={result.returncode}; stderr:\n{result.stderr}")
 
+        # The wrapper detaches the Python child via `setsid -f` so it can
+        # survive harness teardown under CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+        # (vade-runtime#181 / #182). The sidecar is written asynchronously
+        # after the wrapper returns. Poll for up to 60s; the synthetic jsonl
+        # is small (~4 events) so under normal conditions the export
+        # completes in 1–2s.
         date_path = f"{today.year:04d}/{today.month:02d}/{today.day:02d}"
         sidecar = agent_logs / "transcripts" / date_path / f"{sid}.meta.json"
         err = agent_logs / "transcripts" / date_path / f"{sid}.export-error.txt"
+        import time
+        deadline = time.time() + 60.0
+        while time.time() < deadline:
+            if err.is_file():
+                fail(f"unexpected export-error.txt:\n{err.read_text()[:1000]}")
+            if sidecar.is_file():
+                break
+            time.sleep(0.25)
         if err.is_file():
             fail(f"unexpected export-error.txt:\n{err.read_text()[:1000]}")
         if not sidecar.is_file():
             tree = list((agent_logs / "transcripts").rglob("*"))
-            fail(f"sidecar not at {sidecar}; tree={tree}; stderr:\n{result.stderr}")
+            log_dir = fake_home / ".vade" / "transcript-export-logs"
+            log_dump = ""
+            if log_dir.is_dir():
+                logs = sorted(log_dir.glob("*.log"))
+                if logs:
+                    log_dump = "\n--- detached child log ---\n" + logs[-1].read_text()[-2000:]
+            fail(f"sidecar not at {sidecar} after 60s wait; tree={tree}; stderr:\n{result.stderr}{log_dump}")
 
         meta = json.loads(sidecar.read_text())
 

--- a/scripts/session-end-transcript-export.sh
+++ b/scripts/session-end-transcript-export.sh
@@ -1,14 +1,28 @@
 #!/usr/bin/env bash
-# Bash wrapper invoked by the Stop-hook chain (via vade-hooks/dispatch.sh).
+# Bash wrapper invoked by the SessionEnd-hook chain (via vade-hooks/dispatch.sh).
 # Sources ~/.vade/coo-env so R2_TRANSCRIPTS_* and TRANSCRIPTS_AGE_IDENTITY
-# are populated, then exec's the Python implementation.
+# are populated, then runs the Python implementation.
 #
-# The Python script never raises to its own caller — it always exits 0
-# and drops <sessionId>.export-error.txt on any internal failure. This
-# wrapper preserves that contract: it does not `set -e`, and runs the
-# Python script even if env-sourcing fails.
+# Detach discipline (vade-runtime#NNN, 2026-04-30):
+# Under CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 (PR #177 / commit 9f706d7,
+# 2026-04-29 03:23 UTC) the harness kills the SessionEnd hook process
+# group before the Python export can finish — caught a 48-hour outage
+# (R2 has zero objects from 2026-04-29 onward; eight parallel COO
+# play-afternoon sessions of 2026-04-29 lost permanently). Foreground
+# `exec` did not survive the kill.
 #
-# vade-app/vade-agent-logs#64 Batch 2.
+# Fix: fork the Python via `setsid -f` into a new process session so
+# the wrapper can return 0 immediately and the export survives the
+# harness teardown. Output goes to a per-invocation log under
+# ${HOME}/.vade/transcript-export-logs/ for debugging. The Python
+# script's own contract — always exit 0, drop <id>.export-error.txt
+# on internal failure — is preserved.
+#
+# The fail-open contract holds: env-sourcing failure is non-fatal;
+# the Python script handles missing R2/age creds by writing
+# export-error.txt rather than raising.
+#
+# vade-app/vade-agent-logs#64 Batch 2; detach fix vade-runtime#NNN.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -20,4 +34,26 @@ if [ -f "${HOME}/.vade/coo-env" ]; then
   . "${HOME}/.vade/coo-env" 2>/dev/null || true
 fi
 
-exec "$SCRIPT_DIR/session-end-transcript-export.py" "$@"
+# Per-invocation log directory; created lazily so dry-run callers
+# don't litter $HOME on first import.
+LOG_DIR="${HOME}/.vade/transcript-export-logs"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+
+# Timestamped log filename so concurrent invocations don't collide and
+# so post-hoc debugging is easy. Includes wrapper PID for cross-ref
+# with /proc/<pid> when the process is still alive.
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG_FILE="$LOG_DIR/${TS}-$$.log"
+
+# Fork the Python child into a new session/PG so it survives the
+# harness killing the SessionEnd hook process group. setsid -f
+# (fork) is the load-bearing flag here — `nohup ... &; disown`
+# alone wasn't enough under agent-teams (the harness kills by PG,
+# not by signaling the wrapper). stdin closed; stdout/stderr to log.
+setsid -f "$SCRIPT_DIR/session-end-transcript-export.py" "$@" \
+  </dev/null >"$LOG_FILE" 2>&1
+
+# Wrapper returns 0 immediately. The detached child continues in
+# its own session and writes meta.json + uploads to R2 on its own
+# clock, independent of how the harness handles this hook's exit.
+exit 0


### PR DESCRIPTION
## Summary

Fixes the 48-hour transcript-export outage filed at #181 — every Claude Code session since 2026-04-29T03:23 UTC silently failed to upload its transcript to R2. Eight parallel COO play-afternoon sessions of 2026-04-29 and ~48 hours of subsequent work were permanently lost because the `SessionEnd` hook was being killed by the harness before the foreground `exec`-ed Python export could finish, under agent-teams (PR #177).

The fix is one file (`scripts/session-end-transcript-export.sh`): replace foreground `exec` with `setsid -f` background-detached child + immediate wrapper exit 0. The Python export runs in its own session/process-group, surviving harness teardown.

## Why setsid and not nohup

`nohup ... &; disown` (the pattern in `session-idle-watchdog.sh:174-176`) ignores SIGHUP but the child stays in the parent's process group. The harness kills the SessionEnd hook process **group**, so the child gets SIGTERM/SIGKILL anyway. `setsid -f` forks into a new process group entirely; PG signals from the harness don't reach the export.

## Verification (local, this session)

```
$ time bash scripts/session-end-transcript-export.sh
real    0m0.010s

$ sleep 10 && ls -la ${HOME}/.vade/transcript-export-logs/
-rw-r--r-- 1 root root 396 Apr 30 14:02 20260430T140229Z-26223.log

$ cat $LOG_FILE | tail -3
[session-end-transcript-export] session_id=310bbead-...
[session-end-transcript-export] wrote sidecar: vade-agent-logs/transcripts/2026/04/30/...meta.json
[session-end-transcript-export] auto-PR opened: https://github.com/vade-app/vade-agent-logs/pull/176

$ source ~/.vade/coo-env && python3 scripts/lib/transcript-meta-backfill.py --date 2026/04/30 --dry-run --agent-logs-dir /home/user/vade-agent-logs
DRY  2026/04/30/310bbead-... would write stub (396016 bytes)
summary: seen=1 written=1 skipped=0
```

R2 was empty for 2026-04-30 before this fix; has the object after. Wrapper exits in 10ms; detached child completes the full pipeline (sidecar → R2 → auto-PR).

## What this does NOT fix

- The lost transcripts. Unrecoverable — both R2 and the ephemeral container JSONLs are gone for 2026-04-29 + most of 2026-04-30. See #181.
- Any deeper kill-by-harness behavior. If a future Claude Code release kills entire detached process trees too aggressively, a different design is needed (e.g. nohup-launched systemd-managed worker, or moving the export entirely out of the hook chain).

## Test plan

- [x] Local smoke test: wrapper exits in <100ms; detached child completes export; R2 has the object on direct boto3 list.
- [x] Auto-commit PR opens in vade-agent-logs (verified: vade-agent-logs#176 from the smoke test session).
- [x] Bash syntax-check (`bash -n`) clean.
- [ ] Bootstrap regression CI passes (needs to run on this PR — the workflow triggers on `scripts/` changes per `vade-runtime/CLAUDE.md`).
- [ ] Next-session boot uploads its transcript to R2 (will verify on this PR's reviewer's session OR the next interactive COO session).

## Refs

- Closes #181 (incident report).
- Affected sessions named at `coo/lineage/the-eight/` in vade-coo-memory (cohort-level data-loss event).
- Builds on vade-runtime#148 Part A (the export hook) + vade-runtime#146 (session-idle-watchdog, whose nohup pattern was the closest precedent but proved insufficient under agent-teams).

https://claude.ai/code/session_01PGswZBX1oWTiEZhAtLvn12