### PR TITLE
boot: hoist integrity-check banner + cloud-aware loud-skip surfacing (Phase A)

### DIFF
--- a/scripts/coo-bootstrap.sh
+++ b/scripts/coo-bootstrap.sh
@@ -47,6 +47,15 @@ if [ "${VADE_COO_MODE:-0}" != "1" ]; then
   log "coo-bootstrap: VADE_COO_MODE!=1; skipping COO bootstrap entirely."
   COO_BOOTSTRAP_STEP="skip-no-coo-mode"
   bootstrap_log_record SKIP "VADE_COO_MODE!=1"
+  # Cloud-aware loud-skip: write a sentinel the identity-digest hook
+  # surfaces at the TOP of its banner. Mac silent-skips remain silent
+  # (helper no-ops outside cloud context). 2026-05-13 root cause:
+  # this exact gate fired silently when the gitconfig-overwrite guard
+  # blocked the persistence write, leaving every subsequent boot to
+  # hit this skip with no surface. Phase A of vade-coo-memory#762.
+  _write_skip_reason \
+    "VADE_COO_MODE!=1 — coo-bootstrap exited before identity load" \
+    "Fix: VADE_FORCE_COO_BOOTSTRAP=1 VADE_COO_MODE=1 bash /home/user/vade-runtime/scripts/coo-bootstrap.sh; set -a; source ~/.vade/coo-env; set +a; bash /home/user/vade-runtime/scripts/integrity-check.sh"
   trap - EXIT
   exit 0
 fi
@@ -75,6 +84,12 @@ if [ -n "$existing_email" ] \
    && [ "$existing_email" != "noreply@anthropic.com" ]; then
   log "coo-bootstrap: refusing to overwrite $GC (existing user.email=$existing_email is not COO)"
   bootstrap_log_record SKIP "refused to overwrite non-COO gitconfig $GC"
+  # Cloud-aware loud-skip sentinel. This branch fires when an
+  # unexpected user.email squats in $GC — the 2026-05-13 class but
+  # for a non-Anthropic baseline. Mac silent-skips remain silent.
+  _write_skip_reason \
+    "coo-bootstrap refused to overwrite $GC (existing user.email=$existing_email)" \
+    "Fix: inspect $GC, remove the non-COO user section (git config --file $GC --remove-section user), then VADE_FORCE_COO_BOOTSTRAP=1 bash /home/user/vade-runtime/scripts/coo-bootstrap.sh"
   trap - EXIT
   exit 0
 fi
@@ -85,6 +100,13 @@ if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
   log "coo-bootstrap: OP_SERVICE_ACCOUNT_TOKEN unset; skipping COO identity setup."
   COO_BOOTSTRAP_STEP="skip-no-op-token"
   bootstrap_log_record SKIP "OP_SERVICE_ACCOUNT_TOKEN unset"
+  # Cloud-aware loud-skip sentinel. Without OP_SERVICE_ACCOUNT_TOKEN
+  # there's no 1Password access and the secret-fetch chain cannot
+  # complete. Surface this loudly on cloud so the operator knows to
+  # provision the env (Anthropic cloud "Setup script" env var).
+  _write_skip_reason \
+    "OP_SERVICE_ACCOUNT_TOKEN unset — coo-bootstrap cannot fetch secrets" \
+    "Fix: provision OP_SERVICE_ACCOUNT_TOKEN in the Anthropic cloud 'Setup script' env, then resume the container. For ad-hoc recovery, export the token then VADE_FORCE_COO_BOOTSTRAP=1 bash /home/user/vade-runtime/scripts/coo-bootstrap.sh"
   trap - EXIT
   exit 0
 fi
@@ -147,6 +169,10 @@ if [ "${VADE_FORCE_COO_BOOTSTRAP:-0}" != "1" ] \
   log "coo-bootstrap: already complete this container; skipping."
   COO_BOOTSTRAP_STEP="skip-marker-present"
   bootstrap_log_record SKIP "marker present at $COO_BOOT_MARKER (cached PAT validated)"
+  # Benign skip: identity is already loaded. Clear any stale skip
+  # sentinel from a prior failing boot so the digest banner reflects
+  # current state.
+  _clear_skip_reason
   trap - EXIT
   exit 0
 fi
@@ -226,6 +252,11 @@ summarize_coo_identity
 
 mkdir -p "$(dirname "$COO_BOOT_MARKER")"
 touch "$COO_BOOT_MARKER"
+
+# Clear any stale loud-skip sentinel from a prior failing boot now that
+# the full bootstrap has completed successfully. Digest banner picks up
+# the absence on the next session-start.
+_clear_skip_reason
 
 COO_BOOTSTRAP_STEP="complete"
 log "coo-bootstrap: complete"

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -46,6 +46,103 @@ if [ ! -d "$VADE_CLOUD_STATE_DIR" ] && [ -d "$HOME/.vade/local-state" ]; then
   VADE_CLOUD_STATE_DIR="$HOME/.vade/local-state"
 fi
 SETUP_RECEIPT="${VADE_CLOUD_STATE_DIR}/setup-receipt.json"
+INTEGRITY_CHECK="${VADE_CLOUD_STATE_DIR}/integrity-check.json"
+SKIP_SENTINEL="${HOME}/.vade/.coo-bootstrap-skip-reason"
+
+# ── INTEGRITY-CHECK BANNER (TOP OF DIGEST) ───────────────────────────
+#
+# Phase A of vade-coo-memory#762: the integrity-check posture and any
+# loud-skip sentinel from coo-bootstrap surface BEFORE any identity
+# content. The 2026-05-13 boot-skip incident showed that integrity-check
+# at the BOTTOM of the digest (and at step 14 of CLAUDE.md reading
+# order) is a post-hoc verifier — the failing session never reached it.
+# Hoisting both to the top of the first screen makes degradation
+# unmissable; combined with CLAUDE.md step 1 reading the JSON file,
+# the agent's first action on a degraded boot is surface-to-BDFL.
+#
+# Run integrity-check FIRST so the file we read below reflects this
+# session. Original position (after Mem0 banner) eliminated to avoid
+# duplication.
+bash "$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true
+
+_integrity_ok="unknown"
+_integrity_passed="?"
+_integrity_total="?"
+_integrity_degraded=""
+if [ -f "$INTEGRITY_CHECK" ] && check_cmd node; then
+  _integrity_summary="$(node -e '
+    try {
+      const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+      const s = r.summary || {};
+      const ok = s.ok === true ? "true" : (s.ok === false ? "false" : "unknown");
+      const passed = s.passed ?? "?";
+      const total = s.total ?? "?";
+      const degraded = (Array.isArray(s.degraded) ? s.degraded : []).join(",");
+      console.log(ok + "|" + passed + "|" + total + "|" + degraded);
+    } catch { console.log("unknown|?|?|"); }
+  ' "$INTEGRITY_CHECK" 2>/dev/null || echo "unknown|?|?|")"
+  IFS='|' read -r _integrity_ok _integrity_passed _integrity_total _integrity_degraded <<<"$_integrity_summary"
+fi
+
+if [ "$_integrity_ok" = "false" ] || [ -f "$SKIP_SENTINEL" ]; then
+  # DEGRADED BOOT — print loudly at the very top. The 4-line recovery
+  # sequence below is the proven fix from the 2026-05-13 audit
+  # (vade-coo-memory/coo/audits/2026-05-13_boot-skip-failure/recovery-transcript.txt).
+  echo "═══════════════════════════════════════════════════════════════"
+  echo "⚠️  BOOT DEGRADED — DO NOT START SUBSTANTIVE WORK"
+  echo "═══════════════════════════════════════════════════════════════"
+  if [ -f "$SKIP_SENTINEL" ]; then
+    _skip_reason="$(sed -n '1p' "$SKIP_SENTINEL" 2>/dev/null || true)"
+    _skip_hint="$(sed -n '2p' "$SKIP_SENTINEL" 2>/dev/null || true)"
+    echo "  Skip reason:  $_skip_reason"
+    echo "  Recovery:     $_skip_hint"
+    echo ""
+  fi
+  if [ "$_integrity_ok" = "false" ]; then
+    echo "  integrity-check: summary.ok=false  ($_integrity_passed/$_integrity_total)"
+    if [ -n "$_integrity_degraded" ]; then
+      echo "  degraded:        $_integrity_degraded"
+    fi
+    echo ""
+    # Inline failing-invariant details.
+    if check_cmd node && [ -f "$INTEGRITY_CHECK" ]; then
+      node -e '
+        try {
+          const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+          const degraded = Array.isArray(r.summary && r.summary.degraded) ? r.summary.degraded : [];
+          if (degraded.length > 0) {
+            console.log("  Failing invariants:");
+            for (const id of degraded) {
+              const grp = id[0];
+              const entry = (r.groups || {})[grp] && (r.groups || {})[grp][id];
+              const detail = (entry && entry.detail) || "(no detail)";
+              console.log("    " + id + ": " + detail);
+            }
+            console.log("");
+          }
+        } catch (_) {}
+      ' "$INTEGRITY_CHECK" 2>/dev/null || true
+    fi
+  fi
+  echo "  Proven recovery (from 2026-05-13 audit recovery-transcript.txt):"
+  echo "    1) git config --file \$HOME/.gitconfig --remove-section user  # clear non-COO gitconfig"
+  echo "    2) VADE_COO_MODE=1 bash /home/user/vade-runtime/scripts/coo-bootstrap.sh"
+  echo "    3) set -a; source \$HOME/.vade/coo-env; set +a"
+  echo "    4) bash /home/user/vade-runtime/scripts/integrity-check.sh"
+  echo ""
+  echo "  CLAUDE.md step 1 (conditional gate): surface to BDFL, do no other work."
+  echo "═══════════════════════════════════════════════════════════════"
+  echo ""
+elif [ "$_integrity_ok" = "true" ]; then
+  # OK boot — one-line green banner. Detailed integrity table follows
+  # later in the digest (the original "Integrity check" block was
+  # eliminated by this hoist; keep a terse top-line so green sessions
+  # still see the result at first screen).
+  echo "───────────────────────────────────────────────────────────────"
+  echo "Boot integrity: summary.ok=true  ($_integrity_passed/$_integrity_total)  — full report: $INTEGRITY_CHECK"
+  echo "───────────────────────────────────────────────────────────────"
+  echo ""
+fi
 
 if [ ! -f "$CLAUDE_MD" ]; then
   echo "[vade-setup] coo-identity-digest: $CLAUDE_MD not found; skipping."
@@ -389,11 +486,13 @@ echo "                            Sole GitHub write path. github-coo MCP retired
 echo "                            Epic #112 Stream 1; harness github MCP writes deny-listed."
 echo "───────────────────────────────────────────────────────────────"
 
-# Run the integrity check now, before reading results for display.
-# Placed here (not in session-start-sync.sh) so it fires after the
-# platform's git-proxy repo-sync has settled; running it earlier
-# produced boot-time false alarms on F2/F3/F4 (vade-runtime#XXX).
-bash "$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true
+# Note: integrity-check.sh runs at the TOP of the digest now (see
+# the INTEGRITY-CHECK BANNER block above), so the integrity-check.json
+# file is already current by the time this section reads it. Original
+# placement here (after Mem0 banner) was removed by Phase A of
+# vade-coo-memory#762; the integrity-check fires after session-start-sync
+# anyway because this whole script runs after session-start-sync in the
+# SessionStart hook chain.
 
 # Mem0 read/write surface — same banner pattern as "GitHub write surface"
 # above. Per vade-runtime#109, the hosted Mem0 MCP at mcp.mem0.ai hits
@@ -403,7 +502,6 @@ bash "$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true
 # loud ⚠ when degraded — so the agent sees Mem0 posture at turn zero
 # rather than only when integrity-check enumerates degraded invariants.
 # E5 in integrity-check.json is the canonical pass/fail signal.
-INTEGRITY_CHECK="${VADE_CLOUD_STATE_DIR}/integrity-check.json"
 
 echo ""
 echo "───────────────────────────────────────────────────────────────"
@@ -464,60 +562,10 @@ case "$e5_status" in
 esac
 echo "───────────────────────────────────────────────────────────────"
 
-# Integrity check summary — the authoritative "did this session's boot
-# pipeline land correctly" verdict. Written to
-# $VADE_CLOUD_STATE_DIR/integrity-check.json by the call above. The file
-# itself is already read-on-demand by CLAUDE.md §14; this block echoes
-# the summary inline so routine-triggered sessions (non-startup matcher)
-# and automation instances see the posture without having to cat the
-# file themselves. Quorum-automation context: without this, routine
-# instances operated with less situational awareness than interactive
-# COO sessions (observed during quorum #3, PR #90).
-echo ""
-echo "───────────────────────────────────────────────────────────────"
-echo "Integrity check"
-echo "───────────────────────────────────────────────────────────────"
-if [ -f "$INTEGRITY_CHECK" ] && check_cmd node; then
-  node -e '
-    const fs = require("fs");
-    try {
-      const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-      const s = r.summary || {};
-      const ok = s.ok === true;
-      const passed = s.passed ?? "?";
-      const total = s.total ?? "?";
-      const degraded = Array.isArray(s.degraded) ? s.degraded : [];
-      console.log("  summary.ok:      " + (ok ? "true" : "false"));
-      console.log("  passed:          " + passed + "/" + total);
-      if (degraded.length > 0) {
-        console.log("  degraded:        " + degraded.join(", "));
-        console.log("");
-        console.log("  Failing invariants — see groups.<A-E>.<id>.detail in the file:");
-        for (const id of degraded) {
-          const grp = id[0];
-          const entry = (r.groups || {})[grp]?.[id];
-          const detail = entry?.detail || "(no detail)";
-          console.log("    " + id + ": " + detail);
-        }
-      }
-      if (!ok) {
-        console.log("");
-        console.log("  If any invariant is a known false-negative (e.g. B3/D3 per");
-        console.log("  MEMO 2026-04-23-03), cite the memo before acting. Otherwise");
-        console.log("  investigate before touching attributable surfaces.");
-      }
-      console.log("  File:            " + process.argv[1]);
-    } catch (e) {
-      console.log("  (unreadable: " + e.message + ")");
-    }
-  ' "$INTEGRITY_CHECK" 2>/dev/null || cat "$INTEGRITY_CHECK"
-elif [ -f "$INTEGRITY_CHECK" ]; then
-  echo "  node not available; raw file at $INTEGRITY_CHECK"
-else
-  echo "  (no integrity check at $INTEGRITY_CHECK)"
-  echo "  session-start-sync.sh did not run or did not write the receipt."
-fi
-echo "───────────────────────────────────────────────────────────────"
+# Note: detailed integrity-check summary was hoisted to the TOP of the
+# digest in Phase A of vade-coo-memory#762. See the INTEGRITY-CHECK
+# BANNER block near the top of this script. Original block deleted here
+# to avoid duplication.
 
 # Cloud build-time receipt — what did cloud-setup.sh actually do at
 # snapshot build? Present = build ran; missing = build skipped or the

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -29,6 +29,65 @@ bootstrap_log_record() {
   fi
 }
 
+# Cloud-context fingerprint. True when this host is (a) the Anthropic
+# cloud snapshot — fingerprinted by /home/user/.vade-cloud-state existing
+# as a directory — or (b) a fresh Anthropic snapshot where the gitconfig
+# baseline carries user.email=noreply@anthropic.com. Used by
+# _write_skip_reason to decide whether a silent coo-bootstrap skip
+# should leave a loud surface (cloud: yes; Mac: no — Mac silent-skips
+# are intentional, e.g. bare `claude` from any cwd outside a COO context).
+#
+# Detection deliberately does NOT use OP_SERVICE_ACCOUNT_TOKEN: that env
+# var is itself one of the silent-skip gates (line 84 in coo-bootstrap.sh).
+# Any cloud failure mode where env didn't propagate (the 2026-05-13
+# regression class) would have OP_SERVICE_ACCOUNT_TOKEN unset and would
+# read as Mac under a token-based check, silently skip without a
+# sentinel, and reproduce the same opaque failure. Filesystem and
+# gitconfig fingerprints are reliable across that class.
+_is_cloud_context() {
+  [ -d /home/user/.vade-cloud-state ] && return 0
+  local gc="${VADE_COO_GITCONFIG:-${HOME}/.gitconfig}"
+  if [ -f "$gc" ]; then
+    local em
+    em="$(git config --file "$gc" --get user.email 2>/dev/null || true)"
+    [ "$em" = "noreply@anthropic.com" ] && return 0
+  fi
+  return 1
+}
+
+# Loud-skip surfacing. When coo-bootstrap takes a silent-skip path in a
+# cloud context, write a sentinel file the identity-digest hook reads
+# to surface the skip reason + recovery hint at the TOP of the digest
+# banner. Closes the surface gap that allowed the 2026-05-13 boot-skip
+# incident to run for ~30 min as generic Claude Code before BDFL caught
+# it. On non-cloud contexts (Mac, local devcontainer outside COO mode)
+# the sentinel is not written — silent skips remain silent because the
+# skip is the correct behavior outside an explicit COO session.
+#
+# Sentinel format: two-line text, "reason" then "hint". The digest hook
+# reads via head/sed; keep both lines short and shell-safe.
+#
+# Idempotent: callers overwrite on every skip pass so the file always
+# reflects the most recent skip. The digest hook clears it when
+# bootstrap eventually completes ok (see coo-identity-digest.sh banner).
+VADE_COO_SKIP_SENTINEL="${HOME}/.vade/.coo-bootstrap-skip-reason"
+_write_skip_reason() {
+  local reason="$1" hint="$2"
+  _is_cloud_context || return 0
+  mkdir -p "$(dirname "$VADE_COO_SKIP_SENTINEL")" 2>/dev/null || return 0
+  {
+    printf '%s\n' "$reason"
+    printf '%s\n' "$hint"
+  } > "$VADE_COO_SKIP_SENTINEL" 2>/dev/null || return 0
+}
+
+# Clear the loud-skip sentinel. Called on a successful bootstrap so a
+# subsequent digest banner doesn't show stale skip reasons after the
+# operator (or VADE_FORCE_COO_BOOTSTRAP=1 re-run) recovers the session.
+_clear_skip_reason() {
+  rm -f "$VADE_COO_SKIP_SENTINEL" 2>/dev/null || true
+}
+
 # Durable cloud-state directory. Lives under /home/user/ so it survives
 # the snapshot-build → session-resume transition; ~/.vade/ is under
 # /root/ in the cloud image and gets fresh on every session boot, which

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -49,6 +49,13 @@ VADE_SETUP_RECEIPT="${VADE_CLOUD_STATE_DIR}/setup-receipt.json"
 # vade-runtime#228.
 VADE_RUNTIME_DIR="${VADE_RUNTIME_DIR:-/home/user/vade-runtime}"
 
+# vade-coo-memory working tree path. Sibling parity with VADE_RUNTIME_DIR;
+# gh-coo-wrap.sh and various skills/hooks resolve memory-repo paths via
+# $VADE_COO_MEMORY_DIR. Persisted into ~/.claude/settings.json env via
+# merge_coo_settings_memory_dir so hook subprocesses inherit it on resume.
+# vade-runtime#265.
+VADE_COO_MEMORY_DIR="${VADE_COO_MEMORY_DIR:-/home/user/vade-coo-memory}"
+
 # Same shape as bootstrap_log_record but writes to the durable build log.
 # Use from cloud-setup.sh and anything else running at snapshot-build
 # time — PROBE entries, step transitions, timing — so sessions can
@@ -1555,6 +1562,16 @@ merge_coo_settings_runtime_dir() {
   _write_claude_settings_runtime_dir "$VADE_RUNTIME_DIR"
 }
 
+# Persist VADE_COO_MEMORY_DIR into ~/.claude/settings.json env. Same shape and
+# rationale as merge_coo_settings_runtime_dir / merge_coo_settings_state_dir:
+# host-stable path, no PATH rewrite, safe to re-write on every session start.
+# Hook subprocesses, skills, and the gh-coo-wrap shim resolve memory-repo
+# paths via $VADE_COO_MEMORY_DIR (see gh-coo-wrap.sh:257); persist it so
+# they inherit the value on resume. vade-runtime#265.
+merge_coo_settings_memory_dir() {
+  _write_claude_settings_memory_dir "$VADE_COO_MEMORY_DIR"
+}
+
 # Merge COO env vars into ~/.claude/settings.json "env" object. Claude
 # Code reads this at process startup, so ${GITHUB_MCP_PAT} etc. in
 # .mcp.json substitute correctly. Idempotent.
@@ -1829,6 +1846,42 @@ _write_claude_settings_runtime_dir() {
   ' "$settings_file"
   chmod 600 "$settings_file"
   log "  merged VADE_RUNTIME_DIR into $settings_file"
+}
+
+# Write VADE_COO_MEMORY_DIR into ~/.claude/settings.json env without touching
+# the PATH key. Same shape and rationale as _write_claude_settings_runtime_dir.
+# vade-runtime#265.
+_write_claude_settings_memory_dir() {
+  [ "${VADE_COO_MODE:-0}" = "1" ] || return 0
+  local memory_dir="$1"
+  [ -n "$memory_dir" ] || return 0
+  if ! check_cmd node; then
+    log "Warning: node missing; skipping ~/.claude/settings.json memory-dir merge"
+    return 0
+  fi
+  local settings_dir="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+  local settings_file="$settings_dir/settings.json"
+  mkdir -p "$settings_dir"
+  [ -f "$settings_file" ] || echo '{}' > "$settings_file"
+
+  VADE_COO_MEMORY_DIR="$memory_dir" node -e '
+    const fs = require("fs");
+    const path = process.argv[1];
+    let cfg = {};
+    try { cfg = JSON.parse(fs.readFileSync(path, "utf8")) || {}; }
+    catch (e) {
+      console.error("[vade-setup] " + path + " unparseable; aborting memory-dir merge.");
+      process.exit(1);
+    }
+    const merged = Object.assign({}, cfg.env || {});
+    if (process.env.VADE_COO_MEMORY_DIR) {
+      merged.VADE_COO_MEMORY_DIR = process.env.VADE_COO_MEMORY_DIR;
+    }
+    cfg.env = merged;
+    fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
+  ' "$settings_file"
+  chmod 600 "$settings_file"
+  log "  merged VADE_COO_MEMORY_DIR into $settings_file"
 }
 
 # Ensure openssh-client is present (provides ssh-keygen + ssh-keyscan).

--- a/scripts/session-start-sync.sh
+++ b/scripts/session-start-sync.sh
@@ -85,6 +85,12 @@ merge_coo_settings_state_dir
 # the call above (no PATH rewrite). vade-runtime#228 carries the
 # specific evidence (the Night's Watch standing-order call form).
 merge_coo_settings_runtime_dir
+# Persist VADE_COO_MEMORY_DIR into ~/.claude/settings.json env. Sibling
+# parity with VADE_RUNTIME_DIR — gh-coo-wrap.sh and various skills/hooks
+# resolve the memory-repo path via $VADE_COO_MEMORY_DIR, and without
+# this merge it doesn't survive into subprocess env across resume.
+# vade-runtime#265.
+merge_coo_settings_memory_dir
 # Refresh the external-touch (F6) cache when it's older than 24h.
 # Build-time prewarm in cloud-setup.sh handles the fresh-snapshot case;
 # this catches snapshots resumed after the cache has gone stale and


### PR DESCRIPTION
## Summary

Phase A of the boot architecture audit commission (parent: [vade-app/vade-coo-memory#762](https://github.com/vade-app/vade-coo-memory/issues/762)). Plan: `vade-coo-memory/coo/instruments/_runs/2026-05-15_boot-architecture-audit.md`.

Closes the substrate-side gaps that allowed the 2026-05-13 boot-skip incident: a cloud session booted with `VADE_COO_MODE` unset, `coo-bootstrap.sh` silently `exit 0`-ed at one of its five silent-skip gates, and the COO ran for ~30 min as generic Claude Code before BDFL caught it. PR #266 (already merged) closed the specific trigger; this PR closes the class.

Three substrate moves + one inline fix for [vrt#265](https://github.com/vade-app/vade-runtime/issues/265):

- **Move 2 — `coo-identity-digest.sh` reorder.** Hoist the integrity-check banner to the TOP of the digest output (before COO identity / identity-layer / lineage / memos). On `summary.ok=false` OR loud-skip sentinel present, print a `⚠️ BOOT DEGRADED` banner with the proven 4-line recovery sequence from the 2026-05-13 audit recovery-transcript.txt. Agent sees failure AND fix on the first screen, before any identity content.
- **Move 3 — cloud-aware loud-skip surfacing.** At each of the three `exit 0` silent-skip gates in `coo-bootstrap.sh` (VADE_COO_MODE!=1, non-COO gitconfig refusal, OP_SERVICE_ACCOUNT_TOKEN unset), write a sentinel file `~/.vade/.coo-bootstrap-skip-reason` with reason + recovery hint. The Move-2 digest hook reads the sentinel and surfaces it prominently in the banner. **Mac silent-skips remain silent** — `_is_cloud_context` fingerprint (filesystem `/home/user/.vade-cloud-state` OR Anthropic-baseline gitconfig `noreply@anthropic.com`, deliberately NOT `OP_SERVICE_ACCOUNT_TOKEN` because that token is itself a silent-skip gate) ensures the helper no-ops outside cloud. Sentinel cleared on benign marker-skip and on successful bootstrap completion. New helpers `_is_cloud_context` / `_write_skip_reason` / `_clear_skip_reason` live in `scripts/lib/common.sh`.
- **vrt#265 inline.** `merge_coo_settings_memory_dir` parallel to `merge_coo_settings_runtime_dir` / `merge_coo_settings_state_dir`: closes the gap where `VADE_COO_MEMORY_DIR` (used by `gh-coo-wrap.sh:257` and various skills/hooks) didn't survive into subprocess env across resume.

Companion PR to [vade-coo-memory PR](https://github.com/vade-app/vade-coo-memory/pulls?q=is%3Apr+head%3Aclaude%2Fphase-a-boot-fail-loud-6kz9w): CLAUDE.md step 1 (Move 1) reads the integrity-check.json as a conditional gate — substantive work proceeds only on green. The two PRs are paired; the verification gate is only fully exercisable after both merge.

## Test plan

- [x] Local: `bash -n` on every modified script.
- [x] Local: degraded-banner end-to-end test with fixture `integrity-check.json` (summary.ok=false) + fixture sentinel — banner prints "⚠️  BOOT DEGRADED" with skip reason, recovery hint, failing invariants, and the proven 4-line recovery sequence.
- [x] Local: `_is_cloud_context` returns 0 on Anthropic-fingerprint gitconfig, 1 on Mac-like gitconfig (`venpopov@example.com`).
- [x] Local: `bash scripts/coo-identity-digest.sh` on current container (29/29 OK) prints the one-line green banner at the top.
- [ ] CI: `scripts/ci/run-bootstrap-regression.sh` — D4 invariant covers VADE_COO_MEMORY_DIR not yet required by integrity-check (would need a separate enhancement). Existing invariants still pass.
- [ ] Post-merge fresh-container verification per the handoff prompt (separate comment on this PR).

Closes vade-app/vade-runtime#263.
Closes vade-app/vade-runtime#265.
Refs vade-app/vade-coo-memory#762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019chYSNsa6LiJz4Cim2jcB6