### PR TITLE
local-COO isolation: gate writers on VADE_COO_MODE + honor CLAUDE_CONFIG_DIR

### DIFF
--- a/scripts/ci/run-bootstrap-regression.sh
+++ b/scripts/ci/run-bootstrap-regression.sh
@@ -155,6 +155,15 @@ log "Running scripts/session-start-sync.sh"
 # Tag the integrity-check report with a CI-flavored session id so any
 # operator triaging the artifact can tell it's not a real session.
 export CLAUDE_CODE_SESSION_ID="ci-bootstrap-regression-${GITHUB_RUN_ID:-local}"
+# Simulate Claude Code's resume behavior: at session-start, Claude Code
+# reads settings.json.env and exports those keys into its own process
+# env, where hook subprocesses (session-start-sync, coo-bootstrap, etc.)
+# inherit them. cloud-setup.sh runs in a separate shell whose runtime
+# export of VADE_COO_MODE=1 does not survive into this stage; the
+# persisted settings.json.env is the durable carrier. Without this the
+# COO-mode-gated writers in lib/common.sh early-exit and D-group
+# invariants (D4) degrade.
+export VADE_COO_MODE=1
 bash "$RUNTIME_DST/scripts/session-start-sync.sh"
 
 # Run integrity-check.sh explicitly. In live sessions this is called by

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -13,6 +13,15 @@
 # /home/user/ before this runs, so we just point at /home/user/vade-runtime.
 set -euo pipefail
 
+# The cloud snapshot IS the COO session by construction. Export
+# VADE_COO_MODE=1 so coo-bootstrap and the merge_coo_settings_* writers
+# in lib/common.sh fire normally. On Ven's local Mac the analogous flag
+# is set only by the `claude-coo` zsh wrapper, gating COO-mode writes
+# to opt-in sessions and leaving bare `claude` launches untouched —
+# even when fired from inside the vade-app workspace where project-
+# scope hooks would otherwise re-trigger the COO pipeline.
+export VADE_COO_MODE=1
+
 # Derive workspace root from script location so the bootstrap-regression
 # CI (.github/workflows/bootstrap-regression.yml) can stage a sandboxed
 # /tmp/<root>/vade-runtime tree without colliding with the production

--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -35,6 +35,22 @@ _on_exit() {
 }
 trap _on_exit EXIT
 
+# Defense-in-depth: coo-bootstrap is a no-op outside an explicit COO
+# session. cloud-setup.sh exports VADE_COO_MODE=1 once for the lifetime
+# of the cloud snapshot; the local `claude-coo` zsh wrapper exports it
+# on Ven's Mac only when explicitly invoked. Outside those contexts —
+# bare `claude` from any cwd, including from inside the vade-app
+# workspace where project-scope hooks would otherwise fire this chain —
+# the entire bootstrap pipeline (gitconfig write, secret fetch,
+# settings.json merge) early-exits without touching the user's state.
+if [ "${VADE_COO_MODE:-0}" != "1" ]; then
+  log "coo-bootstrap: VADE_COO_MODE!=1; skipping COO bootstrap entirely."
+  COO_BOOTSTRAP_STEP="skip-no-coo-mode"
+  bootstrap_log_record SKIP "VADE_COO_MODE!=1"
+  trap - EXIT
+  exit 0
+fi
+
 # Ensure baseline COO identity in gitconfig BEFORE any early-exit gate.
 # Signing keys and full-fidelity gitconfig still gated behind
 # write_coo_gitconfig (which needs OP_SERVICE_ACCOUNT_TOKEN). This minimal
@@ -44,6 +60,18 @@ trap _on_exit EXIT
 COO_BOOTSTRAP_STEP="ensure_coo_identity_minimal"
 GC="${VADE_COO_GITCONFIG:-${HOME}/.gitconfig}"
 mkdir -p "$(dirname "$GC")"
+# Belt-and-suspenders guard: refuse to overwrite a gitconfig owned by
+# someone other than COO. Catches the case where VADE_COO_MODE=1 leaks
+# into a context (manual debugging, future regression in the wrapper)
+# where VADE_COO_GITCONFIG is unset and GC defaults to a personal
+# $HOME/.gitconfig. No-op on cloud (fresh snapshot has empty gitconfig).
+existing_email="$(git config --file "$GC" --get user.email 2>/dev/null || true)"
+if [ -n "$existing_email" ] && [ "$existing_email" != "coo@vade-app.dev" ]; then
+  log "coo-bootstrap: refusing to overwrite $GC (existing user.email=$existing_email is not COO)"
+  bootstrap_log_record SKIP "refused to overwrite non-COO gitconfig $GC"
+  trap - EXIT
+  exit 0
+fi
 git config --file "$GC" user.name "COO"
 git config --file "$GC" user.email "coo@vade-app.dev"
 
@@ -73,7 +101,7 @@ fi
 COO_ENV_FILE="${HOME}/.vade/coo-env"
 COO_BOOT_MARKER="${HOME}/.vade/.coo-bootstrap-done"
 _settings_env_complete() {
-  local settings="${HOME}/.claude/settings.json"
+  local settings="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/settings.json"
   [ -f "$settings" ] || return 1
   check_cmd node || return 0  # node missing: fall back to marker-only trust
   node -e '

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -34,7 +34,7 @@ fi
 CLAUDE_MD="$MEM_REPO/CLAUDE.md"
 MEMO_INDEX="$MEM_REPO/coo/memo_index.json"
 BOOTSTRAP_LOG="${HOME}/.vade/coo-bootstrap.log"
-SETTINGS_FILE="${HOME}/.claude/settings.json"
+SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/settings.json"
 WORKSPACE_IDENTITY_LINK="$WORKSPACE_ROOT/CLAUDE.md"
 WORKSPACE_MCP_LINK="$WORKSPACE_ROOT/.mcp.json"
 WORKSPACE_MCP_SRC="$WORKSPACE_ROOT/vade-runtime/.mcp.json"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -349,7 +349,7 @@ install_deps() {
 # both files exist; otherwise we fall back to a plain copy.
 sync_claude_config() {
   local src="${1:-/home/user/vade-runtime/.claude}"
-  local dst="${2:-$HOME/.claude}"
+  local dst="${2:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}}"
   if [ ! -d "$src" ]; then
     log "sync_claude_config: source $src missing; skipping"
     return 0
@@ -1568,6 +1568,13 @@ merge_coo_settings_runtime_dir() {
 # Both are only exported when the corresponding filesystem path
 # exists, so this is a no-op outside the Claude cloud image.
 _write_claude_settings_env() {
+  # Defense-in-depth gate: only fire inside an explicit COO session.
+  # cloud-setup.sh exports VADE_COO_MODE=1 for the snapshot lifetime;
+  # the local `claude-coo` wrapper exports it on Ven's Mac. Outside
+  # those contexts (bare `claude` from anywhere, including project-
+  # scope hook firings from vade-app on local), this writer no-ops so
+  # it cannot contaminate the user's personal ~/.claude/settings.json.
+  [ "${VADE_COO_MODE:-0}" = "1" ] || return 0
   local pat="$1" agentmail="$2" mem0="$3" vade_auth_token="${4:-}"
   local r2_access_key_id="${5:-}" r2_secret_access_key="${6:-}" age_identity="${7:-}"
   local vade_bearer_token="${8:-}" vade_mcp_url="${9:-}"
@@ -1577,7 +1584,7 @@ _write_claude_settings_env() {
     log "Warning: node missing; skipping ~/.claude/settings.json env merge"
     return 0
   fi
-  local settings_dir="${HOME}/.claude"
+  local settings_dir="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
   local settings_file="$settings_dir/settings.json"
   mkdir -p "$settings_dir"
   [ -f "$settings_file" ] || echo '{}' > "$settings_file"
@@ -1607,6 +1614,11 @@ _write_claude_settings_env() {
       process.exit(1);
     }
     const merged = Object.assign({}, cfg.env || {});
+    // Persist VADE_COO_MODE=1 so SessionStart hooks on subsequent
+    // resumes inherit it from settings.json.env. Without this, the
+    // runtime export from cloud-setup.sh is one-shot and every cloud
+    // resume would early-exit coo-bootstrap plus the merge writers.
+    merged.VADE_COO_MODE = "1";
     if (process.env.GITHUB_MCP_PAT) {
       merged.GITHUB_MCP_PAT = process.env.GITHUB_MCP_PAT;
       merged.GITHUB_TOKEN = process.env.GITHUB_MCP_PAT;
@@ -1681,12 +1693,13 @@ _write_claude_settings_env() {
 #   was treated as a directory name). This pass captures the actual
 #   bootstrap-shell PATH and serializes it.
 _write_claude_settings_paths() {
+  [ "${VADE_COO_MODE:-0}" = "1" ] || return 0
   local cloud_state_dir="$1" bindir="$2"
   if ! check_cmd node; then
     log "Warning: node missing; skipping ~/.claude/settings.json paths merge"
     return 0
   fi
-  local settings_dir="${HOME}/.claude"
+  local settings_dir="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
   local settings_file="$settings_dir/settings.json"
   mkdir -p "$settings_dir"
   [ -f "$settings_file" ] || echo '{}' > "$settings_file"
@@ -1750,12 +1763,13 @@ _write_claude_settings_paths() {
 # value would replace the well-formed PATH bootstrap captured at install
 # time. Idempotent. vade-runtime#171.
 _write_claude_settings_state_dir() {
+  [ "${VADE_COO_MODE:-0}" = "1" ] || return 0
   local cloud_state_dir="$1"
   if ! check_cmd node; then
     log "Warning: node missing; skipping ~/.claude/settings.json state-dir merge"
     return 0
   fi
-  local settings_dir="${HOME}/.claude"
+  local settings_dir="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
   local settings_file="$settings_dir/settings.json"
   mkdir -p "$settings_dir"
   [ -f "$settings_file" ] || echo '{}' > "$settings_file"
@@ -1786,12 +1800,13 @@ _write_claude_settings_state_dir() {
 # inherit a thin PATH that would clobber the well-formed install-time
 # PATH if rewritten). Idempotent. vade-runtime#228.
 _write_claude_settings_runtime_dir() {
+  [ "${VADE_COO_MODE:-0}" = "1" ] || return 0
   local runtime_dir="$1"
   if ! check_cmd node; then
     log "Warning: node missing; skipping ~/.claude/settings.json runtime-dir merge"
     return 0
   fi
-  local settings_dir="${HOME}/.claude"
+  local settings_dir="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
   local settings_file="$settings_dir/settings.json"
   mkdir -p "$settings_dir"
   [ -f "$settings_file" ] || echo '{}' > "$settings_file"


### PR DESCRIPTION
## Summary

Closes the leak where Ven's personal Mac `~/.claude/settings.json` and
`~/.gitconfig` get clobbered on every Claude Code launch — from any cwd
— by the COO SessionStart hook chain. Same code path was structurally
fine on the cloud snapshot (COO-dedicated container, `$HOME=/home/user`
== COO config root), but on Mac it was injecting Linux paths
(`UV_CACHE_DIR=/home/user/.cache/uv`, `VADE_RUNTIME_DIR=/home/user/vade-runtime`)
and live secrets into personal user-scope state, and forcing
`user.email=coo@vade-app.dev` over Ven's personal git identity.

This PR is the cloud-side half of the recovery plan. The Mac-side
cleanup (delete contaminated `~/.claude/{settings.json,skills,vade-hooks}`,
add `claude-coo` zsh wrapper) will follow on Ven's machine after merge.

## What changed

### Defense-in-depth: `VADE_COO_MODE` gate

The four `_write_claude_settings_*` helpers in `lib/common.sh` and the
top of `coo-bootstrap.sh` early-exit unless `VADE_COO_MODE=1` is set.
On cloud, `cloud-setup.sh` exports the flag once during snapshot build,
and `_write_claude_settings_env` persists it into `settings.json.env`
so subsequent SessionStart hook fires inherit it via Claude Code's
process env on resume. On Ven's Mac, the forthcoming `claude-coo` zsh
wrapper will export the flag only when explicitly invoked — bare
`claude` from any cwd, including inside the vade-app workspace where
project-scope hooks would otherwise re-fire the COO pipeline, leaves
personal config untouched.

### `CLAUDE_CONFIG_DIR`-aware paths

`sync_claude_config`'s default `dst`, each `_write_claude_settings_*`
helper's `settings_dir`, the `_settings_env_complete` probe in
`coo-bootstrap.sh`, and `SETTINGS_FILE` in `coo-identity-digest.sh` now
honor `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`. With the gate above, this
enables the `claude-coo` wrapper to redirect the COO config tree to
`~/.claude-coo/` without touching `~/.claude/`. `CLAUDE_CONFIG_DIR` is
verified honored by the Claude Code CLI (2.1.139) via inspection of
the binary, even though it's undocumented in the public settings page.

### Belt-and-suspenders guard

`ensure_coo_identity_minimal` refuses to overwrite a gitconfig whose
`user.email` is non-empty and non-COO. No-op on a fresh cloud snapshot
(empty gitconfig); load-bearing on Ven's Mac during the migration
window before the wrapper lands.

### CI parity

`run-bootstrap-regression.sh` now exports `VADE_COO_MODE=1` before
invoking `session-start-sync.sh`, simulating Claude Code's resume env
injection (settings.json.env → process.env → hook subprocess inherit).
Without this the D-group invariants would degrade in the fake-env
regression suite even though real cloud operates correctly.

## Cloud-safety analysis

All five files patched, all behavior under the gate matches today's
behavior when `VADE_COO_MODE=1` is set:

- `cloud-setup.sh` sets `VADE_COO_MODE=1` first thing → the gate is
  always satisfied during snapshot build.
- `_write_claude_settings_env` persists `VADE_COO_MODE=1` into the env
  block → on resume, Claude Code re-exports it → SessionStart hooks
  inherit it → coo-bootstrap and the merge writers run as today.
- Without `CLAUDE_CONFIG_DIR` exported (cloud never exports it), the
  path fallback resolves to `$HOME/.claude` — byte-identical to today's
  hardcoded paths.
- Phase 5 gitconfig guard: on a fresh cloud snapshot
  `git config --file ~/.gitconfig --get user.email` returns empty, so
  the guard does not fire and the write proceeds.

Local regression suite confirms `summary.ok=true`, 17/17 invariants
pass, zero degradations (run with `PATH` adjusted to avoid a
pre-existing test-env shim recursion in my dev container; unrelated to
this PR).

## Mac-side follow-up (not in this PR)

Per the review document at
`plans/root-claude-uploads-44cb40e0-3ead-453e-agile-hearth.md` in the
session that produced this PR. Sequence after merge:

1. Backup `~/.claude/{settings.json,skills,vade-hooks}` + `~/.gitconfig`
   to `~/.vade/backups/pre-recovery-<date>`.
2. Delete the contaminated `~/.claude/{settings.json,skills,vade-hooks}`.
3. Write a minimal personal `~/.claude/settings.json` (no vade env, no
   vade hooks).
4. `touch ~/.config/git/config.local` to silence the dangling include.
5. Add `claude-coo` zsh function to `~/.dotfiles/zsh/.config/zsh/functions.zsh`
   that exports `VADE_COO_MODE=1` + `CLAUDE_CONFIG_DIR=$HOME/.claude-coo`
   + `VADE_COO_GITCONFIG=$HOME/.vade/gitconfig-coo` +
   `GIT_CONFIG_GLOBAL=$HOME/.vade/gitconfig-coo` before exec-ing claude.
6. First `claude-coo` launch populates `~/.claude-coo/` via the
   patched helpers.

## Test plan

- [x] Local `run-bootstrap-regression.sh` passes 17/17 invariants
- [x] `bash -n` syntax check on all five touched files
- [x] `_settings_env_complete` probe path verified to honor
      `CLAUDE_CONFIG_DIR`
- [x] `merge_coo_settings_env` writes `VADE_COO_MODE=1` into env block
- [x] Belt-and-suspenders guard verified no-op on empty gitconfig
- [ ] Layer-1 bootstrap-regression CI on this PR (GitHub Actions)
- [ ] Mac-side smoke test (Ven, post-merge): bare `claude` from `~`
      leaves `~/.claude/settings.json` minimal; `claude-coo` from `~`
      populates `~/.claude-coo/`; both leave `~/.gitconfig` as
      Ven's personal identity

## Refs

Closes: n/a (architectural change, no tracked issue resolved).

Related but not closed: #253 (VADE_RUNTIME_DIR env-var absent in
nightly container — orthogonal investigation, may be partially helped
by the gate's stricter discipline), #191 (hardcoded `/Users/venpopov`
paths in committed `.claude/settings.json` — adjacent cleanup, not
in scope here).

https://claude.ai/code/session_01WBSKxXL85YkRohXZBjrLR8