### PR TITLE
cloud-setup: hosted-MCP env var wiring (#5)

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -197,6 +197,31 @@ else
   log "Warning: @takescake/1password-mcp install failed at build time; first session will pay an npx-on-demand fetch."
 fi
 
+# Hosted-MCP wiring per vade-runtime#5. When the operator sets
+# VADE_BEARER_TOKEN (the canonical name per issue#5 + vade-core/docs/
+# remote-mcp.md) in the cloud-env config, alias it to VADE_AUTH_TOKEN
+# so the existing vade-runtime/.mcp.json `${VADE_AUTH_TOKEN}` substitution
+# in the vade-canvas SSE entry resolves at MCP-server-spawn time. The
+# internal env-var name stays untouched until a coordinated cross-repo
+# rename across vade-runtime/.mcp.json + vade-core/.mcp.json is scheduled.
+#
+# VADE_MCP_URL is documented for forward compatibility — the URL is
+# currently hardcoded as https://mcp.vade-app.dev/sse in .mcp.json; if
+# a future revision substitutes `${VADE_MCP_URL}`, the propagation
+# below ensures the env var reaches MCP-server-spawn time.
+#
+# When neither env var is set: the vade-canvas entry stays in
+# .mcp.json but ${VADE_AUTH_TOKEN} substitutes to empty; the SSE
+# transport surfaces a 401 (recognizable to operators) and the rest of
+# Claude Code (edit-only flow, other MCPs) is unaffected.
+if [ -n "${VADE_BEARER_TOKEN:-}" ] && [ -z "${VADE_AUTH_TOKEN:-}" ]; then
+  export VADE_AUTH_TOKEN="$VADE_BEARER_TOKEN"
+  build_log_record OK "cloud-setup: aliased VADE_BEARER_TOKEN → VADE_AUTH_TOKEN for hosted-MCP wiring (vade-runtime#5)"
+fi
+if [ -n "${VADE_MCP_URL:-}" ]; then
+  build_log_record INFO "cloud-setup: VADE_MCP_URL=$VADE_MCP_URL (informational; .mcp.json URL hardcoded for now)"
+fi
+
 # COO identity bootstrap runs only when OP_SERVICE_ACCOUNT_TOKEN is set
 # in the cloud environment config. Non-fatal on failure — the base VADE
 # env should still come up even if 1Password is unreachable.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1241,7 +1241,9 @@ merge_coo_settings_env() {
     "${VADE_AUTH_TOKEN:-}" \
     "${R2_TRANSCRIPTS_ACCESS_KEY_ID:-}" \
     "${R2_TRANSCRIPTS_SECRET_ACCESS_KEY:-}" \
-    "${TRANSCRIPTS_AGE_IDENTITY:-}"
+    "${TRANSCRIPTS_AGE_IDENTITY:-}" \
+    "${VADE_BEARER_TOKEN:-}" \
+    "${VADE_MCP_URL:-}"
 }
 
 # Persist non-secret bootstrap-derived path state into ~/.claude/settings.json
@@ -1282,6 +1284,7 @@ merge_coo_settings_state_dir() {
 _write_claude_settings_env() {
   local pat="$1" agentmail="$2" mem0="$3" vade_auth_token="${4:-}"
   local r2_access_key_id="${5:-}" r2_secret_access_key="${6:-}" age_identity="${7:-}"
+  local vade_bearer_token="${8:-}" vade_mcp_url="${9:-}"
   if ! check_cmd node; then
     log "Warning: node missing; skipping ~/.claude/settings.json env merge"
     return 0
@@ -1301,6 +1304,8 @@ _write_claude_settings_env() {
   R2_TRANSCRIPTS_ACCESS_KEY_ID="$r2_access_key_id" \
   R2_TRANSCRIPTS_SECRET_ACCESS_KEY="$r2_secret_access_key" \
   TRANSCRIPTS_AGE_IDENTITY="$age_identity" \
+  VADE_BEARER_TOKEN="$vade_bearer_token" \
+  VADE_MCP_URL="$vade_mcp_url" \
   NODE_PATH="$node_path" PLAYWRIGHT_BROWSERS_PATH="$pw_browsers" node -e '
     const fs = require("fs");
     const path = process.argv[1];
@@ -1332,6 +1337,12 @@ _write_claude_settings_env() {
     }
     if (process.env.TRANSCRIPTS_AGE_IDENTITY) {
       merged.TRANSCRIPTS_AGE_IDENTITY = process.env.TRANSCRIPTS_AGE_IDENTITY;
+    }
+    if (process.env.VADE_BEARER_TOKEN) {
+      merged.VADE_BEARER_TOKEN = process.env.VADE_BEARER_TOKEN;
+    }
+    if (process.env.VADE_MCP_URL) {
+      merged.VADE_MCP_URL = process.env.VADE_MCP_URL;
     }
     if (process.env.NODE_PATH) {
       merged.NODE_PATH = process.env.NODE_PATH;


### PR DESCRIPTION
## Summary

Implements vade-runtime#5 (hosted-MCP wiring in `cloud-setup.sh`) per /exec-mode disposition 2026-05-01.

Closes #5

### What changes

**`scripts/cloud-setup.sh`** — adds a small block before `coo-bootstrap` invocation:

- If `VADE_BEARER_TOKEN` is set (the canonical name per issue#5 + `vade-core/docs/remote-mcp.md`) AND `VADE_AUTH_TOKEN` is unset: alias `VADE_BEARER_TOKEN` → `VADE_AUTH_TOKEN` so the existing `${VADE_AUTH_TOKEN}` substitution in `.mcp.json`'s vade-canvas entry resolves at MCP-server-spawn time.
- If `VADE_MCP_URL` is set: log it (informational; URL is currently hardcoded in `.mcp.json`, but the propagation below makes a future `${VADE_MCP_URL}` substitution land cleanly).

**`scripts/lib/common.sh`** — extends `merge_coo_settings_env` + `_write_claude_settings_env`:

- Two new positional args (8th and 9th): `VADE_BEARER_TOKEN`, `VADE_MCP_URL`.
- Both written to `~/.claude/settings.json` env when present in process env, matching the existing pattern for `GITHUB_MCP_PAT`, `MEM0_API_KEY`, etc.
- Idempotent (only written when value is non-empty).

### Why this shape

The issue body (filed 2026-04-25) predates the current `.mcp.json` having vade-canvas registered. Since then, vade-canvas IS registered with `${VADE_AUTH_TOKEN}` substitution. The issue's spec (`VADE_BEARER_TOKEN`, `VADE_MCP_URL`) is the operator-facing interface; aliasing keeps the spec without forcing a coordinated cross-repo rename across `vade-runtime/.mcp.json` + `vade-core/.mcp.json`.

The "skip silently when env vars absent" requirement is partially satisfied: the vade-canvas entry persists in `.mcp.json`, but the empty-substituted bearer surfaces a recognizable 401 in the SSE transport rather than a hard failure that breaks edit-only flow. A full conditional-skip would require dynamic `.mcp.json` composition, which is out of scope for this small wiring change.

### Test plan

- [x] `scripts/cloud-setup.sh` `bash -n` (syntax check)
- [x] `scripts/lib/common.sh` `bash -n` (syntax check)
- [x] When `VADE_BEARER_TOKEN` is set in cloud-env config and re-runs `cloud-setup.sh`, build log shows the alias message
- [x] `~/.claude/settings.json` env contains `VADE_BEARER_TOKEN` after `merge_coo_settings_env` runs (when set in process env)
- [ ] Manual verification on a fresh container with `VADE_BEARER_TOKEN` set: hosted-MCP connects (deferred to next M1 sprint per #4)
- [x] Bootstrap-regression CI run on this PR (Layer 1; see `.github/workflows/bootstrap-regression.yml`)

https://claude.ai/code/session_0118tDBbig3uoePkWP8DTBMN