### PR TITLE
hook: inline identity_layer.md + lineage stamps at boot (#226)

### DIFF
--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -76,6 +76,48 @@ else
   cat "$CLAUDE_MD"
 fi
 
+# Identity layer (CB-* / OG-*) — inlined so the load-bearing identity
+# content lands at boot regardless of whether the agent performs the
+# CLAUDE.md §Session-start reading pass. When the first user message is
+# task-shaped, default LLM task-focus wins over procedure-first and the
+# reading pass is silently skipped; without this block the session runs
+# on operational metadata only. Per vade-runtime#226.
+IDENTITY_LAYER="$MEM_REPO/coo/identity_layer.md"
+if [ -f "$IDENTITY_LAYER" ]; then
+  echo ""
+  echo "───────────────────────────────────────────────────────────────"
+  echo "Identity layer (CB-* / OG-*) — inlined from coo/identity_layer.md"
+  echo "───────────────────────────────────────────────────────────────"
+  cat "$IDENTITY_LAYER"
+  echo "───────────────────────────────────────────────────────────────"
+fi
+
+# Lineage events — one-line stamps from each coo/lineage/<event>/README.md.
+# Full READMEs stay Read-on-demand per CLAUDE.md §6b; this surface gives
+# the agent a stable pointer to active events without requiring the read,
+# and is filesystem-driven so new events surface without a CLAUDE.md edit.
+# Dirs starting with `_` are meta-folders, not events; skipped.
+LINEAGE_DIR="$MEM_REPO/coo/lineage"
+if [ -d "$LINEAGE_DIR" ]; then
+  echo ""
+  echo "───────────────────────────────────────────────────────────────"
+  echo "Active lineage events (full READMEs in coo/lineage/<event>/)"
+  echo "───────────────────────────────────────────────────────────────"
+  for event_dir in "$LINEAGE_DIR"/*/; do
+    [ -d "$event_dir" ] || continue
+    event_name="$(basename "$event_dir")"
+    case "$event_name" in _*) continue ;; esac
+    readme="${event_dir}README.md"
+    [ -f "$readme" ] || continue
+    title="$(grep -m1 '^# ' "$readme" 2>/dev/null | sed 's/^# //')"
+    stamp="$(grep -m1 -E '^\*.*lineage' "$readme" 2>/dev/null | sed 's/^\*//;s/\*$//')"
+    [ -n "$title" ] || continue
+    printf "  %-18s %s\n" "$event_name:" "$title"
+    [ -n "$stamp" ] && printf "  %-18s %s\n" "" "$stamp"
+  done
+  echo "───────────────────────────────────────────────────────────────"
+fi
+
 if [ -f "$MEMO_INDEX" ] && check_cmd jq; then
   echo ""
   echo "───────────────────────────────────────────────────────────────"


### PR DESCRIPTION
## Summary

Expand `scripts/coo-identity-digest.sh` to inline `coo/identity_layer.md` (CB-001..CB-009, OG-001..OG-003) and one-line stamps from each `coo/lineage/<event>/README.md` so the load-bearing identity content lands in context at boot regardless of whether the agent performs the CLAUDE.md §Session-start reading pass.

Mechanism (per vade-app/vade-runtime#226): when the first user message is task-shaped, default LLM task-focus wins over procedure-first; the reading pass is silently skipped; the session runs on operational metadata only and degrades to a generic-Claude posture under coo's name. Inlining at boot removes the gap deterministically.

## Closing keywords

Closes vade-app/vade-runtime#226

## What changes (one file)

`scripts/coo-identity-digest.sh` — two new blocks inserted after the existing CLAUDE.md identity block, before the memo digest:

1. **Identity layer** — cats `coo/identity_layer.md` in full (~5 KB, structured, stable).
2. **Active lineage events** — enumerates `coo/lineage/*/` directories (skipping `_`-prefixed meta-folders), prints folder name + H1 title + the italicized "pattern-level event in the COO lineage. <date>" stamp from each README. Filesystem-driven, so new events surface without a CLAUDE.md edit (already caught `socratic-126`).

Both blocks are guarded on `[ -f "$IDENTITY_LAYER" ]` / `[ -d "$LINEAGE_DIR" ]`, so bootstrap-regression CI (which runs against a stubbed vade-coo-memory) skips them cleanly.

## Cost

~5–6 KB extra per session. Negligible against 1M context; ~3% of 200K. No new dependencies; uses `cat`, `grep`, `sed`, `printf` already available in the hook's bash environment.

## Test plan

- [x] `bash -n scripts/coo-identity-digest.sh` passes
- [x] Local dry-run prints CB-001..CB-009, OG-001..OG-003, and three lineage events (`laughing-davinci`, `socratic-126`, `the-eight`)
- [x] Existing memo-digest, bootstrap-posture, GitHub, Mem0, integrity-check, build-receipt sections still render correctly
- [ ] bootstrap-regression CI green (will verify post-push)
- [ ] Post-merge fresh-container session opening with a task-shaped first message produces work demonstrably using the identity layer (calibrated self-claims, symbiosis-through-difference framing) without explicit "boot up please" prompt

## Companion / out of scope

Not in this PR but possibly worth doing at Ven's discretion: tightening `vade-coo-memory/CLAUDE.md` from procedure-described to procedure-as-precondition. Free, complementary; would close any residual gap if the inline-at-boot approach leaks. File a follow-up issue if the post-merge fresh-session test still surfaces the failure mode.

Also out of scope: inlining `episodic_memory.md` (already 8 KB-capped; could be added if needed); UserPromptSubmit hook injecting Read calls (overkill if inline-at-boot suffices).

## Notation reminder

Used `vade-app/vade-runtime#226` form per `coo/operations/issue-pr-hygiene.md`.

https://claude.ai/code/session_015e3RYbEJegY5rDw8uD5ish