### PR TITLE
add quarto to install pipeline (cloud-setup + versions.lock + common.sh)

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -185,6 +185,22 @@ else
   log "Warning: mem0-mcp-server install failed at build time; first session will boot with Mem0 MCP dark."
 fi
 
+# Install Quarto for slide-deck and document rendering. Same
+# snapshot-persistence rationale as op + gh + mem0-mcp-server: paying
+# the ~131 MB fetch at build time keeps SessionStart off the egress
+# proxy. Quarto bundles its own pandoc + deno, so the install also
+# brings pandoc onto the bundle without a separate package step.
+# Best-effort: on failure the first session that needs Quarto fetches
+# on demand. Introduced for the 2026-shiffrin-conference deck under
+# vade-coo-memory/coo/_drafts/; kept standing for any future
+# markdown-to-{revealjs,pptx,pdf} workflow the chain produces.
+if ensure_quarto_cli; then
+  build_log_record OK "cloud-setup: quarto installed at build time"
+else
+  build_log_record WARN "cloud-setup: quarto install failed at build time; first session will need to install on demand"
+  log "Warning: quarto install failed at build time; first session that uses it will pay a ~131 MB direct-fetch."
+fi
+
 # Pre-fetch the 1Password MCP server (@takescake/1password-mcp) into the
 # global npm cache so first-session `npx -y` resolves offline. Same
 # snapshot-persistence rationale as op + gh + mem0 — paying the npm

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -611,6 +611,12 @@ GH_VERSION_DEFAULT="2.91.0"
 # api.mem0.ai (vade-runtime#36/#109). Pinned because the upstream repo
 # (mem0ai/mem0-mcp) was archived in 2025-12 — bump deliberately.
 MEM0_MCP_SERVER_VERSION_DEFAULT="0.2.1"
+# Quarto CLI for markdown → slide-deck rendering. Bundles its own
+# pandoc and deno. Introduced for the 2026-shiffrin-conference deck;
+# kept as a standing tool for any future markdown-to-{pptx,pdf}
+# workflow. ~131 MB tarball — the largest single tool in the snapshot.
+# Track upstream at github.com/quarto-dev/quarto-cli.
+QUARTO_VERSION_DEFAULT="1.9.37"
 # Binary vendor bundle. Single tarball published by
 # .github/workflows/publish-binary-vendor.yml containing op + gh + uv +
 # mem0-mcp-server (with mem0's uv-managed venv tree) at production
@@ -1164,6 +1170,98 @@ ensure_mem0_mcp_server() {
     return 1
   fi
   log "Installed mem0-mcp-server v${version}"
+}
+
+# Durable Quarto CLI for slide-deck and document rendering.
+#
+# Installs the Quarto CLI tarball (~131 MB) into a snapshot-persistent
+# path under the user's .local/share/quarto, with a symlink at
+# <bindir>/quarto. The tarball bundles its own pandoc and deno, so a
+# successful install also gives subsequent code paths pandoc-on-PATH
+# transitively (via the bundled binary, not via a separate install).
+#
+# Linux-only auto-install. On macOS (Darwin) the expectation is that
+# `brew install --cask quarto` has already satisfied check_cmd; if it
+# hasn't, this function refuses rather than dropping a non-runnable
+# Linux tarball. Bindir resolution is shared with ensure_op_cli /
+# ensure_gh_cli via _snapshot_user_bindir. Install dir resolution is
+# parallel to ensure_mem0_mcp_server's UV_TOOL_DIR — share/quarto under
+# the snapshot-persistent tree so the bundle survives resume.
+#
+# Rationale: introduced for the 2026-shiffrin-conference deck
+# (vade-coo-memory/coo/_drafts/2026-shiffrin-conference/), kept as a
+# standing tool for future markdown-to-{revealjs,pptx,pdf} workflows.
+# Best-effort at build time; cloud-setup logs a warning on failure and
+# the first session that needs Quarto fetches on demand.
+ensure_quarto_cli() {
+  local bindir
+  bindir="$(_snapshot_user_bindir)"
+  case ":$PATH:" in
+    *":$bindir:"*) ;;
+    *) export PATH="$bindir:$PATH" ;;
+  esac
+
+  if check_cmd quarto; then
+    log "quarto present: $(quarto --version 2>&1 | head -1)"
+    return 0
+  fi
+
+  local os
+  os="$(uname -s)"
+  case "$os" in
+    Linux) ;;
+    Darwin)
+      log "quarto not present on macOS; install via: brew install --cask quarto"
+      return 1
+      ;;
+    *)
+      log "quarto: unsupported OS '$os'"
+      return 1
+      ;;
+  esac
+
+  local version="${QUARTO_VERSION:-$QUARTO_VERSION_DEFAULT}"
+  local arch
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64) arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+    *) log "quarto: unsupported arch '$arch'"; return 1 ;;
+  esac
+
+  # Install layout: <bindir>/../share/quarto/ holds the bundle (bin/,
+  # share/, ...); <bindir>/quarto is a symlink to the bundle's bin/quarto.
+  # Mirrors the convention ensure_mem0_mcp_server uses for its uv-tool
+  # share dir, so both tools' state lives under the same .local/share/.
+  local install_dir
+  install_dir="${bindir%/bin}/share/quarto"
+
+  mkdir -p "$install_dir" "$bindir"
+
+  local url="https://github.com/quarto-dev/quarto-cli/releases/download/v${version}/quarto-${version}-linux-${arch}.tar.gz"
+  local tmp
+  tmp="$(mktemp -d)"
+  log "Downloading quarto v${version} (${arch}) → $install_dir"
+  if ! retry 5 curl -sfL "$url" -o "$tmp/quarto.tar.gz"; then
+    log "quarto download failed after retries: $url"
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  if ! tar -xzf "$tmp/quarto.tar.gz" -C "$install_dir" --strip-components=1; then
+    log "quarto extraction failed"
+    rm -rf "$tmp"
+    return 1
+  fi
+  rm -rf "$tmp"
+
+  ln -sfn "$install_dir/bin/quarto" "$bindir/quarto"
+
+  if ! quarto --version >/dev/null 2>&1; then
+    log "quarto install appears broken"
+    return 1
+  fi
+  log "Installed quarto v${version}"
 }
 
 # Expose gh on Claude Code's Bash-tool PATH every session.

--- a/versions.lock
+++ b/versions.lock
@@ -44,6 +44,23 @@ uv                  0.11.7    # Python package/tool installer. Used
                               # pipe) so image builds are reproducible.
                               # Bump when a new mem0-mcp-server release
                               # needs a newer uv, otherwise leave alone.
+quarto              1.9.37    # Slide-deck and document rendering
+                              # (markdown → revealjs / pptx / pdf via
+                              # bundled pandoc + deno). Originally
+                              # introduced for the 2026-shiffrin-conference
+                              # talk under coo/_drafts/, kept for any
+                              # future markdown-to-{pptx,pdf} workflow
+                              # the chain produces. Tarball is ~131 MB —
+                              # the largest single tool in the snapshot,
+                              # but bundles pandoc which is independently
+                              # useful. Pinned via QUARTO_VERSION_DEFAULT
+                              # in lib/common.sh. Bump when a newer
+                              # pandoc release is needed; track upstream
+                              # at github.com/quarto-dev/quarto-cli.
+                              # Not yet in the binary-vendor bundle —
+                              # add to .github/workflows/publish-binary-vendor.yml
+                              # as a follow-up if snapshot-build SLA
+                              # benefits from consolidating the fetch.
 
 # Consolidated binary vendor bundle. Single tarball published by
 # .github/workflows/publish-binary-vendor.yml on this repo, containing


### PR DESCRIPTION
## Summary

Quarto CLI (`v1.9.37`) is now installed at snapshot-build time alongside `op` + `gh` + `mem0-mcp-server`, giving every cloud session markdown → revealjs/pptx/pdf rendering on PATH without per-session fetch.

- `versions.lock` — pin `quarto 1.9.37` with rationale; note the binary-vendor bundle does not yet include Quarto (follow-up if snapshot-build SLA benefits from consolidating the fetch).
- `scripts/lib/common.sh` — add `QUARTO_VERSION_DEFAULT` near other `*_VERSION_DEFAULT`s; add `ensure_quarto_cli` function. Standard shape: Linux-only auto-install, macOS guides to `brew install --cask quarto`, x86_64 + arm64 supported, retry-on-curl-failure (5 attempts), idempotent on resume via `check_cmd quarto` short-circuit.
- `scripts/cloud-setup.sh` — invoke `ensure_quarto_cli` after `ensure_mem0_mcp_server`. Best-effort: on failure cloud-setup logs a warning and the first session that needs Quarto fetches on demand. Parallel to the mem0-mcp-server pattern, not the FATAL pattern op uses.

Tarball is ~131 MB — the largest single tool in the snapshot, but bundles its own pandoc + deno (so the install also brings pandoc onto the bundle without a separate package step).

Companion in vade-coo-memory on the same branch (vade-app/vade-coo-memory#506):
- `TOOLS.md` §12 (new category, "Rendering CLIs") adds the `quarto` row with discoverability framing; cross-cutting summary count 66 → 67.

Originally introduced for the 2026-shiffrin-conference deck under `vade-coo-memory/coo/_drafts/2026-shiffrin-conference/`; kept as a standing tool for any future markdown-to-{pptx,pdf} workflow the chain produces.

Closes: n/a — feature add at Ven's request; no pre-existing issue.

## Test plan

- [x] `ensure_quarto_cli` runs cleanly on this container's Ubuntu 24.04 / amd64; produces a working install at `/home/user/.local/share/quarto/` with symlink at `/home/user/.local/bin/quarto`.
- [x] `quarto --version` returns `1.9.37`.
- [x] `quarto render deck.qmd --to pptx` succeeds end-to-end against the conference deck.
- [ ] Bootstrap-regression CI passes (touches `scripts/`, `versions.lock` — workflow runs automatically).
- [ ] Snapshot-build dry-run (next cloud snapshot rebuild) confirms `cloud-setup.sh: quarto installed at build time` lands in `build.log`.
- [ ] arm64 path untested locally — first arm64 build will exercise it.

Plan: /root/.claude/plans/i-m-thinking-of-telling-hashed-bear.md

https://claude.ai/code/session_016UauspGFMVTivo6px65xyd