### PR TITLE
Add poppler-utils for notebooklm-pipeline slide-deck post-processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,11 @@ ARG USERNAME=node
 # for the uv-managed mem0-mcp-server install below, age for at-rest
 # encryption of session transcripts uploaded by the Stop hook
 # (vade-app/vade-agent-logs#64 Batch 2; recipient pubkey at
-# scripts/lib/transcripts-recipient.age, identity in 1Password).
+# scripts/lib/transcripts-recipient.age, identity in 1Password),
+# poppler-utils for `pdftoppm` (PDF→PNG extraction used by the
+# notebooklm-pipeline skill's slide-deck post-processing step;
+# libpoppler134 ships transitively with other deps but the CLI
+# tools require the explicit utils package).
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git \
       ca-certificates \
@@ -27,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       python3 \
       python3-venv \
       age \
+      poppler-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # 1Password CLI — pinned in versions.lock. Baked at image-build time so

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -201,6 +201,20 @@ else
   log "Warning: quarto install failed at build time; first session that uses it will pay a ~131 MB direct-fetch."
 fi
 
+# Install poppler-utils for `pdftoppm` (PDF→PNG extraction). Used by
+# the notebooklm-pipeline skill's Step 7 to extract per-page PNGs from
+# generated slide-deck PDFs for embed-ready review. Base cloud image
+# ships libpoppler134 transitively but not the CLI tools, so without
+# this install the skill's slide-deck post-processing fails mid-run
+# with "command not found". Cheap and idempotent — pay once at
+# snapshot bake.
+if ensure_poppler_utils; then
+  build_log_record OK "cloud-setup: poppler-utils installed at build time"
+else
+  build_log_record WARN "cloud-setup: poppler-utils install failed at build time; notebooklm-pipeline slide-deck post-processing will be skipped"
+  log "Warning: poppler-utils install failed at build time; notebooklm-pipeline Step 7 (slide-deck PDF→PNG) will skip on use."
+fi
+
 # Pre-fetch the 1Password MCP server (@takescake/1password-mcp) into the
 # global npm cache so first-session `npx -y` resolves offline. Same
 # snapshot-persistence rationale as op + gh + mem0 — paying the npm

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1845,6 +1845,38 @@ ensure_openssh_client() {
   return 1
 }
 
+# Ensure poppler-utils is present (provides pdftoppm / pdftotext /
+# pdfinfo). pdftoppm is used by the notebooklm-pipeline skill's Step 7
+# to extract per-page PNGs from generated slide-deck PDFs for embed-
+# ready review. The base cloud image ships libpoppler134 transitively
+# but not the CLI tools, so absent this install the slide-deck post-
+# processing step fails with "command not found" mid-skill — surfacing
+# the friction late rather than at snapshot-build time.
+# Returns 0 if available (or successfully installed), 1 otherwise.
+ensure_poppler_utils() {
+  if check_cmd pdftoppm; then
+    return 0
+  fi
+  if ! check_cmd apt-get; then
+    log "poppler-utils missing and apt-get unavailable; slide-deck PDF→PNG extraction will be skipped"
+    return 1
+  fi
+  log "Installing poppler-utils (provides pdftoppm for notebooklm-pipeline slide-deck post-processing)"
+  if sudo -n true 2>/dev/null; then
+    sudo apt-get update -qq >/dev/null 2>&1 || true
+    sudo apt-get install -y --no-install-recommends poppler-utils >/dev/null 2>&1
+  else
+    apt-get update -qq >/dev/null 2>&1 || true
+    apt-get install -y --no-install-recommends poppler-utils >/dev/null 2>&1
+  fi
+  if check_cmd pdftoppm; then
+    log "poppler-utils installed"
+    return 0
+  fi
+  log "poppler-utils install failed (no sudo or apt denied); slide-deck PDF→PNG extraction will be skipped"
+  return 1
+}
+
 # Compute ssh-key fingerprint from a pubkey file. Returns empty on
 # failure. Wraps the pipeline so we can call it without tripping
 # pipefail/set -e in the caller.

--- a/versions.lock
+++ b/versions.lock
@@ -110,6 +110,19 @@ age                 debian-bookworm   # X25519 file encryption.
                                       # scripts/lib/transcripts-recipient.age;
                                       # identity in 1Password at
                                       # op://COO/transcripts-age-key/credential.
+poppler-utils       debian-bookworm   # Provides pdftoppm / pdftotext /
+                                      # pdfinfo. pdftoppm used by the
+                                      # notebooklm-pipeline skill's
+                                      # Step 7 to extract per-page PNGs
+                                      # from generated slide-deck PDFs
+                                      # for embed-ready review. Base
+                                      # image ships libpoppler134
+                                      # transitively but not the CLI
+                                      # tools, so the SKILL.md's earlier
+                                      # "available by default" claim
+                                      # was wrong until the Dockerfile
+                                      # add at vade-runtime claude/
+                                      # test-notebooklm-infographic-zDPyU.
 
 # Python libraries resolved at run time via `uv run --script` inline
 # PEP 723 metadata (no system-wide install). Listed here so the pin is


### PR DESCRIPTION
## Summary

Surfaced while testing the new `notebooklm-pipeline` skill on a fresh
session against external (quarto.org) sources. The skill's Step 7
post-processing claims `pdftoppm` "ships in poppler-utils; available
in the COO container by default" — false. The base cloud image only
ships `libpoppler134` (the rendering library) transitively, not the
`poppler-utils` CLI package. Without this fix, any slide-deck bundle
fails mid-skill with `pdftoppm: command not found`.

Three places fixed:

- **Dockerfile** — add `poppler-utils` to the apt-install list for
  the local devcontainer.
- **scripts/cloud-setup.sh** — call `ensure_poppler_utils` at snapshot
  bake so cloud sessions get `pdftoppm` without per-session install.
- **scripts/lib/common.sh** — new `ensure_poppler_utils` helper
  modeled on `ensure_openssh_client`.
- **versions.lock** — documented in the system-packages block.

Surfaced by testing the new `notebooklm-pipeline` skill end-to-end on
a fresh session. The infographic test didn't itself need `pdftoppm`,
but the missing-tool path matched the user's preference for "auto
available or discoverable for new sessions".

SKILL.md updates (softening the "available by default" claim) will
follow on a separate vade-coo-memory PR; this PR is the structural
fix that makes the claim true going forward.

Closes: n/a

https://claude.ai/code/session_015DA5iEaYXPg76iXpsY14tK