### PR TITLE
transcript-export: first-write-wins R2 PUT + watchdog mark-only (#204, #208)

### DIFF
--- a/scripts/session-end-transcript-export.py
+++ b/scripts/session-end-transcript-export.py
@@ -264,8 +264,24 @@ def _op_read(ref: str) -> str:
 
 
 def _r2_upload(local: Path, key: str) -> dict:
-    """Upload a local file to R2 at the given key. Returns a dict with
-    bucket+key+endpoint for the sidecar; raises on failure."""
+    """Upload a local file to R2 at the given key with first-write-wins
+    semantics. Returns a dict with bucket+key+endpoint for the sidecar
+    plus `ceded: bool` indicating whether another writer already held
+    the key. Raises on non-precondition failures.
+
+    First-write-wins via `IfNoneMatch='*'` (vade-runtime#204, MEMO 2026-05-03-bgk3):
+    age encryption is non-deterministic (fresh X25519 ephemeral keypair
+    per call), so two writers encrypting the same plaintext produce
+    different ciphertext bytes. Without atomic-create, last-write-wins
+    on R2 leaves a meta.json `ciphertext_sha256` referencing bytes that
+    are no longer there. R2 honors S3's `IfNoneMatch: *` (Cloudflare
+    2024+) and returns HTTP 412 PreconditionFailed when the key
+    already exists; the second writer cedes silently.
+
+    Caller MUST check `ceded` before writing meta.json — a ceded
+    writer's SHA does not match what's in R2 and writing it would
+    re-create the mismatch this fix prevents.
+    """
     access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
     secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
     if not access_key or not secret_key:
@@ -283,6 +299,7 @@ def _r2_upload(local: Path, key: str) -> dict:
 
     import boto3  # imported lazily — uv resolves on first run
     from botocore.config import Config
+    from botocore.exceptions import ClientError
 
     s3 = boto3.client(
         "s3",
@@ -295,8 +312,23 @@ def _r2_upload(local: Path, key: str) -> dict:
             retries={"max_attempts": 3, "mode": "standard"},
         ),
     )
-    s3.upload_file(str(local), bucket, key)
-    return {"bucket": bucket, "key": key, "endpoint": endpoint}
+
+    try:
+        with open(local, "rb") as fin:
+            s3.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=fin,
+                IfNoneMatch="*",
+            )
+        return {"bucket": bucket, "key": key, "endpoint": endpoint, "ceded": False}
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        if code == "PreconditionFailed" or status == 412:
+            _stderr(f"R2 PUT ceded (key exists, first-write-wins): {key}")
+            return {"bucket": bucket, "key": key, "endpoint": endpoint, "ceded": True}
+        raise
 
 
 def _emit_export_error(sidecar_dir: Path, session_id: str, exc: BaseException) -> None:
@@ -606,7 +638,28 @@ def main() -> int:
                 }
             else:
                 upload = _r2_upload(ciphertext, r2_key)
-                r2_target = {**upload, "uploaded": True}
+                # First-write-wins cede (vade-runtime#204): another writer
+                # already holds this R2 key. Our ciphertext_sha256 does NOT
+                # match what's in R2 — writing meta.json with our SHA would
+                # re-create the mismatch this fix prevents. Drop a
+                # breadcrumb so operators can trace which session ceded,
+                # then exit cleanly without writing the sidecar or
+                # opening the auto-PR. The canonical writer's meta.json
+                # (or transcript-meta-backfill.py's stub) wins.
+                if upload.get("ceded"):
+                    _emit_meta_pr_error(
+                        sidecar_dir,
+                        session_id,
+                        f"R2 PUT ceded to first writer (key={r2_key}); skipped meta.json write",
+                    )
+                    return 0
+                # Strip the transient `ceded` flag so meta.json schema stays
+                # clean — only the canonical-writer path reaches here, so
+                # `ceded` is always False.
+                r2_target = {
+                    k: v for k, v in upload.items() if k != "ceded"
+                }
+                r2_target["uploaded"] = True
 
             sidecar = {
                 "schema_version": 1,

--- a/scripts/session-end-transcript-export.sh
+++ b/scripts/session-end-transcript-export.sh
@@ -47,6 +47,17 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Cold-start precondition (vade-runtime#208): on a fresh hosted
+# container the SessionEnd hook fires before Claude Code creates
+# ~/.claude/projects/. Without this gate the Python script bails with
+# "~/.claude/projects not found" and writes a cosmetic
+# unknown.export-error.txt that pollutes operator dashboards. Treat
+# the missing-projects case as a no-op: there's no live transcript to
+# export, by definition.
+if [ ! -d "${HOME}/.claude/projects" ]; then
+  exit 0
+fi
+
 # Source coo-env if present (provides R2 + age secrets). Fail-open: if
 # the file is missing, the Python script sees empty env vars and
 # degrades to writing export-error.txt (per design — never blocks).

--- a/scripts/session-idle-watchdog.sh
+++ b/scripts/session-idle-watchdog.sh
@@ -20,23 +20,35 @@
 #   3. If grace passes without activity, the worker fires the close
 #      sequence (--close), then exits 0.
 #
-# Close sequence (mechanical, since no Claude is running):
-#   a. Invoke `session-end-transcript-export.sh` with CLAUDE_SESSION_ID
-#      pinned to the watched jsonl's basename. The export hook already
-#      handles redact + age + R2 upload + meta.json sidecar drop.
-#   b. Write a stub session log at
+# Close sequence (mark-only since vade-runtime#204):
+#   a. Write a stub session log at
 #      <vade-agent-logs>/sessions/YYYY/MM/DD/coo-idle-close-<id>.md
 #      with status=incomplete, started_at/ended_at from jsonl event
-#      timestamps, and a pointer to the meta.json sidecar.
-#   c. POST a minimal Mem0 episodic entry (event=session_summary,
+#      timestamps, and a pointer to the meta.json sidecar IF one
+#      already exists (from a prior SessionEnd that ran inside this
+#      session's lifetime).
+#   b. POST a minimal Mem0 episodic entry (event=session_summary,
 #      idle_close=true, summary_pending=true, artifact_refs=[stub-log,
 #      sidecar]) via the Mem0 REST API with $MEM0_API_KEY from coo-env.
 #      Tier-1 safe text only — no transcript content (MEMO-2026-04-11-10).
-#   d. git add + commit + push the stub-log and any new sidecar files
+#   c. git add + commit + push the stub-log and any new sidecar files
 #      under `<vade-agent-logs>/transcripts/**/<id>.{meta,export-error}.{json,txt}`.
 #      Identity is the cloud container's vade-coo gitconfig + PAT, so
 #      attribution stays correct.
-#   e. PID-file cleanup, exit 0.
+#   d. PID-file cleanup, exit 0.
+#
+# Mark-only rationale (vade-runtime#204, MEMO 2026-05-03-bgk3):
+# Pre-#204 the watchdog also invoked session-end-transcript-export.sh
+# from cmd_close — a second writer racing the SessionEnd-final hook
+# against the same R2 key. Under age's non-deterministic encryption,
+# the second write replaced the ciphertext bytes that the first
+# writer's meta.json's `ciphertext_sha256` referenced — endemic 65%
+# SHA mismatch (W18d data). The architectural fix pairs storage-level
+# IfNoneMatch (in session-end-transcript-export.py:_r2_upload) with
+# canonical-writer designation: SessionEnd-final wins, watchdog
+# records intent only. The SIGTERM trap in cmd_run remains a
+# last-resort export under container teardown — safe under
+# IfNoneMatch since a parallel SessionEnd-final will cede cleanly.
 #
 # SessionStart on the next session reads any prior `coo-idle-close-*.md`
 # files via `session-lifecycle.sh --start` and surfaces a boot reminder
@@ -267,14 +279,14 @@ cmd_close() {
     log "coo-env not found at $COO_ENV — Mem0/git steps will degrade"
   fi
 
-  # ---- a. Mechanical export ------------------------------------------------
-  if [ -x "$EXPORT_HOOK" ]; then
-    log "invoking transcript export hook with CLAUDE_SESSION_ID=$session_id"
-    CLAUDE_SESSION_ID="$session_id" bash "$EXPORT_HOOK" </dev/null \
-      >> "$WATCHDOG_LOG" 2>&1 || true
-  else
-    log "export hook missing or non-executable at $EXPORT_HOOK; skipping"
-  fi
+  # ---- a. Mark-only — no R2 export from cmd_close (vade-runtime#204) ------
+  # The watchdog records intent and writes the stub session log; the
+  # canonical R2 write belongs to SessionEnd-final (or to the SIGTERM
+  # trap in cmd_run if the container is tearing down with us alive).
+  # Pre-#204 this step invoked session-end-transcript-export.sh and
+  # raced the SessionEnd-final hook for the same session_id, producing
+  # the W18d 65%-mismatch population. Removed deliberately.
+  log "mark-only close (vade-runtime#204): not invoking export hook from cmd_close"
 
   # Resolve agent-logs working tree once — both the closer-spawn path
   # and the stub-fallback path need it.


### PR DESCRIPTION
## Summary

Three coupled changes implementing #204 fix shape #1 (architectural decision ratified in run-2026-05-03T022041, paired with MEMO-2026-05-03-bgk3) plus #208 cold-start gate as a sibling cleanup.

**`session-end-transcript-export.py` — first-write-wins R2 PUT**

`_r2_upload` now uses `s3.put_object(IfNoneMatch='*')` instead of `s3.upload_file`. Cloudflare R2 honors S3's atomic-create precondition (since 2024); a second writer for the same key gets HTTP 412 PreconditionFailed, returns `ceded=True`, and `main()` exits without writing meta.json. Mechanism (per MEMO-2026-05-03-bgk3): age encryption is non-deterministic (fresh X25519 ephemeral keypair per call), so two writers encrypting the same plaintext produce different ciphertext bytes. Pre-fix, last-write-wins on R2 left meta.json `ciphertext_sha256` referencing bytes that were no longer there — endemic 65% SHA mismatch over W18d's 49 gap sessions.

The cede path drops a `<id>.meta-pr-error.txt` breadcrumb (reusing #211's instrumentation) so operators can trace which session ceded.

**`session-idle-watchdog.sh` — `cmd_close` mark-only**

`cmd_close` no longer invokes the export hook. Watchdog records intent (stub session log + Mem0 + git commit); SessionEnd-final holds canonical-writer status. The SIGTERM trap in `cmd_run` retains a last-resort export under container teardown — IfNoneMatch makes the residual race safe.

**`session-end-transcript-export.sh` — cold-start precondition gate (closes #208)**

Wrapper exits 0 silently when `~/.claude/projects/` does not exist (cold-start hosted container fires SessionEnd-class hook before Claude Code creates its projects directory). Pre-fix this dropped a cosmetic `unknown.export-error.txt` per cold-start that polluted operator dashboards.

## What's not in scope

- **`scripts/lib/transcript-meta-backfill.py`**: no changes. The script downloads R2 read-only and computes SHA against the bytes there, then writes a stub meta.json. Under first-write-wins those bytes are stable, so backfill produces matching meta.json's correctly. Agent B's prior briefing flagged this as "may be incompatible" — verified during implementation that it isn't.
- **#207 close-out**: deferred to session-end empirical telemetry (this session is the first running with #211's binaries; the breadcrumb directory will be the test).
- **#210 consumer fallback**: separate PR (different review surface; sibling branch).
- **#209 E7 alarm**: deferred per briefing 018 — calibrate against post-#204 mismatch rate.

## Test plan

- [x] `bash -n` syntax check on both shell scripts.
- [x] `python3 -m ast` parse check on the Python script.
- [ ] **Empirical at session-end**: this session's SessionEnd hook runs the new code. Three positive signals:
  1. R2 PUT succeeds (no 412 since this is the first writer for this `session_id` key).
  2. meta.json written; auto-PR opens against `vade-agent-logs`.
  3. No `<id>.meta-pr-error.txt` breadcrumb in `vade-agent-logs/transcripts/2026/05/03/`.
- [ ] **Empirical with two writers**: a future session where SessionEnd + idle-watchdog SIGTERM trap both fire — second writer should cede with breadcrumb, no SHA mismatch.

## Refs

- vade-runtime#204 (root cause + ratified fix shape)
- MEMO-2026-05-03-bgk3 (class hazard: non-determinism + multi-fire)
- vade-runtime#211 (sibling fix; budget bump + breadcrumbs that this PR builds on)
- vade-runtime#207, #209, #210 (related cluster filings)
- Briefing 018 (`vade-coo-memory/coo/briefings/018-transcripts-pipeline-post-211-verification-and-completion.md`)

Closes: #204, #208

https://claude.ai/code/session_01CnWos9EjteaRgfDLGAV539