### PR TITLE
F6: update detail message for two-semantics external-touch (vcm#508)

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -1041,9 +1041,13 @@ fi
 #   python3 $F_REPO/bin/external-touch.py \
 #     --refresh-cache $VADE_CLOUD_STATE_DIR/external-touch-cache.json
 #
-# F6 only fires on above-floor violations; no-mirror cases are
-# excluded due to known matcher false-negatives (see
-# coo/instruments/external-touch.md §5).
+# F6 fires on:
+#   - recurring categories (foundations, retrospectives): above-floor
+#     violations only — no-mirror exempt due to matcher false-negatives.
+#   - one-shot categories (lineage, per vade-coo-memory#508):
+#     no-mirror-past-window violations (age from first commit > floor).
+#     Mirrored-once = satisfied permanently.
+# See coo/instruments/external-touch.md §2.
 #
 # Numbering note: same axis as F5 — extends integrity-check.sh's
 # F-series numerically; this implements disposition-proposal F5
@@ -1069,10 +1073,10 @@ try:
 except Exception:
   print('?')
 " 2>/dev/null)
-      _add F6 true "no above-floor external-touch violations (cache age: ${f6_age}d)"
+      _add F6 true "no external-touch floor violations (cache age: ${f6_age}d)"
     elif [ "$f6_rc" -eq 1 ]; then
       f6_violations=$(grep -E '^\[' "$f6_tmp_err" 2>/dev/null | head -3 | tr '\n' ';' | sed 's/;$//')
-      _add F6 false "external-touch above-floor: ${f6_violations:-unknown}"
+      _add F6 false "external-touch violation: ${f6_violations:-unknown}"
     else
       _add F6 skip "external-touch.py exited rc=$f6_rc"
     fi


### PR DESCRIPTION
## Summary

Pairs with [vade-coo-memory#509](https://github.com/vade-app/vade-coo-memory/pull/509) (one-shot semantics for the lineage category in `bin/external-touch.py`, closing [vcm#508](https://github.com/vade-app/vade-coo-memory/issues/508)).

Updates `scripts/integrity-check.sh` F6 reporting so the detail string is accurate for both violation classes:

- Comment block describes both classes (recurring above-floor + one-shot no-mirror-past-window).
- Success message: `"no external-touch floor violations"` (was `"no above-floor external-touch violations"`).
- Failure message: `"external-touch violation:"` (was `"external-touch above-floor:"`).

The grep extracting violation lines from the script's stderr is unchanged — `bin/external-touch.py` already prints both violation kinds in `[category] basename: ...` form.

## Test plan

- [x] `bash scripts/integrity-check.sh` reads 27/27 ok with F6 detail: `"no external-touch floor violations (cache age: 0.0d)"`
- [x] Bash syntax check: `bash -n scripts/integrity-check.sh`
- [ ] Bootstrap-regression CI (will run on PR open) — F6 stays `:fast_forward: skip` in fake-env (CI live-only probe), so the change is not exercised on the CI sticky comment; verification is via the real boot integrity check on this session.

## Refs

Pairs: vade-coo-memory#509 (the substantive close of vcm#508 lands there). Surfacing: [vrt#233](https://github.com/vade-app/vade-runtime/pull/233) post-merge confirmation, F6 column.

Closes: n/a

https://claude.ai/code/session_01ND1YwkDRxyY3NjQaLdVEEQ