### PR TITLE
gh-coo-wrap: route GH_TOKEN by --repo owner for cross-org public-repo writes

### DIFF
--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -58,6 +58,47 @@ sid="${CLAUDE_CODE_REMOTE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
 SESSION_URL=""
 [ -n "$sid" ] && SESSION_URL="https://claude.ai/code/session_${sid#cse_}"
 
+# PAT routing for cross-org public-repo writes (MEMO-2026-05-11-6xv2).
+# `$GITHUB_MCP_PAT` is fine-grained, scoped to vade-app/* — the default
+# bounded write surface. `$GITHUB_PUBLIC_PAT` is a classic PAT with
+# `public_repo` scope, provisioned for writes to public repos outside
+# vade-app/* (anthropics/claude-code, upstream skill repos, etc).
+#
+# Routing: if --repo <owner>/<name> is in argv and owner != vade-app
+# AND $GITHUB_PUBLIC_PAT is set, swap GH_TOKEN to the public PAT for
+# this invocation. vade-app/* and no-explicit-repo invocations pass
+# through unchanged.
+extract_owner() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --repo|-R)
+        shift
+        if [ $# -gt 0 ]; then
+          printf '%s' "${1%%/*}"
+          return 0
+        fi
+        ;;
+      --repo=*)
+        repo="${1#--repo=}"
+        printf '%s' "${repo%%/*}"
+        return 0
+        ;;
+      -R=*)
+        repo="${1#-R=}"
+        printf '%s' "${repo%%/*}"
+        return 0
+        ;;
+    esac
+    shift
+  done
+  return 0
+}
+
+target_owner="$(extract_owner "$@")"
+if [ -n "$target_owner" ] && [ "$target_owner" != "vade-app" ] && [ -n "${GITHUB_PUBLIC_PAT:-}" ]; then
+  export GH_TOKEN="$GITHUB_PUBLIC_PAT"
+fi
+
 # Resolve issue/PR shape-check script. Advisory only; missing-tolerant.
 # Source: vade-coo-memory/bin/issue-pr-shape-check.py (lands via
 # vade-coo-memory#226). The wrapper uses the script when present;


### PR DESCRIPTION
## Summary

Wires `gh-coo-wrap` to route `GH_TOKEN` by target repo owner. Authorized per [MEMO-2026-05-11-6xv2](https://github.com/vade-app/vade-coo-memory/blob/main/coo/memos/2026-05-11-6xv2.md) (paired PR [vade-app/vade-coo-memory#700](https://github.com/vade-app/vade-coo-memory/pull/700) lands the memo + ops doc).

**Behavior.**
- If `--repo <owner>/<name>` is in argv and `<owner> != vade-app` AND the public PAT env var is set: substitute `GH_TOKEN` for that invocation.
- `vade-app/*` writes and no-explicit-repo invocations pass through unchanged.
- When the public PAT env var is absent (e.g. today): wrapper passes through with current env; cross-org writes return 403 and surface to Ven.

**Why.** The fine-grained MCP PAT is scoped to `vade-app/*` (intentional bounded surface). Cross-org public-repo writes (filing issues on `anthropics/claude-code`, contributing to upstream skill repos) need broader scope. Classic PAT with `public_repo` is the matching shape. Routing keeps the broader scope opt-in via env-var presence rather than always-on.

**No behavior change today.** The public PAT is not yet provisioned. The wrapper modification is a pre-positioning so that when Ven creates the PAT and adds it to the container env, the routing just works.

## Test plan

- [x] Wrapper still runs when the public PAT env var is unset (existing behavior)
- [x] `extract_owner` returns empty when no `--repo` flag is in argv
- [ ] Once PAT lands, a test write to anthropics/claude-code via `--repo anthropics/claude-code` confirms the routing (filing the multi-PR-same-repo UI bug from this session)

Closes: n/a — substrate enablement, no underlying issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULo6jDdQnqwGprAkYnKTxG