### PR TITLE
bootstrap: persist R2_TRANSCRIPTS_* + age identity in settings.json env

### DIFF
--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -82,6 +82,10 @@ _settings_env_complete() {
     try { cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8")) || {}; }
     catch { process.exit(1); }
     const env = cfg.env || {};
+    // Bootstrap-blocking required-list: every key here, when missing, force-re-runs
+    // the full bootstrap. VADE_AUTH_TOKEN is intentionally NOT in this list — it
+    // is passed through merge_coo_settings_env (best-effort) but feature-gated and
+    // may be empty in some environments without warranting a full re-run.
     const required = ["GITHUB_MCP_PAT", "GITHUB_TOKEN", "AGENTMAIL_API_KEY", "MEM0_API_KEY",
                       "R2_TRANSCRIPTS_ACCESS_KEY_ID", "R2_TRANSCRIPTS_SECRET_ACCESS_KEY",
                       "TRANSCRIPTS_AGE_IDENTITY",

--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -83,6 +83,8 @@ _settings_env_complete() {
     catch { process.exit(1); }
     const env = cfg.env || {};
     const required = ["GITHUB_MCP_PAT", "GITHUB_TOKEN", "AGENTMAIL_API_KEY", "MEM0_API_KEY",
+                      "R2_TRANSCRIPTS_ACCESS_KEY_ID", "R2_TRANSCRIPTS_SECRET_ACCESS_KEY",
+                      "TRANSCRIPTS_AGE_IDENTITY",
                       "VADE_CLOUD_STATE_DIR", "PATH"];
     for (const k of required) { if (!env[k]) process.exit(1); }
     // PATH content sanity: Claude Code does not shell-expand env values,

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1238,7 +1238,10 @@ merge_coo_settings_env() {
     "${GITHUB_MCP_PAT:-}" \
     "${AGENTMAIL_API_KEY:-}" \
     "${MEM0_API_KEY:-}" \
-    "${VADE_AUTH_TOKEN:-}"
+    "${VADE_AUTH_TOKEN:-}" \
+    "${R2_TRANSCRIPTS_ACCESS_KEY_ID:-}" \
+    "${R2_TRANSCRIPTS_SECRET_ACCESS_KEY:-}" \
+    "${TRANSCRIPTS_AGE_IDENTITY:-}"
 }
 
 # Persist non-secret bootstrap-derived path state into ~/.claude/settings.json
@@ -1268,6 +1271,7 @@ merge_coo_settings_paths() {
 # exists, so this is a no-op outside the Claude cloud image.
 _write_claude_settings_env() {
   local pat="$1" agentmail="$2" mem0="$3" vade_auth_token="${4:-}"
+  local r2_access_key_id="${5:-}" r2_secret_access_key="${6:-}" age_identity="${7:-}"
   if ! check_cmd node; then
     log "Warning: node missing; skipping ~/.claude/settings.json env merge"
     return 0
@@ -1284,6 +1288,9 @@ _write_claude_settings_env() {
 
   GITHUB_MCP_PAT="$pat" AGENTMAIL_API_KEY="$agentmail" MEM0_API_KEY="$mem0" \
   VADE_AUTH_TOKEN="$vade_auth_token" \
+  R2_TRANSCRIPTS_ACCESS_KEY_ID="$r2_access_key_id" \
+  R2_TRANSCRIPTS_SECRET_ACCESS_KEY="$r2_secret_access_key" \
+  TRANSCRIPTS_AGE_IDENTITY="$age_identity" \
   NODE_PATH="$node_path" PLAYWRIGHT_BROWSERS_PATH="$pw_browsers" node -e '
     const fs = require("fs");
     const path = process.argv[1];
@@ -1306,6 +1313,15 @@ _write_claude_settings_env() {
     }
     if (process.env.VADE_AUTH_TOKEN) {
       merged.VADE_AUTH_TOKEN = process.env.VADE_AUTH_TOKEN;
+    }
+    if (process.env.R2_TRANSCRIPTS_ACCESS_KEY_ID) {
+      merged.R2_TRANSCRIPTS_ACCESS_KEY_ID = process.env.R2_TRANSCRIPTS_ACCESS_KEY_ID;
+    }
+    if (process.env.R2_TRANSCRIPTS_SECRET_ACCESS_KEY) {
+      merged.R2_TRANSCRIPTS_SECRET_ACCESS_KEY = process.env.R2_TRANSCRIPTS_SECRET_ACCESS_KEY;
+    }
+    if (process.env.TRANSCRIPTS_AGE_IDENTITY) {
+      merged.TRANSCRIPTS_AGE_IDENTITY = process.env.TRANSCRIPTS_AGE_IDENTITY;
     }
     if (process.env.NODE_PATH) {
       merged.NODE_PATH = process.env.NODE_PATH;


### PR DESCRIPTION
## Summary

Extend `merge_coo_settings_env` to write the 3 R2/age secrets that `fetch_coo_secrets` already fetches from 1Password into `~/.claude/settings.json` env block:

- `R2_TRANSCRIPTS_ACCESS_KEY_ID`
- `R2_TRANSCRIPTS_SECRET_ACCESS_KEY`
- `TRANSCRIPTS_AGE_IDENTITY`

## Why

These three vars exist in `/root/.vade/coo-env` (written by `fetch_coo_secrets`) but the merge into `settings.json` only carried 4 of the 8 secrets. Tool subprocesses (Bash / Skill / sub-agents) only inherit `settings.json` env, so they had no R2 credentials.

Concrete impact: the Night's Watch §1 transcript-sidecar pass has been silently blocked for 3 consecutive nights. Throttle item `r2_credentials_missing_night_env` is live as of vade-coo-memory#359.

vade-coo-memory#243 (closed) was filed on the assumption these vars were present in the nightly run-env; this PR makes that assumption true.

## Changes

- `scripts/lib/common.sh`:
  - `_write_claude_settings_env`: 3 new positional args; node-script branches that write each to the merged env when non-empty.
  - `merge_coo_settings_env`: pass the 3 vars through from the bootstrap shell.
- `scripts/coo-bootstrap.sh`:
  - `_settings_env_complete` required-list adds the 3 keys, so a stale bootstrap marker forces a re-run when they're missing.

## Verification

Isolated test (preserves live `~/.claude/settings.json`):

```sh
TMPHOME=$(mktemp -d) && (
  source /root/.vade/coo-env
  source /home/user/vade-runtime/scripts/lib/common.sh
  HOME="$TMPHOME"
  merge_coo_settings_env
  jq '.env | keys' "$TMPHOME/.claude/settings.json"
)
```

Pre-patch settings.json env has 4 secrets; post-patch has 7. Confirmed.

## Out of scope (filing separately)

`boto3` install in the cloud container image. The Night's Watch needs both env credentials AND the boto3 module to enumerate R2. This PR fixes the credential-pass; boto3 install belongs in `Dockerfile`.

## Test plan

- [x] Isolated bootstrap test (above) shows 7 secrets post-patch.
- [ ] Live verification on next fresh-boot with `VADE_FORCE_COO_BOOTSTRAP=1` (handoff comment incoming).
- [ ] First post-merge nightly produces transcript sidecars instead of skipping the §1 pass.

## Authority

vade-runtime CLAUDE.md "may do autonomously" includes drafting script changes + opening PRs. Merging to main requires explicit BDFL approval.

https://claude.ai/code/session_01AKJyJFURFkjVei7Y9SdEko