### PR TITLE
external-touch cache-refresh trigger: build-time + per-session (#429 follow-up)

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -257,6 +257,16 @@ else
   log "OP_SERVICE_ACCOUNT_TOKEN not visible at setup time; SessionStart hook will run coo-bootstrap."
 fi
 
+# Pre-warm the external-touch (F6) cache into the snapshot so the first
+# session of a fresh container reports F6 ok rather than "cache absent
+# — refresh via bin/external-touch.py" (which required a manual handoff
+# step on every cold boot). Runs after coo-bootstrap so $GITHUB_MCP_PAT
+# is exported; fail-open if either is missing or external-touch.py is
+# absent (CI fake-env stages a stub vade-coo-memory without it).
+# vade-coo-memory#429 cache-refresh follow-up.
+. "$HOME/.vade/coo-env" 2>/dev/null || true
+prewarm_external_touch_cache "$WORKSPACE_ROOT"
+
 # Durable receipt so sessions can diagnose build-time state without
 # parsing logs. coo-identity-digest surfaces this in the SessionStart
 # digest block.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -840,6 +840,74 @@ PREWARM_PY
   rm -f "$prewarm_script"
 }
 
+# Refresh the external-touch (F6) cache by invoking
+# vade-coo-memory/bin/external-touch.py --refresh-cache. Two callers:
+#
+#   1. cloud-setup.sh after coo-bootstrap → builds the cache into the
+#      snapshot so F6 reports ok on the first session of a fresh
+#      container (rather than skipping with "cache absent — refresh via
+#      bin/external-touch.py" until manually run).
+#   2. session-start-sync.sh → refreshes if the cache is older than
+#      $2 hours, catching long-running snapshots whose baked-in cache
+#      has gone stale.
+#
+# Args: $1 workspace_root (e.g., /home/user); $2 max_age_hours (optional —
+# refresh only if the cache is older than this; omit to always refresh).
+#
+# Fail-open on every gate (gh missing, PAT missing, script absent, refresh
+# fails) so a degraded snapshot doesn't block boot. Non-zero exits log a
+# WARN; F6 will fall back to its own "cache absent" skip path.
+prewarm_external_touch_cache() {
+  local workspace_root="${1:-}"
+  local max_age_hours="${2:-}"
+  if [ -z "$workspace_root" ]; then
+    build_log_record WARN "external-touch: prewarm called without workspace_root; skipping"
+    return 0
+  fi
+  local script="$workspace_root/vade-coo-memory/bin/external-touch.py"
+  local cache_path="${VADE_EXTERNAL_TOUCH_CACHE:-$VADE_CLOUD_STATE_DIR/external-touch-cache.json}"
+
+  if [ ! -f "$script" ]; then
+    build_log_record WARN "external-touch: $script absent; F6 cache pre-warm skipped"
+    return 0
+  fi
+  if ! check_cmd python3 || ! check_cmd gh; then
+    build_log_record WARN "external-touch: python3/gh missing; F6 cache pre-warm skipped"
+    return 0
+  fi
+  # Need either an exported PAT (build-time after coo-bootstrap; or
+  # session-start with coo-env autosourced) or an interactively-authed gh.
+  if [ -z "${GITHUB_MCP_PAT:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}" ] \
+      && ! gh auth status >/dev/null 2>&1; then
+    build_log_record WARN "external-touch: no gh auth; F6 cache pre-warm skipped"
+    return 0
+  fi
+
+  # Freshness gate — only when max_age_hours is given. mtime comparison
+  # is portable across GNU/BSD stat by trying both flags.
+  if [ -n "$max_age_hours" ] && [ -f "$cache_path" ]; then
+    local cache_mtime now_secs age_hours
+    cache_mtime=$(stat -c %Y "$cache_path" 2>/dev/null \
+                || stat -f %m "$cache_path" 2>/dev/null \
+                || echo 0)
+    now_secs=$(date +%s)
+    age_hours=$(( (now_secs - cache_mtime) / 3600 ))
+    if [ "$age_hours" -lt "$max_age_hours" ] 2>/dev/null; then
+      build_log_record OK "external-touch: cache age ${age_hours}h < ${max_age_hours}h floor; refresh skipped"
+      return 0
+    fi
+  fi
+
+  mkdir -p "$VADE_CLOUD_STATE_DIR" 2>/dev/null || true
+  if GH_TOKEN="${GITHUB_MCP_PAT:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}" \
+      python3 "$script" --refresh-cache "$cache_path" >/dev/null 2>>"$VADE_BUILD_LOG"; then
+    build_log_record OK "external-touch: cache pre-warmed at $cache_path"
+  else
+    build_log_record WARN "external-touch: cache pre-warm failed; F6 will skip on next session"
+  fi
+  return 0
+}
+
 ensure_op_cli() {
   # Install into a snapshot-persistent path so a build-time install is
   # still on disk at session-resume time. /root/ resets each resume in

--- a/scripts/session-start-sync.sh
+++ b/scripts/session-start-sync.sh
@@ -78,6 +78,13 @@ ensure_gh_coo_wrap "$SCRIPT_DIR/gh-coo-wrap.sh"
 # would clobber the well-formed PATH coo-bootstrap captured at install time.
 # vade-runtime#171.
 merge_coo_settings_state_dir
+# Refresh the external-touch (F6) cache when it's older than 24h.
+# Build-time prewarm in cloud-setup.sh handles the fresh-snapshot case;
+# this catches snapshots resumed after the cache has gone stale and
+# session-resume environments where the build skipped the prewarm
+# (no PAT at build time, etc.). Fail-open: if gh/PAT missing or refresh
+# fails, F6 falls back to its own "cache absent" skip path.
+prewarm_external_touch_cache "$WORKSPACE_ROOT_DERIVED" 24
 # integrity-check.sh runs in coo-identity-digest.sh instead of here,
 # so the check fires after the platform's repo-sync has settled
 # (vade-runtime#XXX; moved from here to eliminate boot-time false alarms).


### PR DESCRIPTION
## Summary

Wires \`bin/external-touch.py --refresh-cache\` (in vade-coo-memory) into the setup chain so F6 reports ok on every fresh boot — closes the 2026-05-04 manual handoff prompt where every fresh container needed \`python3 .../external-touch.py --refresh-cache ...\` run by hand before integrity-check passed.

## What changed

1. **\`lib/common.sh: prewarm_external_touch_cache\`** — new helper, mirroring the \`prewarm_uv_cache\` patterns. Args: \`workspace_root\` + optional \`max_age_hours\` (skip refresh if cache younger than this; omit to always refresh). Fail-open at every gate (script absent, gh missing, PAT missing, refresh failure) — logs a WARN and returns 0.

2. **\`cloud-setup.sh\`** — calls the helper after coo-bootstrap, where \`fetch_coo_secrets\` has exported \`GITHUB_MCP_PAT\` into the build shell via \`~/.vade/coo-env\`. The cache lands in the snapshot.

3. **\`session-start-sync.sh\`** — calls the helper with \`max_age_hours=24\`. Catches snapshots resumed after the baked-in cache has gone stale, and session-resume cases where the build skipped the prewarm.

## CI compatibility

The bootstrap-regression CI stages a stub \`vade-coo-memory\` without \`bin/\`. The function hits the missing-script gate, logs a WARN to build.log, and returns 0. Verified locally:

\`\`\`
2026-05-04T12:06:13Z OK cloud-setup: coo-bootstrap completed
2026-05-04T12:06:13Z WARN external-touch: /tmp/.../bin/external-touch.py absent; F6 cache pre-warm skipped
\`\`\`

(The local CI run hung in a pre-existing mock-\`git\` issue unrelated to this PR; the GitHub Actions runner doesn't reproduce that.)

## Verified locally

\`\`\`
$ rm /home/user/.vade-cloud-state/external-touch-cache.json
$ bash scripts/session-start-sync.sh
$ ls -la /home/user/.vade-cloud-state/external-touch-cache.json
-rw-r--r-- 1 root root 14420 May  4 12:04 .../external-touch-cache.json
$ bash scripts/integrity-check.sh
VADE integrity: 26/26 OK
\`\`\`

Re-run after refresh shows the freshness gate working:

\`\`\`
2026-05-04T12:05:13Z OK external-touch: cache age 0h < 24h floor; refresh skipped
\`\`\`

## Companion PR

Pairs with **vade-coo-memory#486** which ships matcher v2 (closes 8 documented false-negative retros). Together they close two #429 follow-ups: cache-refresh workflow trigger + matcher v2.

## Test plan

- [x] Local: cache-absent → session-start-sync refreshes → F6 ok
- [x] Local: cache-fresh → session-start-sync skips via 24h gate
- [x] Local: integrity-check 26/26 OK after both flows
- [ ] CI: bootstrap-regression passes
- [ ] Post-merge: fresh-boot session shows F6 ok in integrity-check (no manual handoff)

## Refs

- vade-coo-memory#429 — Stage 2 + cache-refresh follow-up tracker
- vade-coo-memory#486 — companion PR (matcher v2)

https://claude.ai/code/session_01BDkEwHQn6T9Rg3jqnFANe4