### PR TITLE
integrity-check F1: accept hyphenated MEMO- + hash-suffix IDs (closes #179)

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -486,7 +486,7 @@ if [ -d "$F_REPO/.git" ] && check_cmd git; then
     [ -n "$touched" ] || continue
     f1_total=$((f1_total + 1))
     body=$(git -C "$F_REPO" log -1 --format='%B' "$sha" 2>/dev/null || echo '')
-    if ! printf '%s' "$body" | grep -qE 'MEMO [0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+|#[0-9]+'; then
+    if ! printf '%s' "$body" | grep -qE 'MEMO[- ][0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-z]+|#[0-9]+'; then
       f1_bad+=("${sha:0:10}")
     fi
   done < <(git -C "$F_REPO" log --since="$F_CUTOFF_GIT" --format='%H' 2>/dev/null)


### PR DESCRIPTION
## Summary

One-line regex fix to `scripts/integrity-check.sh` per the spec in vade-runtime#179.

## Diff

\`\`\`diff
-    if ! printf '%s' \"\$body\" | grep -qE 'MEMO [0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+|#[0-9]+'; then
+    if ! printf '%s' \"\$body\" | grep -qE 'MEMO[- ][0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-z]+|#[0-9]+'; then
\`\`\`

## What this fixes

The F1 invariant required commits touching `coo/`, `identity/`, `context/`, or `CLAUDE.md` to cite a memo or issue. The regex only matched the legacy spaced form `MEMO YYYY-MM-DD-NN`, but two protocol changes have since happened:

1. **MEMO-2026-04-26-06** mandated the **hyphenated** form `MEMO-YYYY-MM-DD-...` outside `coo/memos.md` itself (autolink + iOS phone-detection compliance).
2. **MEMO-2026-04-27-5kaq** adopted **hash-suffix IDs** like `5kaq`, `7yi7`, `vpji`, `c7c4` (post-issue #210 layout).

Three letter-arc commits on 2026-04-29 fired false-positive F1 because they cite `MEMO-2026-04-27-03` correctly under the new convention but the regex still demanded the old shape:
- 6c56f76bd9 — Stage C voice-restoring re-weave: v3 letter to Anthropic
- ea0ea0aed6 — Stage A re-voicing of v2 letter to Anthropic
- 47708d582f — v2 letter Stage A: independent re-voicing

## Test plan

- [x] After this change, integrity-check `summary.ok=true` (verified locally: 21/21 passed, F1 green)
- [x] Both forms accepted during transition (`MEMO ` and `MEMO-`)
- [x] Hash-suffix IDs accepted (`[0-9a-z]+`)

## Follow-up

Once F4 confirms no spaced-form commits remain post-cutoff, tighten the regex to `MEMO-` only (strict canonical form). Tracked separately if anyone wants to file it.

Closes #179.

https://claude.ai/code/session_01GJzRoXAgyAKSshFqi5jsER