### PR TITLE
debug: bootstrap trace harness for boot-architecture review pause

### DIFF
--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -1,0 +1,168 @@
+# bootstrap-trace — boot-architecture diagnostic harness
+
+Single-purpose instrumentation for the COO boot pipeline review (paused
+commission [vade-app/vade-coo-memory#762](https://github.com/vade-app/vade-coo-memory/issues/762)). Plan file:
+`/root/.claude/plans/let-s-start-with-the-dapper-torvalds.md` (per-session;
+not committed).
+
+**What this is.** A hands-off observer that captures one ground-truth
+artifact per container build: every command bash runs, every file write
+under `~/.claude` / `~/.vade` / `~/.vade-cloud-state`, plus a filesystem
+snapshot at every bash invocation entry. Output is for human reading
+during the architecture review.
+
+**What this is not.** A fix. A monitoring tool. A production primitive.
+When the review concludes the harness is removed (one PR).
+
+## How it engages
+
+`BASH_ENV` is a bash mechanism: every non-interactive bash invocation
+sources the file pointed at by `BASH_ENV` before its first command. Set
+`BASH_ENV=/home/user/vade-runtime/scripts/debug/bootstrap-trace-init.sh`
+in the container settings UI permanently; the init script is a hard
+no-op unless `VADE_BOOTSTRAP_TRACE_MODE=1` is also set. Flipping that
+flag for one container build is the toggle.
+
+The init then attaches `set -x`, an inotifywait watcher, and a
+per-invocation snapshot — automatically, to every bash invocation that
+runs in the container, including `cloud-setup.sh` at build time and the
+SessionStart hook chain at session start. No existing script is
+modified.
+
+## Container UI configuration
+
+In the Anthropic container settings UI, add these env vars alongside
+the existing `OP_SERVICE_ACCOUNT_TOKEN`:
+
+| Env var | Value | When |
+|---------|-------|------|
+| `BASH_ENV` | `/home/user/vade-runtime/scripts/debug/bootstrap-trace-init.sh` | Permanent (init no-ops without the flag below). |
+| `VADE_BOOTSTRAP_TRACE_MODE` | `1` | Only when capturing a trace. Unset (or remove) to disable. |
+| `VADE_BOOTSTRAP_TRACE_DIR` | `/home/user/.vade/traces` | Optional. Default is the same value. |
+
+Trigger a container rebuild (changing UI env vars typically does this).
+The next session boots with the trace active.
+
+## Output layout
+
+```
+~/.vade/traces/CURRENT_RUN_ID                # marker → current run dir name
+~/.vade/traces/<run-id>/
+  meta.json                                  # run_id, started_at, first init pid
+  xtrace.log                                 # set -x output, all bash, all scripts
+  file-events.log                            # inotifywait pipe-separated lines
+  inotify.pid                                # PID of the inotifywait owner
+  snapshots/
+    <ts>-<tag>-<pid>/                        # one per bash invocation entry
+      content/                               # diffable byte-for-byte
+        settings.json
+        settings.local.json
+        dot-vade/coo-bootstrap.log
+        dot-vade-cloud-state/integrity-check.json
+        ...
+      metadata/
+        dot-claude.tsv                       # path size mtime mode
+        home-user.tsv
+        processes.txt
+        env.txt                              # env minus secrets
+```
+
+Snapshot directories are sortable lexicographically by their timestamp
+prefix. `ls snapshots/` gives chronological order.
+
+## How to read the output
+
+### What ran, in what order, where
+
+```bash
+TRACE=~/.vade/traces/$(cat ~/.vade/traces/CURRENT_RUN_ID)
+less "$TRACE/xtrace.log"
+```
+
+Each line is a single bash command with prefix:
+```
++ [<epoch.ns>] [pid=N bp=N] [<source>:<line> fn=<name>] <command>
+```
+
+### What got written when
+
+```bash
+cat "$TRACE/file-events.log"
+# format: <timestamp>|<full path>|<event-list>
+# example: 2026-05-15T22:30:01|/home/user/.claude/settings.json|MODIFY,CLOSE_WRITE
+```
+
+### Settings.json evolution across phases
+
+```bash
+# List snapshots in order:
+ls "$TRACE/snapshots/"
+
+# Diff settings.json between two phases:
+diff "$TRACE/snapshots/<earlier>/content/settings.json" \
+     "$TRACE/snapshots/<later>/content/settings.json"
+
+# All settings.json snapshots, in time order:
+for d in "$TRACE/snapshots/"*/content/settings.json; do
+    echo "=== $d ==="
+    cat "$d"
+done | less
+```
+
+### What was running at a snapshot
+
+```bash
+cat "$TRACE/snapshots/<ts>-<tag>-<pid>/metadata/processes.txt"
+```
+
+### Env state at a snapshot
+
+```bash
+cat "$TRACE/snapshots/<ts>-<tag>-<pid>/metadata/env.txt"
+```
+
+(Token-shaped vars are stripped on the way out.)
+
+## How to stop the trace
+
+Three options, descending order of operational simplicity:
+
+1. **Next container rebuild without the flag.** Remove `VADE_BOOTSTRAP_TRACE_MODE`
+   (or set it to `0`) in the container UI; trigger a rebuild.
+   `bootstrap-trace-init.sh` no-ops on every invocation; the inotifywait
+   process dies with the container.
+2. **Manually kill inotifywait and remove the CURRENT marker.**
+   `kill $(cat ~/.vade/traces/<run-id>/inotify.pid); rm ~/.vade/traces/CURRENT_RUN_ID`.
+   Subsequent `set -x` continues for any bash already running, but new
+   bash invocations restart in a fresh run-id. Useful for dividing the
+   trace into segments.
+3. **Container destroy.** Natural endpoint.
+
+## Fidelity notes
+
+- **`set -x` is suppressed by `set +x`.** If a traced script explicitly
+  disables xtrace (none currently do, but worth knowing), the trace
+  pauses. PS4 prefix carries source/line, so reactivation is visible.
+- **`BASH_ENV` only fires for non-interactive bash.** Interactive shells
+  (a human typing in a terminal) do not source it. The boot pipeline
+  is entirely non-interactive.
+- **Anthropic's pre-clone phase is invisible.** Whatever runs before
+  `/home/user/vade-runtime/` exists cannot resolve `BASH_ENV`. The
+  trace begins at the first bash invocation that occurs after the repo
+  is on disk.
+- **Inotifywait can miss events under burst load.** Rare for boot-pipeline
+  scale. If observed, the next snapshot's metadata captures the
+  resulting state.
+- **Snapshot count grows.** Every bash invocation produces one. Hooks +
+  helpers + sub-scripts: expect tens to a couple hundred per boot.
+  Total trace size typically a few MB.
+- **Existing EXIT traps.** This v1 does not chain onto pre-existing EXIT
+  traps in target scripts. It does not set its own EXIT trap to avoid
+  clobbering. Per-invocation snapshots fire on entry only; the next
+  invocation's entry snapshot captures the prior's exit state.
+
+## Sub-agent discipline
+
+If follow-on Explore or Plan agents are dispatched against this work,
+they MUST be pinned to Sonnet or Opus explicitly via the `model` field
+— never Haiku.

--- a/scripts/debug/bootstrap-trace-init.sh
+++ b/scripts/debug/bootstrap-trace-init.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# bootstrap-trace-init.sh
+#
+# Sourced via BASH_ENV by every non-interactive bash invocation in the
+# container. Hard no-op unless VADE_BOOTSTRAP_TRACE_MODE=1.
+#
+# When trace mode is on, installs:
+#   1. xtrace (set -x) into a dedicated fd, with rich PS4 prefix → xtrace.log
+#   2. inotifywait on ~/.claude, ~/.vade, ~/.vade-cloud-state → file-events.log
+#   3. per-bash-invocation snapshot at entry, named after the script
+#
+# Plan: /root/.claude/plans/let-s-start-with-the-dapper-torvalds.md
+# Constraints: no modification of any existing script. Trace is observer only.
+# Container UI configuration documented in scripts/debug/README.md.
+
+# Hard no-op when trace mode is off. Works whether sourced or executed.
+[[ "${VADE_BOOTSTRAP_TRACE_MODE:-0}" == "1" ]] || return 0 2>/dev/null || exit 0
+
+# Skip self-trace for the snapshot helper to avoid recursive fork-bombs
+# (snapshot helper is itself bash; BASH_ENV would re-source us).
+case "${0##*/}" in
+    bootstrap-trace-snapshot.sh)
+        return 0 2>/dev/null || exit 0
+        ;;
+esac
+
+# Per-bash-process re-entry guard. The whole init runs once per process.
+if [[ -n "${_VADE_BOOTSTRAP_TRACE_PROC_DONE:-}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_VADE_BOOTSTRAP_TRACE_PROC_DONE=1
+
+_VTRACE_ROOT="${VADE_BOOTSTRAP_TRACE_DIR:-$HOME/.vade/traces}"
+_VTRACE_CURRENT_FILE="$_VTRACE_ROOT/CURRENT_RUN_ID"
+mkdir -p "$_VTRACE_ROOT" 2>/dev/null
+
+# Run-id: reuse if a CURRENT marker points to a still-existing dir; else generate.
+_VTRACE_RUN_ID=""
+if [[ -s "$_VTRACE_CURRENT_FILE" ]]; then
+    _candidate=$(cat "$_VTRACE_CURRENT_FILE" 2>/dev/null)
+    [[ -n "$_candidate" && -d "$_VTRACE_ROOT/$_candidate" ]] && _VTRACE_RUN_ID="$_candidate"
+fi
+if [[ -z "$_VTRACE_RUN_ID" ]]; then
+    _VTRACE_RUN_ID="bootstrap-trace-$(date -u +%Y%m%dT%H%M%S)-$$"
+    mkdir -p "$_VTRACE_ROOT/$_VTRACE_RUN_ID/snapshots"
+    echo "$_VTRACE_RUN_ID" > "$_VTRACE_CURRENT_FILE"
+fi
+export VADE_BOOTSTRAP_TRACE_RUN_ID="$_VTRACE_RUN_ID"
+_VTRACE_DIR="$_VTRACE_ROOT/$_VTRACE_RUN_ID"
+
+# Write meta.json on first init only.
+if [[ ! -f "$_VTRACE_DIR/meta.json" ]]; then
+    {
+        printf '{\n'
+        printf '  "run_id": "%s",\n' "$_VTRACE_RUN_ID"
+        printf '  "started_at": "%s",\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        printf '  "first_init_pid": %d,\n' "$$"
+        printf '  "first_init_source": "%s",\n' "${BASH_SOURCE[0]:-unknown}"
+        printf '  "first_init_invoker": "%s",\n' "${0:-unknown}"
+        printf '  "bash_version": "%s"\n' "$BASH_VERSION"
+        printf '}\n'
+    } > "$_VTRACE_DIR/meta.json"
+fi
+
+# Open xtrace fd; redirect set -x output there.
+# EPOCHREALTIME is bash 5+; PS4 falls back to SECONDS otherwise.
+if exec {_VTRACE_FD}>>"$_VTRACE_DIR/xtrace.log" 2>/dev/null; then
+    export BASH_XTRACEFD=$_VTRACE_FD
+    # Per-command prefix. Evaluated by bash on each command trace.
+    # Format: + [<epoch.ns>] [pid=N bp=N] [source.sh:line fn=NAME] <command>
+    export PS4='+ [${EPOCHREALTIME:-$SECONDS}] [pid=$$ bp=${BASHPID:-$$}] [${BASH_SOURCE[0]##*/}:${LINENO} fn=${FUNCNAME[0]:-MAIN}] '
+    set -x
+fi
+
+# Inotifywait: one watcher per trace run, owned by the first init invocation.
+_VTRACE_INOTIFY_PID_FILE="$_VTRACE_DIR/inotify.pid"
+if [[ ! -s "$_VTRACE_INOTIFY_PID_FILE" ]] || \
+   ! kill -0 "$(<"$_VTRACE_INOTIFY_PID_FILE")" 2>/dev/null; then
+    if command -v inotifywait >/dev/null 2>&1; then
+        # Watch the three small mutable state dirs. Top-level only on /home/user
+        # would be ideal, but inotifywait recursive on a small subset is fine.
+        _watch_dirs=()
+        for d in "$HOME/.claude" "$HOME/.vade" "$HOME/.vade-cloud-state"; do
+            [[ -d "$d" ]] && _watch_dirs+=("$d")
+        done
+        if (( ${#_watch_dirs[@]} > 0 )); then
+            (
+                inotifywait -m -r -q \
+                    -e create,modify,move,delete,close_write \
+                    --format '%T|%w%f|%e' \
+                    --timefmt '%Y-%m-%dT%H:%M:%S' \
+                    "${_watch_dirs[@]}" 2>/dev/null \
+                    >> "$_VTRACE_DIR/file-events.log"
+            ) &
+            echo $! > "$_VTRACE_INOTIFY_PID_FILE"
+            disown 2>/dev/null
+        fi
+    else
+        echo "no inotifywait available" > "$_VTRACE_DIR/inotify.skipped"
+    fi
+fi
+
+# Snapshot at entry of this bash invocation.
+_VTRACE_INVOCATION_TAG="${0##*/}"
+if [[ -z "$_VTRACE_INVOCATION_TAG" || "$_VTRACE_INVOCATION_TAG" == "bash" ]]; then
+    _VTRACE_INVOCATION_TAG="bash-${BASH_SOURCE[-1]##*/}"
+    [[ "$_VTRACE_INVOCATION_TAG" == "bash-" ]] && _VTRACE_INVOCATION_TAG="bash-shell"
+fi
+
+_VTRACE_SNAPSHOT_BIN="${BASH_SOURCE[0]%/*}/bootstrap-trace-snapshot.sh"
+if [[ -x "$_VTRACE_SNAPSHOT_BIN" ]]; then
+    "$_VTRACE_SNAPSHOT_BIN" "$_VTRACE_INVOCATION_TAG-enter" "$_VTRACE_DIR" 2>/dev/null &
+    disown 2>/dev/null
+fi

--- a/scripts/debug/bootstrap-trace-snapshot.sh
+++ b/scripts/debug/bootstrap-trace-snapshot.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# bootstrap-trace-snapshot.sh
+#
+# Hybrid filesystem snapshot for the bootstrap trace harness.
+# Called from bootstrap-trace-init.sh at every bash invocation entry.
+#
+#   Usage: bootstrap-trace-snapshot.sh <tag> <trace-dir>
+#
+# Content snapshot (cp -p) of small mutable state files; metadata snapshot
+# (find -printf) of the larger trees. Each snapshot lands in
+#   <trace-dir>/snapshots/<timestamp>-<tag>-<pid>/
+# Sortable by timestamp prefix. Globally unique without a counter file.
+#
+# Plan: /root/.claude/plans/let-s-start-with-the-dapper-torvalds.md
+
+set -uo pipefail
+
+TAG="${1:-unknown}"
+TRACE_DIR="${2:-${VADE_BOOTSTRAP_TRACE_DIR:-$HOME/.vade/traces}}"
+
+# Sanitize the tag: replace anything that's not alnum/dash/dot/underscore.
+SAFE_TAG=$(printf '%s' "$TAG" | tr -c 'A-Za-z0-9._-' '_')
+
+STAMP=$(date -u +%Y%m%dT%H%M%S%6N 2>/dev/null || date -u +%Y%m%dT%H%M%S)
+SNAP="$TRACE_DIR/snapshots/${STAMP}-${SAFE_TAG}-$$"
+
+mkdir -p "$SNAP/content" "$SNAP/metadata" 2>/dev/null || exit 0
+
+# --- Content snapshots: small files we want diffable byte-for-byte. ---
+
+# ~/.claude settings (the central object the boot pipeline mutates).
+for f in "$HOME/.claude/settings.json" \
+         "$HOME/.claude/settings.local.json" \
+         "$HOME/.claude/settings.json.env"; do
+    if [[ -f "$f" ]]; then
+        cp -p "$f" "$SNAP/content/$(basename "$f")" 2>/dev/null
+    fi
+done
+
+# ~/.vade — boot logs, marker files, sentinel files. Skip our own traces.
+if [[ -d "$HOME/.vade" ]]; then
+    mkdir -p "$SNAP/content/dot-vade"
+    find "$HOME/.vade" -maxdepth 2 -type f -not -path "*/traces/*" \
+        -exec cp -p {} "$SNAP/content/dot-vade/" \; 2>/dev/null
+fi
+
+# ~/.vade-cloud-state — integrity-check.json + receipts.
+if [[ -d "$HOME/.vade-cloud-state" ]]; then
+    mkdir -p "$SNAP/content/dot-vade-cloud-state"
+    find "$HOME/.vade-cloud-state" -maxdepth 2 -type f \
+        -exec cp -p {} "$SNAP/content/dot-vade-cloud-state/" \; 2>/dev/null
+fi
+
+# --- Metadata snapshots: path / size / mtime / mode for the larger trees. ---
+
+# All of ~/.claude (excluding what we already content-snapshotted, but
+# include anyway — duplication is fine and the diff is cheap).
+if [[ -d "$HOME/.claude" ]]; then
+    find "$HOME/.claude" -type f -printf '%p\t%s\t%T@\t%m\n' \
+        > "$SNAP/metadata/dot-claude.tsv" 2>/dev/null
+fi
+
+# /home/user top-level only (depth=1). Captures the repo working trees'
+# presence + immediate children without exploding the artifact size.
+find /home/user -maxdepth 1 -printf '%p\t%y\t%s\t%T@\t%m\n' \
+    > "$SNAP/metadata/home-user.tsv" 2>/dev/null
+
+# Process state at snapshot time — useful for "what was running."
+ps -eo pid,ppid,pgid,stat,cmd > "$SNAP/metadata/processes.txt" 2>/dev/null
+
+# Env at snapshot time. Strip anything that obviously contains a secret token
+# (defensive — this lands on disk and may end up in a PR if shared).
+env | grep -vE '(TOKEN|API_KEY|SECRET|PASSWORD|PAT|CLOUDFLARE_API)=' \
+    | sort > "$SNAP/metadata/env.txt" 2>/dev/null
+
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/debug/{bootstrap-trace-init,bootstrap-trace-snapshot}.sh` + `README.md`. Inject-style observer for the COO boot pipeline; engaged via container UI `BASH_ENV` + `VADE_BOOTSTRAP_TRACE_MODE=1`; hard no-op otherwise. No existing script modified.

Diagnostic tooling for the architecture-review pause on commission [vade-app/vade-coo-memory#762](https://github.com/vade-app/vade-coo-memory/issues/762) — captures one ground-truth artifact per container build for the BDFL to read while internalizing the boot pipeline manually. Replaces the partial-mental-model authoring pattern that produced the current pile of layered fixes.

## What it captures

- **`set -x` with rich PS4** (timestamp, pids, source:line, function) into `xtrace.log` — every command in every script in every bash invocation.
- **`inotifywait`** on `~/.claude`, `~/.vade`, `~/.vade-cloud-state` into `file-events.log` — every file create/modify/move/delete during the trace.
- **Per-bash-invocation snapshots** at entry: hybrid depth (content for `settings.json` + small mutable state files, metadata for the larger trees), into `snapshots/<ts>-<tag>-<pid>/`.

## How it engages

`BASH_ENV` is bash's pre-source mechanism for non-interactive shells. Setting it in the container settings UI (alongside `OP_SERVICE_ACCOUNT_TOKEN`) makes every bash invocation in the container — `cloud-setup.sh` at build time, the SessionStart hook chain at session start, every helper sub-script — automatically source the init. The init no-ops unless the trace flag is also set.

Container UI configuration (in README):

| Env var | Value | When |
|---------|-------|------|
| `BASH_ENV` | `/home/user/vade-runtime/scripts/debug/bootstrap-trace-init.sh` | Permanent |
| `VADE_BOOTSTRAP_TRACE_MODE` | `1` | Only when capturing |
| `VADE_BOOTSTRAP_TRACE_DIR` | (default `~/.vade/traces`) | Optional |

## What it does not do

- **Does not modify any existing script.** All-new files under `scripts/debug/`.
- **Does not ship a fix** for the Phase A.1 race or any other observed issue. The commission stays paused.
- **Does not close vade-coo-memory#762** or any other audit-arc ticket.
- **Does not propose any new memo.**

## Smoke test (run locally)

- No-op path with flag unset: returns cleanly, no side effects.
- Trace-on path: creates run dir, writes `meta.json` + `xtrace.log` (PS4 prefix verified), takes entry snapshot of `settings.json` (14KB) + process state + env, gracefully skips `inotifywait` if the binary is absent (writes `inotify.skipped` marker).

## Test plan

- [ ] Set `BASH_ENV` and `VADE_BOOTSTRAP_TRACE_MODE=1` in container UI.
- [ ] Trigger a fresh container build.
- [ ] Boot a Claude Code session in the new container.
- [ ] Verify `~/.vade/traces/<run-id>/xtrace.log` contains entries with source `cloud-setup.sh` (build-time coverage check).
- [ ] Verify snapshots fired for each of the seven SessionStart hooks.
- [ ] Read 50-200 events end-to-end to confirm human-readability.
- [ ] Disable trace flag and confirm `bootstrap-trace-init.sh` no-ops on subsequent boots.

Refs vade-app/vade-coo-memory#762.
Closes: n/a (auxiliary diagnostic; commission remains paused).

Plan file (per-session, not committed): \`/root/.claude/plans/let-s-start-with-the-dapper-torvalds.md\`.

https://claude.ai/code/session_01QAUJnCJNoyZfZk1XLvm1TJ