### PR TITLE
gh/git substrate: close cross-org PAT-routing gaps

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,6 +66,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/vade-hooks/dispatch.sh\" bash-token-guard"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/vade-hooks/dispatch.sh\" bash-github-api-guard"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -271,7 +271,8 @@
       "Bash(mkdir -p /home/user/vade-coo-memory/coo/_drafts/2026-05-10_f1-outreach)",
       "Bash(flyctl secrets *)",
       "mcp__claude_ai_Mem0__get_memories",
-      "mcp__claude_ai_Mem0__search_memories"
+      "mcp__claude_ai_Mem0__search_memories",
+      "Bash(cp /home/user/vade-runtime/.claude/settings.json /home/user/.claude/settings.json && diff /home/user/.claude/settings.json /home/user/vade-runtime/.claude/settings.json && echo \"sync OK\")"
     ],
     "deny": [
       "Bash(rm -rf /:*)",

--- a/scripts/bash-github-api-guard.sh
+++ b/scripts/bash-github-api-guard.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# PreToolUse Bash hook: refuse direct HTTP client subprocess calls to
+# `api.github.com`. Forces the agent down the `gh` path, where the
+# `gh-coo-wrap.sh` shim auto-routes the correct PAT by repo owner.
+#
+# Why: When the agent reaches for `curl https://api.github.com/...` it
+# bypasses every layer that exists to make GitHub interactions
+# anti-fragile: PAT routing, session-URL injection, body-shape lint.
+# The 2026-05-11 cross-fork fork failure was the direct cause —
+# `gh repo fork venpopov/X` would have routed correctly; `curl ...
+# /repos/venpopov/X/forks` did not. This hook converts the wrong
+# reflex into a hard refusal at the substrate.
+#
+# Contract: reads Claude Code's PreToolUse JSON on stdin,
+# `{"tool_input": {"command": "..."}}`. Always exits 0. To block, emits
+# `{"decision": "block", "reason": "..."}` on stdout. To allow, emits
+# nothing.
+#
+# Block rules (any pipeline stage):
+#   - First command word is one of the HTTP-client family:
+#       curl, wget, http, https, httpie
+#     AND any argument contains `api.github.com`.
+#   - First command word is `python`/`python3`/`python2`/`node`/`bun`/
+#     `deno`/`ruby`/`perl` AND the next arg is `-c` / `-e` AND the
+#     script body contains `api.github.com`.
+#
+# Allow rules (allowed shapes that mention api.github.com):
+#   - `gh ...` (auto-routes via gh-coo-wrap.sh)
+#   - File-read / file-edit / grep / sed of a file that happens to
+#     contain `api.github.com` (cat, head, tail, less, grep, rg, sed,
+#     awk, jq, vim, etc.) — first command word not in the blocked set.
+#   - Pipeline whose ONLY mention is in a non-network stage.
+#
+# Bypass:
+#   - VADE_GITHUB_API_GUARD_BYPASS=1 → unconditionally allow. Set this
+#     for a deliberate diagnostic; flag in commit / PR if persisted.
+#
+# Reference: MEMO-2026-05-12-22m9, vade-runtime#TBD.
+
+set -uo pipefail
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && exit 0
+
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)"
+[ -z "$cmd" ] && exit 0
+
+# Bypass shortcut: env var set on the agent's shell.
+case "$cmd" in
+  *VADE_GITHUB_API_GUARD_BYPASS=1*) exit 0 ;;
+esac
+if [ "${VADE_GITHUB_API_GUARD_BYPASS:-}" = "1" ]; then
+  exit 0
+fi
+
+# Fast pre-filter: if api.github.com is not in the command at all,
+# allow immediately. Keep the hook's hot-path cheap.
+case "$cmd" in
+  *api.github.com*) ;;
+  *) exit 0 ;;
+esac
+
+# Delegate the structural analysis to python3 (already a dependency
+# for bash-token-guard.sh). Bash heredoc parsing inside $() is fragile
+# across macOS bash 3.2 and Linux bash 5.x; the python sub-process
+# sidesteps quoting issues.
+leak_reason="$(python3 - "$cmd" <<'PY' 2>/dev/null || true
+import re, sys
+cmd = sys.argv[1]
+
+# HTTP-client command words that block on api.github.com mention.
+HTTP_CLIENTS = {"curl", "wget", "http", "https", "httpie"}
+# Interpreter command words that block when -c/-e arg contains
+# api.github.com in the inline script.
+INTERPRETERS = {"python", "python3", "python2", "node", "nodejs",
+                "bun", "deno", "ruby", "perl"}
+INLINE_FLAGS = {"-c", "-e", "--command", "--eval"}
+
+def split_pipelines(s):
+    """Split on `|` (pipe) but not `||`. Respect quotes."""
+    out, cur = [], []
+    in_s = in_d = False
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        nxt = s[i+1] if i+1 < len(s) else ''
+        if ch == '\\' and not in_s:
+            cur.append(ch)
+            if nxt:
+                cur.append(nxt); i += 2; continue
+        if ch == "'" and not in_d:
+            in_s = not in_s; cur.append(ch); i += 1; continue
+        if ch == '"' and not in_s:
+            in_d = not in_d; cur.append(ch); i += 1; continue
+        if (not in_s and not in_d and ch == '|'
+                and nxt != '|' and (i == 0 or s[i-1] != '|')):
+            out.append(''.join(cur)); cur = []; i += 1; continue
+        cur.append(ch); i += 1
+    out.append(''.join(cur))
+    return out
+
+def split_logical(s):
+    """Split on `&&` / `||` / `;` / newline, respecting quotes."""
+    out, cur = [], []
+    in_s = in_d = False
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        nxt = s[i+1] if i+1 < len(s) else ''
+        if ch == '\\' and not in_s:
+            cur.append(ch)
+            if nxt:
+                cur.append(nxt); i += 2; continue
+        if ch == "'" and not in_d:
+            in_s = not in_s; cur.append(ch); i += 1; continue
+        if ch == '"' and not in_s:
+            in_d = not in_d; cur.append(ch); i += 1; continue
+        if not in_s and not in_d:
+            if ch == '&' and nxt == '&':
+                out.append(''.join(cur)); cur = []; i += 2; continue
+            if ch == '|' and nxt == '|':
+                out.append(''.join(cur)); cur = []; i += 2; continue
+            if ch == ';':
+                out.append(''.join(cur)); cur = []; i += 1; continue
+            if ch == '\n':
+                out.append(''.join(cur)); cur = []; i += 1; continue
+        cur.append(ch); i += 1
+    out.append(''.join(cur))
+    return out
+
+# Tokenize a segment into rough command words. We don't need perfect
+# shell tokenization — just the first command word + a flag scan.
+def first_cmd_word(seg):
+    # Strip leading env-var assignments (VAR=val cmd ...).
+    s = seg.lstrip()
+    # Skip leading env-var assignments.
+    while True:
+        m = re.match(r'\s*([A-Za-z_][A-Za-z0-9_]*=\S*)\s+', s)
+        if m:
+            s = s[m.end():]
+        else:
+            break
+    # Strip leading `&` / redirects.
+    s = re.sub(r'^[\s\d&<>]+', '', s)
+    m = re.match(r'(\S+)', s)
+    return (m.group(1) if m else ''), s
+
+def args_contain_target(s):
+    """Return True if 'api.github.com' appears anywhere in the
+    segment (after the command word)."""
+    return 'api.github.com' in s
+
+def check_segment(seg):
+    """Return a block reason if this segment violates, else ''."""
+    if 'api.github.com' not in seg:
+        return ''
+    cmd_word, rest = first_cmd_word(seg)
+    if not cmd_word:
+        return ''
+    # Strip a leading absolute path so /usr/bin/curl resolves to curl.
+    base = cmd_word.rsplit('/', 1)[-1]
+    # Strip a trailing semicolon if any leaked through tokenization.
+    base = base.rstrip(';')
+    # Allow `gh ...` — that's the desired path.
+    if base == 'gh':
+        return ''
+    if base in HTTP_CLIENTS:
+        return (f"direct {base} call to api.github.com "
+                "bypasses gh's auto-routing (PAT selection by repo owner)")
+    if base in INTERPRETERS:
+        # Only flag if the inline script (-c / -e arg) references
+        # api.github.com. Walk args after the command word.
+        toks = re.split(r'\s+', rest.strip())
+        # toks[0] is base again; scan from toks[1:].
+        i = 1
+        while i < len(toks):
+            t = toks[i]
+            if t in INLINE_FLAGS:
+                # Next token is the inline script — but quoted scripts
+                # span multiple tokens. Easier: rejoin from after the
+                # flag and check the rest of `rest` for api.github.com.
+                tail = rest.split(t, 1)[1] if t in rest else ''
+                if 'api.github.com' in tail:
+                    return (f"inline {base} {t} script references "
+                            "api.github.com; bypasses gh's auto-routing")
+                break
+            i += 1
+        return ''
+    return ''
+
+reasons = []
+# Logical splits — each statement is independent.
+for stmt in split_logical(cmd):
+    # Pipeline splits — each stage is a separate command.
+    for stage in split_pipelines(stmt):
+        r = check_segment(stage)
+        if r:
+            reasons.append(r)
+            break  # one reason per statement is enough
+
+if reasons:
+    print(reasons[0])
+    sys.exit(0)
+PY
+)"
+
+if [ -n "$leak_reason" ]; then
+  jq -n --arg reason "$leak_reason" '{
+    decision: "block",
+    reason: ("[bash-github-api-guard] " + $reason + ". Use `gh api PATH` (auto-routes credentials by repo owner) or a `gh` subcommand. Examples: `gh api repos/OWNER/REPO`, `gh repo fork OWNER/REPO`, `gh pr create --repo OWNER/REPO ...`. Bypass for a deliberate diagnostic: prefix `VADE_GITHUB_API_GUARD_BYPASS=1`. See MEMO-2026-05-12-22m9.")
+  }'
+  exit 0
+fi
+
+exit 0

--- a/scripts/ci/test-gh-coo-wrap.sh
+++ b/scripts/ci/test-gh-coo-wrap.sh
@@ -22,8 +22,11 @@ trap 'rm -rf "$WORK"' EXIT
 
 # Mock gh-real: dump its argv, one per line, to stdout. For
 # --body-file we also dump the file contents marked with FILE-CONTENT:.
+# Also prints GH_TOKEN so routing-layer tests can assert which PAT
+# the wrapper selected for this invocation.
 cat > "$WORK/gh-real" <<'EOF'
 #!/usr/bin/env bash
+printf 'GH_TOKEN=%s\n' "${GH_TOKEN:-<unset>}"
 i=0
 for a in "$@"; do
   i=$((i+1))
@@ -213,6 +216,110 @@ else
   printf '  FAIL  missing real binary: exit %s, expected 127\n' "$ec"
   printf '         stderr: %s\n' "$err"
 fi
+
+# ============================================================
+# PAT routing tests (MEMO-2026-05-11-6xv2 + MEMO-2026-05-12-22m9).
+# ============================================================
+# These tests assert which PAT the wrapper exports as GH_TOKEN
+# based on the target repo owner. The mock prints GH_TOKEN as its
+# first output line; tests assert that prefix.
+
+export GITHUB_MCP_PAT="MCP_PAT_TESTING"
+export GITHUB_PUBLIC_PAT="PUBLIC_PAT_TESTING"
+export GH_TOKEN="MCP_PAT_TESTING"  # default state at session start
+
+printf '\nPAT routing tests:\n'
+
+# --- vade-app/* (MCP PAT, no swap) ---
+
+# Existing --repo flag form, vade-app — no swap
+out="$("$WRAPPER" --repo vade-app/foo pr comment 1 --body "x")"
+assert_contains "vade-app via --repo: keeps MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# Positional repo arg, vade-app — no swap (new coverage)
+out="$("$WRAPPER" repo view vade-app/foo)"
+assert_contains "gh repo view vade-app/foo: keeps MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# gh api repos/vade-app/...
+out="$("$WRAPPER" api repos/vade-app/foo/issues)"
+assert_contains "gh api repos/vade-app: keeps MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# gh api orgs/vade-app
+out="$("$WRAPPER" api orgs/vade-app/repos)"
+assert_contains "gh api orgs/vade-app: keeps MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# --- non-vade-app (PUBLIC PAT swap) ---
+
+# Existing --repo flag form, non-vade-app — swaps
+out="$("$WRAPPER" --repo venpopov/foo pr comment 1 --body "x")"
+assert_contains "venpopov via --repo: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# gh repo fork positional (the failure case that motivated this PR)
+out="$("$WRAPPER" repo fork venpopov/foo)"
+assert_contains "gh repo fork venpopov/foo: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+out="$("$WRAPPER" repo fork anthropics/claude-code --org vade-coo)"
+assert_contains "gh repo fork anthropics/... --org vade-coo: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# gh repo create non-vade-app
+out="$("$WRAPPER" repo create venpopov/new-repo --public)"
+assert_contains "gh repo create venpopov/new-repo: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# gh repo clone with HTTPS URL
+out="$("$WRAPPER" repo clone https://github.com/anthropics/foo)"
+assert_contains "gh repo clone https URL: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# gh repo clone with SSH URL
+out="$("$WRAPPER" repo clone git@github.com:anthropics/foo)"
+assert_contains "gh repo clone SSH URL: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# gh api repos/<non-vade-app>/...
+out="$("$WRAPPER" api repos/anthropics/claude-code/issues)"
+assert_contains "gh api repos/anthropics/...: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# gh api repos/<non-vade-app>/.../forks (the today fork failure case)
+out="$("$WRAPPER" api -X POST repos/venpopov/foo/forks)"
+assert_contains "gh api -X POST repos/venpopov/.../forks: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# gh api orgs/<non-vade-app>
+out="$("$WRAPPER" api orgs/anthropics/repos)"
+assert_contains "gh api orgs/anthropics: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# gh api users/<non-vade-app>
+out="$("$WRAPPER" api users/octocat)"
+assert_contains "gh api users/octocat: swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# gh api with leading slash on path
+out="$("$WRAPPER" api /repos/anthropics/foo)"
+assert_contains "gh api /repos/... (leading slash): swaps to PUBLIC_PAT" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# --- template/flag-value disambiguation ---
+
+# gh repo create --template anthropics/foo vade-app/new — must pick vade-app, not anthropics
+out="$("$WRAPPER" repo create --template anthropics/foo vade-app/new --public)"
+assert_contains "gh repo create --template foreign/X vade-app/Y: keeps MCP_PAT (target wins)" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# Symmetric: --template vade-app/foo venpopov/new — must pick venpopov, swap
+out="$("$WRAPPER" repo create --template vade-app/foo venpopov/new --public)"
+assert_contains "gh repo create --template vade-app/X venpopov/Y: swaps to PUBLIC_PAT (target wins)" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
+
+# --- GITHUB_PUBLIC_PAT unset: no override even for non-vade-app ---
+
+out="$(env -u GITHUB_PUBLIC_PAT GITHUB_MCP_PAT="$GITHUB_MCP_PAT" GH_TOKEN="$GH_TOKEN" CLAUDE_CODE_REMOTE_SESSION_ID="$CLAUDE_CODE_REMOTE_SESSION_ID" COO_GH_REAL="$WORK/gh-real" "$WRAPPER" repo fork venpopov/foo)"
+assert_contains "GITHUB_PUBLIC_PAT unset: no swap, keeps MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# --- uncovered subcommands: no swap ---
+
+# gh repo list (action not in our list) — no routing fires
+out="$("$WRAPPER" repo list venpopov)"
+# Note: 'venpopov' here is the *owner argument* to `gh repo list`; we
+# deliberately don't extract from `gh repo list` since its positional
+# is owner-only (not owner/name). MCP_PAT remains.
+assert_contains "gh repo list <owner>: keeps MCP_PAT (uncovered action)" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# gh release create (uncovered) — no swap
+out="$("$WRAPPER" release create v1.0.0)"
+assert_contains "gh release create: keeps MCP_PAT (uncovered)" "$out" "GH_TOKEN=MCP_PAT_TESTING"
 
 printf '\n'
 printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"

--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -58,16 +58,39 @@ sid="${CLAUDE_CODE_REMOTE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
 SESSION_URL=""
 [ -n "$sid" ] && SESSION_URL="https://claude.ai/code/session_${sid#cse_}"
 
-# PAT routing for cross-org public-repo writes (MEMO-2026-05-11-6xv2).
+# PAT routing for cross-org public-repo writes (MEMO-2026-05-11-6xv2,
+# expanded by MEMO-2026-05-12-22m9 — coverage extension to positional
+# repo args and `gh api` URL paths).
+#
 # `$GITHUB_MCP_PAT` is fine-grained, scoped to vade-app/* — the default
 # bounded write surface. `$GITHUB_PUBLIC_PAT` is a classic PAT with
 # `public_repo` scope, provisioned for writes to public repos outside
 # vade-app/* (anthropics/claude-code, upstream skill repos, etc).
 #
-# Routing: if --repo <owner>/<name> is in argv and owner != vade-app
+# Routing: if any covered surface in argv names an owner != vade-app
 # AND $GITHUB_PUBLIC_PAT is set, swap GH_TOKEN to the public PAT for
-# this invocation. vade-app/* and no-explicit-repo invocations pass
+# this invocation. vade-app/* and unrecognized-shape invocations pass
 # through unchanged.
+#
+# Covered surfaces:
+#   1. `--repo <owner>/<name>` / `-R <owner>/<name>` flag form
+#      → extract_owner (the original layer).
+#   2. Positional `<owner>/<name>` after the action of
+#      `gh repo {fork,create,clone,view,sync,rename,archive,delete,
+#                edit,set-default,deploy-key,unarchive}`
+#      → extract_owner_positional.
+#   3. URL path after `gh api`:
+#        repos/<owner>/<repo>[/...]   → <owner>
+#        orgs/<owner>[/...]           → <owner>
+#        users/<owner>[/...]          → <owner>
+#      → extract_owner_positional.
+#
+# False-positive bound (template repo case): on
+# `gh repo create --template owner-a/foo owner-b/new`, naive scanning
+# picks owner-a, but `--template` is treated as value-taking below so
+# the positional resolves to owner-b. The flag-value allowlist
+# (__gh_valued_flag) is conservative; unknown flags are treated as
+# boolean (their next arg is treated as positional).
 extract_owner() {
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -94,7 +117,135 @@ extract_owner() {
   return 0
 }
 
+# __gh_valued_flag: returns 0 iff $1 is a known gh flag that consumes
+# the next arg as its value. Conservative — false-negative (treating a
+# valued flag as boolean) can mis-route in rare template/source cases;
+# false-positive (treating a boolean as valued) skips an arg silently.
+__gh_valued_flag() {
+  case "$1" in
+    -X|--method|-H|--header|-F|--field|-f|--raw-field|-q|--jq|\
+    -t|--template|--input|--hostname|--cache|--description|\
+    --gitignore|--license|--homepage|--remote|--source|--team|\
+    --org|--clone-into|--fork-name|--remote-name|--target-name|\
+    --upstream-remote-name|--default-branch|--add-topic|\
+    --remove-topic|--include|--exclude|--limit|--label|--assignee|\
+    --milestone|--project|--draft|--head|--base|--reviewer|--body|\
+    --body-file|--title|--editor|--message|--from|--to)
+      return 0 ;;
+  esac
+  return 1
+}
+
+# extract_owner_positional: positional + URL-path forms not covered by
+# extract_owner. Returns owner on match, empty on no-match (caller is
+# expected to fall through).
+extract_owner_positional() {
+  # Skip leading global flags before the subcommand. gh accepts a small
+  # set here (--hostname, --help, --version); --repo / -R is also valid
+  # pre-subcommand but already handled by extract_owner.
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --hostname)
+        shift; [ $# -gt 0 ] && shift ;;
+      --hostname=*) shift ;;
+      --help|-h|--version) shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  [ $# -gt 0 ] || return 0
+  local sub="$1"; shift
+
+  if [ "$sub" = "api" ]; then
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --*=*) shift ;;
+        --*|-*)
+          if __gh_valued_flag "$1"; then
+            shift; [ $# -gt 0 ] && shift
+          else
+            shift
+          fi
+          ;;
+        *)
+          local path="${1#/}"
+          case "$path" in
+            repos/*/*)
+              path="${path#repos/}"
+              printf '%s' "${path%%/*}"
+              return 0
+              ;;
+            orgs/*)
+              path="${path#orgs/}"
+              printf '%s' "${path%%/*}"
+              return 0
+              ;;
+            users/*)
+              path="${path#users/}"
+              printf '%s' "${path%%/*}"
+              return 0
+              ;;
+          esac
+          return 0
+          ;;
+      esac
+    done
+    return 0
+  fi
+
+  if [ "$sub" = "repo" ]; then
+    [ $# -gt 0 ] || return 0
+    local act="$1"; shift
+    case "$act" in
+      fork|create|clone|view|sync|rename|archive|delete|edit|set-default|deploy-key|unarchive)
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --*=*) shift ;;
+            --*|-*)
+              if __gh_valued_flag "$1"; then
+                shift; [ $# -gt 0 ] && shift
+              else
+                shift
+              fi
+              ;;
+            *)
+              case "$1" in
+                https://github.com/*/*)
+                  local v="${1#https://github.com/}"
+                  printf '%s' "${v%%/*}"
+                  return 0
+                  ;;
+                http://github.com/*/*)
+                  local v="${1#http://github.com/}"
+                  printf '%s' "${v%%/*}"
+                  return 0
+                  ;;
+                git@github.com:*/*)
+                  local v="${1#git@github.com:}"
+                  printf '%s' "${v%%/*}"
+                  return 0
+                  ;;
+                http://*|https://*|git@*|ssh://*)
+                  shift; continue ;;
+                */*)
+                  printf '%s' "${1%%/*}"
+                  return 0
+                  ;;
+              esac
+              shift
+              ;;
+          esac
+        done
+        ;;
+    esac
+  fi
+
+  return 0
+}
+
 target_owner="$(extract_owner "$@")"
+[ -z "$target_owner" ] && target_owner="$(extract_owner_positional "$@")"
 if [ -n "$target_owner" ] && [ "$target_owner" != "vade-app" ] && [ -n "${GITHUB_PUBLIC_PAT:-}" ]; then
   export GH_TOKEN="$GITHUB_PUBLIC_PAT"
 fi

--- a/scripts/git-push-with-fallback.sh
+++ b/scripts/git-push-with-fallback.sh
@@ -127,13 +127,7 @@ main() {
     return "$rc"
   fi
 
-  if [ -z "${GITHUB_MCP_PAT:-}" ]; then
-    log_err "git proxy push failed but GITHUB_MCP_PAT is unset; cannot fall back"
-    log_err "  run scripts/coo-bootstrap.sh (or source ~/.vade/coo-env) to populate it"
-    return "$rc"
-  fi
-
-  local remote current_url repo_path
+  local remote current_url repo_path repo_owner
   remote="$(resolve_remote_from_args "$@")"
   if ! current_url="$(git remote get-url "$remote" 2>/dev/null)" || [ -z "$current_url" ]; then
     log_err "could not resolve remote '$remote'; not falling back"
@@ -150,10 +144,32 @@ main() {
     log_err "could not extract owner/repo from '$current_url'; not falling back"
     return "$rc"
   fi
+  repo_owner="${repo_path%%/*}"
 
-  local direct_url="https://vade-coo:${GITHUB_MCP_PAT}@github.com/${repo_path}.git"
-  local masked_url="https://vade-coo:***@github.com/${repo_path}.git"
-  log_err "git proxy push failed; retrying via $masked_url"
+  # PAT selection by remote owner (MEMO-2026-05-12-22m9). vade-app/*
+  # remotes use the fine-grained MCP PAT (default write surface);
+  # other remotes use the classic public-repo PAT when available.
+  # Mirrors the gh-coo-wrap routing layer for symmetric coverage —
+  # `git push` to a fork at venpopov/foo would otherwise fall back
+  # with the wrong PAT and re-403.
+  local fallback_pat fallback_pat_name fallback_user
+  if [ "$repo_owner" != "vade-app" ] && [ -n "${GITHUB_PUBLIC_PAT:-}" ]; then
+    fallback_pat="$GITHUB_PUBLIC_PAT"
+    fallback_pat_name="GITHUB_PUBLIC_PAT"
+    fallback_user="vade-coo"
+  elif [ -n "${GITHUB_MCP_PAT:-}" ]; then
+    fallback_pat="$GITHUB_MCP_PAT"
+    fallback_pat_name="GITHUB_MCP_PAT"
+    fallback_user="vade-coo"
+  else
+    log_err "git proxy push failed but no GitHub PAT is set (GITHUB_MCP_PAT, GITHUB_PUBLIC_PAT); cannot fall back"
+    log_err "  run scripts/coo-bootstrap.sh (or source ~/.vade/coo-env) to populate them"
+    return "$rc"
+  fi
+
+  local direct_url="https://${fallback_user}:${fallback_pat}@github.com/${repo_path}.git"
+  local masked_url="https://${fallback_user}:***@github.com/${repo_path}.git"
+  log_err "git proxy push failed; retrying via $masked_url (using $fallback_pat_name)"
 
   # Build fallback args: substitute direct_url for the remote token, and
   # drop -u / --set-upstream (the upstream-tracking config gets written

--- a/scripts/hooks/test-bash-github-api-guard.sh
+++ b/scripts/hooks/test-bash-github-api-guard.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# test-bash-github-api-guard: smoke-test scripts/bash-github-api-guard.sh.
+#
+# Mirrors the test-bash-token-guard.sh shape: pipe PreToolUse JSON
+# envelopes into the hook, assert block / allow per case.
+#
+# Run: bash scripts/hooks/test-bash-github-api-guard.sh
+# Exit: 0 on all pass, 1 otherwise.
+#
+# Reference: MEMO-2026-05-12-22m9, vade-runtime#TBD.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../bash-github-api-guard.sh"
+
+[ -x "$HOOK" ] || { echo "FAIL: hook not executable at $HOOK"; exit 1; }
+command -v jq >/dev/null || { echo "FAIL: jq required"; exit 1; }
+command -v python3 >/dev/null || { echo "FAIL: python3 required"; exit 1; }
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+run_hook() {
+  local cmd="$1"
+  jq -n --arg c "$cmd" '{tool_input: {command: $c}}' | "$HOOK" 2>/dev/null
+}
+
+expect_block() {
+  local name="$1" cmd="$2"
+  local out
+  out="$(run_hook "$cmd")"
+  if printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  BLOCK: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("BLOCK: $name")
+    printf '  FAIL  BLOCK: %s\n' "$name"
+    printf '         command: %s\n' "$cmd"
+    printf '         hook output: %s\n' "$out"
+  fi
+}
+
+expect_allow() {
+  local name="$1" cmd="$2"
+  local out
+  out="$(run_hook "$cmd")"
+  if [ -z "$out" ] || ! printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  ALLOW: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("ALLOW: $name")
+    printf '  FAIL  ALLOW: %s\n' "$name"
+    printf '         command: %s\n' "$cmd"
+    printf '         hook output: %s\n' "$out"
+  fi
+}
+
+printf 'BLOCK fixtures (must be refused):\n'
+expect_block "curl https://api.github.com/repos/foo/bar/forks" \
+  'curl https://api.github.com/repos/foo/bar/forks'
+expect_block "curl -X POST https://api.github.com/repos/foo/bar/forks" \
+  'curl -X POST https://api.github.com/repos/foo/bar/forks'
+expect_block "curl with Authorization header" \
+  'curl -H "Authorization: token $GITHUB_PUBLIC_PAT" https://api.github.com/user'
+expect_block "wget https://api.github.com/..." \
+  'wget https://api.github.com/repos/foo/bar'
+expect_block "/usr/bin/curl absolute path" \
+  '/usr/bin/curl https://api.github.com/repos/foo/bar'
+expect_block "python3 -c with requests to api.github.com" \
+  'python3 -c "import requests; requests.post(\"https://api.github.com/repos/foo/bar/forks\")"'
+expect_block "node -e with fetch to api.github.com" \
+  'node -e "fetch(\"https://api.github.com/foo\")"'
+expect_block "ruby -e with api.github.com" \
+  'ruby -e "require \"net/http\"; Net::HTTP.get(URI(\"https://api.github.com/foo\"))"'
+expect_block "pipeline: cat | curl https://api.github.com" \
+  'cat body.json | curl -X POST -d @- https://api.github.com/repos/foo/bar/issues'
+expect_block "logical: && curl api.github.com" \
+  'echo starting && curl https://api.github.com/user'
+expect_block "logical: ; curl api.github.com" \
+  'true; curl https://api.github.com/user'
+
+printf '\nALLOW fixtures (must pass through):\n'
+expect_allow "gh api repos/foo/bar" \
+  'gh api repos/foo/bar'
+expect_allow "gh api -X POST repos/foo/bar/forks" \
+  'gh api -X POST repos/foo/bar/forks'
+expect_allow "gh repo fork foo/bar" \
+  'gh repo fork foo/bar'
+expect_allow "gh pr create --repo foo/bar" \
+  'gh pr create --repo foo/bar --title t --body x'
+expect_allow "grep -r api.github.com . (text search)" \
+  'grep -r api.github.com .'
+expect_allow "sed editing a file mentioning api.github.com" \
+  'sed -i "s/api.github.com/example/" file'
+expect_allow "cat file.txt (no api.github.com in cmd)" \
+  'cat file.txt'
+expect_allow "curl https://example.com (not api.github.com)" \
+  'curl https://example.com/something'
+expect_allow "curl raw.githubusercontent.com (not the API)" \
+  'curl https://raw.githubusercontent.com/foo/bar/main/x'
+expect_allow "curl github.com (not api subdomain)" \
+  'curl https://github.com/foo/bar'
+expect_allow "python3 my_script.py (no api.github.com in argv)" \
+  'python3 my_script.py'
+expect_allow "git push origin main" \
+  'git push origin main'
+expect_allow "VADE_GITHUB_API_GUARD_BYPASS=1 curl api.github.com" \
+  'VADE_GITHUB_API_GUARD_BYPASS=1 curl https://api.github.com/user'
+expect_allow "echo with api.github.com string (not a fetch)" \
+  'echo "api.github.com is the endpoint"'
+expect_allow "comment containing api.github.com" \
+  '# fix curl to api.github.com later
+echo done'
+
+printf '\nTotal: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Three changes converging on a single anti-fragile shape: any GitHub interaction goes through `gh` or `git push`, both auto-route the correct PAT by owner (vade-app/* → `GITHUB_MCP_PAT`, anything else → `GITHUB_PUBLIC_PAT`). Direct `curl`/`wget`/`python -c` to `api.github.com` is refused at PreToolUse. Zero per-turn decisions, no remembered conventions.

1. **`gh-coo-wrap.sh`** — `extract_owner_positional` covers positional `<owner>/<name>` on `gh repo {fork,create,clone,view,sync,rename,archive,delete,edit,set-default,deploy-key,unarchive}`, URL paths on `gh api repos/...|orgs/...|users/...`, and URL forms on `gh repo clone`. Template-vs-target disambiguation via a known-valued-flag table. The MEMO-2026-05-11-6xv2 routing layer (only `--repo` flag) was the direct cause of the 2026-05-11 `gh repo fork venpopov/X` 403.

2. **`git-push-with-fallback.sh`** — PAT selection mirrors gh-coo-wrap. Non-vade-app remotes use `GITHUB_PUBLIC_PAT` in the direct-URL fallback. Previously the fallback always used `GITHUB_MCP_PAT`, which 403s on cross-org fork pushes.

3. **`bash-github-api-guard.sh`** — new PreToolUse Bash hook (sibling to `bash-token-guard.sh`). Refuses `curl/wget/http/httpie` to api.github.com and inline `python/node/ruby/perl -c/-e` scripts that reference api.github.com. Allows `gh ...` and any non-network command (grep/sed/cat). Bypass via `VADE_GITHUB_API_GUARD_BYPASS=1`.

## Test plan

- [x] `bash scripts/ci/test-gh-coo-wrap.sh` — 51/51 pass (20 new routing tests covering positional + api path + template disambiguation)
- [x] `bash scripts/hooks/test-bash-github-api-guard.sh` — 26/26 pass (11 BLOCK + 15 ALLOW)
- [x] `bash scripts/hooks/test-bash-token-guard.sh` — 11/11 pass (unchanged)
- [x] Bash syntax check on all three modified scripts
- [ ] Bootstrap-regression workflow on this PR (CI)
- [ ] Live probe in a fresh session: \`gh repo fork venpopov/X\` succeeds without manual PAT prefix

## Companion artifacts

- Memo MEMO-2026-05-12-22m9 lands in vade-coo-memory (companion PR this session)
- vade-core CLAUDE.md push-failure prose updated in vade-app/vade-core PR (companion this session)
- TOOLS.md + adoption_tracker rows + drift-gate workflow in the vade-coo-memory PR

## Boot impact

Modifies \`.claude/settings.json\` (adds the new hook entry). Per MEMO-2026-04-25-03, a fresh container boot is the verification surface. Handoff comment follows as a standalone reply.

Closes: n/a

https://claude.ai/code/session_01Kt4QUsK5CSs6y73DANpi43