### PR TITLE
bootstrap: persist UV_CACHE_DIR for snapshot-stable uv-script venvs

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1380,8 +1380,18 @@ _write_claude_settings_paths() {
     *":${bindir}") live_path="${live_path%:${bindir}}" ;;
   esac
 
+  # UV_CACHE_DIR redirects uv's script-environment cache (used by
+  # `uv run --script` shebangs in transcript-meta-backfill.py and
+  # session-end-transcript-export.py) to a snapshot-persistent path
+  # under /home/user/. Default uv cache lands at /root/.cache/uv/
+  # which is ephemeral on cloud-sandbox resume — every nightly resume
+  # would otherwise pay a fresh boto3 resolve + install + egress hop.
+  # Set here in the paths block (not the env-secrets block) because
+  # this is a non-secret path-state value with no PAT-validation gate.
+  local uv_cache_dir="/home/user/.cache/uv"
+
   VADE_CLOUD_STATE_DIR="$cloud_state_dir" VADE_BINDIR="$bindir" \
-  VADE_LIVE_PATH="$live_path" node -e '
+  VADE_LIVE_PATH="$live_path" UV_CACHE_DIR="$uv_cache_dir" node -e '
     const fs = require("fs");
     const path = process.argv[1];
     let cfg = {};
@@ -1402,6 +1412,9 @@ _write_claude_settings_paths() {
       const bindir = process.env.VADE_BINDIR;
       const live = process.env.VADE_LIVE_PATH;
       merged.PATH = live ? bindir + ":" + live : bindir;
+    }
+    if (process.env.UV_CACHE_DIR) {
+      merged.UV_CACHE_DIR = process.env.UV_CACHE_DIR;
     }
     cfg.env = merged;
     fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");


### PR DESCRIPTION
## Summary

Set `UV_CACHE_DIR=/home/user/.cache/uv` in `~/.claude/settings.json` env via `merge_coo_settings_paths`, so `uv run --script` cache survives cloud-sandbox resume.

## Why

Two scripts use `uv run --script` shebangs with inline `dependencies = ["boto3>=1.34,<2"]` frontmatter:
- `scripts/session-end-transcript-export.py`
- `scripts/lib/transcript-meta-backfill.py`

`uv` installs boto3 lazily into a script-environment venv on first run. Default cache path is `/root/.cache/uv/` — ephemeral on every cloud-sandbox resume. Result: every nightly resume pays a fresh resolve + install + egress hop. When the egress proxy is flaky at that moment, the install fails silently and the Night's Watch §1 transcript-sidecar pass skips.

Redirecting the cache to `/home/user/.cache/uv` (snapshot-persistent) means uv reuses the venv across boots — no fresh install per resume, no exposure to the egress-flake class.

Companion to #189 (R2_TRANSCRIPTS_* env-pass, merged 2026-05-01). Together they fully resolve the operational legs of the `r2_credentials_missing_night_env` throttle that vade-coo-memory#359 flagged for the third consecutive night.

## What changed

`scripts/lib/common.sh` `_write_claude_settings_paths`: add a local `uv_cache_dir="/home/user/.cache/uv"`; pass it as `UV_CACHE_DIR` to the node merge child; add a conditional that writes it to settings.json env.

Sized as a path-state value (not a secret), so it lives next to `VADE_CLOUD_STATE_DIR` + `PATH` in the paths block, not the secrets block.

## Verification

Isolated test (preserves live settings.json):

```sh
TMPHOME=$(mktemp -d) && (
  source /home/user/vade-runtime/scripts/lib/common.sh
  HOME="$TMPHOME"
  VADE_CLOUD_STATE_DIR="/home/user/.vade-cloud-state"
  merge_coo_settings_paths
  jq '.env' "$TMPHOME/.claude/settings.json"
)
```

Post-patch `.env` contains `UV_CACHE_DIR: "/home/user/.cache/uv"`. Confirmed.

## Test plan

- [x] Isolated test shows new key
- [ ] Post-merge fresh boot: `jq '.env.UV_CACHE_DIR' /root/.claude/settings.json` returns the path
- [ ] First nightly post-merge produces transcript sidecars (the actual outcome that retires #359's throttle)
- [ ] Second nightly: cache hit; install latency drops to near-zero (validates the cache-persistence claim)

## Authority

vade-runtime CLAUDE.md "may do autonomously" includes drafting script changes + opening PRs. Merge requires explicit BDFL approval.

https://claude.ai/code/session_01AKJyJFURFkjVei7Y9SdEko