### PR TITLE
cloud-setup: pre-warm uv cache for boto3-using transcript scripts

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -112,6 +112,12 @@ else
   build_log_record WARN "cloud-setup: binary vendor bundle unavailable; falling back to per-binary direct fetch"
 fi
 
+# Pre-warm uv cache for the boto3-dependent transcript scripts so fresh
+# snapshots start with a hot cache. Closes #202. Runs after
+# ensure_binaries_from_vendor (provides uv) and before any per-binary
+# install path so the cache lives on the snapshot before later steps.
+prewarm_uv_cache
+
 # Install the op CLI at snapshot-build time so the SessionStart-hook
 # bootstrap fallback never has to fetch it through the egress proxy
 # mid-session. The binary lands in /home/user/.local/bin/op which

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -790,6 +790,56 @@ for a in data.get("assets", []):
   log "binary vendor: installed op gh uv mem0-mcp-server to $bindir"
 }
 
+# Pre-warm the uv cache so fresh snapshots don't pay a cold PyPI fetch
+# the first time a uv-shebang script runs. SessionEnd transcript export,
+# transcript-fetch (Night's Watch / Weekly Watch / transcript-analyzer),
+# and transcript-meta-backfill share `boto3>=1.34,<2`; on a flaky-egress
+# fresh container the first invocation can fail with `boto3 missing`
+# (issue #202). PR #190 added UV_CACHE_DIR=/home/user/.cache/uv to
+# settings.json env so the cache survives the snapshot → resume
+# transition; this function seeds that path at build time.
+#
+# Approach: run a dummy uv-script with the same PEP 723 metadata as the
+# three real scripts so uv resolves boto3>=1.34,<2 and persists the
+# wheel/sdist into UV_CACHE_DIR. The dummy exits immediately; the cache
+# survives.
+#
+# Fail-open: if uv is missing or the resolve fails (e.g., PyPI flake at
+# build time), per-script first-run PyPI fetch remains the fallback. No
+# additional error surface.
+prewarm_uv_cache() {
+  if ! check_cmd uv; then
+    build_log_record WARN "cloud-setup: uv not present; skipping uv cache pre-warm"
+    return 0
+  fi
+  local cache_dir="${UV_CACHE_DIR:-/home/user/.cache/uv}"
+  mkdir -p "$cache_dir" 2>/dev/null || true
+
+  local prewarm_script
+  prewarm_script="$(mktemp --suffix=.py)" || return 0
+  cat >"$prewarm_script" <<'PREWARM_PY'
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["boto3>=1.34,<2"]
+# ///
+# uv-cache pre-warm sentinel — see scripts/lib/common.sh prewarm_uv_cache.
+# Mirrors the PEP 723 metadata of the three boto3-using scripts:
+#   session-end-transcript-export.py, transcript-fetch.py,
+#   transcript-meta-backfill.py
+# Running this resolves boto3>=1.34,<2 into UV_CACHE_DIR so the real
+# scripts get a warm cache on first invocation.
+import sys
+sys.exit(0)
+PREWARM_PY
+
+  if UV_CACHE_DIR="$cache_dir" uv run --script "$prewarm_script" >/dev/null 2>&1; then
+    build_log_record OK "cloud-setup: uv cache pre-warmed (boto3>=1.34,<2 in $cache_dir)"
+  else
+    build_log_record WARN "cloud-setup: uv cache pre-warm failed; first uv-script run on this snapshot will fetch from PyPI (issue #202)"
+  fi
+  rm -f "$prewarm_script"
+}
+
 ensure_op_cli() {
   # Install into a snapshot-persistent path so a build-time install is
   # still on disk at session-resume time. /root/ resets each resume in


### PR DESCRIPTION
## Summary

Three uv-shebang scripts (`session-end-transcript-export.py`, `lib/transcript-fetch.py`, `lib/transcript-meta-backfill.py`) share `boto3>=1.34,<2`. PR #190 added `UV_CACHE_DIR=/home/user/.cache/uv` to settings.json env so the cache survives container resumes; it did **not** seed the path at snapshot build. First uv-script invocation on a fresh snapshot does a network fetch to PyPI; on flaky egress it fails with `boto3 missing` — the failure mode Night's Watch and Weekly Watch sweeps have hit.

## Change

- `scripts/lib/common.sh`: new `prewarm_uv_cache()` writes a dummy uv-script with the same PEP 723 metadata as the three real scripts and runs it once via `uv run --script`. uv resolves `boto3>=1.34,<2` into `UV_CACHE_DIR`, dummy exits, cache survives into the snapshot.
- `scripts/cloud-setup.sh`: call `prewarm_uv_cache` after `ensure_binaries_from_vendor` (uv guaranteed present) and before per-binary install paths.
- Fail-open: uv missing or PyPI flake → log `WARN`, return 0; first-run PyPI fetch remains the fallback. No new error surface.

## Smoke test

Sourced common.sh and called `prewarm_uv_cache` against a scratch `UV_CACHE_DIR`:
- Cold resolve: **0.78s**
- Cache size: 4K → 40M
- `boto3` wheel cached at `wheels-v5/pypi/boto3`

## Test plan

- [ ] Bootstrap-regression CI passes (`scripts/ci/run-bootstrap-regression.sh`). The CI runs `cloud-setup.sh` end-to-end in fake-env mode; uv is installed via the binary vendor bundle so `prewarm_uv_cache` should succeed (or fail-open if CI lacks PyPI egress).
- [ ] On a fresh snapshot rebuild, confirm `/home/user/.cache/uv/wheels-v5/pypi/boto3` is present at SessionStart (before any uv-script has fired).
- [ ] Run a NW/WR-style `transcript-fetch.py` loop on a fresh snapshot; confirm no `boto3 missing` errors and per-invocation cost is warm-cache (≪1s).

## Refs

- Closes #202.
- Refs PR #190 (UV_CACHE_DIR persistence — set the path; this seeds it).
- Refs PR #199 (wait-with-detach; covers SessionEnd specifically — but NW/WR run outside that budget so this PR is the cleaner fix for them).

https://claude.ai/code/session_01TtBu776bS3ByZ1jpNFjhDk