### PR TITLE
transcript-export: embed meta in R2 object metadata (close SIGKILL window properly)

### DIFF
--- a/scripts/lib/transcript-fetch.py
+++ b/scripts/lib/transcript-fetch.py
@@ -23,11 +23,14 @@ Usage:
 Meta resolution order (when --meta is omitted):
   1. vade-agent-logs/transcripts/**/<id>.meta.json walk (fast local path).
   2. R2 GetObject at transcripts/meta/<id>.meta.json (vade-runtime#207
-     fix shape (b), 2026-05-03 — R2 is the canonical durable record;
-     the vade-agent-logs copy is best-effort secondary). The walk
-     misses for any session whose auto-PR chain failed (the original
-     #207 symptom), so the R2 fallback is what makes meta-asymmetric
-     sessions readable.
+     fix shape (b), 2026-05-03 — flat-key fast-resolve index;
+     best-effort secondary post-this-PR).
+  3. R2 list_objects_v2 + head_object on the ciphertext: parse the
+     embedded `x-amz-meta-vade-meta-json` user-metadata value
+     (this PR — atomic body+meta single-PUT eliminates the cross-PUT
+     SIGKILL window that left tier 2 sessions orphaned in
+     2026-05-03 round-2 verification). Slower (one list + one head)
+     but always works for any session whose ciphertext landed.
 
 The decrypted jsonl is written to a per-invocation temp file under
 $HOME/.vade/transcript-cache/. Callers should `--cleanup` it when
@@ -167,16 +170,83 @@ def _r2_download(bucket: str, key: str, endpoint: str, dst: Path) -> None:
     s3.download_file(bucket, key, str(dst))
 
 
+def _find_ciphertext_key_by_session_id(s3, bucket: str, session_id: str) -> str | None:
+    """List `transcripts/` and return the first ciphertext key whose
+    filename matches `<session_id>.jsonl.gz.age`. Returns None if no
+    such key exists.
+
+    Used by the object-metadata fallback tier (this PR). Bucket
+    lifecycle keeps the listed surface bounded; if it grows we can
+    add a `--window-days` bound by walking date prefixes instead.
+    """
+    suffix = f"/{session_id}.jsonl.gz.age"
+    for page in s3.get_paginator("list_objects_v2").paginate(
+        Bucket=bucket, Prefix="transcripts/"
+    ):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(suffix):
+                return obj["Key"]
+    return None
+
+
+def _fetch_meta_from_r2_object_metadata(
+    s3, bucket: str, session_id: str
+) -> dict | None:
+    """Tier 3: list R2 for the ciphertext, head_object, parse the
+    embedded `vade-meta-json` user-metadata value.
+
+    Returns parsed sidecar dict on success, None when no ciphertext
+    exists for `session_id` or no embedded meta is present (caller
+    raises FileNotFoundError after exhausting all tiers).
+
+    R2/S3 lowercases user-metadata keys on read, so we look up the
+    lowercase form. If the export script truncated `redaction_hits`
+    to fit the 2 KB user-metadata cap, the marker key
+    `vade-meta-truncated` carries the dropped field name.
+    """
+    ciphertext_key = _find_ciphertext_key_by_session_id(s3, bucket, session_id)
+    if not ciphertext_key:
+        return None
+    head = s3.head_object(Bucket=bucket, Key=ciphertext_key)
+    metadata = head.get("Metadata") or {}
+    encoded = metadata.get("vade-meta-json")
+    if not encoded:
+        return None
+    try:
+        sidecar = json.loads(encoded)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"R2 object-metadata vade-meta-json on {ciphertext_key} "
+            f"is not valid JSON: {e!r}"
+        ) from e
+    truncated = metadata.get("vade-meta-truncated")
+    if truncated:
+        # Synthesize the dropped field as empty so downstream consumers
+        # don't blow up on KeyError. The flat-key + sidecar tiers carry
+        # the un-truncated copy if the operator needs full data.
+        sidecar.setdefault(truncated, {} if truncated == "redaction_hits" else None)
+        sidecar["_object_metadata_truncated"] = truncated
+    sidecar["_recovered_from_object_metadata"] = True
+    return sidecar
+
+
 def _fetch_meta_from_r2(session_id: str) -> dict:
     """Resolve meta.json for `session_id` directly from R2.
 
-    Used as a fallback when vade-agent-logs lookup fails. Post-#207 fix
-    shape (b): the R2 meta at `transcripts/meta/<id>.meta.json` is the
-    canonical durable record; the vade-agent-logs copy is best-effort
-    secondary for GitHub browsing. Sessions whose auto-PR chain failed
-    have R2 meta but no vade-agent-logs file.
+    Two tiers (vade-agent-logs walk is upstream of this function):
+      a. flat-key GET at `transcripts/meta/<id>.meta.json` — fast,
+         single GetObject; populated by the export hook's secondary
+         meta PUT (post-#215). Best-effort.
+      b. object-metadata HEAD on the ciphertext (this PR): list
+         `transcripts/` for the session's `.jsonl.gz.age`, head_object,
+         parse the embedded `vade-meta-json`. Slower (one list + one
+         head) but is the canonical durability path — the export hook
+         embeds meta on the ciphertext PUT itself, so any session whose
+         ciphertext landed has meta here regardless of whether tier (a)
+         succeeded.
 
-    Returns the parsed sidecar dict.
+    Returns the parsed sidecar dict; raises FileNotFoundError if
+    neither tier resolves.
     """
     endpoint = _op_read("op://COO/r2-transcripts/endpoint")
     bucket = _op_read("op://COO/r2-transcripts/bucket")
@@ -190,10 +260,21 @@ def _fetch_meta_from_r2(session_id: str) -> dict:
     s3 = _r2_client(endpoint)
     try:
         obj = s3.get_object(Bucket=bucket, Key=meta_key)
-    except Exception as e:
-        raise FileNotFoundError(
-            f"meta.json not on R2 at {meta_key!r}: {e!r}"
-        ) from e
+    except Exception as flatkey_err:
+        # Tier (a) miss — fall through to tier (b).
+        _stderr(
+            f"flat-key meta GET miss ({meta_key!r}); "
+            "falling through to object-metadata on the ciphertext"
+        )
+        sidecar = _fetch_meta_from_r2_object_metadata(s3, bucket, session_id)
+        if sidecar is None:
+            raise FileNotFoundError(
+                f"meta.json not resolvable for session_id={session_id} on R2: "
+                f"flat-key {meta_key!r} miss ({flatkey_err!r}); "
+                "no ciphertext with embedded vade-meta-json found either"
+            ) from flatkey_err
+        return sidecar
+
     body = obj["Body"].read()
     try:
         return json.loads(body.decode("utf-8"))

--- a/scripts/lib/transcript-meta-backfill.py
+++ b/scripts/lib/transcript-meta-backfill.py
@@ -6,13 +6,14 @@
 """
 transcript-meta-backfill.py — vade-coo-memory#243.
 
-Stub-meta generator. The Stop hook (session-end-transcript-export.py)
+Real-meta-or-stub generator. The Stop hook (session-end-transcript-export.py)
 writes <id>.meta.json locally but doesn't commit it; until vade-runtime#148
 Part A lands and is reliable, sessions can leave R2 ciphertext orphaned
 from any sidecar in the agent-logs working tree. This script enumerates
 R2 directly, finds session_ids without a sibling meta.json in
-vade-agent-logs/transcripts/<date>/, and drops a stub <id>.meta.json
-that the transcript-analyzer agent accepts.
+vade-agent-logs/transcripts/<date>/, and writes a meta.json — using the
+real meta embedded as R2 object-metadata when present (this PR), falling
+back to a stub when not.
 
 Pipeline per session_id:
   1. boto3 list_objects_v2 against the configured R2 prefix.
@@ -20,9 +21,13 @@ Pipeline per session_id:
      - If the agent-logs working tree already holds a real meta.json
        at the same date-path, skip.
      - If a stub meta.json already exists (carrying _stub: true), skip.
-     - Otherwise download the ciphertext to a temp file, compute
-       sha256, write a stub meta.json with the fields the analyzer
-       reads.
+     - head_object on the ciphertext: if `x-amz-meta-vade-meta-json`
+       is present (export hook PRs since this one), parse and write
+       the REAL meta with `_recovered_from_object_metadata: true`.
+       Skip SHA recompute — the embedded ciphertext_sha256 is canonical.
+     - Otherwise download the ciphertext, compute sha256, write a
+       stub meta.json with the fields the analyzer reads (legacy path
+       for sessions written before object-metadata embedding shipped).
 
 The stub is intentionally shallow — the analyzer doesn't need
 events_processed or bytes_post_redaction; it computes those itself
@@ -280,6 +285,65 @@ def _write_stub(
     return sidecar_path
 
 
+def _try_recover_real_meta_from_object_metadata(
+    s3, bucket: str, key: str
+) -> tuple[dict | None, str | None]:
+    """HEAD the ciphertext key; if the export hook embedded the full
+    meta as `x-amz-meta-vade-meta-json` (this PR), parse and return it.
+
+    Returns (sidecar_dict, truncation_marker) on success, (None, None)
+    when the metadata header is absent (legacy session). Raises only
+    on non-recoverable parse errors so the caller can fall through to
+    the stub path on missing-metadata, vs. surfacing on corruption.
+
+    R2/S3 lowercases user-metadata keys on read.
+    """
+    head = s3.head_object(Bucket=bucket, Key=key)
+    metadata = head.get("Metadata") or {}
+    encoded = metadata.get("vade-meta-json")
+    if not encoded:
+        return None, None
+    sidecar = json.loads(encoded)  # let JSONDecodeError propagate
+    truncated = metadata.get("vade-meta-truncated")
+    return sidecar, truncated
+
+
+def _write_recovered(
+    sidecar_dir: Path,
+    session_id: str,
+    sidecar: dict,
+    truncated: str | None,
+) -> Path:
+    """Write a recovered-from-object-metadata sidecar to disk.
+
+    Adds two forensic markers:
+      - `_recovered_from_object_metadata: true`
+      - `_object_metadata_truncated: <field>` when the export hook
+        dropped a field to fit the 2 KB user-metadata cap.
+
+    The dict is otherwise byte-identical to what the export hook would
+    have written to flat-key + local sidecar — this is the REAL meta,
+    not a stub. Distinguished from `_stub: true` for downstream forensics.
+    """
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    sidecar_path = sidecar_dir / f"{session_id}.meta.json"
+    enriched = dict(sidecar)
+    enriched["_recovered_from_object_metadata"] = True
+    if truncated:
+        enriched["_object_metadata_truncated"] = truncated
+        # Synthesize the dropped field as an empty container so the
+        # analyzer doesn't trip over a missing key.
+        enriched.setdefault(
+            truncated, {} if truncated == "redaction_hits" else None
+        )
+    enriched["recovered_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    enriched["recovery_source"] = "vade-runtime/scripts/lib/transcript-meta-backfill.py"
+    with open(sidecar_path, "w") as f:
+        json.dump(enriched, f, indent=2)
+        f.write("\n")
+    return sidecar_path
+
+
 def _backfill_one(
     entry: dict,
     date_path: str,
@@ -295,8 +359,39 @@ def _backfill_one(
     if skip:
         return f"SKIP {date_path}/{session_id} ({reason})"
 
+    # Tier 1 (this PR): try to recover the REAL meta from R2 object
+    # metadata embedded by the export hook on the ciphertext PUT.
+    # When present, this is byte-identical to what the export hook
+    # would have written — preferred over stub generation, which loses
+    # all the runtime telemetry (events_processed, bytes_*, redaction_hits).
+    try:
+        recovered, truncated = _try_recover_real_meta_from_object_metadata(
+            s3, bucket, entry["key"]
+        )
+    except json.JSONDecodeError as e:
+        return (
+            f"FAIL {date_path}/{session_id} "
+            f"object-metadata vade-meta-json unparseable: {e!r}"
+        )
+    if recovered is not None:
+        if dry_run:
+            return (
+                f"DRY  {date_path}/{session_id} "
+                "would write REAL meta from object-metadata"
+                + (f" (truncated: {truncated})" if truncated else "")
+            )
+        sidecar = _write_recovered(sidecar_dir, session_id, recovered, truncated)
+        return f"WROTE {date_path}/{session_id} ({sidecar}) [recovered from object-metadata]"
+
+    # Tier 2 (legacy): no embedded meta — generate a stub from the
+    # ciphertext bytes. Sessions written before object-metadata
+    # embedding shipped, or sessions whose meta exceeded the 2 KB cap
+    # entirely.
     if dry_run:
-        return f"DRY  {date_path}/{session_id} would write stub ({entry['size']} bytes)"
+        return (
+            f"DRY  {date_path}/{session_id} "
+            f"would write stub ({entry['size']} bytes; no object-metadata)"
+        )
 
     with tempfile.TemporaryDirectory(prefix=f"meta-backfill-{session_id}-") as tmp:
         ciphertext = Path(tmp) / f"{session_id}.jsonl.gz.age"
@@ -314,7 +409,7 @@ def _backfill_one(
         sha,
         entry["last_modified"],
     )
-    return f"WROTE {date_path}/{session_id} ({sidecar})"
+    return f"WROTE {date_path}/{session_id} ({sidecar}) [stub]"
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/session-end-transcript-export.py
+++ b/scripts/session-end-transcript-export.py
@@ -20,18 +20,23 @@ Pipeline per invocation:
      encryption per BDFL approval (vade-agent-logs#64 security review).
   6. boto3 upload to Cloudflare R2 at
      transcripts/YYYY/MM/DD/<id>.jsonl.gz.age (date from first event
-     timestamp, falling back to UTC-now).
+     timestamp, falling back to UTC-now). The meta.json dict is built
+     BEFORE this PUT and embedded as R2 user-metadata
+     (`x-amz-meta-vade-meta-json`) on the same call — body and meta
+     commit together in one atomic PUT (canonical durability layer
+     post-this-PR; closes the cross-PUT SIGKILL window that #215's
+     two-PUT layout left exposed).
   7. boto3 upload of meta.json to Cloudflare R2 at
-     transcripts/meta/<id>.meta.json (primary durability per
-     vade-runtime#207 fix shape (b), 2026-05-03). Flat-by-id key so
-     transcript-fetch can resolve meta from session_id alone without
-     needing the date hierarchy.
+     transcripts/meta/<id>.meta.json — best-effort secondary
+     fast-resolve index for transcript-fetch (avoids list+head_object
+     on the normal path). Failure here is recoverable via the embedded
+     object-metadata from step 6.
   8. Write a sidecar at <vade-agent-logs>/transcripts/YYYY/MM/DD/<id>.meta.json
      with parser_version, exported_at, event count, byte sizes,
      redaction hits, ciphertext sha256, and the R2 object keys.
      Best-effort secondary copy for GitHub-browsable history; failure
-     here no longer affects durability since R2 already holds the
-     canonical record from step 7.
+     here is recoverable via either step 6 (embedded) or step 7
+     (flat-key) — the meta is durable on R2 either way.
 
 Always exits 0. Any uncaught failure drops <id>.export-error.txt next
 to where the meta.json would have gone, so the absence of meta.json +
@@ -269,7 +274,31 @@ def _op_read(ref: str) -> str:
         return ""
 
 
-def _r2_upload(local: Path, key: str) -> dict:
+def _r2_endpoint_bucket() -> tuple[str, str]:
+    """Resolve R2 endpoint + bucket via `op` once.
+
+    Callers that PUT twice (ciphertext + flat-key meta) should resolve
+    once here and pass the values into `_r2_upload` to avoid duplicate
+    `op` invocations. Raises if either slot is empty.
+    """
+    endpoint = _op_read("op://COO/r2-transcripts/endpoint")
+    bucket = _op_read("op://COO/r2-transcripts/bucket")
+    if not endpoint or not bucket:
+        raise RuntimeError(
+            "R2 endpoint or bucket not readable from "
+            "op://COO/r2-transcripts/{endpoint,bucket}"
+        )
+    return endpoint, bucket
+
+
+def _r2_upload(
+    local: Path,
+    key: str,
+    *,
+    metadata: dict[str, str] | None = None,
+    endpoint: str | None = None,
+    bucket: str | None = None,
+) -> dict:
     """Upload a local file to R2 at the given key with first-write-wins
     semantics. Returns a dict with bucket+key+endpoint for the sidecar
     plus `ceded: bool` indicating whether another writer already held
@@ -287,6 +316,15 @@ def _r2_upload(local: Path, key: str) -> dict:
     Caller MUST check `ceded` before writing meta.json — a ceded
     writer's SHA does not match what's in R2 and writing it would
     re-create the mismatch this fix prevents.
+
+    `metadata` is the optional R2 user-metadata dict (`x-amz-meta-*`
+    headers, max 2 KB total, ASCII-only values). Body and metadata
+    commit together in one atomic PUT — used by the export pipeline
+    to embed meta.json on the ciphertext PUT, eliminating the
+    cross-PUT SIGKILL window that #215's two-PUT layout left exposed.
+    Orthogonal to `IfNoneMatch="*"`: the precondition is evaluated
+    server-side before commit, so a 412 cede leaves no metadata
+    behind either.
     """
     access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
     secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
@@ -295,12 +333,13 @@ def _r2_upload(local: Path, key: str) -> dict:
             "R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY "
             "missing — fetch_coo_secrets did not populate them"
         )
-    endpoint = _op_read("op://COO/r2-transcripts/endpoint")
-    bucket = _op_read("op://COO/r2-transcripts/bucket")
-    if not endpoint or not bucket:
-        raise RuntimeError(
-            "R2 endpoint or bucket not readable from "
-            "op://COO/r2-transcripts/{endpoint,bucket}"
+    if endpoint is None or bucket is None:
+        endpoint, bucket = _r2_endpoint_bucket()
+    if metadata is not None:
+        # R2 user-metadata is ISO-8859-1 string-only; ascii-encoded JSON
+        # caller-side keeps that constraint trivially.
+        assert all(isinstance(v, str) for v in metadata.values()), (
+            "R2 user-metadata values must be strings"
         )
 
     import boto3  # imported lazily — uv resolves on first run
@@ -319,14 +358,17 @@ def _r2_upload(local: Path, key: str) -> dict:
         ),
     )
 
+    put_kwargs = {
+        "Bucket": bucket,
+        "Key": key,
+        "IfNoneMatch": "*",
+    }
+    if metadata is not None:
+        put_kwargs["Metadata"] = metadata
+
     try:
         with open(local, "rb") as fin:
-            s3.put_object(
-                Bucket=bucket,
-                Key=key,
-                Body=fin,
-                IfNoneMatch="*",
-            )
+            s3.put_object(Body=fin, **put_kwargs)
         return {"bucket": bucket, "key": key, "endpoint": endpoint, "ceded": False}
     except ClientError as e:
         code = e.response.get("Error", {}).get("Code", "")
@@ -335,6 +377,56 @@ def _r2_upload(local: Path, key: str) -> dict:
             _stderr(f"R2 PUT ceded (key exists, first-write-wins): {key}")
             return {"bucket": bucket, "key": key, "endpoint": endpoint, "ceded": True}
         raise
+
+
+def _encode_meta_for_object_metadata(sidecar: dict) -> dict[str, str] | None:
+    """Encode the meta sidecar dict for embedding as R2 object metadata.
+
+    Returns a dict suitable for `s3.put_object(Metadata=...)` — keys
+    are the `x-amz-meta-*` user-metadata names (R2 lowercases them on
+    read, so use lowercase here too), values are ASCII-only strings.
+
+    Atomic-PUT durability: the ciphertext body and these metadata
+    headers commit together in one HTTP request. This eliminates the
+    cross-PUT SIGKILL window that #215's two sequential PUTs (ciphertext
+    + flat-key meta.json) left exposed (round-2 verification 2026-05-03
+    16:43Z: ciphertext landed, meta did not, no breadcrumb).
+
+    Degradation ladder (R2 caps user-metadata at 2 KB total):
+      1. Full encode → if ≤ 1900 B (safe margin), return.
+      2. Drop `redaction_hits` (largest variable field) → retry; if
+         ≤ 1900 B, return with `vade-meta-truncated` marker.
+      3. Still too large → return None; caller skips the embed and
+         relies on the secondary flat-key + sidecar + auto-PR layers.
+    None is not a fatal error — the secondary layers carry full meta;
+    the atomicity guarantee only weakens for outlier sessions, leaving
+    behavior identical to today's for those.
+    """
+    LIMIT = 1900  # safe margin under R2's 2 KB user-metadata cap
+    SCHEMA = str(sidecar.get("schema_version", 2))
+
+    encoded = json.dumps(sidecar, separators=(",", ":"), ensure_ascii=True)
+    if len(encoded.encode("utf-8")) <= LIMIT:
+        return {"vade-meta-json": encoded, "vade-meta-schema": SCHEMA}
+
+    truncated = {k: v for k, v in sidecar.items() if k != "redaction_hits"}
+    encoded2 = json.dumps(truncated, separators=(",", ":"), ensure_ascii=True)
+    if len(encoded2.encode("utf-8")) <= LIMIT:
+        _stderr(
+            f"meta exceeded {LIMIT}B; dropped redaction_hits from object-metadata "
+            "(full meta still in flat-key + sidecar)"
+        )
+        return {
+            "vade-meta-json": encoded2,
+            "vade-meta-schema": SCHEMA,
+            "vade-meta-truncated": "redaction_hits",
+        }
+
+    _stderr(
+        f"meta still too large after dropping redaction_hits "
+        f"({len(encoded2.encode('utf-8'))}B > {LIMIT}B); skipping object-metadata embed"
+    )
+    return None
 
 
 def _emit_export_error(sidecar_dir: Path, session_id: str, exc: BaseException) -> None:
@@ -634,47 +726,33 @@ def main() -> int:
             ciphertext_size = ciphertext.stat().st_size
 
             r2_key = f"transcripts/{date_path}/{session_id}.jsonl.gz.age"
+            meta_r2_key = f"transcripts/meta/{session_id}.meta.json"
             dry_run = os.environ.get("VADE_TRANSCRIPT_EXPORT_DRY_RUN", "").strip() == "1"
+
+            # Pre-resolve R2 endpoint+bucket once so we can build the
+            # sidecar dict BEFORE the ciphertext PUT. The sidecar gets
+            # embedded as object metadata on the ciphertext PUT itself
+            # (this PR) — single atomic PUT eliminates the cross-PUT
+            # SIGKILL window that #215's two-PUT layout left exposed.
             if dry_run:
+                r2_endpoint = "<dry-run>"
+                r2_bucket = "<dry-run>"
                 r2_target = {
-                    "bucket": "<dry-run>",
+                    "bucket": r2_bucket,
                     "key": r2_key,
-                    "endpoint": "<dry-run>",
+                    "endpoint": r2_endpoint,
                     "uploaded": False,
+                    "meta_key": meta_r2_key,
                 }
             else:
-                upload = _r2_upload(ciphertext, r2_key)
-                # First-write-wins cede (vade-runtime#204): another writer
-                # already holds this R2 key. Our ciphertext_sha256 does NOT
-                # match what's in R2 — writing meta.json with our SHA would
-                # re-create the mismatch this fix prevents. Drop a
-                # breadcrumb so operators can trace which session ceded,
-                # then exit cleanly without writing the sidecar or
-                # opening the auto-PR. The canonical writer's meta.json
-                # (or transcript-meta-backfill.py's stub) wins.
-                if upload.get("ceded"):
-                    _emit_meta_pr_error(
-                        sidecar_dir,
-                        session_id,
-                        f"R2 PUT ceded to first writer (key={r2_key}); skipped meta.json write",
-                    )
-                    return 0
-                # Strip the transient `ceded` flag so meta.json schema stays
-                # clean — only the canonical-writer path reaches here, so
-                # `ceded` is always False.
+                r2_endpoint, r2_bucket = _r2_endpoint_bucket()
                 r2_target = {
-                    k: v for k, v in upload.items() if k != "ceded"
+                    "bucket": r2_bucket,
+                    "key": r2_key,
+                    "endpoint": r2_endpoint,
+                    "uploaded": True,  # optimistic; cede branch returns 0 below
+                    "meta_key": meta_r2_key,
                 }
-                r2_target["uploaded"] = True
-
-            # Flat-by-id meta key on R2 (vade-runtime#207 fix shape (b),
-            # 2026-05-03): transcript-fetch resolves meta from session_id
-            # alone without needing the date hierarchy, so this prefix is
-            # NOT colocated with the date-organized ciphertext. Both keys
-            # are recorded in r2_target so backfill / forensic tooling can
-            # navigate either direction.
-            meta_r2_key = f"transcripts/meta/{session_id}.meta.json"
-            r2_target["meta_key"] = meta_r2_key
 
             sidecar = {
                 "schema_version": 2,
@@ -696,23 +774,58 @@ def main() -> int:
                 "age_recipient_pubkey": _read_recipient_pubkey(),
             }
 
-            # R2 PUT(meta) — primary durability for vade-runtime#207. The
-            # auto-PR git-push chain races container teardown and silently
-            # SIGKILLs mid-pipeline; R2 is the only durable surface that
-            # survives the kill window between ciphertext upload and
-            # session-end. By staging meta to R2 here, before the
-            # vade-agent-logs git operations, we guarantee that any
-            # session whose ciphertext landed also has its meta — without
-            # depending on git-push, gh-pr-create, or container survival.
-            # The local file write + auto-PR below remain best-effort
-            # secondary for GitHub-browsable history.
+            # Atomic ciphertext PUT carrying meta as R2 object metadata.
+            # One HTTP request, one SIGKILL window: body and meta commit
+            # together or not at all. This collapses the prior two-PUT
+            # layout (#215) whose ~100-500ms inter-PUT gap was apparently
+            # still inside the container-teardown SIGKILL window
+            # (round-2 verification 2026-05-03T16:43Z: ciphertext landed,
+            # meta did not, no breadcrumb).
+            #
+            # The flat-key meta PUT and local sidecar below remain as
+            # best-effort secondary indexing layers (fast-resolve for
+            # transcript-fetch + GitHub-browsable history); failures
+            # there are recoverable via the embedded object-metadata.
+            embed_metadata = (
+                _encode_meta_for_object_metadata(sidecar) if not dry_run else None
+            )
+
+            if not dry_run:
+                upload = _r2_upload(
+                    ciphertext, r2_key,
+                    metadata=embed_metadata,
+                    endpoint=r2_endpoint, bucket=r2_bucket,
+                )
+                # First-write-wins cede (vade-runtime#204): another writer
+                # already holds this R2 key. Our ciphertext_sha256 does NOT
+                # match what's in R2 — writing meta.json with our SHA would
+                # re-create the mismatch this fix prevents. Drop a
+                # breadcrumb so operators can trace which session ceded,
+                # then exit cleanly without writing the sidecar or
+                # opening the auto-PR. The canonical writer's meta
+                # (in their object-metadata + flat-key) wins.
+                if upload.get("ceded"):
+                    _emit_meta_pr_error(
+                        sidecar_dir,
+                        session_id,
+                        f"R2 PUT ceded to first writer (key={r2_key}); skipped meta.json write",
+                    )
+                    return 0
+
+            # Best-effort secondary: flat-key meta PUT (fast-resolve index
+            # for transcript-fetch.py — avoids list+head_object on the
+            # normal path). If this fails, fetch falls through to the
+            # object-metadata tier on the ciphertext key.
             meta_temp = tmp_path / f"{session_id}.meta.json"
             meta_temp.write_text(json.dumps(sidecar, indent=2) + "\n")
             if dry_run:
                 _stderr(f"R2 meta PUT skipped (DRY_RUN=1): would write to {meta_r2_key}")
             else:
                 try:
-                    meta_upload = _r2_upload(meta_temp, meta_r2_key)
+                    meta_upload = _r2_upload(
+                        meta_temp, meta_r2_key,
+                        endpoint=r2_endpoint, bucket=r2_bucket,
+                    )
                     if meta_upload.get("ceded"):
                         _stderr(
                             f"R2 meta PUT ceded (idempotent re-fire): key={meta_r2_key}"
@@ -720,19 +833,20 @@ def main() -> int:
                     else:
                         _stderr(f"wrote R2 meta: {meta_r2_key}")
                 except BaseException as e:
-                    # Best-effort: meta R2 PUT failure doesn't block; the
-                    # local file write + auto-PR chain remain as fallback.
-                    # Drop a durable breadcrumb so operators can detect the
-                    # primary-durability path failed (the local fallback
-                    # may still succeed and mask the issue otherwise).
+                    # Best-effort: flat-key meta PUT failure doesn't
+                    # block; the embedded object-metadata on the
+                    # ciphertext PUT is the canonical durability layer.
+                    # Drop a breadcrumb for operator visibility; absence
+                    # of meta in flat-key + presence of object-metadata
+                    # is recoverable via the fetch fallback chain.
                     _stderr(
                         f"R2 meta PUT failed: {e!r} "
-                        "(best-effort; falling through to local + auto-PR)"
+                        "(best-effort secondary; object-metadata is canonical)"
                     )
                     _emit_meta_pr_error(
                         sidecar_dir,
                         session_id,
-                        f"R2 meta PUT failed: {e!r}",
+                        f"R2 meta PUT (flat-key secondary) failed: {e!r}",
                     )
 
             sidecar_path = sidecar_dir / f"{session_id}.meta.json"


### PR DESCRIPTION
## Summary

- **Atomic single-PUT.** The full meta dict is JSON-encoded as `x-amz-meta-vade-meta-json` user-metadata on the ciphertext PUT itself. Body and meta commit together in one HTTP request — collapsing the cross-PUT SIGKILL window that #215's two-PUT layout left exposed.
- **Defense-in-depth retained.** The flat-key meta PUT (#215, `transcripts/meta/<id>.meta.json`), local sidecar, and auto-PR all stay in place as best-effort secondary indexing layers. Failures there are recoverable via the embedded object-metadata.
- **Fetch + backfill learn the new tier.** `transcript-fetch.py` adds a list+head_object fallback after the flat-key GET miss; `transcript-meta-backfill.py` recovers REAL meta from object-metadata before falling back to stub generation.

## Why this is the fourth attempt

PR #215 merged 16:18Z, verified n=1 at 16:43Z by round-2 session `8b2913a0-…`: ciphertext landed, meta did not, no breadcrumb. Container next-build was 2-3s after ciphertext PUT — apparent SIGKILL inside the inter-PUT gap. `BaseException` can't catch SIGKILL.

The prior three fixes (`#182` setsid, `#199` wait-with-detach, `#212`+`#215` atomic + R2-side meta) each closed one layer and exposed the next; all relied on the export script surviving long enough to complete its work. **This change does not.** The atomicity guarantee comes from the storage layer (R2 honoring S3 PutObject contract) rather than from script-survival timing.

## Test plan

- [x] `python3 -m py_compile` all 3 files
- [x] `scripts/ci/test-transcript-export.py` (sidecar shape preserved; `r2.meta_key` still set; schema v2 unchanged)
- [x] Synthetic encode tests: typical (918 B), bloated `redaction_hits` (drops + retries to 861 B with truncation marker), pathological (returns None; caller falls back)
- [ ] **Post-merge: real-session verification** — fresh-container handoff in PR comment. Victory bar: **N=10 consecutive real session-ends produce ciphertexts whose `head_object.Metadata.vade-meta-json` parses cleanly with matching `session_id`, zero orphans across the window.**

## Edge cases verified

| Risk | Status |
|---|---|
| boto3 pin `>=1.34,<2` (`versions.lock:101`) supports `Metadata={}` | stable since 1.x |
| `put_object` never auto-promotes to multipart | ciphertexts 50-500 KB |
| `IfNoneMatch="*"` × `Metadata={}` interaction | orthogonal; cede leaves no metadata behind |
| R2 lowercases user-metadata keys on read | fetch + backfill use lowercase form |
| ISO-8859-1 metadata constraint | `ensure_ascii=True` keeps output plain ASCII |
| age recipient-key rotation | meta carries `age_recipient_pubkey`; fetch uses current `TRANSCRIPTS_AGE_IDENTITY` |

## Out of scope

- **#201** (E6 R2-orphan invariant) — sibling work; pair-shipping turns "n=1 verification" into Night's Watch graph. Should land before declaring victory.
- **#200** (CI smoke test for SessionEnd-hook timing) — sibling defense-in-depth.

## Rollback

Mechanical. Readers fall back to existing tiers automatically. Sessions written under this PR's code remain readable post-revert via the third fetch tier (list+head_object) as long as embedded metadata is preserved on R2.

Closes #207 (properly, not optimistically). Refs MEMO-2026-05-03-bgk3, vade-coo-memory#453.

https://claude.ai/code/session_01C2GvjMagxe3HDdHtXM1zP5