### PR TITLE
cloud-setup: pre-install notebooklm-py at snapshot bake

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -215,6 +215,20 @@ else
   log "Warning: poppler-utils install failed at build time; notebooklm-pipeline Step 7 (slide-deck PDF→PNG) will skip on use."
 fi
 
+# Pre-install notebooklm-py for the notebooklm-pipeline skill. Without
+# this, the wrapper's `_ensure_pip_package("notebooklm-py[browser]", ...)`
+# runs on every fresh snapshot's first invocation, adding ~5–10 s of
+# pip latency + noisy stderr (including "Running pip as root" warnings)
+# before any user-visible work. Chromium itself is already pre-baked at
+# /opt/pw-browsers via image-level PLAYWRIGHT_BROWSERS_PATH, so this
+# only needs to land the Python package.
+if ensure_notebooklm_py; then
+  build_log_record OK "cloud-setup: notebooklm-py installed at build time"
+else
+  build_log_record WARN "cloud-setup: notebooklm-py install failed at build time; first session will pay the install latency"
+  log "Warning: notebooklm-py install failed at build time; notebooklm-pipeline skill will install on first use."
+fi
+
 # Pre-fetch the 1Password MCP server (@takescake/1password-mcp) into the
 # global npm cache so first-session `npx -y` resolves offline. Same
 # snapshot-persistence rationale as op + gh + mem0 — paying the npm

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1877,6 +1877,30 @@ ensure_poppler_utils() {
   return 1
 }
 
+# Ensure notebooklm-py is present (the library the notebooklm-pipeline
+# skill drives). Without this pre-install the wrapper pays a ~5–10 s
+# pip-install latency + noisy stderr on every fresh snapshot's first
+# invocation. Chromium itself is pre-baked at /opt/pw-browsers via the
+# image-level PLAYWRIGHT_BROWSERS_PATH, so this only needs to land the
+# Python package.
+# Returns 0 if importable (or successfully installed), 1 otherwise.
+ensure_notebooklm_py() {
+  if python3 -c 'import notebooklm' >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! check_cmd python3; then
+    log "python3 missing; cannot pre-install notebooklm-py"
+    return 1
+  fi
+  log "Pre-installing notebooklm-py[browser] for notebooklm-pipeline skill"
+  if python3 -m pip install --quiet --user 'notebooklm-py[browser]' >/dev/null 2>&1; then
+    log "notebooklm-py installed"
+    return 0
+  fi
+  log "notebooklm-py install failed; first session that runs the skill will pay the install cost"
+  return 1
+}
+
 # Compute ssh-key fingerprint from a pubkey file. Returns empty on
 # failure. Wraps the pipeline so we can call it without tripping
 # pipefail/set -e in the caller.


### PR DESCRIPTION
## Summary

- Adds \`ensure_notebooklm_py\` helper to \`scripts/lib/common.sh\` and wires it into \`scripts/cloud-setup.sh\` alongside \`ensure_poppler_utils\`.
- Removes the ~5–10 s pip-install latency + noisy "Running pip as root" warnings that fire on every fresh snapshot's first invocation of the notebooklm-pipeline skill.
- Chromium itself is already pre-baked at \`/opt/pw-browsers\` via the image-level \`PLAYWRIGHT_BROWSERS_PATH\`, so this only lands the Python package.

Closes: n/a

## Context

Surfaced during the 2026-05-12 fresh-eyes friction sweep of the notebooklm-pipeline skill (companion PR: vade-app/vade-coo-memory#742). Ven called out that runtime pip installs aren't the right pattern — pre-bake at snapshot time like everything else.

The helper is idempotent (skips if \`import notebooklm\` already succeeds) and best-effort (logs and continues on failure, so the wrapper's runtime install still works as fallback).

## Test plan

- [ ] Bootstrap regression CI passes
- [ ] Locally: \`bash -n scripts/cloud-setup.sh\` + \`bash -n scripts/lib/common.sh\` (already verified clean)
- [ ] After next snapshot bake: confirm \`python3 -c 'import notebooklm'\` succeeds without prior wrapper invocation
- [ ] Wrapper's first run on a fresh snapshot prints no "installing notebooklm-py[browser]" line

https://claude.ai/code/session_01YMk1aqwbWinQRh5D5qMwuU