### PR TITLE
F4: PR-body fallback closes f4-marker race retroactively

### DIFF
--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -991,16 +991,12 @@ fi
 # (author email coo@vade-app.dev) or carry 'ven-human-action:' in body.
 # Silent venpopov-authored commits on coo-scope paths are F4-relevant.
 #
-# F4_ALLOWLIST_SHA — explicit per-commit carve-outs where the marker
-# was present in the PR body at merge time but the f4-marker workflow
-# raced past a fast manual merge, leaving the commit body without the
-# marker. Each entry must cite the originating PR + tracking issue.
+# F4_ALLOWLIST_SHA — explicit per-commit carve-outs for direct-to-main
+# commits with no PR (the PR-body fallback below can't help when there
+# is no PR). PR-merge commits where the f4-marker workflow raced past
+# the merge are handled by the fallback at audit time, not this list.
 # Tracked structurally at vade-coo-memory#271.
 F4_ALLOWLIST_SHA=(
-  # 0fd421a198 — vade-coo-memory#262 "add insight analysis" (Ven-
-  # authored doc-add); PR body carries ven-human-action marker but
-  # the merge stripped it. See vade-coo-memory#271 for the race fix.
-  "0fd421a198"
   # 7cb8a86da4 — vade-coo-memory direct commit "update gitignore" by
   # Ven on 2026-05-01 outside the PR flow (no PR body, so the f4-marker
   # workflow at vade-coo-memory/.github/workflows/f4-marker.yml had no
@@ -1031,6 +1027,26 @@ if [ -d "$F_REPO/.git" ] && check_cmd git; then
       case "$sha" in "$allow_sha"*) allowed=1; break ;; esac
     done
     [ "$allowed" -eq 1 ] && continue
+    # PR-body fallback for f4-marker race (vade-coo-memory#271): the
+    # f4-marker workflow may inject the marker into the PR body after
+    # the merge, leaving the commit body without it. When the commit
+    # subject ends in "(#NNN)", look up the PR body via gh api and
+    # accept if the marker is present there. Falls open (commit lands
+    # in f4_bad) when gh missing or auth fails — same observability
+    # as today.
+    pr_num=""
+    subject=$(git -C "$F_REPO" log -1 --format='%s' "$sha" 2>/dev/null || echo '')
+    if [[ "$subject" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
+      pr_num="${BASH_REMATCH[1]}"
+    fi
+    if [ -n "$pr_num" ] && check_cmd gh; then
+      pr_body=$(GH_TOKEN="${GITHUB_MCP_PAT:-${GH_TOKEN:-}}" \
+        gh api "repos/vade-app/vade-coo-memory/pulls/$pr_num" \
+        --jq '.body' 2>/dev/null || true)
+      if printf '%s' "$pr_body" | grep -q 'ven-human-action:'; then
+        continue
+      fi
+    fi
     f4_bad+=("${sha:0:10}($email)")
   done < <(git -C "$F_REPO" log --since="$F_CUTOFF_GIT" --format='%H|%ae|%B%x00' 2>/dev/null | awk 'BEGIN{RS="\0"} { sub(/^\n/, ""); if (NF) { gsub(/\n/,"\\n"); print } }')
 


### PR DESCRIPTION
## Summary

When the commit subject ends in `(#NNN)`, F4 now looks up the PR body via `gh api` and accepts attribution if the `ven-human-action:` marker is present there. Closes the race where a fast manual merge lands before the f4-marker workflow injects, leaving the commit body without the marker even though the live PR body carries it.

Drops `0fd421a198` from `F4_ALLOWLIST_SHA` — PR #262's body still carries the marker, so the fallback retroactively clears it. The allowlist is now scoped to direct-to-main commits with no PR (where the fallback can't help by definition); `7cb8a86da4` stays.

Closes vade-app/vade-coo-memory#271.

## Why Option 1 of the three candidates

The PR body *is* the canonical record of Ven's intent; the commit-body copy is a sync artefact. Looking in both places at audit time is closer to truth than blocking the merge until the sync lands. Option 2 (branch-protection gate) requires a comment-1 fix to the workflow's `if:` first and adds a workflow-status-required-check pattern we don't otherwise use. Option 3 (move marker injection earlier) is the largest change for no architectural gain — the existing PR-body location is fine if treated as the canonical lookup target.

## Failure modes

All degrade to existing F4 behavior:
- `gh` not installed → `check_cmd` fails → fallback skipped → commit lands in `f4_bad`
- `gh` installed but no token → auth error → empty body → grep miss → `f4_bad`
- gh api rate limit → empty body → `f4_bad`
- PR doesn't exist → 404 → empty body → `f4_bad`

No new failure surface.

## Test plan

- [x] PR-number regex unit-tested across 6 cases (numbered PRs at end-of-subject, mid-subject false positives, trailing whitespace, non-PR subjects)
- [x] Live test against PR #262 (Ven-authored, marker present) — fallback would clear
- [x] Live test against PR #546 (vade-coo-authored, no marker) — fallback would mark bad (but vade-coo email clears it earlier in the loop)
- [x] `bash scripts/integrity-check.sh` on this branch returns `summary.ok: true; passed: 28/28`; F4 detail: `51/51 commits resolve to vade-coo or carry ven-human-action`
- [ ] CI bootstrap-regression run: F1–F4 should continue to skip cleanly under fake-env (vade-coo-memory stub has no `.git`); no behavior change in CI

https://claude.ai/code/session_017QVvdMhjGHmzr9wwNLYmMQ