### PR TITLE
scripts: surface PR merge-conflict transitions via subscribe-pr-mergeable.sh

### DIFF
--- a/scripts/auto-subscribe-pr.sh
+++ b/scripts/auto-subscribe-pr.sh
@@ -41,6 +41,10 @@ case "$pn" in *[!0-9]*|'') exit 0 ;; esac
 jq -n --arg owner "$owner" --arg repo "$repo" --argjson pn "$pn" '{
   hookSpecificOutput: {
     hookEventName: "PostToolUse",
-    additionalContext: ("[auto-subscribe-pr] A pull request was just created at " + $owner + "/" + $repo + "#" + ($pn|tostring) + ". Call mcp__github__subscribe_pr_activity with owner=\"" + $owner + "\", repo=\"" + $repo + "\", pullNumber=" + ($pn|tostring) + " in your next tool batch so CI failures, comments, and reviews on this PR stream into this session as github-webhook-activity events.")
+    additionalContext: (
+      "[auto-subscribe-pr] A pull request was just created at " + $owner + "/" + $repo + "#" + ($pn|tostring) + ". In your next tool batch, set up two parallel subscriptions:\n" +
+      "  1. Call mcp__github__subscribe_pr_activity with owner=\"" + $owner + "\", repo=\"" + $repo + "\", pullNumber=" + ($pn|tostring) + " — streams CI failures, comments, and reviews into this session as github-webhook-activity events.\n" +
+      "  2. Start a Monitor on /home/user/vade-runtime/scripts/subscribe-pr-mergeable.sh " + $owner + "/" + $repo + " " + ($pn|tostring) + " — emits one stdout line per mergeable-state transition (clean to conflict and back) and a terminal line on merge/close. Closes the conflict-notification gap that subscribe_pr_activity does not cover (vade-runtime#254)."
+    )
   }
 }'

--- a/scripts/subscribe-pr-mergeable.sh
+++ b/scripts/subscribe-pr-mergeable.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# subscribe-pr-mergeable: poll a GitHub PR's mergeable state; emit one
+# stdout line per transition (MERGEABLE <-> CONFLICTING; final MERGED /
+# CLOSED).
+#
+# Closes the gap that `mcp__github__subscribe_pr_activity` doesn't fill:
+# GitHub does not emit a webhook event when `mergeable_state` transitions
+# from clean to dirty (base-branch motion turns an open PR into a merge
+# conflict), so the existing subscription can't surface it. This script
+# polls instead. Sibling to subscribe-discussion.sh.
+#
+# Suitable for the `Monitor` tool: each printed line is one event
+# notification, flushed. Exits 0 once the PR enters a terminal state
+# (MERGED or CLOSED), since the subscription is naturally over.
+#
+# Usage:
+#   subscribe-pr-mergeable.sh <owner/repo> <pr-number> [poll_seconds]
+#
+# Defaults: poll every 120s. `mergeable` lags base-branch pushes by
+# ~30s; tighter polling mostly observes UNKNOWN transients.
+#
+# State: per-PR last-known state file under
+# ${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state}/pr-mergeable-watch/
+# records the last-emitted mergeable value. First run records the
+# current state silently (no event emitted) and only future
+# transitions surface.
+#
+# UNKNOWN handling: `mergeable` reports UNKNOWN transiently while GitHub
+# recomputes after a push. Transitions through UNKNOWN are not emitted;
+# only transitions between concrete states (MERGEABLE <-> CONFLICTING)
+# fire events. UNKNOWN is recorded internally so a subsequent
+# concrete-value read can be compared against the last concrete state,
+# not against UNKNOWN.
+#
+# Authentication: relies on GITHUB_MCP_PAT or GH_TOKEN being set.
+#
+# Exit codes:
+#   0  graceful shutdown (SIGINT/SIGTERM) or terminal state (MERGED/CLOSED)
+#   1  missing GitHub token
+#   2  argument error
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: subscribe-pr-mergeable.sh <owner/repo> <pr-number> [poll_seconds]
+
+Poll a GitHub PR's mergeable state; emit one stdout line per
+transition, suitable for `Monitor` tail-streaming.
+
+Arguments:
+  <owner/repo>     Target repository (e.g. vade-app/vade-coo-memory)
+  <pr-number>      Pull request number
+  [poll_seconds]   Polling interval, default 120
+
+Environment:
+  GITHUB_MCP_PAT        GitHub PAT (preferred)
+  GH_TOKEN              Fallback if MCP PAT unset
+  VADE_CLOUD_STATE_DIR  State directory root (defaults to ~/.vade-cloud-state)
+
+Examples:
+  subscribe-pr-mergeable.sh vade-app/vade-coo-memory 734
+  subscribe-pr-mergeable.sh vade-app/vade-runtime 254 60
+EOF
+}
+
+if [ $# -lt 2 ]; then
+  usage >&2
+  exit 2
+fi
+
+case "$1" in -h|--help) usage; exit 0 ;; esac
+
+repo="$1"
+number="$2"
+poll="${3:-120}"
+
+if ! [[ "$repo" == */* ]]; then
+  echo "error: repo must be in <owner/name> form (got: $repo)" >&2
+  exit 2
+fi
+if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+  echo "error: pr-number must be a positive integer (got: $number)" >&2
+  exit 2
+fi
+if ! [[ "$poll" =~ ^[0-9]+$ ]]; then
+  echo "error: poll_seconds must be a positive integer (got: $poll)" >&2
+  exit 2
+fi
+
+owner="${repo%%/*}"
+name="${repo##*/}"
+
+token="${GITHUB_MCP_PAT:-${GH_TOKEN:-}}"
+if [ -z "$token" ]; then
+  echo "error: GITHUB_MCP_PAT or GH_TOKEN must be set" >&2
+  exit 1
+fi
+
+state_root="${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state}"
+state_dir="$state_root/pr-mergeable-watch"
+mkdir -p "$state_dir"
+state_file="$state_dir/${owner}__${name}__${number}.state"
+
+trap 'echo "[pr-mergeable-watch] shutdown ($repo#$number)" >&2; exit 0' INT TERM
+
+last_concrete=""
+if [ -f "$state_file" ]; then
+  last_concrete="$(cat "$state_file" 2>/dev/null || true)"
+fi
+first_run=1
+if [ -n "$last_concrete" ]; then
+  first_run=0
+fi
+
+echo "[pr-mergeable-watch] subscribed: $repo#$number (poll ${poll}s)" >&2
+
+while true; do
+  if ! resp=$(GH_TOKEN="$token" gh pr view "$number" \
+      --repo "$repo" \
+      --json state,mergeable,mergeStateStatus 2>/dev/null); then
+    echo "[pr-mergeable-watch] poll failed; retrying in ${poll}s" >&2
+    sleep "$poll"
+    continue
+  fi
+
+  state="$(printf '%s' "$resp"   | jq -r '.state // ""'             2>/dev/null || true)"
+  merge="$(printf '%s' "$resp"   | jq -r '.mergeable // ""'         2>/dev/null || true)"
+  status="$(printf '%s' "$resp"  | jq -r '.mergeStateStatus // ""'  2>/dev/null || true)"
+
+  case "$state" in
+    MERGED|CLOSED)
+      echo "PR $repo#$number $state (final)"
+      rm -f "$state_file"
+      exit 0
+      ;;
+  esac
+
+  case "$merge" in
+    MERGEABLE|CONFLICTING)
+      if [ "$first_run" = "1" ]; then
+        printf '%s\n' "$merge" > "$state_file"
+        echo "[pr-mergeable-watch] initial state: $merge (mergeStateStatus=$status)" >&2
+        last_concrete="$merge"
+        first_run=0
+      elif [ "$merge" != "$last_concrete" ]; then
+        echo "PR $repo#$number mergeable: $last_concrete → $merge (mergeStateStatus=$status)"
+        printf '%s\n' "$merge" > "$state_file"
+        last_concrete="$merge"
+      fi
+      ;;
+    UNKNOWN|"")
+      : # transient — don't emit, don't update last_concrete
+      ;;
+    *)
+      echo "[pr-mergeable-watch] unexpected mergeable value: $merge" >&2
+      ;;
+  esac
+
+  sleep "$poll"
+done


### PR DESCRIPTION
## Summary

- Adds `scripts/subscribe-pr-mergeable.sh` — polling subscription that emits stdout transitions between MERGEABLE and CONFLICTING for a single PR, and a terminal line on MERGED/CLOSED. Sibling to `subscribe-discussion.sh`. Closes the gap that `mcp__github__subscribe_pr_activity` doesn't fill (GitHub does not emit webhooks on `mergeable_state` transitions — it's a derived, pollable field).
- Updates `scripts/auto-subscribe-pr.sh` to prompt the agent to start a `Monitor` on the new script in the same tool batch as the existing `subscribe_pr_activity` call, so opening any PR auto-wires both event sources.

## Worked failure that motivated this

Session 01LdwS2g59R8C6FuJDDDxgWp opened vade-coo-memory#734, subscribed via `subscribe_pr_activity`, continued working. When vade-coo-memory#713 (the 2026-05-12 nightly briefing) merged on main, vcm#734's `mergeable_state` flipped to `DIRTY` — no webhook fired, no event surfaced. Ven asked about the conflict 9 minutes later; the agent had no signal. The same shape will recur whenever base-branch motion conflicts with any open PR a session is watching.

## Design

- **Poll interval default 120s.** `mergeable_state` lags base-branch pushes by ~30s while GitHub recomputes; tighter polling mostly observes UNKNOWN transients.
- **UNKNOWN handling.** Transitions through UNKNOWN are not emitted; only MERGEABLE↔CONFLICTING fire events. UNKNOWN is treated as "no signal" — the last-known concrete value is retained for the next comparison.
- **Terminal state.** When `state` becomes MERGED or CLOSED, the script emits a final line, removes its state file, and exits 0. The Monitor naturally completes.
- **State directory.** `${VADE_CLOUD_STATE_DIR:-~/.vade-cloud-state}/pr-mergeable-watch/<owner>__<repo>__<pr>.state` — first run records the initial state silently (no event); only transitions surface on subsequent polls.
- **Auth.** Honors `GITHUB_MCP_PAT` (preferred), `GH_TOKEN` (fallback). Same shape as `subscribe-discussion.sh`.

## v1 note

The cleaner long-term fix would be a `mcp__github__subscribe_pr_mergeable_activity` companion primitive that does the polling inside the github MCP server. That requires upstream changes; this script is the v0 bridge.

## Test plan

- [x] `--help` prints usage.
- [x] Smoke test against vade-coo-memory#734 (currently MERGEABLE, CLEAN): initial-state line printed to stderr, no stdout event, state file persisted.
- [x] Second run with persisted state: no stdout event (state unchanged), clean shutdown.
- [x] Hook updated; synthetic-payload smoke test produces the expected two-subscription prompt.
- [x] Hook no-op path still no-ops (non-`gh pr create` commands).
- [ ] End-to-end: open a PR, base-branch push a conflicting commit, observe `subscribe-pr-mergeable.sh` emit `MERGEABLE → CONFLICTING` within poll interval + GitHub lag. (Best verified by next agent session post-merge.)

## Companion PR

A vade-coo-memory PR (to be filed next) updates CLAUDE.md §"PR-watch discipline" to (a) name the new subscription alongside `subscribe_pr_activity` and (b) add an interim discipline rule for the window before this lands: on any PR-merge webhook event, re-check `mergeable_state` of other open PRs the COO authored.

Closes #254

https://claude.ai/code/session_01LdwS2g59R8C6FuJDDDxgWp