### PR TITLE
feat(bootstrap+integrity): wire CLOUDFLARE_API_TOKEN + account_id; add E9 probe (closes #236)

### DIFF
--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -188,26 +188,33 @@ if [ "$_digest_saw_fresh" -eq 0 ]; then
   fi
 fi
 
-env_has_pat="no"; env_has_mail="no"
-[ -n "${GITHUB_MCP_PAT:-}" ]    && env_has_pat="yes"
-[ -n "${AGENTMAIL_API_KEY:-}" ] && env_has_mail="yes"
+env_has_pat="no"; env_has_mail="no"; env_has_cf="no"
+[ -n "${GITHUB_MCP_PAT:-}" ]      && env_has_pat="yes"
+[ -n "${AGENTMAIL_API_KEY:-}" ]   && env_has_mail="yes"
+# CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID move as a pair (the
+# account-scoped verify + wrangler --account-id both need both).
+# Surface as a single yes/no so the boot line stays one-screen-wide.
+[ -n "${CLOUDFLARE_API_TOKEN:-}" ] && [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] && env_has_cf="yes"
 
-settings_pat="unknown"; settings_mail="unknown"
+settings_pat="unknown"; settings_mail="unknown"; settings_cf="unknown"
 if [ -f "$SETTINGS_FILE" ] && check_cmd node; then
   probe="$(node -e '
     const fs = require("fs");
     try {
       const cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
       const e = cfg.env || {};
-      console.log((e.GITHUB_MCP_PAT ? "yes" : "no") + " " + (e.AGENTMAIL_API_KEY ? "yes" : "no"));
-    } catch (_) { console.log("unknown unknown"); }
-  ' "$SETTINGS_FILE" 2>/dev/null || echo "unknown unknown")"
-  settings_pat="${probe%% *}"
-  settings_mail="${probe##* }"
+      console.log(
+        (e.GITHUB_MCP_PAT ? "yes" : "no") + " " +
+        (e.AGENTMAIL_API_KEY ? "yes" : "no") + " " +
+        ((e.CLOUDFLARE_API_TOKEN && e.CLOUDFLARE_ACCOUNT_ID) ? "yes" : "no")
+      );
+    } catch (_) { console.log("unknown unknown unknown"); }
+  ' "$SETTINGS_FILE" 2>/dev/null || echo "unknown unknown unknown")"
+  read -r settings_pat settings_mail settings_cf <<<"$probe"
 fi
 
-echo "  Process env:       GITHUB_MCP_PAT=$env_has_pat  AGENTMAIL_API_KEY=$env_has_mail"
-echo "  settings.json env: GITHUB_MCP_PAT=$settings_pat  AGENTMAIL_API_KEY=$settings_mail"
+echo "  Process env:       GITHUB_MCP_PAT=$env_has_pat  AGENTMAIL_API_KEY=$env_has_mail  CLOUDFLARE=$env_has_cf"
+echo "  settings.json env: GITHUB_MCP_PAT=$settings_pat  AGENTMAIL_API_KEY=$settings_mail  CLOUDFLARE=$settings_cf"
 
 if [ "$env_has_pat" = "yes" ] && [ "$env_has_mail" = "yes" ]; then
   echo "  Full identity loaded; MCP tools (github, agentmail) should have env."

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -759,6 +759,73 @@ else
 fi
 _add E8 "$E8_ok" "$E8_detail"
 
+# E9: Cloudflare API token reachable + scoped per MEMO-2026-05-09-vwk2.
+# Probe contract:
+#   - GET https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/tokens/verify
+#     with Authorization: Bearer $CLOUDFLARE_API_TOKEN.
+#   - Pass: HTTP 200 + result.status == "active".
+# Surfaces revocation, expiry, or scope-change between snapshots and
+# reports expires_on so the next rotation deadline is loud.
+# Account-scoped endpoint because the COO token is an Account-owned
+# API token (cfat_ prefix); the user-scoped /user/tokens/verify
+# endpoint rejects account tokens with code 1000 "Invalid API Token".
+# Best-effort: token is feature-gated (not all sessions need Cloudflare
+# access), so missing $CLOUDFLARE_API_TOKEN or $CLOUDFLARE_ACCOUNT_ID
+# is `skip`, not `false`. CI fake-env mode also skips.
+E9_ok=skip
+E9_detail="requires CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID in env"
+if [ -n "${VADE_CI_WORKSPACE_ROOT:-}" ] || [ -n "${VADE_BINDIR_OVERRIDE:-}" ]; then
+  E9_ok=skip
+  E9_detail="skipped in CI fake-env (VADE_CI_WORKSPACE_ROOT or VADE_BINDIR_OVERRIDE set); live-only probe"
+elif [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+  E9_ok=skip
+  E9_detail="CLOUDFLARE_API_TOKEN or CLOUDFLARE_ACCOUNT_ID not in hook env (settings.json env will populate for wrangler spawn; this probe runs in a hook subprocess that may not have inherited yet)"
+elif ! check_cmd curl || ! check_cmd node; then
+  E9_ok=skip
+  E9_detail="curl or node missing; cannot probe"
+else
+  # No -f so we keep the response body on 4xx (parsing it gives us the
+  # real Cloudflare error message instead of a generic "non-2xx").
+  E9_resp="$(curl -sS -m 8 \
+    -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/tokens/verify" 2>/dev/null || true)"
+  if [ -z "$E9_resp" ]; then
+    E9_ok=false
+    E9_detail="api.cloudflare.com unreachable from this hook (no body returned within 8s); check egress to api.cloudflare.com or DNS"
+  else
+    E9_verdict="$(printf '%s' "$E9_resp" | node -e '
+      let d = ""; process.stdin.on("data", c => d += c);
+      process.stdin.on("end", () => {
+        try {
+          const o = JSON.parse(d);
+          if (o.success && o.result && o.result.status === "active") {
+            const id = String(o.result.id || "").slice(0, 8);
+            const exp = o.result.expires_on || "no-expiry";
+            process.stdout.write("ok|" + id + "|" + exp);
+          } else {
+            const errCode = (o.errors && o.errors[0] && o.errors[0].code) || "?";
+            const errMsg = ((o.errors && o.errors[0] && o.errors[0].message) || "unknown error").slice(0, 120);
+            const status = (o.result && o.result.status) || "missing";
+            process.stdout.write("bad|" + status + "|code=" + errCode + " " + errMsg);
+          }
+        } catch (e) {
+          process.stdout.write("bad|parse-failed|body: " + d.slice(0, 200));
+        }
+      });
+    ' 2>/dev/null || echo "bad|node-failed|node parse subprocess failed")"
+    IFS='|' read -r E9_verdict_kind E9_verdict_a E9_verdict_b <<<"$E9_verdict"
+    if [ "$E9_verdict_kind" = "ok" ]; then
+      E9_ok=true
+      E9_detail="Cloudflare API token active (id-prefix=$E9_verdict_a; expires=$E9_verdict_b; verified against /accounts/$CLOUDFLARE_ACCOUNT_ID/tokens/verify per MEMO-2026-05-09-vwk2)"
+    else
+      E9_ok=false
+      E9_detail="Cloudflare token verify failed: status=$E9_verdict_a $E9_verdict_b"
+    fi
+  fi
+fi
+_add E9 "$E9_ok" "$E9_detail"
+
 # ── Group F: Culture-system substrate discipline ─────────────
 # Implements E1–E4 from coo/foundations/2026-04-22_we-can-claim-a-record.md
 # §5d (label delta: the essay calls these E1–E4; Group E is occupied by

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1339,7 +1339,7 @@ fetch_coo_secrets() {
   log "Fetching COO secrets from 1Password vault COO"
   local github_pat="" agentmail_key="" mem0_key=""
   local r2_access_key_id="" r2_secret_access_key="" age_identity=""
-  local vade_auth_token=""
+  local vade_auth_token="" cloudflare_api_token="" cloudflare_account_id=""
   local got=0
 
   if github_pat="$(retry 3 op read 'op://COO/vade-coo-self-2026-04/token')" && [ -n "$github_pat" ]; then
@@ -1408,6 +1408,35 @@ fetch_coo_secrets() {
     log "  WARN: op://COO/vade-canvas-coo/credential unavailable; VADE_AUTH_TOKEN will be unset (vade-core/.mcp.json placeholder resolves empty; vade-canvas MCP unreachable from vade-core/ cwd)"
   fi
 
+  # Cloudflare API token for COO-driven Worker deploys + DNS edits on
+  # vade-app.dev. Carve-out scope: MEMO-2026-05-09-vwk2 (in-scope:
+  # `wrangler deploy/secret` on existing Workers, DNS CRUD on
+  # vade-app.dev, Workers Routes binding, all reads; out-of-scope:
+  # creating new R2/D1/KV/Workers/zones, plan upgrades — BDFL approval).
+  # Best-effort: missing item warns and leaves CLOUDFLARE_API_TOKEN
+  # unset (wrangler then fails with a clean auth error rather than a
+  # stale or wrong-account credential).
+  if cloudflare_api_token="$(retry 3 op read 'op://COO/cloudflare-api-token-vade-coo/credential')" && [ -n "$cloudflare_api_token" ]; then
+    log "  read Cloudflare API token (len=${#cloudflare_api_token})"
+    got=$((got+1))
+  else
+    cloudflare_api_token=""
+    log "  WARN: op://COO/cloudflare-api-token-vade-coo/credential unavailable; CLOUDFLARE_API_TOKEN will be unset (wrangler deploy/secret and DNS edits unauthenticated)"
+  fi
+
+  # Cloudflare account_id pairs with the token. Account-owned tokens
+  # (cfat_ prefix) require account-scoped endpoints for verify/list
+  # operations; the integrity probe and any direct API calls need the
+  # account UUID. wrangler reads CLOUDFLARE_ACCOUNT_ID from env when
+  # multiple accounts are visible.
+  if cloudflare_account_id="$(retry 3 op read 'op://COO/cloudflare-api-token-vade-coo/account_id')" && [ -n "$cloudflare_account_id" ]; then
+    log "  read Cloudflare account id (len=${#cloudflare_account_id})"
+    got=$((got+1))
+  else
+    cloudflare_account_id=""
+    log "  WARN: op://COO/cloudflare-api-token-vade-coo/account_id unavailable; CLOUDFLARE_ACCOUNT_ID will be unset (E9 probe will skip; wrangler may prompt for account selection)"
+  fi
+
   if [ "$got" -eq 0 ]; then
     log "  no COO secrets could be fetched; skipping env file write"
     return 1
@@ -1432,6 +1461,8 @@ fetch_coo_secrets() {
       if [ -n "$r2_secret_access_key" ]; then echo "export R2_TRANSCRIPTS_SECRET_ACCESS_KEY='$r2_secret_access_key'"; fi
       if [ -n "$age_identity" ];         then echo "export TRANSCRIPTS_AGE_IDENTITY='$age_identity'"; fi
       if [ -n "$vade_auth_token" ];      then echo "export VADE_AUTH_TOKEN='$vade_auth_token'"; fi
+      if [ -n "$cloudflare_api_token" ]; then echo "export CLOUDFLARE_API_TOKEN='$cloudflare_api_token'"; fi
+      if [ -n "$cloudflare_account_id" ]; then echo "export CLOUDFLARE_ACCOUNT_ID='$cloudflare_account_id'"; fi
     } > "$env_file"
   )
   chmod 600 "$env_file"
@@ -1449,6 +1480,8 @@ fetch_coo_secrets() {
   if [ -n "$r2_secret_access_key" ]; then export R2_TRANSCRIPTS_SECRET_ACCESS_KEY="$r2_secret_access_key"; fi
   if [ -n "$age_identity" ];         then export TRANSCRIPTS_AGE_IDENTITY="$age_identity"; fi
   if [ -n "$vade_auth_token" ];      then export VADE_AUTH_TOKEN="$vade_auth_token"; fi
+  if [ -n "$cloudflare_api_token" ]; then export CLOUDFLARE_API_TOKEN="$cloudflare_api_token"; fi
+  if [ -n "$cloudflare_account_id" ]; then export CLOUDFLARE_ACCOUNT_ID="$cloudflare_account_id"; fi
   return 0
 }
 
@@ -1468,7 +1501,9 @@ merge_coo_settings_env() {
     "${R2_TRANSCRIPTS_SECRET_ACCESS_KEY:-}" \
     "${TRANSCRIPTS_AGE_IDENTITY:-}" \
     "${VADE_BEARER_TOKEN:-}" \
-    "${VADE_MCP_URL:-}"
+    "${VADE_MCP_URL:-}" \
+    "${CLOUDFLARE_API_TOKEN:-}" \
+    "${CLOUDFLARE_ACCOUNT_ID:-}"
 }
 
 # Persist non-secret bootstrap-derived path state into ~/.claude/settings.json
@@ -1519,6 +1554,7 @@ _write_claude_settings_env() {
   local pat="$1" agentmail="$2" mem0="$3" vade_auth_token="${4:-}"
   local r2_access_key_id="${5:-}" r2_secret_access_key="${6:-}" age_identity="${7:-}"
   local vade_bearer_token="${8:-}" vade_mcp_url="${9:-}"
+  local cloudflare_api_token="${10:-}" cloudflare_account_id="${11:-}"
   if ! check_cmd node; then
     log "Warning: node missing; skipping ~/.claude/settings.json env merge"
     return 0
@@ -1540,6 +1576,8 @@ _write_claude_settings_env() {
   TRANSCRIPTS_AGE_IDENTITY="$age_identity" \
   VADE_BEARER_TOKEN="$vade_bearer_token" \
   VADE_MCP_URL="$vade_mcp_url" \
+  CLOUDFLARE_API_TOKEN="$cloudflare_api_token" \
+  CLOUDFLARE_ACCOUNT_ID="$cloudflare_account_id" \
   NODE_PATH="$node_path" PLAYWRIGHT_BROWSERS_PATH="$pw_browsers" node -e '
     const fs = require("fs");
     const path = process.argv[1];
@@ -1577,6 +1615,12 @@ _write_claude_settings_env() {
     }
     if (process.env.VADE_MCP_URL) {
       merged.VADE_MCP_URL = process.env.VADE_MCP_URL;
+    }
+    if (process.env.CLOUDFLARE_API_TOKEN) {
+      merged.CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
+    }
+    if (process.env.CLOUDFLARE_ACCOUNT_ID) {
+      merged.CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
     }
     if (process.env.NODE_PATH) {
       merged.NODE_PATH = process.env.NODE_PATH;

--- a/scripts/lib/transcript-redaction.json
+++ b/scripts/lib/transcript-redaction.json
@@ -87,6 +87,20 @@
       "notes": "AgentMail API key (length 76 per coo-bootstrap.sh). Prefix unverified — refine when shape known."
     },
     {
+      "id": "cloudflare-api-token",
+      "regex": "\\bcfat_[A-Za-z0-9_-]{40,}\\b",
+      "replacement": "[REDACTED:cloudflare-api-token]",
+      "secret_var": "CLOUDFLARE_API_TOKEN",
+      "notes": "Cloudflare Account-owned API token (cfat_ prefix; introduced ~2024). Live token observed at length 53 (cfat_ + 48 chars). MEMO-2026-05-09-vwk2."
+    },
+    {
+      "id": "cloudflare-account-id",
+      "regex": "\\baccounts/[a-f0-9]{32}\\b",
+      "replacement": "accounts/[REDACTED:cloudflare-account-id]",
+      "secret_var": "CLOUDFLARE_ACCOUNT_ID",
+      "notes": "Cloudflare account UUID (32-char lowercase hex). Not strictly secret (appears in committed wrangler.jsonc and Cloudflare URLs throughout the platform), but the Secret Registration Rule requires every fetch_coo_secrets export to have a pattern. Context-scoped to accounts/<id> URL paths to avoid false positives against arbitrary 32-char hex (commit SHAs, file hashes, etc)."
+    },
+    {
       "id": "stripe-key",
       "regex": "\\b(?:sk|rk)_live_[A-Za-z0-9]{24,}\\b",
       "replacement": "[REDACTED:stripe-key]",


### PR DESCRIPTION
## Summary

Wires `CLOUDFLARE_API_TOKEN` (and the paired `CLOUDFLARE_ACCOUNT_ID`) through the COO bootstrap, adds an integrity probe E9 that verifies the token against the live Cloudflare API, and surfaces presence in the `coo-identity-digest` boot block. Concrete operationalization of MEMO-2026-05-09-vwk2 (vade-coo-memory#534 — merged).

## Changes

- **`scripts/lib/common.sh`** — `fetch_coo_secrets` reads `op://COO/cloudflare-api-token-vade-coo/credential` and `.../account_id` (best-effort, like `VADE_AUTH_TOKEN`; missing items warn). Both written to `~/.vade/coo-env`, exported to the current shell, and merged into `~/.claude/settings.json` env via `_write_claude_settings_env`. Wrangler picks `CLOUDFLARE_API_TOKEN` up automatically; `CLOUDFLARE_ACCOUNT_ID` resolves account ambiguity for sessions that touch multiple accounts (we don't, but it's required for the verify endpoint).
- **`scripts/integrity-check.sh`** — new E9 probe. GET `/accounts/$CLOUDFLARE_ACCOUNT_ID/tokens/verify`, asserts `result.status == "active"`, reports `expires_on` in the detail string so the rotation deadline is loud at every boot. `curl` without `-f` so the response body survives 4xx and gets parsed for the real error message instead of a generic "non-2xx".
- **`scripts/coo-identity-digest.sh`** — process-env + settings.json env lines now carry `CLOUDFLARE=yes/no`. Token + account_id surface as a pair since the account-scoped verify needs both.

## Live test (this session)

```
$ CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ACCOUNT_ID=... bash scripts/integrity-check.sh
VADE integrity: 28/28 OK — /home/user/.vade-cloud-state/integrity-check.json

$ jq '.groups.E.E9' /home/user/.vade-cloud-state/integrity-check.json
{
  "ok": true,
  "detail": "Cloudflare API token active (id-prefix=5f99b199; expires=2026-08-07T23:59:59Z; verified against /accounts/<id>/tokens/verify per MEMO-2026-05-09-vwk2)"
}
```

Without the token in env (the existing-session case until a fresh container boot picks up the new secret):
```
$ jq '.groups.E.E9' /home/user/.vade-cloud-state/integrity-check.json
{ "ok": null, "skipped": true, "detail": "...not in hook env..." }
```

## Two things worth flagging

1. **Token type discovery.** The token Ven minted is an Account-owned API token (`cfat_` prefix), introduced by Cloudflare in late 2024. It rejects the user-scoped `/user/tokens/verify` endpoint (which the original probe sketch in #236 used) with code 1000 "Invalid API Token". The probe now uses the correct account-scoped endpoint. This is the reason `CLOUDFLARE_ACCOUNT_ID` got pulled into scope — it wasn't in the original task list but it's required for verify and useful for `wrangler` in multi-account contexts.

2. **Token expiry vs memo's "yearly cadence".** The minted token expires `2026-08-07T23:59:59Z` (90 days, Cloudflare's default). MEMO-2026-05-09-vwk2 says "rotation: yearly cadence or on incident." 90-day forced rotation is tighter than the memo's policy intent. Two options:
   - Re-mint the token with a 1-year (or no-expiry) end date and patch the rotation cadence in the memo to match.
   - Accept Cloudflare's 90-day window as the operative cadence and amend the memo to "rotate at token expiration or on incident, whichever comes first."
   No code change needed either way — E9 will surface the expiry deadline at every boot regardless.

## Test plan

- [x] `bash -n` syntax check on all three modified scripts.
- [x] Live E9 probe with real token from 1Password — ok with id-prefix + expiry reported.
- [x] Live E9 probe without token in env — `skip` (not `false`), correct "feature-gated" behavior.
- [x] Live E9 probe with token but wrong endpoint (the original sketch using `/user/tokens/verify`) — observed 1000 "Invalid API Token" in this session and corrected the probe before commit.
- [ ] **Manual on next fresh container boot:** confirm `coo-identity-digest` shows `CLOUDFLARE=yes` on both env lines and integrity-check reports E9 ok with the live token. The current session won't pick up the new wiring without `VADE_FORCE_COO_BOOTSTRAP=1` since the boot marker is already set.

Closes #236.

https://claude.ai/code/session_01TsJ55w6B64BMmGWKBaK64o