### PR TITLE
integrity-check: E7 R2 SHA-mismatch sample probe (#209)

### DIFF
--- a/scripts/integrity-check-e7-r2-sha.py
+++ b/scripts/integrity-check-e7-r2-sha.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["boto3>=1.34,<2"]
+# ///
+"""
+integrity-check-e7-r2-sha.py — R2 ciphertext SHA-mismatch sample probe.
+
+Samples the K most-recent post-fix vade-agent-logs meta.json files,
+GETs each R2 object, computes SHA256 over the bytes, compares to
+meta.ciphertext_sha256. Output one line on stdout:
+
+  OK|<sampled>|<mismatches>|<errors>     — probe completed
+  SKIP|<reason>                            — preconditions unmet
+  ERROR|<message>                          — probe configuration failed
+
+Stderr carries per-row detail when --verbose. Always exits 0 on
+probe-completion (a mismatch finding does not exit nonzero); exits
+nonzero only on internal/configuration errors.
+
+Additive observability over the now-fixed pipeline: vade-runtime#212
+landed atomic IfNoneMatch first-write-wins in
+session-end-transcript-export.py at 2026-05-03T09:01:47Z (closing #204
++ MEMO 2026-05-03-bgk3). Mismatches in post-fix sessions would
+indicate a regression in the encrypt-then-PUT flow; pre-fix sessions
+are filtered out via the post-cutoff parameter.
+
+vade-runtime#209 — proposed E7 boot-time integrity invariant.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def _emit(line: str) -> None:
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+def _parse_iso(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--logs-dir",
+        default="/home/user/vade-agent-logs/transcripts",
+        help="Path to vade-agent-logs/transcripts root.",
+    )
+    ap.add_argument(
+        "--sample-k",
+        type=int,
+        default=3,
+        help="Number of most-recent eligible meta.json files to sample.",
+    )
+    ap.add_argument(
+        "--post-cutoff",
+        default="2026-05-03T09:01:47+00:00",
+        help="Only sample meta.json with exported_at >= this (ISO8601). "
+        "Default = vade-runtime#212 merge time.",
+    )
+    ap.add_argument("--verbose", action="store_true", help="Per-row detail to stderr.")
+    args = ap.parse_args()
+
+    access = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
+    secret = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
+    if not access or not secret:
+        _emit("SKIP|R2_TRANSCRIPTS_ACCESS_KEY_ID/SECRET_ACCESS_KEY missing")
+        return 0
+
+    logs_dir = Path(args.logs_dir)
+    if not logs_dir.is_dir():
+        _emit(f"SKIP|logs-dir not found: {logs_dir}")
+        return 0
+
+    try:
+        cutoff = _parse_iso(args.post_cutoff)
+    except ValueError:
+        _emit(f"ERROR|invalid --post-cutoff: {args.post_cutoff}")
+        return 1
+
+    candidates: list[tuple[datetime, Path, dict]] = []
+    for meta_path in logs_dir.rglob("*.meta.json"):
+        try:
+            data = json.loads(meta_path.read_text())
+        except Exception:
+            continue
+        if not data.get("r2", {}).get("uploaded"):
+            continue
+        ea = data.get("exported_at", "")
+        if not ea:
+            continue
+        try:
+            exported_at = _parse_iso(ea)
+        except ValueError:
+            continue
+        if exported_at < cutoff:
+            continue
+        candidates.append((exported_at, meta_path, data))
+
+    if not candidates:
+        _emit("SKIP|no eligible post-cutoff meta.json's")
+        return 0
+
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    sample = candidates[: args.sample_k]
+
+    try:
+        import boto3
+        from botocore.config import Config
+        from botocore.exceptions import ClientError
+    except ImportError as e:
+        _emit(f"ERROR|boto3 import failed: {e}")
+        return 1
+
+    first = sample[0][2]
+    endpoint = first.get("r2", {}).get("endpoint")
+    bucket = first.get("r2", {}).get("bucket")
+    if not endpoint or not bucket:
+        _emit("ERROR|endpoint/bucket missing from meta.r2")
+        return 1
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access,
+        aws_secret_access_key=secret,
+        region_name="auto",
+        config=Config(
+            signature_version="s3v4",
+            retries={"max_attempts": 2, "mode": "standard"},
+        ),
+    )
+
+    mismatches = 0
+    errors = 0
+    for exported_at, meta_path, data in sample:
+        key = data.get("r2", {}).get("key", "")
+        expected = data.get("ciphertext_sha256", "")
+        try:
+            obj = s3.get_object(Bucket=bucket, Key=key)
+            body = obj["Body"].read()
+            actual = hashlib.sha256(body).hexdigest()
+            if actual != expected:
+                mismatches += 1
+                if args.verbose:
+                    print(
+                        f"MISMATCH {key}: expected={expected[:12]}… actual={actual[:12]}…",
+                        file=sys.stderr,
+                    )
+            elif args.verbose:
+                print(f"MATCH {key}: sha={actual[:12]}…", file=sys.stderr)
+        except ClientError as e:
+            errors += 1
+            code = e.response.get("Error", {}).get("Code", "unknown")
+            if args.verbose:
+                print(f"ERROR {key}: ClientError {code}", file=sys.stderr)
+        except Exception as e:
+            errors += 1
+            if args.verbose:
+                print(f"ERROR {key}: {type(e).__name__}: {e}", file=sys.stderr)
+
+    _emit(f"OK|{len(sample)}|{mismatches}|{errors}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -527,6 +527,89 @@ else
 fi
 _add E5 "$E5_ok" "$E5_detail"
 
+# E6: reserved for vade-runtime#201 (R2 transcript-absence alarm: alarms
+# when sessions exist locally but R2 has no objects in the prior 24h).
+# Currently OPEN, not yet implemented. E7 below deliberately gaps over
+# E6 rather than colliding with the proposed-but-not-yet-shipped invariant.
+_add E6 skip "reserved for vade-runtime#201 (R2 absence detection; not yet implemented)"
+
+# E7: R2 ciphertext SHA-mismatch sample (vade-runtime#209, MEMO 2026-05-03-bgk3).
+# Samples the K most-recent post-fix vade-agent-logs meta.json files,
+# GETs each R2 object, compares SHA256 to meta.ciphertext_sha256.
+# Fires (degraded) when any mismatch is found in the sample.
+#
+# Additive observability over the now-fixed pipeline: vade-runtime#212
+# landed atomic IfNoneMatch first-write-wins in
+# session-end-transcript-export.py at 2026-05-03T09:01:47Z (closing #204
+# + MEMO 2026-05-03-bgk3). Mismatches in post-fix sessions would
+# indicate a regression; pre-fix sessions are filtered out via the
+# probe's --post-cutoff parameter.
+#
+# Cost: K=3 GETs of ~400KB ciphertext each ≈ 1-2MB / 2-3s per boot.
+# Skips when R2 creds missing, vade-agent-logs absent, uv missing, or
+# CI fake-env active. Live-only invariant (CI staging has no R2).
+#
+# Tunable via env: VADE_E7_SAMPLE_K (default 3),
+# VADE_E7_POST_CUTOFF (default 2026-05-03T09:01:47+00:00).
+E7_ok=skip
+E7_detail="prerequisites missing"
+E7_K="${VADE_E7_SAMPLE_K:-3}"
+E7_CUTOFF="${VADE_E7_POST_CUTOFF:-2026-05-03T09:01:47+00:00}"
+E7_LOGS_DIR="${VADE_E7_LOGS_DIR:-/home/user/vade-agent-logs/transcripts}"
+if [ -n "${VADE_CI_WORKSPACE_ROOT:-}" ] || [ -n "${VADE_BINDIR_OVERRIDE:-}" ]; then
+  E7_ok=skip
+  E7_detail="skipped in CI fake-env (VADE_CI_WORKSPACE_ROOT or VADE_BINDIR_OVERRIDE set); live-only probe"
+elif [ -z "${R2_TRANSCRIPTS_ACCESS_KEY_ID:-}" ] || [ -z "${R2_TRANSCRIPTS_SECRET_ACCESS_KEY:-}" ]; then
+  E7_ok=skip
+  E7_detail="R2_TRANSCRIPTS_{ACCESS,SECRET}_KEY missing in env (live probe needs creds)"
+elif [ ! -d "$E7_LOGS_DIR" ]; then
+  E7_ok=skip
+  E7_detail="$E7_LOGS_DIR absent (no meta.json corpus to sample)"
+elif ! check_cmd uv; then
+  E7_ok=skip
+  E7_detail="uv missing (required for boto3 probe)"
+elif ! check_cmd timeout; then
+  E7_ok=skip
+  E7_detail="timeout missing (cannot bound probe)"
+else
+  E7_probe_script="$SCRIPT_DIR/integrity-check-e7-r2-sha.py"
+  if [ ! -x "$E7_probe_script" ]; then
+    E7_ok=skip
+    E7_detail="probe script not executable: $E7_probe_script"
+  else
+    E7_out="$(timeout 20 "$E7_probe_script" \
+      --sample-k "$E7_K" \
+      --post-cutoff "$E7_CUTOFF" \
+      --logs-dir "$E7_LOGS_DIR" \
+      2>/dev/null || echo 'ERROR|probe-timeout-or-failure')"
+    IFS='|' read -r E7_status E7_a E7_b E7_c <<<"$E7_out"
+    case "$E7_status" in
+      OK)
+        if [ "${E7_b:-0}" = "0" ] && [ "${E7_c:-0}" = "0" ]; then
+          E7_ok=true
+          E7_detail="$E7_a/$E7_a post-fix R2 ciphertext SHAs match meta sidecars (K=$E7_K, cutoff $E7_CUTOFF)"
+        else
+          E7_ok=false
+          E7_detail="$E7_b/$E7_a post-fix R2 ciphertext SHA mismatches + $E7_c errors — regression in #212 atomic IfNoneMatch fix or upload contract; see vade-runtime#209, MEMO 2026-05-03-bgk3"
+        fi
+        ;;
+      SKIP)
+        E7_ok=skip
+        E7_detail="probe skip: ${E7_a:-no reason} ${E7_b:-} ${E7_c:-}"
+        ;;
+      ERROR)
+        E7_ok=false
+        E7_detail="probe error: ${E7_a:-no message} ${E7_b:-} ${E7_c:-}"
+        ;;
+      *)
+        E7_ok=false
+        E7_detail="probe produced unexpected output: $(printf '%s' "$E7_out" | head -c 200)"
+        ;;
+    esac
+  fi
+fi
+_add E7 "$E7_ok" "$E7_detail"
+
 # ── Group F: Culture-system substrate discipline ─────────────
 # Implements E1–E4 from coo/foundations/2026-04-22_we-can-claim-a-record.md
 # §5d (label delta: the essay calls these E1–E4; Group E is occupied by


### PR DESCRIPTION
## Summary

Adds boot-time integrity invariant **E7** — additive observability over the now-fixed encrypted-transcript pipeline. Samples the K most-recent post-fix `meta.json` files in `vade-agent-logs`, GETs each R2 object, computes SHA256, compares to `meta.ciphertext_sha256`. Fires (degraded) on any mismatch.

Pipeline status: PR #212 landed atomic `IfNoneMatch="*"` first-write-wins at 2026-05-03T09:01:47Z (closing #204 + MEMO 2026-05-03-bgk3). E7 catches regressions in that fix or any future encrypt-then-PUT contract drift.

## Implementation

- **`scripts/integrity-check-e7-r2-sha.py`** — uv-script + boto3 probe. Defaults: `--sample-k=3`, `--post-cutoff=2026-05-03T09:01:47+00:00`. Output: line-based `OK|N|M|E` / `SKIP|reason` / `ERROR|message`. Tunable via env: `VADE_E7_SAMPLE_K`, `VADE_E7_POST_CUTOFF`, `VADE_E7_LOGS_DIR`.
- **`scripts/integrity-check.sh`** — bash glue mirroring the E5 pattern. Skips cleanly when R2 creds missing, `vade-agent-logs` absent, `uv` missing, or `VADE_CI_WORKSPACE_ROOT` / `VADE_BINDIR_OVERRIDE` set (CI fake-env).

E6 number reserved for #201 (R2 absence detection) which remains open. E7 deliberately gaps over E6 rather than colliding with that proposed-but-not-yet-shipped invariant.

## Cost

K=3 GETs of ~400KB ciphertext ≈ 1–2MB / 2–3s per boot. Comparable to the E5 Mem0 probe budget.

## Verification

- **Probe correctness:** running with a looser cutoff (2026-04-01) against the documented W18d corpus correctly flagged the `e56b45d4` mismatch (1 of 3 in pre-cutoff sample; expected `630faa861dbd…`, actual `ceea4aa242f1…`).
- **Post-fix corpus:** empty in this clone (no `meta.json` files in `transcripts/2026/05/`). Probe SKIPs cleanly with `"no eligible post-cutoff meta.json's"` — genuine signal, not a bug.
- **Integrity check still 22/22:** `summary.ok=true`, no degraded invariants. E6 + E7 land as `skipped` rather than degraded.

## Test plan

- [ ] Verify on a fresh container after a post-fix session lands a `meta.json`: E7 should report `OK|N|0|0` for matching SHAs.
- [ ] Inject a synthetic mismatch (e.g., manually overwrite meta.json's `ciphertext_sha256` to a wrong value) and confirm E7 fires `degraded` with the regression-detection detail.
- [ ] Confirm CI bootstrap-regression continues to pass (E7 should skip in fake-env mode via `VADE_CI_WORKSPACE_ROOT`).

## Refs

- Closes: vade-runtime#209
- Cluster: #204 (root cause), #207 (post-#199 meta.json race), #210 (consumer resilience), #212 (atomic fix), #213 (consumer flag), #201 (proposed E6)
- Memo of record: MEMO-2026-05-03-bgk3 (class hazard); MEMO-2026-04-28-4umz (PR shape)
- Session: https://claude.ai/code/session_016LN6whrKpNL7TD8t3HHyeo