### PR TITLE
scripts/lib: add list-r2-transcripts.py (uv-script wrapper for nightly R2 enum)

### DIFF
--- a/scripts/lib/list-r2-transcripts.py
+++ b/scripts/lib/list-r2-transcripts.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["boto3>=1.34,<2"]
+# ///
+"""
+list-r2-transcripts.py — vade-coo-memory#499.
+
+Print R2 transcript keys under a given prefix, one per line (text mode)
+or as a JSON array of {key, size, last_modified} (--json mode).
+
+Reads R2 credentials and bucket coordinates from 1Password
+(`op read op://COO/r2-transcripts/{endpoint,bucket}`) and the env vars
+`R2_TRANSCRIPTS_ACCESS_KEY_ID` / `R2_TRANSCRIPTS_SECRET_ACCESS_KEY`,
+matching `transcript-meta-backfill.py`'s helper functions.
+
+Why a separate script: the nightly task previously inlined the R2
+enumeration as a `python3 - <<PY` heredoc with a bare `import boto3`,
+which fails because the ambient Python lacks boto3 (vrt#203 only
+prewarms uv's cache). Calling this script via the shebang
+(`#!/usr/bin/env -S uv run --script`) routes through uv with the
+PEP-723 deps block, so boto3 resolves cleanly.
+
+Usage:
+  list-r2-transcripts.py transcripts/2026/05/06/
+  list-r2-transcripts.py --json transcripts/2026/05/06/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+def _op_read(ref: str) -> str:
+    if not shutil.which("op"):
+        return ""
+    try:
+        out = subprocess.run(
+            ["op", "read", ref],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return out.stdout.strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return ""
+
+
+def _r2_creds() -> tuple[str, str, str, str]:
+    access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
+    secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
+    if not access_key or not secret_key:
+        raise RuntimeError(
+            "R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY "
+            "missing — source ~/.vade/coo-env first"
+        )
+    endpoint = _op_read("op://COO/r2-transcripts/endpoint")
+    bucket = _op_read("op://COO/r2-transcripts/bucket")
+    if not endpoint or not bucket:
+        raise RuntimeError(
+            "op://COO/r2-transcripts/{endpoint,bucket} unreadable — "
+            "verify OP_SERVICE_ACCOUNT_TOKEN and 1Password provisioning"
+        )
+    return access_key, secret_key, endpoint, bucket
+
+
+def _r2_client(access_key: str, secret_key: str, endpoint: str):
+    import boto3
+    from botocore.config import Config
+
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="auto",
+        config=Config(
+            signature_version="s3v4",
+            retries={"max_attempts": 3, "mode": "standard"},
+        ),
+    )
+
+
+def list_keys(prefix: str) -> list[dict]:
+    access_key, secret_key, endpoint, bucket = _r2_creds()
+    s3 = _r2_client(access_key, secret_key, endpoint)
+    out: list[dict] = []
+    for page in s3.get_paginator("list_objects_v2").paginate(
+        Bucket=bucket, Prefix=prefix
+    ):
+        for obj in page.get("Contents", []):
+            out.append(
+                {
+                    "key": obj["Key"],
+                    "size": obj["Size"],
+                    "last_modified": obj["LastModified"].isoformat(),
+                }
+            )
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "prefix",
+        help="R2 key prefix, e.g. transcripts/2026/05/06/",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="emit JSON array of {key, size, last_modified}",
+    )
+    args = p.parse_args()
+
+    keys = list_keys(args.prefix)
+    if args.json:
+        json.dump(keys, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        for k in keys:
+            print(k["key"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/lib/list-r2-transcripts.py` — a small uv-script utility that lists R2 transcript ciphertexts under a given prefix.

```
list-r2-transcripts.py transcripts/2026/05/06/
list-r2-transcripts.py --json transcripts/2026/05/06/
```

## Why

The nightly task spec (`vade-coo-memory/coo/nightly_review_task.md` §1.a) previously inlined R2 enumeration as a `python3 - <<PY` heredoc with a bare `import boto3`. boto3 is not in the system Python (verified 2026-05-06 in both interactive and nightly containers); vrt#203 only prewarms uv's cache, which is hit by uv-script shebangs but bypassed by direct `python3` invocation. Result: the nightly skipped the R2 enumeration + transcript-analyzer sidecar pass for **three consecutive nights** (5/4, 5/5, 5/6), throttled silently.

This script provides the routing fix on the runtime side. Companion spec change in vade-coo-memory (separate PR) updates §1.a to call this.

## Design notes

- Uses `#!/usr/bin/env -S uv run --script` shebang + PEP-723 deps block — same shape as `transcript-meta-backfill.py` in the same directory.
- `_op_read`, `_r2_creds`, `_r2_client` helpers are duplicated from `transcript-meta-backfill.py` rather than factored. Keeps each script standalone (matches existing lib/ pattern); factor later if a third script joins the family and the duplication is genuinely costly.
- Default text output (one key per line) for shell-pipeline use; `--json` for richer downstream tooling (vcm#481 verification recipe step 0 will use this).

## Test plan

- [x] `--help` resolves PEP-723 deps and prints usage (verified locally — uv installed 7 packages in 87ms, no errors)
- [x] Live R2 list against `transcripts/2026/05/04/` returns the 6 known post-vrt#216 ciphertexts
- [x] Live R2 list against `transcripts/2026/05/05/` and `…/05/06/` returns empty (matches integrity-check E6 reading — surfaces the actual regression vcm#481 will investigate tomorrow)
- [ ] Reviewer: spot-check the script against the `transcript-meta-backfill.py` helpers for drift

Refs vade-coo-memory#499.

Closes: n/a — implementation half of cross-repo fix; vade-coo-memory PR closes vcm#499.

https://claude.ai/code/session_01Wa1F45uSJkR6WCFJ3P6Sp4