### PR TITLE
integrity-check: add D5b — surface local-scope user.email divergences (#338)

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -236,6 +236,35 @@ else
   _add D5 false "gitconfig user.email=$GIT_EMAIL (expected coo@vade-app.dev)"
 fi
 
+# D5b — local-scope .git/config divergence surface
+# D5 covers the global ~/.gitconfig (vade-coo-memory#287, fixed by
+# vade-runtime#184). Per-repo .git/config can override it silently:
+# a clone performed during a poisoned-bootstrap session may stamp
+# local user.email at clone time, surviving subsequent global-scope
+# corrections (vade-coo-memory#338). This probe scans repos under
+# WORKSPACE_ROOT and surfaces local-scope user.email values that
+# diverge from coo@vade-app.dev.
+#
+# Surface-only — does NOT rewrite. Some repos may carry intentional
+# per-repo identities (forks, vendored externals); auto-rewrite would
+# clobber them. When D5b fires, the operator-side fix is:
+#   git -C <path> config --local --unset user.email
+#   git -C <path> config --local --unset user.name
+D5b_bad=()
+for _repo_dir in "$WORKSPACE_ROOT"/*/; do
+  _repo_dir="${_repo_dir%/}"
+  [ -d "$_repo_dir/.git" ] || continue
+  _local_email="$(git -C "$_repo_dir" config --local user.email 2>/dev/null || true)"
+  if [ -n "$_local_email" ] && [ "$_local_email" != "coo@vade-app.dev" ]; then
+    D5b_bad+=("$(basename "$_repo_dir"):$_local_email")
+  fi
+done
+if [ "${#D5b_bad[@]}" -eq 0 ]; then
+  _add D5b true "no local-scope user.email overrides diverge from coo@vade-app.dev"
+else
+  _add D5b false "local-scope user.email override(s): ${D5b_bad[*]}"
+fi
+
 if [ -f "$HOME/.ssh/vade-coo-auth" ] && [ -f "$HOME/.ssh/vade-coo-sign" ]; then
   # Keys present; now check the signing posture is internally consistent.
   # Per MEMO 2026-04-23-04, cloud sessions (harness sets gpg.ssh.program


### PR DESCRIPTION
## Summary

Adds **D5b** to `scripts/integrity-check.sh` — a new invariant
inserted after D5 that walks `$WORKSPACE_ROOT/*/`, reads each repo's
local `user.email`, and surfaces any value that diverges from
`coo@vade-app.dev`. **Surface-only — does NOT rewrite.**

Closes vade-coo-memory#338.

D5 covers global `~/.gitconfig` (closed by vade-runtime#184). Per-repo
`.git/config` can override silently — a clone performed during a
poisoned-bootstrap session may stamp local `user.email` at clone time,
surviving subsequent global-scope corrections (the failure mode #338
names).

Surface-don't-rewrite framing per Agent 2's analysis (carried in
briefing 012 and ratified in MEMO-2026-04-30-nvem): some repos may
carry intentional per-repo identities (forks, vendored externals);
auto-rewrite would clobber them. When D5b fires, the operator-side fix
is documented in the memo.

## What lands

One file changed: `scripts/integrity-check.sh` (+29 lines, inserted
between the existing D5 block and the D6 keys+signing block).

Paired memo: MEMO-2026-04-30-nvem (vade-coo-memory PR #TBD on the
same branch `claude/cleanup-sweep-followups-qtcbb`).

## Probe verification (local, this session)

- 21/22 → 22/22 OK after the change in clean container state.
- Poison test: `git -C vade-governance config --local user.email test@test.com`
  → integrity-check reports `21/22 DEGRADED — degraded (D5b)` with detail
  `local-scope user.email override(s): vade-governance:test@test.com`.
- Unset: `git -C vade-governance config --local --unset user.email`
  → `22/22 OK`, D5b clears.

## Pre-merge gating

This PR adds an invariant to `scripts/integrity-check.sh`. The
bootstrap-regression CI suite exercises the same script; it should
report D5b cleanly because the staged repos lack `.git`. Wait for the
sticky CI comment to confirm before merging.

## Post-merge confirmation

On a fresh container boot (new cloud session, post-merge):

1. `jq '.summary' "$VADE_CLOUD_STATE_DIR/integrity-check.json"` reports
   `passed: 22, total: 22, ok: true` (was 21/21 pre-merge).
2. `jq '.groups.D.D5b' "$VADE_CLOUD_STATE_DIR/integrity-check.json"`
   reports `ok: true` with detail
   `no local-scope user.email overrides diverge from coo@vade-app.dev`.

If a poisoned local `.git/config` is encountered in a real session,
D5b fires `false` with the offending repo + value, and the operator
runs the unset recipe in the paired memo.

## Out of scope (not in this PR)

- `user.name` parity check (D5 is email-only; consistency over coverage).
- Auto-repair subcommand (re-imports the clobber risk that motivated
  surface-only).
- `.vade-allow-local-identity` opt-out marker for intentional overrides
  (deferred — current container has zero local overrides; not needed yet).

## Refs

- vade-coo-memory#338 — issue
- vade-coo-memory#287 — primary report (global path)
- vade-runtime#184 — global-scope fix (merged 2026-04-30)
- MEMO-2026-04-30-nvem — paired memo

https://claude.ai/code/session_016LdvD8bYF637qKqfU9P1zt