### PR TITLE
Add subscribe-agentmail.sh — inbox poll bridge for Monitor

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -262,7 +262,9 @@
       "Bash(git -C /Users/vepopo/GitHub/VADE/repos/vade-coo-memory mv coo/project_tracker.md coo/_archive/project_tracker.md)",
       "Bash(git commit -m 'Step 9 Phase 2 sentinel: code-origin ping:*)",
       "Bash(node -e 'const s=JSON.parse\\(require\\(\"fs\"\\).readFileSync\\(\"/Users/vepopo/.claude/settings.json\",\"utf8\"\\)\\); console.log\\(\"enabledPlugins:\", s.enabledPlugins, \"autoMemoryEnabled:\", s.autoMemoryEnabled, \"defaultMode:\", s.permissions?.defaultMode\\)')",
-      "Bash(node -e 'const s=JSON.parse\\(require\\(\"fs\"\\).readFileSync\\(\"/Users/vepopo/GitHub/vade-app/.claude/settings.json\",\"utf8\"\\)\\); console.log\\(\"SessionStart chains:\", s.hooks?.SessionStart?.length\\)')"
+      "Bash(node -e 'const s=JSON.parse\\(require\\(\"fs\"\\).readFileSync\\(\"/Users/vepopo/GitHub/vade-app/.claude/settings.json\",\"utf8\"\\)\\); console.log\\(\"SessionStart chains:\", s.hooks?.SessionStart?.length\\)')",
+      "Bash(cp \"/root/.claude/uploads/5fcbce96-b00c-4893-93ce-8b5d4957c74d/b6b51051-Why_I_am_not_a_Turing_machine.pdf\" /home/user/vade-coo-memory/coo/_drafts/2026-05-10_f1-outreach/holyoak-2024-why-i-am-not-a-turing-machine.pdf)",
+      "Bash(mkdir -p /home/user/vade-coo-memory/coo/_drafts/2026-05-10_f1-outreach)"
     ],
     "deny": [
       "Bash(rm -rf /:*)",

--- a/scripts/subscribe-agentmail.sh
+++ b/scripts/subscribe-agentmail.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# subscribe-agentmail: poll an AgentMail inbox; emit one stdout line per
+# new received message.
+#
+# Analog to subscribe-discussion.sh — same Monitor-friendly shape: each
+# printed line is one event notification, flushed.
+#
+# Usage:
+#   subscribe-agentmail.sh <inbox> [poll_seconds]
+#
+# Defaults: poll every 60s.
+#
+# State: per-inbox "seen" file under
+# ${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state}/agentmail-watch/
+# records message IDs already emitted, so restarts don't re-emit
+# history. First run records the current state silently (no events
+# emitted) and only future activity surfaces.
+#
+# Filter: only emits messages labelled "received" (inbound). Skips
+# outbound `sent` from the same inbox; webhook noise (drafts, etc.)
+# is excluded by the same filter.
+#
+# Authentication: AGENTMAIL_API_KEY required in env.
+#
+# Exit codes:
+#   0  graceful shutdown (SIGINT/SIGTERM)
+#   1  missing AGENTMAIL_API_KEY
+#   2  argument error
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: subscribe-agentmail.sh <inbox> [poll_seconds]
+
+Poll an AgentMail inbox; emit one stdout line per new received
+message, suitable for `Monitor` tail-streaming.
+
+Arguments:
+  <inbox>          Inbox address (e.g. vade-coo@agentmail.to)
+  [poll_seconds]   Polling interval, default 60
+
+Environment:
+  AGENTMAIL_API_KEY     AgentMail API key (required)
+  VADE_CLOUD_STATE_DIR  State directory root (defaults to ~/.vade-cloud-state)
+
+Examples:
+  subscribe-agentmail.sh vade-coo@agentmail.to
+  subscribe-agentmail.sh vade-coo@agentmail.to 30
+EOF
+}
+
+if [ $# -lt 1 ]; then
+  usage >&2
+  exit 2
+fi
+
+case "$1" in -h|--help) usage; exit 0 ;; esac
+
+inbox="$1"
+poll="${2:-60}"
+
+if ! [[ "$inbox" == *@* ]]; then
+  echo "error: inbox must be in <user>@<domain> form (got: $inbox)" >&2
+  exit 2
+fi
+if ! [[ "$poll" =~ ^[0-9]+$ ]]; then
+  echo "error: poll_seconds must be a positive integer (got: $poll)" >&2
+  exit 2
+fi
+
+if [ -z "${AGENTMAIL_API_KEY:-}" ]; then
+  echo "error: AGENTMAIL_API_KEY must be set" >&2
+  exit 1
+fi
+
+state_root="${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state}"
+state_dir="$state_root/agentmail-watch"
+mkdir -p "$state_dir"
+safe_name=$(echo "$inbox" | tr '@/' '__')
+state_file="$state_dir/${safe_name}.seen"
+touch "$state_file"
+
+trap 'echo "[agentmail-watch] shutdown ($inbox)" >&2; exit 0' INT TERM
+
+echo "[agentmail-watch] subscribed: $inbox (poll ${poll}s)" >&2
+
+while true; do
+  if ! resp=$(curl -s -H "Authorization: Bearer $AGENTMAIL_API_KEY" \
+      "https://api.agentmail.to/v0/inboxes/$inbox/messages?limit=20" 2>/dev/null); then
+    echo "[agentmail-watch] poll failed; retrying in ${poll}s" >&2
+    sleep "$poll"
+    continue
+  fi
+
+  STATE_FILE="$state_file" python3 - "$resp" <<'PY'
+import json, os, sys
+
+try:
+    resp = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(0)
+
+state_file = os.environ['STATE_FILE']
+
+with open(state_file, 'r') as f:
+    seen = {line.strip() for line in f if line.strip()}
+
+first_run = not seen
+new_ids = []
+
+messages = resp.get('messages', []) or []
+
+def emit(m):
+    labels = m.get('labels', []) or []
+    if 'received' not in labels:
+        return
+    preview = (m.get('preview') or '').replace('\n', ' ').strip()
+    if len(preview) > 140:
+        preview = preview[:137] + '...'
+    sender = m.get('from') or '<unknown>'
+    subject = m.get('subject') or '(no subject)'
+    print(f"[message] {sender} @ {m.get('timestamp', '?')}: {subject}", flush=True)
+    print(f"  preview: {preview}", flush=True)
+    print(f"  thread:  {m.get('thread_id')}", flush=True)
+    print(f"  msg_id:  {m.get('message_id')}", flush=True)
+
+for m in messages:
+    mid = m.get('message_id')
+    if not mid:
+        continue
+    if mid not in seen:
+        new_ids.append(mid)
+        if not first_run:
+            emit(m)
+
+if new_ids:
+    with open(state_file, 'a') as f:
+        for nid in new_ids:
+            f.write(nid + '\n')
+
+if first_run and new_ids:
+    print(f"[agentmail-watch] initial state recorded: {len(new_ids)} existing items", file=sys.stderr, flush=True)
+PY
+
+  sleep "$poll"
+done


### PR DESCRIPTION
## Summary

- Adds `scripts/subscribe-agentmail.sh`, an analog to `subscribe-discussion.sh` for AgentMail inboxes. Polls a given inbox, emits one stdout line per new received message — suitable for `Monitor`-tool tail-streaming.
- State file under `${VADE_CLOUD_STATE_DIR:-~/.vade-cloud-state}/agentmail-watch/` records seen message IDs so restarts don't re-emit history. First run records the current state silently.
- Filter: only `received`-labelled messages emit (skips outbound `sent`, drafts, etc.). Auth via `AGENTMAIL_API_KEY`. Defaults to 60s poll.
- V0 bridge until an upstream MCP subscribe primitive lands for AgentMail (analog to vade-runtime#206 for discussions).

**Use case:** watching the F1 outreach thread (vade-coo@agentmail.to) for Keith Holyoak's reply per MEMO-2026-05-10-4vy5 — the chain's first true external contact attempt. The interactive COO session uses this script under `Monitor` so a reply lands as a chat-stream notification rather than requiring a Ven prompt to surface.

## Closing keywords

Closes: n/a

V0 bridge; supersession would be an upstream `mcp__agentmail__subscribe_inbox_activity` primitive analogous to PR-watch (the vade-runtime#206 pattern).

## Cross-repo references

`Refs: vade-app/vade-coo-memory#436` — F1 commission tracker.
`Refs: vade-app/vade-runtime#206` — discussion-watch v0 bridge precedent.

## Test plan

- [x] `--help` prints usage.
- [x] First run records existing state silently (20 entries on smoke-test).
- [x] State file at `~/.vade-cloud-state/agentmail-watch/<safe-inbox>.seen`.
- [x] Filter excludes outbound `sent` (verified against my own outgoing reply in the F1 thread).
- [ ] Live test: a new received message in the inbox emits one stdout line (deferred until Keith's reply lands; until then the smoke-test confirms initial-state recording).

https://claude.ai/code/session_01K5fY88ZsGxuHqPoKPiKTx3