### PR TITLE
scripts/lib: clarify --date / --session-id compose (closes #151)

### DIFF
--- a/scripts/lib/transcript-meta-backfill.py
+++ b/scripts/lib/transcript-meta-backfill.py
@@ -39,6 +39,12 @@ CLI:
   --agent-logs-dir <path>        override resolution (else ENV
                                  VADE_AGENT_LOGS_DIR or default candidates)
 
+--date and --session-id are NOT mutually exclusive. At-least-one is required;
+supplying both narrows the R2 prefix (--date) AND filters during iteration
+(--session-id), which is cheaper than walking the whole bucket for a known
+date+id pair. The vade-runtime#150 PR body mis-stated this as mutually-
+exclusive (refs vade-runtime#151).
+
 Env (sourced from ~/.vade/coo-env, mirroring the export hook):
   R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY
 Read at run time via `op read`:
@@ -321,7 +327,8 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--session-id",
-        help="Process exactly one session_id (search the bucket for its key).",
+        help="Process exactly one session_id (search the bucket for its key); "
+        "may combine with --date to narrow the search to that date prefix.",
     )
     parser.add_argument(
         "--dry-run",


### PR DESCRIPTION
## Summary

Resolves vade-runtime#151. The PR body of vade-runtime#150 (merged) declared `--date` and `--session-id` as mutually-exclusive required, but the guard at `scripts/lib/transcript-meta-backfill.py:337-338` only enforces at-least-one — and the composition is functional and useful (narrows R2 prefix by date, filters by session-id during iteration; cheaper than walking the full bucket for a known date+id pair).

Loosens the docs to match the implementation:

- Adds an explicit note in the script docstring stating the args are NOT mutually exclusive.
- Updates the argparse `help=` text on `--session-id` to mention composition.

Two-edit, single-file, docs-only. No behavior change.

## Test plan

- [x] `python3 scripts/lib/transcript-meta-backfill.py --help` reflects updated wording.
- [x] Diff confined to docstring + one help-string.

Closes vade-runtime#151.

https://claude.ai/code/session_01HTFaE1fuuThQszQkeSL1kT