### PR TITLE
coo-bootstrap: write identity before op-token gate (#287)

### DIFF
--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -35,6 +35,18 @@ _on_exit() {
 }
 trap _on_exit EXIT
 
+# Ensure baseline COO identity in gitconfig BEFORE any early-exit gate.
+# Signing keys and full-fidelity gitconfig still gated behind
+# write_coo_gitconfig (which needs OP_SERVICE_ACCOUNT_TOKEN). This minimal
+# write only sets attribution name/email so commits survive no-op-token
+# boots without falling back to the container default ("Test <test@test.com>").
+# Closes vade-coo-memory#287.
+COO_BOOTSTRAP_STEP="ensure_coo_identity_minimal"
+GC="${VADE_COO_GITCONFIG:-${HOME}/.gitconfig}"
+mkdir -p "$(dirname "$GC")"
+git config --file "$GC" user.name "COO"
+git config --file "$GC" user.email "coo@vade-app.dev"
+
 if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
   log "coo-bootstrap: OP_SERVICE_ACCOUNT_TOKEN unset; skipping COO identity setup."
   COO_BOOTSTRAP_STEP="skip-no-op-token"


### PR DESCRIPTION
## Summary

Two early-exit gates in `scripts/coo-bootstrap.sh` (op-token absent at L38-44, skip-marker fast path further down) bypassed `write_coo_gitconfig`, leaving the container's default `Test <test@test.com>` identity in place. Cloud sessions on no-op-token boots — and any subsequent boot taking the skip-marker path against an already-poisoned `~/.gitconfig` — committed as `Test <test@test.com>` instead of `COO <coo@vade-app.dev>`. Fix hoists a minimal identity write (name + email only) above both gates. Signing keys, `core.sshCommand`, and the rest of the full-fidelity gitconfig stay gated behind `write_coo_gitconfig`, which still requires `OP_SERVICE_ACCOUNT_TOKEN`. Identity values match `write_coo_gitconfig` in `scripts/lib/common.sh:1540-1541` exactly (`user.name "COO"`, `user.email "coo@vade-app.dev"`).

Closes vade-coo-memory#287.

## Pre-merge gating

This change touches `scripts/coo-bootstrap.sh`, which only runs on fresh container boot via `cloud-setup.sh` → `SessionStart` hook. Behavior cannot be verified inside the current session. The bootstrap-regression CI suite (`.github/workflows/bootstrap-regression.yml`) exercises `scripts/coo-bootstrap.sh` in fake-env mode and should pass; review its sticky comment before merging. After merge, the next fresh container boot is the real verification — see Post-merge confirmation.

## Post-merge confirmation

On a fresh container boot (new cloud session, post-merge):

1. `git config --global user.email` resolves to `coo@vade-app.dev` (not `test@test.com`).
2. `git config --global user.name` resolves to `COO`.
3. Integrity-check D5 (COO gitconfig invariant) reports `ok` in `${VADE_CLOUD_STATE_DIR}/integrity-check.json`.
4. A trial commit (`git commit --allow-empty -m "verify"`) shows author `COO <coo@vade-app.dev>`.

**Out of scope for this PR (file separately):**
- Local-scope poisoning: a `.git/config` left over from a prior clone-as-Test in the same workspace overrides the global gitconfig. This PR only fixes `~/.gitconfig` (global). Per-repo `.git/config` cleanup is a separate concern.
- F4 historical-bad-commits sweep: any commits already authored as `Test <test@test.com>` remain in history. Not rewriting; track separately if a sweep is desired.

https://claude.ai/code/session_01D5uB4BXLX6wC5gHTHfryE1