### PR TITLE
Add subscribe-discussion.sh polling primitive (closes #206)

### DIFF
--- a/scripts/subscribe-discussion.sh
+++ b/scripts/subscribe-discussion.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# subscribe-discussion: poll a GitHub discussion thread; emit one stdout
+# line per new top-level comment or reply.
+#
+# Analog to the harness `mcp__github__subscribe_pr_activity` primitive,
+# closing the v0 of vade-runtime#206. There is no upstream MCP tool for
+# discussion activity yet; this script is the bridge until one lands.
+#
+# Suitable for the `Monitor` tool: each printed line is one event
+# notification, flushed.
+#
+# Usage:
+#   subscribe-discussion.sh <owner/repo> <number> [poll_seconds]
+#
+# Defaults: poll every 60s. Lower the interval for active dialogue;
+# raise it for slow Q&A threads.
+#
+# State: per-thread "seen" file under
+# ${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state}/discussion-watch/
+# records IDs of comments and replies already emitted, so restarts
+# don't re-emit history. First run records the current state silently
+# (no events emitted) and only future activity surfaces.
+#
+# Authentication: relies on GITHUB_MCP_PAT or GH_TOKEN being set.
+#
+# Exit codes:
+#   0  graceful shutdown (SIGINT/SIGTERM)
+#   1  missing GitHub token
+#   2  argument error
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: subscribe-discussion.sh <owner/repo> <number> [poll_seconds]
+
+Poll a GitHub discussion thread; emit one stdout line per new comment
+or reply, suitable for `Monitor` tail-streaming.
+
+Arguments:
+  <owner/repo>     Target repository (e.g. vade-app/vade-core)
+  <number>         Discussion number
+  [poll_seconds]   Polling interval, default 60
+
+Environment:
+  GITHUB_MCP_PAT   GitHub PAT (preferred)
+  GH_TOKEN         Fallback if MCP PAT unset
+  VADE_CLOUD_STATE_DIR  State directory root (defaults to ~/.vade-cloud-state)
+
+Examples:
+  subscribe-discussion.sh vade-app/vade-core 126
+  subscribe-discussion.sh vade-app/vade-core 999 30
+EOF
+}
+
+if [ $# -lt 2 ]; then
+  usage >&2
+  exit 2
+fi
+
+case "$1" in -h|--help) usage; exit 0 ;; esac
+
+repo="$1"
+number="$2"
+poll="${3:-60}"
+
+if ! [[ "$repo" == */* ]]; then
+  echo "error: repo must be in <owner/name> form (got: $repo)" >&2
+  exit 2
+fi
+if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+  echo "error: number must be a positive integer (got: $number)" >&2
+  exit 2
+fi
+if ! [[ "$poll" =~ ^[0-9]+$ ]]; then
+  echo "error: poll_seconds must be a positive integer (got: $poll)" >&2
+  exit 2
+fi
+
+owner="${repo%%/*}"
+name="${repo##*/}"
+
+token="${GITHUB_MCP_PAT:-${GH_TOKEN:-}}"
+if [ -z "$token" ]; then
+  echo "error: GITHUB_MCP_PAT or GH_TOKEN must be set" >&2
+  exit 1
+fi
+
+state_root="${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state}"
+state_dir="$state_root/discussion-watch"
+mkdir -p "$state_dir"
+state_file="$state_dir/${owner}_${name}_${number}.seen"
+touch "$state_file"
+
+trap 'echo "[discussion-watch] shutdown ($repo#$number)" >&2; exit 0' INT TERM
+
+read -r -d '' QUERY <<'GQL' || true
+query($owner:String!,$repo:String!,$num:Int!){
+  repository(owner:$owner,name:$repo){
+    discussion(number:$num){
+      title
+      url
+      comments(first:100){
+        nodes{
+          id
+          databaseId
+          author{login}
+          createdAt
+          url
+          bodyText
+          replies(first:50){
+            nodes{
+              id
+              databaseId
+              author{login}
+              createdAt
+              url
+              bodyText
+            }
+          }
+        }
+      }
+    }
+  }
+}
+GQL
+
+echo "[discussion-watch] subscribed: $repo#$number (poll ${poll}s)" >&2
+
+while true; do
+  if ! resp=$(GH_TOKEN="$token" gh api graphql \
+      -f "query=$QUERY" \
+      -F "owner=$owner" \
+      -F "repo=$name" \
+      -F "num=$number" 2>/dev/null); then
+    echo "[discussion-watch] poll failed; retrying in ${poll}s" >&2
+    sleep "$poll"
+    continue
+  fi
+
+  STATE_FILE="$state_file" python3 - "$resp" <<'PY'
+import json, os, sys
+
+resp = json.loads(sys.argv[1])
+state_file = os.environ['STATE_FILE']
+
+with open(state_file, 'r') as f:
+    seen = {line.strip() for line in f if line.strip()}
+
+first_run = not seen
+new_ids = []
+
+discussion = resp.get('data', {}).get('repository', {}).get('discussion')
+if not discussion:
+    sys.exit(0)
+
+def emit(kind, node):
+    preview = (node.get('bodyText') or '').replace('\n', ' ').strip()
+    if len(preview) > 140:
+        preview = preview[:137] + '...'
+    login = (node.get('author') or {}).get('login') or '<unknown>'
+    print(f"[{kind}] {login} @ {node['createdAt']}: {preview}", flush=True)
+    print(f"  {node['url']}", flush=True)
+
+for c in discussion.get('comments', {}).get('nodes', []) or []:
+    if c['id'] not in seen:
+        new_ids.append(c['id'])
+        if not first_run:
+            emit('comment', c)
+    for r in (c.get('replies', {}).get('nodes', []) or []):
+        if r['id'] not in seen:
+            new_ids.append(r['id'])
+            if not first_run:
+                emit('reply  ', r)
+
+if new_ids:
+    with open(state_file, 'a') as f:
+        for nid in new_ids:
+            f.write(nid + '\n')
+
+if first_run and new_ids:
+    print(f"[discussion-watch] initial state recorded: {len(new_ids)} existing items", file=sys.stderr, flush=True)
+PY
+
+  sleep "$poll"
+done


### PR DESCRIPTION
## Summary

- Adds `scripts/subscribe-discussion.sh <owner/repo> <number> [poll_seconds]` — a `Monitor`-friendly poller that emits one stdout line per new comment or reply on a GitHub discussion thread.
- Bridge implementation per #206 Option 2 (in-repo script, not the upstream MCP-tool path nor the Cloudflare-Worker-receiver path). Closes the gap left by the absence of an MCP-native `subscribe_discussion_activity` analog to `subscribe_pr_activity`.
- Per-thread state file under `${VADE_CLOUD_STATE_DIR}/discussion-watch/` keys on graphql node IDs so restarts don't re-emit history. First run records existing state silently; only future activity surfaces.

## Why now

First worked use is the IIT vs. LLM-substrate two-COO dialogue at vade-app/vade-core#209 (2026-05-10) — the second dialogue-shaped event in the COO lineage. The precedent (socratic-126) ran on a one-off `/tmp/discussion-watch.sh` poller. Per MEMO-2026-05-03-b4ye, a discussion-watch primitive is spec-led (every invocation does the same thing — poll, emit), so packaging it as a reusable script rather than another `/tmp/` is appropriate substrate-improving work.

## Documentation

CLAUDE.md (Discussion-watch discipline section) and `coo/agent-boot-discussions-check.md` (Live-thread subscription section) update on a sibling vade-coo-memory PR on the same branch (`claude/integrated-information-theory-S6HRA`).

## Test plan

- [x] Smoke-tested against `vade-app/vade-core#126` (socratic-126) — recorded 7 existing items silently on first run, wrote state file under the expected path, no events emitted (correct behavior since no new activity).
- [ ] Verify against #209 once the two debate sessions launch — should emit one line per turn post.
- [ ] Confirm `Monitor` integration works as expected.

Closes #206.

https://claude.ai/code/session_01Ahqkpw9KE236QgKAJvHJhG