### PR TITLE
F4_ALLOWLIST_SHA: add 7cb8a86da4 (Ven-direct gitignore update)

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -634,6 +634,15 @@ F4_ALLOWLIST_SHA=(
   # authored doc-add); PR body carries ven-human-action marker but
   # the merge stripped it. See vade-coo-memory#271 for the race fix.
   "0fd421a198"
+  # 7cb8a86da4 — vade-coo-memory direct commit "update gitignore" by
+  # Ven on 2026-05-01 outside the PR flow (no PR body, so the f4-marker
+  # workflow at vade-coo-memory/.github/workflows/f4-marker.yml had no
+  # surface to inject ven-human-action: into). Direct-to-main quick-fix
+  # by the BDFL is allowlisted by the same precedent that retired the
+  # 2 historical Ven-human-action quick-fixes pre-2026-04-26 (cf. the
+  # F_CUTOFF_GIT comment block above). Cleared in run-2026-05-02T120959
+  # full-bootup pass.
+  "7cb8a86da4"
 )
 if [ -d "$F_REPO/.git" ] && check_cmd git; then
   f4_total=0


### PR DESCRIPTION
## Summary

Allowlist a Ven-direct quick-fix commit on `vade-coo-memory` main that the F4 invariant check flagged as missing the `ven-human-action:` marker.

The commit:
- `7cb8a86da4` — "update gitignore" by `vencislav.popov@gmail.com`, 2026-05-01.
- Direct push to main outside the PR flow. The `f4-marker.yml` workflow only injects the marker into PR-merged commits; direct pushes have no PR body for the workflow to act on.

Same precedent as the 2 historical Ven-human-action quick-fixes that informed the 2026-04-26 `F_CUTOFF_GIT` bump (cf. comment block above `F_CUTOFF_GIT`). Allowlist is the cleaner mechanism for a single one-off; another cutoff bump would over-correct.

Cleared in run-2026-05-02T120959 full-bootup pass alongside F2 and F3 fixes in vade-coo-memory#425.

## Test plan

- [x] `bash scripts/integrity-check.sh` reports F4 as 50/50 green after this change
- [x] Comment cites the originating commit, the direct-push circumstance, and the precedent (consistent with the existing `0fd421a198` allowlist entry's commenting style)
- [x] No mechanism-level change to F4 — only data (SHA + reasoning)

Refs: vade-coo-memory#424 (paired bootup PR in vade-coo-memory#425 addresses F2 + F3).

Closes: n/a

https://claude.ai/code/session_01FYFR9UJyzHzNK39PJZsEz7