### PR TITLE
session-end-transcript-export: budget bump 20s→60s + durable error breadcrumbs (#207)

### DIFF
--- a/scripts/session-end-transcript-export.py
+++ b/scripts/session-end-transcript-export.py
@@ -313,6 +313,30 @@ def _emit_export_error(sidecar_dir: Path, session_id: str, exc: BaseException) -
     _stderr(f"wrote export-error: {err_path}")
 
 
+def _emit_meta_pr_error(sidecar_dir: Path, session_id: str, reason: str) -> None:
+    """Write a durable breadcrumb when the auto-PR step fails or is
+    skipped for non-design reasons. Sidecar lives next to where
+    meta.json would have landed in vade-agent-logs/transcripts/<date>/
+    so the failure is visible to operators (and to a next-session-on-
+    same-container debugger) even after the container that wrote it
+    tears down — closing the diagnostic gap left by stderr-only logging
+    in container-ephemeral LOG_FILE. Companion to _emit_export_error.
+
+    Refs vade-runtime#207 (the meta-vs-R2 asymmetry being instrumented)."""
+    try:
+        sidecar_dir.mkdir(parents=True, exist_ok=True)
+        err_path = sidecar_dir / f"{session_id}.meta-pr-error.txt"
+        with open(err_path, "w") as f:
+            f.write("# session-end-transcript-export.py: meta auto-PR failed/skipped\n")
+            f.write(f"# generated: {datetime.datetime.now(datetime.timezone.utc).isoformat()}\n")
+            f.write(f"# session_id: {session_id}\n\n")
+            f.write(f"reason: {reason}\n")
+        _stderr(f"wrote meta-pr-error: {err_path} (reason: {reason})")
+    except OSError as e:
+        # Best-effort durable logging; don't let breadcrumb failure cascade.
+        _stderr(f"could not write meta-pr-error breadcrumb: {e!r}")
+
+
 def _open_meta_pr(
     agent_logs_dir: Path,
     sidecar_path: Path,
@@ -325,17 +349,27 @@ def _open_meta_pr(
     vade-agent-logs).
 
     Best-effort: any failure is logged via export-error.txt and we
-    return None. Never raises, never blocks session end.
+    return None. Never raises, never blocks session end. Non-design
+    failures (env regressions, git op failures) also drop a durable
+    `<id>.meta-pr-error.txt` next to where meta.json would have gone
+    via _emit_meta_pr_error — so the asymmetry documented at #207
+    (R2 PUT yes, meta.json git-push no) becomes diagnosable rather
+    than silent across container teardowns.
 
     Returns the PR URL on success, None otherwise.
 
-    Skipped (no error) when:
+    Skipped silently (no breadcrumb) when:
       - VADE_TRANSCRIPT_EXPORT_DRY_RUN=1 or VADE_TRANSCRIPT_EXPORT_NO_PR=1
-      - GITHUB_MCP_PAT not set
+      - the auto-meta branch already exists upstream (idempotent re-fire)
+
+    Skipped with breadcrumb (operator should notice):
+      - GITHUB_MCP_PAT not set in hook env
       - `gh` binary not on PATH
       - agent_logs_dir is not a git working tree
-      - the auto-meta branch already exists upstream (idempotent re-fire)
+      - sidecar missing on disk (internal bug)
     """
+    sidecar_dir = sidecar_path.parent
+
     if os.environ.get("VADE_TRANSCRIPT_EXPORT_DRY_RUN", "").strip() == "1":
         _stderr("auto-PR skipped (DRY_RUN=1)")
         return None
@@ -346,15 +380,23 @@ def _open_meta_pr(
     pat = os.environ.get("GITHUB_MCP_PAT", "").strip()
     if not pat:
         _stderr("auto-PR skipped (GITHUB_MCP_PAT not set)")
+        _emit_meta_pr_error(sidecar_dir, session_id, "GITHUB_MCP_PAT not set in hook env")
         return None
     if not shutil.which("gh"):
         _stderr("auto-PR skipped (gh binary not on PATH)")
+        _emit_meta_pr_error(sidecar_dir, session_id, "gh binary not on PATH")
         return None
     if not (agent_logs_dir / ".git").exists():
         _stderr(f"auto-PR skipped ({agent_logs_dir} is not a git tree)")
+        _emit_meta_pr_error(
+            sidecar_dir, session_id, f"{agent_logs_dir} is not a git tree"
+        )
         return None
     if not sidecar_path.is_file():
         _stderr(f"auto-PR skipped (sidecar missing: {sidecar_path})")
+        _emit_meta_pr_error(
+            sidecar_dir, session_id, f"sidecar missing on disk: {sidecar_path}"
+        )
         return None
 
     short_sid = session_id[:12]
@@ -383,6 +425,9 @@ def _open_meta_pr(
     head_proc = _git("rev-parse", "HEAD", capture=True)
     if head_proc.returncode != 0:
         _stderr(f"auto-PR skipped (HEAD unresolvable: {head_proc.stderr.strip()})")
+        _emit_meta_pr_error(
+            sidecar_dir, session_id, f"HEAD unresolvable: {head_proc.stderr.strip()}"
+        )
         return None
     original_ref_proc = _git("rev-parse", "--abbrev-ref", "HEAD", capture=True)
     original_ref = (
@@ -395,6 +440,11 @@ def _open_meta_pr(
         fetch = _git("fetch", "origin", "main", capture=True)
         if fetch.returncode != 0:
             _stderr(f"auto-PR fetch origin/main failed: {fetch.stderr.strip()}")
+            _emit_meta_pr_error(
+                sidecar_dir,
+                session_id,
+                f"fetch origin/main failed: {fetch.stderr.strip()}",
+            )
             return None
 
         # Stage just the new meta.json against the index AT origin/main
@@ -402,6 +452,11 @@ def _open_meta_pr(
         switch = _git("switch", "-c", branch, "origin/main", capture=True)
         if switch.returncode != 0:
             _stderr(f"auto-PR switch -c {branch} failed: {switch.stderr.strip()}")
+            _emit_meta_pr_error(
+                sidecar_dir,
+                session_id,
+                f"switch -c {branch} failed: {switch.stderr.strip()}",
+            )
             return None
 
         # Re-write the sidecar at the same relative path on the new
@@ -413,6 +468,9 @@ def _open_meta_pr(
         add = _git("add", "--", rel_sidecar, capture=True)
         if add.returncode != 0:
             _stderr(f"auto-PR git add failed: {add.stderr.strip()}")
+            _emit_meta_pr_error(
+                sidecar_dir, session_id, f"git add failed: {add.stderr.strip()}"
+            )
             return None
 
         commit_msg = (
@@ -431,11 +489,17 @@ def _open_meta_pr(
         )
         if commit.returncode != 0:
             _stderr(f"auto-PR git commit failed: {commit.stderr.strip()}")
+            _emit_meta_pr_error(
+                sidecar_dir, session_id, f"git commit failed: {commit.stderr.strip()}"
+            )
             return None
 
         push = _git("push", "-u", "origin", branch, capture=True)
         if push.returncode != 0:
             _stderr(f"auto-PR git push failed: {push.stderr.strip()}")
+            _emit_meta_pr_error(
+                sidecar_dir, session_id, f"git push failed: {push.stderr.strip()}"
+            )
             return None
 
         body = (
@@ -473,6 +537,9 @@ def _open_meta_pr(
         )
         if pr.returncode != 0:
             _stderr(f"auto-PR gh pr create failed: {pr.stderr.strip()}")
+            _emit_meta_pr_error(
+                sidecar_dir, session_id, f"gh pr create failed: {pr.stderr.strip()}"
+            )
             return None
         url = pr.stdout.strip().splitlines()[-1] if pr.stdout.strip() else ""
         _stderr(f"auto-PR opened: {url}")

--- a/scripts/session-end-transcript-export.sh
+++ b/scripts/session-end-transcript-export.sh
@@ -89,7 +89,17 @@ setsid -f bash -c \
 # local sessions the harness will PG-kill the wrapper before the
 # budget elapses; the detached child survives via setsid -f and
 # completes anyway (#182 behavior preserved).
-BUDGET_SEC="${VADE_TRANSCRIPT_EXPORT_BUDGET_SEC:-20}"
+#
+# Budget sizing (vade-runtime#207, 2026-05-03): the marker is
+# touched after the entire Python pipeline exits, including
+# _open_meta_pr's git fetch/switch/commit/push + gh pr create.
+# Empirical worst case on cold cache: ~5-10s pre-R2 + ~5-15s for
+# auto-PR git ops + ~3-5s for `gh pr create` = up to ~30s. The
+# original 20s default left auto-PR to die mid-flight on hosted
+# teardown (R2 PUT yes, meta.json git-push no — the asymmetry
+# documented in #207). 60s covers the empirical worst case with
+# margin while keeping the user-visible session-end pause bounded.
+BUDGET_SEC="${VADE_TRANSCRIPT_EXPORT_BUDGET_SEC:-60}"
 i=0
 while [ "$i" -lt "$BUDGET_SEC" ]; do
   if [ -f "$MARKER" ]; then


### PR DESCRIPTION
## Summary

Two-commit fix for vade-runtime#207 (meta-vs-R2 asymmetry surfaced post-#199):

- **a9f165b** — bump `VADE_TRANSCRIPT_EXPORT_BUDGET_SEC` default from 20 → 60. The marker is touched after the entire Python pipeline (including `_open_meta_pr`'s git fetch/switch/commit/push + gh pr create); empirical worst case on cold cache is ~30s, so 20s left auto-PR to die mid-flight on hosted teardown.
- **c38bbcb** — add `_emit_meta_pr_error` helper called at every non-design failure / skip in `_open_meta_pr`. Writes `<id>.meta-pr-error.txt` next to where meta.json would have gone, so the why-it-failed signal survives container teardown.

Together: (1) gives the existing pipeline enough wall-clock to actually complete, and (2) makes any remaining silent failures diagnosable rather than invisible.

Empirical anchor — auto-PR has been silent since 2026-05-01 (PR vade-agent-logs#194 was the last successful auto-meta sidecar) even though session 71e2128d successfully PUT to R2 at 2026-05-03T02:37:13Z post-#199. Without the breadcrumb fix in (2), we won't be able to confirm whether (1) alone was sufficient.

## What this does NOT fix

The architectural fix (#207's shape #3 — write meta.json to R2 as a sibling object instead of via git push) is deferred. If (1)+(2) prove insufficient and the breadcrumbs reveal a non-budget root cause, that's the next escalation.

## Test plan

- [ ] **Pre-merge** — bootstrap-regression CI passes; static syntax check passes (already verified locally: `python3 -c "import ast; ast.parse(...)"`).
- [ ] **Post-merge** — fresh hosted container session: confirm the next session's R2 PUT lands AND a meta auto-PR opens against vade-agent-logs (or, if it fails, a `.meta-pr-error.txt` breadcrumb appears).
- [ ] **Negative path** — run with `unset GITHUB_MCP_PAT` locally; confirm `<id>.meta-pr-error.txt` is written with `reason: GITHUB_MCP_PAT not set in hook env`.
- [ ] No regression in agent-teams local sessions (harness PG-kills wrapper regardless of budget; `setsid -f` detached child unchanged).

Closes: n/a (#207 stays open until the breadcrumbs verify the fix in production)

https://claude.ai/code/session_01PCESuePb5jd7oD6eJ9Eevm