### PR TITLE
integrity-check: move to coo-identity-digest + E5 retry

### DIFF
--- a/scripts/ci/run-bootstrap-regression.sh
+++ b/scripts/ci/run-bootstrap-regression.sh
@@ -13,8 +13,9 @@
 #      stay untouched.
 #   5. Run scripts/cloud-setup.sh (writes setup-receipt.json + invokes
 #      coo-bootstrap.sh under the mocks).
-#   6. Run scripts/session-start-sync.sh (which calls integrity-check.sh
-#      and emits integrity-check.json).
+#   6. Run scripts/session-start-sync.sh + integrity-check.sh explicitly
+#      (in live sessions integrity-check.sh runs inside coo-identity-digest;
+#      CI only runs session-start-sync, so we call it directly here).
 #   7. Read integrity-check.json, subtract VADE_CI_ALLOWLIST, fail if any
 #      degraded invariants remain.
 #   8. Render a markdown summary (groups + per-invariant table) to
@@ -155,6 +156,12 @@ log "Running scripts/session-start-sync.sh"
 # operator triaging the artifact can tell it's not a real session.
 export CLAUDE_CODE_SESSION_ID="ci-bootstrap-regression-${GITHUB_RUN_ID:-local}"
 bash "$RUNTIME_DST/scripts/session-start-sync.sh"
+
+# Run integrity-check.sh explicitly. In live sessions this is called by
+# coo-identity-digest.sh (hook position 4, after the platform repo-sync
+# settles). CI only runs session-start-sync, so we invoke it directly.
+log "Running scripts/integrity-check.sh"
+bash "$RUNTIME_DST/scripts/integrity-check.sh" 2>/dev/null || true
 
 # ── 7. Read integrity-check + apply allowlist ────────────────────
 INTEGRITY="${VADE_CLOUD_STATE_DIR:-$WORKSPACE_ROOT/.vade-cloud-state}/integrity-check.json"

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -340,6 +340,12 @@ echo "                            Sole GitHub write path. github-coo MCP retired
 echo "                            Epic #112 Stream 1; harness github MCP writes deny-listed."
 echo "───────────────────────────────────────────────────────────────"
 
+# Run the integrity check now, before reading results for display.
+# Placed here (not in session-start-sync.sh) so it fires after the
+# platform's git-proxy repo-sync has settled; running it earlier
+# produced boot-time false alarms on F2/F3/F4 (vade-runtime#XXX).
+bash "$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true
+
 # Mem0 read/write surface — same banner pattern as "GitHub write surface"
 # above. Per vade-runtime#109, the hosted Mem0 MCP at mcp.mem0.ai hits
 # the same Node `undici` DNS-cache-overflow class that kills github-coo,
@@ -410,8 +416,8 @@ esac
 echo "───────────────────────────────────────────────────────────────"
 
 # Integrity check summary — the authoritative "did this session's boot
-# pipeline land correctly" verdict. session-start-sync.sh writes this
-# to $VADE_CLOUD_STATE_DIR/integrity-check.json on every boot. The file
+# pipeline land correctly" verdict. Written to
+# $VADE_CLOUD_STATE_DIR/integrity-check.json by the call above. The file
 # itself is already read-on-demand by CLAUDE.md §14; this block echoes
 # the summary inline so routine-triggered sessions (non-startup matcher)
 # and automation instances see the posture without having to cat the

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -456,6 +456,74 @@ else
       E5_detail="api.mem0.ai unreachable: handshake ok but get_memories round-trip failed — $_e5_rt_err. Probe: curl https://api.mem0.ai/v1/ping/ ; if 503/DNS-cache-overflow, defer Mem0 writes (memo-sync, identity loads) until upstream recovers."
     fi
   fi
+
+  # E5 retry: one attempt after a 2s delay on transient failures.
+  # Addresses boot-time false alarms when api.mem0.ai or the MCP server
+  # hasn't finished initialising by the time the probe first fires.
+  if [ "$E5_ok" = false ]; then
+    sleep 2
+    E5_probe_out="$(
+      {
+        printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"integrity-check","version":"1.0"}}}'
+        sleep 0.2
+        printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
+        sleep 0.1
+        printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+        sleep 0.5
+        printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_memories","arguments":{"filters":{"AND":[{"user_id":"coo"}]},"page":1,"page_size":1}}}'
+        sleep 3
+      } | MEM0_API_KEY="$MEM0_API_KEY" timeout 10 "$_mem0_bin" 2>/dev/null \
+        | head -4
+    )"
+    E5_verdict="$(printf '%s' "$E5_probe_out" | node -e '
+      let data = "";
+      process.stdin.on("data", c => data += c);
+      process.stdin.on("end", () => {
+        const lines = data.split("\n").filter(Boolean);
+        let serverName = null;
+        let toolNames = [];
+        let roundTripOk = false;
+        let roundTripError = null;
+        for (const l of lines) {
+          try {
+            const m = JSON.parse(l);
+            if (m.id === 1 && m.result?.serverInfo?.name) serverName = m.result.serverInfo.name;
+            if (m.id === 2 && Array.isArray(m.result?.tools)) toolNames = m.result.tools.map(t => t.name);
+            if (m.id === 3) {
+              if (m.error) {
+                roundTripError = (m.error.message || JSON.stringify(m.error)).slice(0, 160);
+              } else if (m.result?.isError) {
+                const txt = m.result.content?.[0]?.text || JSON.stringify(m.result.content || m.result);
+                roundTripError = ("isError: " + txt).slice(0, 160);
+              } else if (m.result) {
+                roundTripOk = true;
+              }
+            }
+          } catch {}
+        }
+        const required = ["get_memories", "search_memories", "add_memory"];
+        const missing = required.filter(n => !toolNames.includes(n));
+        const handshakeOk = serverName === "mem0" && missing.length === 0;
+        const out = {
+          serverName,
+          toolCount: toolNames.length,
+          missing,
+          handshakeOk,
+          roundTripOk,
+          roundTripError,
+          ok: handshakeOk && roundTripOk,
+        };
+        process.stdout.write(JSON.stringify(out));
+      });
+    ' 2>/dev/null)"
+    if [ -n "$E5_verdict" ] && printf '%s' "$E5_verdict" | grep -q '"ok":true'; then
+      E5_ok=true
+      E5_tools="$(printf '%s' "$E5_verdict" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const o=JSON.parse(d);process.stdout.write(o.toolCount+"")}catch{process.stdout.write("?")}})' 2>/dev/null || echo "?")"
+      E5_detail="stdio Mem0 MCP healthy: $_mem0_bin (handshake ok, $E5_tools tools, get_memories round-trip ok)"
+    fi
+    # If still failing after retry, keep the detail from the first attempt
+    # (it has the specific error message) and let it fall through to _add.
+  fi
 fi
 _add E5 "$E5_ok" "$E5_detail"
 

--- a/scripts/session-start-sync.sh
+++ b/scripts/session-start-sync.sh
@@ -78,7 +78,7 @@ ensure_gh_coo_wrap "$SCRIPT_DIR/gh-coo-wrap.sh"
 # would clobber the well-formed PATH coo-bootstrap captured at install time.
 # vade-runtime#171.
 merge_coo_settings_state_dir
-# Emit integrity-check.json so its snapshot is on disk before the
-# digest hook runs (which may surface a one-line summary). Non-fatal.
-bash "$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true
+# integrity-check.sh runs in coo-identity-digest.sh instead of here,
+# so the check fires after the platform's repo-sync has settled
+# (vade-runtime#XXX; moved from here to eliminate boot-time false alarms).
 boot_log_record session-start-sync end ok


### PR DESCRIPTION
## Summary

- **Move `integrity-check.sh` call from `session-start-sync` to `coo-identity-digest`** (hook position 1 → 4). Running it in position 1 raced the platform's git-proxy repo-sync; F2/F3/F4 checks saw a partially-updated working tree and reported false failures. Position 4 is late enough that the sync has settled.

- **Add E5 retry (2s sleep, one attempt)** on api.mem0.ai round-trip failure. The Mem0 MCP server may not have finished initialising when the probe first fires; one retry eliminates the transient false alarm without materially lengthening happy-path boot time.

## Test plan

- [ ] Fresh container boot: `summary.ok=true` on first display, no re-run needed
- [ ] Mem0 degraded scenario: E5 probe retries once, surfaces genuine degradation if still failing
- [ ] Bootstrap-regression CI passes (E5 skipped in CI by design; F1–F4 skip cleanly on stub workspace)

Closes: n/a (quality-of-life fix; no tracking issue yet)

https://claude.ai/code/session_01YULyre755n3ztfM2AsGK8t