### PR TITLE
debug: trace-timeline enhancements — touch + parent/child + command log

### DIFF
--- a/.claude/skills/trace-timeline/SKILL.md
+++ b/.claude/skills/trace-timeline/SKILL.md
@@ -62,7 +62,10 @@ python3 /home/user/vade-runtime/scripts/debug/render-trace-timeline.py "$TRACE" 
 The script:
 
 - Parses `xtrace.log` (PS4-prefixed, one bash command per line) into
-  per-PID lifespans and event lists.
+  per-PID lifespans and event lists. Also captures a per-PID
+  **command log** (up to ~80 commands per script, excluding noise
+  scripts like `git`, `dispatch.sh`, guards) so the detail panel
+  can show what each script actually did, line by line.
 - Resolves each PID to its real script name using the
   `_VTRACE_INVOCATION_TAG=` line emitted by `bootstrap-trace-init.sh`
   (first-seen wins — long-lived processes that re-source the init for
@@ -70,6 +73,11 @@ The script:
 - Walks `snapshots/*/content/settings.json` for each capture and
   records whether `VADE_RUNTIME_DIR` / `VADE_COO_MEMORY_DIR` /
   `VADE_CLOUD_STATE_DIR` were present.
+- Scans `snapshots/*/metadata/processes.txt` for **PID → PPID
+  relationships** so the renderer can build a process tree (parent
+  chain + tracked children) per PID. Prefers `ps`-side identity over
+  xtrace identity when walking the ancestor chain (handles PID reuse
+  cleanly).
 - Captures these event kinds (one marker each on the timeline):
     - `_write_claude_settings_*` — file writes (orange)
     - `merge_coo_settings_*` — wrapper merge calls (blue)
@@ -77,8 +85,9 @@ The script:
       (green / red / gray)
     - `set -euo pipefail` from a user script — script entry (purple)
     - selected `[vade-setup] …` log lines (gray notes)
-- Writes a single self-contained HTML file (~250 KB) with embedded
-  JSON. No CDN dependencies; opens offline.
+- Writes a single self-contained HTML file (~3–4 MB; size scales with
+  command-log volume and process count) with embedded JSON. No CDN
+  dependencies; opens offline.
 
 ### 3. Deliver
 
@@ -91,13 +100,28 @@ Orient the user briefly:
 - **Default view** is the boot window (0–22 s), noise wrappers
   (`dispatch.sh`, guards, brief `git` subprocesses) hidden.
 - **"boot (0–5 s)"** button zooms onto the actual race.
-- **Ctrl/⌘ + scroll** zooms anywhere; drag the time slider for fine
+- **Desktop**: Ctrl/⌘ + scroll zooms; drag the time slider for fine
   control; the script-name filter input narrows rows.
+- **iPad / touch**: two-finger pinch zooms the timeline; drag pans;
+  tap an event/snapshot to open the detail sheet from the right. Top
+  -right floating buttons handle WebView quirks — `⇕` hides the
+  header+legend to claim ~70 px of vertical, `▼` / `▲` nudge the top
+  padding in 20 px steps for apps whose toolbar overlays the page
+  (Files-app viewer etc). All settings persist via localStorage.
+- **Right sidebar** is resizable: drag its left edge (cursor turns
+  to ↔; hairline highlights yellow). Width persists.
+- **View mode toggle** in the controls bar: `rows` (default —
+  ordered by start time) and `tree` (preorder by parent→child, with
+  SVG L-shaped connectors drawn from each parent's bar down/up to
+  the child's start position, plus depth indent on labels).
 - Snapshot dots above the timeline are **red** when
   `VADE_RUNTIME_DIR` is missing from `settings.json`, **green** when
   present.
-- Click any event marker or snapshot dot for raw xtrace
-  context in the right-hand detail panel.
+- Click any event marker, snapshot dot, or process span for raw
+  xtrace context in the right-hand detail panel. The process detail
+  shows the **full ancestor chain** (each tracked ancestor click-to-
+  jumps), **traced children**, and an expandable **command log** of
+  what the script actually executed.
 
 If the trace contains a D4=false event (the canonical reader-vs-writer
 race for vade-app/vade-coo-memory#762), name it explicitly — the bright
@@ -115,18 +139,23 @@ write markers in the session-start-sync row immediately around it,
 | Why did D-group invariant N fail? | Click the red marker on the integrity-check row → detail panel shows `_add` source line, full `cmd` text, and `detail` string. |
 | When did each script enter? | Purple "enter" markers at the left edge of each row's lifespan bar. |
 | Which subprocess of integrity-check is which `git`? | Toggle off "hide wrappers" and the brief git PIDs appear; click each for its commands count and PID. |
+| What launched X? What did X spawn? | Click X's lifespan bar → detail panel's **ancestor chain** walks PID→PPID up to PID 1 (each tracked link clickable to jump). **Children** lists tracked subprocesses. Or flip the view-mode toggle to **tree** to see all of it visually with SVG connectors. |
+| What did X actually do? | Click X's lifespan bar → detail panel's **command log** shows up to ~80 bash commands the script ran (timestamp · script:line · function · raw bash). Suppressed for noise scripts to keep file size manageable. |
 
 ## What the timeline can't answer
 
 - **Sub-millisecond interleave inside `node -e` blocks.** xtrace records
   bash entry/exit, not syscalls inside spawned binaries. Atomic-rename
   vs read inside a node helper is invisible at this resolution.
-- **Process parent / child tree.** xtrace shows PID+BASHPID but not
-  PPID; use a snapshot's `metadata/processes.txt` (linked in the
-  snapshot detail) for the tree at that instant.
 - **Anything before the first traced bash invocation.** Anthropic's
   pre-clone phase happens before `BASH_ENV` resolves; the trace begins
   at the first bash after the repo is on disk.
+- **All children, including non-bash subprocesses.** The "children"
+  list in the detail panel and the connectors in tree-view only show
+  PIDs that appear in our xtrace (i.e. bash subprocesses that
+  re-sourced `bootstrap-trace-init.sh`). Short-lived non-bash forks
+  like `cp` / `chmod` aren't traced. The `ps cmd` shown on each
+  ancestor row gives the launching context where xtrace silent.
 
 ## Re-running on a fresh trace
 

--- a/scripts/debug/render-trace-timeline.py
+++ b/scripts/debug/render-trace-timeline.py
@@ -38,6 +38,17 @@ PID_FIRST = {}
 PID_LAST = {}
 PID_SCRIPT = {}
 PID_CMD_COUNT = {}
+PID_COMMANDS = {}  # pid -> list of dicts {ts_ms (set later), script, line, fn, cmd_preview}
+COMMANDS_PER_PID_CAP = 80  # bounds output size for chatty PIDs
+
+# PIDs whose script matches one of these get no command log — they're trace
+# plumbing and brief subprocesses, not the user-script work. Saves ~10x in
+# output size when many are present.
+NOISE_SCRIPTS_FOR_CMDLOG = {
+    "dispatch.sh", "bootstrap-trace-init.sh", "common.sh",
+    "bash-token-guard.sh", "bash-github-api-guard.sh",
+    "git", "gh", "jq",
+}
 EVENTS = []
 boot_start = None
 
@@ -62,8 +73,26 @@ with open(xtrace_path) as f:
             PID_FIRST[pid] = ts
             PID_SCRIPT[pid] = script
             PID_CMD_COUNT[pid] = 0
+            PID_COMMANDS[pid] = []
         PID_LAST[pid] = ts
         PID_CMD_COUNT[pid] += 1
+
+        # Capture command for the per-PID command log (capped). Skip the
+        # noisiest internal trace plumbing so the log shows user-relevant
+        # bash commands, not the trace harness's own state-shuffling.
+        if (
+            len(PID_COMMANDS[pid]) < COMMANDS_PER_PID_CAP
+            and fn not in ("_je", "_log", "_json_escape")
+            and not cmd.startswith("_VTRACE_")
+            and not cmd.startswith("local ")
+        ):
+            PID_COMMANDS[pid].append({
+                "ts": ts,
+                "script": script,
+                "line": srcline,
+                "fn": fn,
+                "cmd": cmd[:200],
+            })
 
         # Only honor the FIRST _VTRACE_INVOCATION_TAG per PID. A long-lived
         # script (e.g. coo-identity-digest.sh that sticks around as a monitor)
@@ -169,6 +198,82 @@ if os.path.isdir(snapshots_dir):
 for k in [k for k in PID_SCRIPT if isinstance(k, str) and k.startswith("_tag_seen_")]:
     del PID_SCRIPT[k]
 
+# ── Parent-child derivation from snapshots/*/metadata/processes.txt ───
+# Each snapshot has a `ps`-style dump with columns: PID PPID PGID STAT CMD.
+# Build a single map: tracked PID → (PPID, command_snippet) using the
+# first-seen row per PID (parent doesn't change during a PID's lifespan in
+# practice for bash-spawned children — re-parenting on session leader death
+# is rare enough to ignore for the boot window we care about).
+print(f"Scanning processes.txt across {len(SNAPSHOTS) if 'SNAPSHOTS' in dir() else '?'} snapshots ...", file=sys.stderr)
+PID_PPID = {}      # tracked pid -> ppid (int)
+PID_ALL_PPID = {}  # any pid -> ppid (used by ancestor_chain to walk past untracked intermediates)
+PID_PSCMD = {}     # any pid (tracked or not) -> short ps CMD snippet
+ps_row_re = re.compile(r"^\s*(?P<pid>\d+)\s+(?P<ppid>\d+)\s+\d+\s+\S+\s+(?P<cmd>.*)$")
+tracked = set(PID_FIRST.keys())
+snapshots_dir = os.path.join(TRACE_DIR, "snapshots")
+if os.path.isdir(snapshots_dir):
+    # sorted so first-seen reflects chronology
+    for d in sorted(os.listdir(snapshots_dir)):
+        proc_path = os.path.join(snapshots_dir, d, "metadata", "processes.txt")
+        if not os.path.exists(proc_path):
+            continue
+        try:
+            with open(proc_path) as pf:
+                for ln in pf:
+                    m = ps_row_re.match(ln)
+                    if not m:
+                        continue
+                    pid_n = int(m["pid"])
+                    ppid_n = int(m["ppid"])
+                    cmd_str = m["cmd"].strip()
+                    if pid_n not in PID_PSCMD:
+                        PID_PSCMD[pid_n] = cmd_str[:160]
+                    if pid_n not in PID_ALL_PPID:
+                        PID_ALL_PPID[pid_n] = ppid_n
+                    if pid_n in tracked and pid_n not in PID_PPID:
+                        PID_PPID[pid_n] = ppid_n
+        except Exception:
+            continue
+
+# Derive child lists: tracked_pid -> [tracked children]
+PID_CHILDREN = {p: [] for p in tracked}
+for child, parent in PID_PPID.items():
+    if parent in PID_CHILDREN:
+        PID_CHILDREN[parent].append(child)
+
+def parent_label(pid):
+    """Return a {pid, script, tracked} dict for the parent, or None if root."""
+    ppid = PID_PPID.get(pid)
+    if not ppid:
+        return None
+    if ppid in PID_SCRIPT:
+        return {"pid": ppid, "script": PID_SCRIPT[ppid], "tracked": True}
+    # Parent isn't in our xtrace (e.g. the top-level claude process, /bin/sh)
+    return {"pid": ppid, "script": PID_PSCMD.get(ppid, "(unknown)")[:80], "tracked": False}
+
+def ancestor_chain(pid, cap=8):
+    """Walk PPID upward to root. Each link gets {pid, script, tracked}.
+    Prefers PID_PSCMD (the ps-side ground truth from snapshots) over
+    PID_SCRIPT (the xtrace view, which may be misleading under PID reuse
+    — e.g. PID 2213 starts as `claude` per ps but our xtrace re-uses 2213
+    for a bash subprocess much later). `tracked` is True when the PID
+    also exists in our xtrace, so the click-to-jump still works."""
+    chain = []
+    cur = PID_ALL_PPID.get(pid)
+    seen = set()
+    while cur and cur not in seen and len(chain) < cap:
+        seen.add(cur)
+        tracked = cur in PID_SCRIPT
+        if cur in PID_PSCMD:
+            script_label = PID_PSCMD[cur][:80]
+        elif tracked:
+            script_label = PID_SCRIPT[cur]
+        else:
+            script_label = "(unknown)"
+        chain.append({"pid": cur, "script": script_label, "tracked": tracked})
+        cur = PID_ALL_PPID.get(cur)
+    return chain
+
 PIDS = sorted(PID_FIRST.keys(), key=lambda p: PID_FIRST[p])
 
 
@@ -187,6 +292,27 @@ data = {
             "first_ms": to_ms(PID_FIRST[p]),
             "last_ms": to_ms(PID_LAST[p]),
             "count": PID_CMD_COUNT[p],
+            "parent": parent_label(p),
+            "ancestors": ancestor_chain(p),
+            "children": sorted(PID_CHILDREN.get(p, [])),
+            "ps_cmd": PID_PSCMD.get(p, ""),
+            "commands": (
+                [] if PID_SCRIPT[p] in NOISE_SCRIPTS_FOR_CMDLOG else
+                [
+                    {
+                        "ts_ms": to_ms(c["ts"]),
+                        "script": c["script"],
+                        "line": c["line"],
+                        "fn": c["fn"],
+                        "cmd": c["cmd"],
+                    }
+                    for c in PID_COMMANDS.get(p, [])
+                ]
+            ),
+            "commands_truncated": (
+                PID_SCRIPT[p] not in NOISE_SCRIPTS_FOR_CMDLOG
+                and PID_CMD_COUNT[p] > COMMANDS_PER_PID_CAP
+            ),
         }
         for p in PIDS
     ],
@@ -230,6 +356,9 @@ HTML = (
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="theme-color" content="#1a1a1a">
 <title>Bootstrap trace timeline — """ + run_id + """</title>
 <style>
   :root {
@@ -244,13 +373,25 @@ HTML = (
     --hl: #ffd35a;
   }
   * { box-sizing: border-box; }
-  html, body { margin: 0; padding: 0; height: 100%; }
+  /* --app-vh is set by JS to window.innerHeight so we measure the
+     actually-visible viewport, not the layout viewport which some iPad
+     in-app WebViews (Files, Documents-by-Readdle, etc.) report as the
+     full screen height even when their toolbar overlays the page. */
+  html, body { margin: 0; padding: 0; height: 100%; height: var(--app-vh, 100dvh); }
   body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
     background: var(--bg);
     color: var(--text);
     font-size: 12px;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
+    -webkit-text-size-adjust: 100%;
+    -webkit-tap-highlight-color: transparent;
+    padding-top: calc(env(safe-area-inset-top, 0px) + var(--manual-offset, 0px));
+    padding-left: env(safe-area-inset-left, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    overscroll-behavior: contain;
   }
   #header {
     padding: 8px 12px;
@@ -260,10 +401,38 @@ HTML = (
     align-items: baseline;
     background: var(--panel);
     flex-shrink: 0;
+    position: relative;
   }
   #header strong { color: #fff; font-weight: 600; }
   #header .meta { color: var(--muted); font-size: 11px; }
   #header .meta b { color: var(--text); font-weight: 600; }
+  /* Collapse header + legend when body has [data-chrome=hidden]. Gives back
+     ~70px of vertical for iPad in-app WebViews that overlay their toolbar
+     across the top of the page. Toggle via the chrome button (top-right). */
+  body[data-chrome="hidden"] #header,
+  body[data-chrome="hidden"] #legend { display: none; }
+  body[data-chrome="hidden"] #main { height: calc(var(--app-vh, 100dvh) - var(--manual-offset, 0px)); }
+  #chrome-toggle, .top-fab {
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 6px);
+    width: 32px;
+    height: 32px;
+    border-radius: 16px;
+    border: 1px solid var(--border);
+    background: rgba(40, 40, 40, 0.85);
+    color: var(--text);
+    font-size: 12px;
+    line-height: 1;
+    cursor: pointer;
+    z-index: 200;
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+    padding: 0;
+  }
+  #chrome-toggle { right: calc(env(safe-area-inset-right, 0px) + 6px); }
+  #pad-down { right: calc(env(safe-area-inset-right, 0px) + 44px); }
+  #pad-up   { right: calc(env(safe-area-inset-right, 0px) + 82px); }
+  #chrome-toggle:active, .top-fab:active { background: rgba(60, 60, 60, 0.9); }
 
   #legend {
     padding: 6px 12px;
@@ -281,34 +450,115 @@ HTML = (
 
   #main {
     display: flex;
-    height: calc(100vh - 70px);
+    height: calc(var(--app-vh, 100dvh) - 70px - var(--manual-offset, 0px));
     overflow: hidden;
+    position: relative;
   }
   #chart-area {
     flex-grow: 1;
     overflow: hidden;
     position: relative;
     background: var(--bg);
+    min-width: 0;
   }
   #detail-area {
-    width: 340px;
+    width: var(--detail-width, 340px);
     flex-shrink: 0;
     border-left: 1px solid var(--border);
     overflow-y: auto;
     padding: 12px;
     background: var(--panel);
+    transition: transform 200ms ease-out;
+    position: relative;
+  }
+  #detail-resize {
+    position: absolute;
+    left: -4px;
+    top: 0;
+    bottom: 0;
+    width: 8px;
+    cursor: ew-resize;
+    z-index: 71;
+    background: transparent;
+    /* invisible by default; show a hairline on hover */
+  }
+  #detail-resize:hover, #detail-resize.dragging { background: rgba(255, 211, 90, 0.4); }
+  /* Hide resize handle on narrow viewports — sidebar is overlay, not flex column */
+  @media (max-width: 900px) { #detail-resize { display: none; } }
+  #detail-close {
+    display: none;
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--border);
+    background: #1a1a1a;
+    color: var(--text);
+    border-radius: 18px;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    z-index: 60;
+  }
+  #detail-close:active { background: #333; }
+  /* Narrow-window: detail panel becomes slide-in overlay from right */
+  @media (max-width: 900px) {
+    #detail-area {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: min(420px, 88vw);
+      transform: translateX(105%);
+      box-shadow: -8px 0 24px rgba(0,0,0,0.45);
+      z-index: 70;
+    }
+    #detail-area.open {
+      transform: translateX(0);
+    }
+    #detail-close { display: block; }
+    #legend .leg { font-size: 12px; }
+    #legend .leg.hint { display: none; }
+  }
+  @media (max-width: 600px) {
+    #header { gap: 6px; padding: 6px 8px; font-size: 12px; }
+    #header .meta { font-size: 10px; }
+    #legend { padding: 6px 8px; gap: 8px; }
   }
   #detail-area h3 { margin: 0 0 8px 0; font-size: 12px; color: var(--hl); }
   #detail-area dl { margin: 0; }
   #detail-area dt { color: var(--muted); font-size: 10px; margin-top: 6px; }
-  #detail-area dd { margin: 2px 0 0 0; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; word-break: break-all; }
+  #detail-area dd { margin: 2px 0 0 0; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; overflow-wrap: anywhere; word-break: normal; }
+  #detail-area .anc-list { display: flex; flex-direction: column; gap: 3px; margin-top: 4px; }
+  #detail-area .anc-row { background: rgba(255,255,255,0.04); border-left: 2px solid rgba(255,255,255,0.2); padding: 4px 8px; border-radius: 3px; font-size: 11px; line-height: 1.35; }
+  #detail-area .anc-row .anc-pid { color: var(--muted); font-size: 10px; font-family: ui-monospace, "SF Mono", Menlo, monospace; margin-right: 6px; }
+  #detail-area .anc-row .anc-script { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; overflow-wrap: anywhere; }
+  #detail-area .anc-row.tracked .anc-script { cursor: pointer; text-decoration: underline dotted; text-underline-offset: 2px; }
+  #detail-area .anc-row.untracked { border-left-color: rgba(255,255,255,0.08); opacity: 0.85; }
+  #detail-area .anc-arrow { color: var(--muted); margin-right: 4px; }
+  #detail-area .children-list { display: flex; flex-direction: column; gap: 3px; }
+  #detail-area .children-list .pid-link { padding: 3px 6px; background: rgba(255,255,255,0.03); border-radius: 3px; display: inline-block; }
   #detail-area .hint { color: var(--muted); font-size: 11px; }
+  /* Per-PID command log block */
+  #detail-area details.cmd-log { margin-top: 12px; border-top: 1px solid var(--border); padding-top: 8px; }
+  #detail-area details.cmd-log summary { cursor: pointer; color: var(--hl); font-size: 11px; margin-bottom: 6px; user-select: none; }
+  #detail-area .cmd-list { display: flex; flex-direction: column; gap: 6px; max-height: 50vh; overflow-y: auto; }
+  #detail-area .cmd-row { background: rgba(255,255,255,0.03); padding: 4px 6px; border-radius: 3px; border-left: 2px solid rgba(255,255,255,0.1); }
+  #detail-area .cmd-row .cmd-ts { color: var(--muted); font-size: 10px; margin-right: 8px; }
+  #detail-area .cmd-row .cmd-loc { color: var(--muted); font-size: 10px; }
+  #detail-area .cmd-row .cmd-text { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; margin-top: 2px; white-space: pre-wrap; word-break: break-word; color: var(--text); }
+  #detail-area .cmd-trunc { color: var(--muted); font-size: 10px; font-style: italic; padding: 4px 0; }
+  #detail-area .pid-link:active { opacity: 0.7; }
 
   #chart-scroll {
     position: absolute;
     inset: 0;
     overflow-x: auto;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-x pan-y;
+    overscroll-behavior: contain;
   }
   #chart-inner {
     position: relative;
@@ -338,7 +588,7 @@ HTML = (
     position: sticky;
     left: 0;
     z-index: 9;
-    width: 260px;
+    width: var(--label-width, 260px);
     background: var(--panel);
     border-right: 1px solid var(--border);
   }
@@ -355,20 +605,29 @@ HTML = (
     left: 0;
     top: 0;
     bottom: 0;
-    width: 260px;
+    width: var(--label-width, 260px);
     padding: 3px 8px;
     background: var(--panel);
     border-right: 1px solid var(--border);
     overflow: hidden;
     text-overflow: ellipsis;
     z-index: 5;
+    font-size: 11px;
   }
   .row .label .pid { color: var(--muted); margin-right: 6px; }
   .row .lane {
     position: absolute;
-    left: 260px;
+    left: var(--label-width, 260px);
     top: 0;
     bottom: 0;
+  }
+  @media (max-width: 900px) {
+    :root { --label-width: 160px; }
+  }
+  @media (max-width: 600px) {
+    :root { --label-width: 130px; }
+    .row .label { font-size: 10px; padding: 3px 4px; }
+    .row .label .pid { margin-right: 3px; }
   }
   .span {
     position: absolute;
@@ -388,8 +647,20 @@ HTML = (
     border-radius: 1px;
     cursor: pointer;
     transform: translateX(-2px);
+    /* enlarge invisible hit area for touch without enlarging visual */
+    box-shadow: 0 0 0 0 transparent;
+  }
+  .event::after {
+    content: "";
+    position: absolute;
+    top: -8px;
+    bottom: -8px;
+    left: -6px;
+    right: -6px;
+    /* invisible touch target */
   }
   .event:hover { outline: 2px solid var(--hl); z-index: 6; }
+  .event.selected { outline: 2px solid var(--hl); outline-offset: 1px; z-index: 7; }
   .event.write { background: #ff9c2a; width: 6px; }
   .event.merge { background: #4aa8ff; }
   .event.invariant-pass { background: #4ad06a; }
@@ -412,16 +683,21 @@ HTML = (
   .snap-line.no-rt { border-color: rgba(255,74,74,0.5); }
   .snap-line .marker {
     position: absolute;
-    top: -2px;
-    left: -4px;
-    width: 8px;
-    height: 8px;
+    top: -4px;
+    left: -6px;
+    width: 12px;
+    height: 12px;
     background: inherit;
     pointer-events: auto;
     cursor: pointer;
   }
   .snap-line.has-rt .marker { background: #4ad06a; border-radius: 50%; }
-  .snap-line.no-rt .marker { background: #ff4a4a; border-radius: 50%; }
+  .snap-line.no-rt .marker { background: #ff4a4a; border-radius: 50%; box-shadow: 0 0 4px rgba(255,74,74,0.5); }
+  .snap-line .marker::after {
+    content: "";
+    position: absolute;
+    inset: -10px;
+  }
 
   #tooltip {
     position: fixed;
@@ -444,39 +720,119 @@ HTML = (
     bottom: 10px;
     background: var(--panel);
     border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 6px 8px;
+    border-radius: 6px;
+    padding: 8px 10px;
     display: flex;
-    gap: 8px;
+    gap: 10px;
     z-index: 50;
     align-items: center;
-    font-size: 11px;
+    font-size: 12px;
+    flex-wrap: wrap;
+    max-width: calc(100vw - 24px);
   }
   #controls button {
     background: #333;
     color: var(--text);
     border: 1px solid #555;
-    padding: 3px 8px;
+    padding: 8px 14px;
     cursor: pointer;
-    border-radius: 3px;
-    font-size: 11px;
+    border-radius: 5px;
+    font-size: 13px;
+    min-height: 36px;
+    min-width: 44px;
   }
   #controls button:hover { background: #444; }
-  #controls input[type=range] { width: 140px; }
-  #controls input[type=text] { background: #1a1a1a; color: var(--text); border: 1px solid #555; padding: 3px 6px; font-size: 11px; border-radius: 3px; width: 140px; }
-  #controls label { display: inline-flex; align-items: center; gap: 3px; cursor: pointer; }
+  #controls button:active { background: #555; }
+  #controls button.active { background: #2a5e8e; border-color: #4a8edb; }
+  #controls input[type=range] { width: 160px; height: 32px; }
+  #controls input[type=range]::-webkit-slider-thumb { width: 22px; height: 22px; }
+  #controls input[type=text] {
+    background: #1a1a1a; color: var(--text); border: 1px solid #555;
+    padding: 8px 10px; font-size: 13px; border-radius: 5px; width: 140px;
+    min-height: 36px;
+  }
+  #controls label {
+    display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+    min-height: 36px;
+    padding: 0 4px;
+  }
+  #controls input[type=checkbox] { width: 18px; height: 18px; }
+  #controls .group { display: inline-flex; align-items: center; gap: 6px; }
+  #controls-toggle {
+    display: none;
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
+    width: 48px;
+    height: 48px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 24px;
+    color: var(--text);
+    font-size: 22px;
+    z-index: 51;
+    cursor: pointer;
+    box-shadow: 0 4px 14px rgba(0,0,0,0.5);
+  }
+  @media (max-width: 900px) {
+    #controls {
+      left: 10px;
+      right: 10px;
+      bottom: 64px;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 8px;
+      max-height: 60vh;
+      overflow-y: auto;
+      display: none;
+    }
+    #controls.open { display: flex; }
+    #controls .group { justify-content: space-between; flex-wrap: wrap; }
+    #controls input[type=range] { width: 100%; flex-grow: 1; }
+    #controls input[type=text] { width: 100%; flex-grow: 1; }
+    #controls-toggle { display: flex; align-items: center; justify-content: center; }
+  }
 
   #stage-bg {
     position: absolute;
-    left: 260px;
+    left: var(--label-width, 260px);
     top: 26px;
     bottom: 0;
     z-index: 1;
     pointer-events: none;
   }
+  /* Tree-view connector overlay (parent → child lines) */
+  #tree-connectors {
+    position: absolute;
+    pointer-events: none;
+    z-index: 3;
+    top: 0;
+    left: 0;
+    overflow: visible;
+  }
+  #tree-connectors path { fill: none; stroke-width: 1.5; }
+  /* Tree-view label indent (depth) */
+  .row.tree-depth-1 .label { padding-left: 16px; }
+  .row.tree-depth-2 .label { padding-left: 24px; }
+  .row.tree-depth-3 .label { padding-left: 32px; }
+  .row.tree-depth-4 .label { padding-left: 40px; }
+  .row.tree-depth-5 .label { padding-left: 48px; }
+  .row.tree-depth-6 .label { padding-left: 56px; }
+  .row.tree-depth-7 .label { padding-left: 64px; }
+  .row.tree-depth-8 .label { padding-left: 72px; }
+  /* Tiny tree marker before the label name */
+  .row[class*="tree-depth-"] .label::before {
+    content: "↳ ";
+    color: var(--muted);
+    margin-left: -8px;
+  }
+  .row.tree-depth-0 .label::before { content: none; }
 </style>
 </head>
 <body>
+<button id="pad-up" class="top-fab" aria-label="Shrink top padding" title="Decrease top offset (▲)">▲</button>
+<button id="pad-down" class="top-fab" aria-label="Grow top padding" title="Increase top offset (▼) — push content down past an overlapping app toolbar">▼</button>
+<button id="chrome-toggle" aria-label="Toggle header" title="Hide/show header — claim ~70px of vertical space if your viewer is cutting off the top">⇕</button>
 <div id="header">
   <strong>Bootstrap trace timeline</strong>
   <span class="meta">
@@ -498,7 +854,7 @@ HTML = (
   <span class="leg"><span class="swatch" style="background:#c0c0c0"></span> log/note</span>
   <span class="leg"><span class="swatch" style="background:#4ad06a;border-radius:50%"></span> snapshot (VADE_RUNTIME_DIR present)</span>
   <span class="leg"><span class="swatch" style="background:#ff4a4a;border-radius:50%"></span> snapshot (missing)</span>
-  <span class="leg" style="margin-left:auto">scroll = pan · ⌘/Ctrl+scroll = zoom · click event/snapshot for detail</span>
+  <span class="leg hint" id="hint-text" style="margin-left:auto">scroll = pan · ⌘/Ctrl+scroll = zoom · click event/snapshot for detail</span>
 </div>
 <div id="main">
   <div id="chart-area">
@@ -508,21 +864,35 @@ HTML = (
         <div id="rows"></div>
       </div>
     </div>
+    <button id="controls-toggle" aria-label="Toggle controls">⚙</button>
     <div id="controls">
-      <span>zoom</span>
-      <input type="range" id="zoom" min="0.05" max="30" step="0.05" value="1">
-      <button id="fit">fit window</button>
-      <button id="boot-zoom">boot (0–5s)</button>
-      <span style="margin-left:8px">filter</span>
-      <input type="text" id="filter" placeholder="script name…">
-      <label><input type="checkbox" id="hide-noise" checked> hide wrappers</label>
-      <label><input type="checkbox" id="boot-only" checked> boot window only</label>
+      <div class="group"><span>view</span>
+        <button id="view-rows" class="active">rows</button>
+        <button id="view-tree">tree</button>
+      </div>
+      <div class="group"><span>zoom</span>
+        <input type="range" id="zoom" min="0.05" max="30" step="0.05" value="1">
+      </div>
+      <div class="group">
+        <button id="fit">fit window</button>
+        <button id="boot-zoom">boot (0–5s)</button>
+      </div>
+      <div class="group"><span>filter</span>
+        <input type="text" id="filter" placeholder="script name…">
+      </div>
+      <div class="group">
+        <label><input type="checkbox" id="hide-noise" checked> hide wrappers</label>
+        <label><input type="checkbox" id="boot-only" checked> boot window only</label>
+      </div>
     </div>
   </div>
   <div id="detail-area">
+    <div id="detail-resize" aria-label="Resize panel"></div>
+    <button id="detail-close" aria-label="Close detail">×</button>
     <h3 id="detail-title">Detail</h3>
     <div id="detail-body" class="hint">
-      Click an event or snapshot to inspect it. Scroll the chart with the trackpad/wheel. Hold ⌘ or Ctrl + scroll to zoom.
+      <span class="touch-hint" style="display:none">Tap an event or snapshot to inspect it. Pinch to zoom, drag to pan.</span>
+      <span class="mouse-hint">Click an event or snapshot to inspect it. Scroll the chart with the trackpad/wheel. Hold ⌘ or Ctrl + scroll to zoom.</span>
     </div>
   </div>
 </div>
@@ -538,6 +908,32 @@ const TARGETS = {
   MIN_PX_PER_MS: 0.05,
   MAX_PX_PER_MS: 30,
 };
+// Resolve the actual label width from the CSS --label-width variable, which
+// changes via @media queries. Recompute on resize.
+function getLabelWidth() {
+  const v = getComputedStyle(document.documentElement).getPropertyValue("--label-width").trim();
+  if (v.endsWith("px")) return parseInt(v, 10);
+  return TARGETS.LABEL_WIDTH;
+}
+
+const IS_TOUCH = (("ontouchstart" in window) || (navigator.maxTouchPoints > 0));
+
+// Set --app-vh to the actually-visible viewport height. Fixes iPad in-app
+// WebViews (Files app, Documents-by-Readdle, etc.) where 100dvh reports the
+// full screen behind the app's toolbar overlay, hiding our header.
+// Prefer visualViewport.height when present — it excludes overlaid chrome in
+// most modern iOS/iPadOS WebViews. Fall back to innerHeight.
+function syncAppVh() {
+  const h = (window.visualViewport && window.visualViewport.height) || window.innerHeight;
+  document.documentElement.style.setProperty("--app-vh", h + "px");
+}
+syncAppVh();
+window.addEventListener("resize", syncAppVh);
+window.addEventListener("orientationchange", syncAppVh);
+if (window.visualViewport) {
+  window.visualViewport.addEventListener("resize", syncAppVh);
+  window.visualViewport.addEventListener("scroll", syncAppVh);
+}
 
 let pxPerMs = 0.5;
 const chartInner = document.getElementById("chart-inner");
@@ -545,6 +941,10 @@ const rowsHost = document.getElementById("rows");
 const axisHost = document.getElementById("axis");
 const scroll = document.getElementById("chart-scroll");
 const tooltip = document.getElementById("tooltip");
+const detailArea = document.getElementById("detail-area");
+const detailClose = document.getElementById("detail-close");
+const controlsEl = document.getElementById("controls");
+const controlsToggle = document.getElementById("controls-toggle");
 
 // resolve a script color by name
 function scriptColor(script) {
@@ -580,7 +980,7 @@ function isNoisePid(p) {
   return false;
 }
 
-function visiblePids() {
+function baseVisiblePids() {
   const filterTxt = (document.getElementById("filter").value || "").toLowerCase();
   const hideNoise = document.getElementById("hide-noise").checked;
   const bootOnly = document.getElementById("boot-only").checked;
@@ -592,6 +992,75 @@ function visiblePids() {
   });
 }
 
+// Tree-view layout: preorder traversal of the visible subset. Each visible
+// PID gets a depth (parent's depth + 1 within the visible set), and the
+// order is DFS from earliest root through descendants. Returns
+// {pids: [...visiblePidsInTreeOrder], depthByPid: Map<pid, depth>,
+//  parentInView: Map<pid, parentPid>}.
+function treeOrderedPids() {
+  const base = baseVisiblePids();
+  const baseSet = new Set(base.map(p => p.pid));
+  // For each visible PID, find its nearest visible ancestor by walking ancestor chain
+  const parentInView = new Map();
+  for (const p of base) {
+    if (!p.ancestors) continue;
+    for (const a of p.ancestors) {
+      if (baseSet.has(a.pid)) {
+        parentInView.set(p.pid, a.pid);
+        break;
+      }
+    }
+  }
+  // Build children adjacency from parentInView
+  const childMap = new Map();
+  for (const [child, parent] of parentInView.entries()) {
+    if (!childMap.has(parent)) childMap.set(parent, []);
+    childMap.get(parent).push(child);
+  }
+  // Sort children of each parent by first_ms (earliest spawn first)
+  const pidById = new Map(base.map(p => [p.pid, p]));
+  for (const kids of childMap.values()) {
+    kids.sort((a, b) => pidById.get(a).first_ms - pidById.get(b).first_ms);
+  }
+  // Roots: visible PIDs without a parent in the visible set
+  const roots = base
+    .filter(p => !parentInView.has(p.pid))
+    .sort((a, b) => a.first_ms - b.first_ms);
+  // DFS preorder
+  const pids = [];
+  const depthByPid = new Map();
+  const seen = new Set();
+  function visit(pid, depth) {
+    if (seen.has(pid)) return;
+    seen.add(pid);
+    const p = pidById.get(pid);
+    if (!p) return;
+    pids.push(p);
+    depthByPid.set(pid, depth);
+    for (const c of (childMap.get(pid) || [])) {
+      visit(c, depth + 1);
+    }
+  }
+  for (const r of roots) visit(r.pid, 0);
+  // Safety: any visible PID we missed (cycles, weird data) — append at depth 0
+  for (const p of base) {
+    if (!seen.has(p.pid)) {
+      pids.push(p);
+      depthByPid.set(p.pid, 0);
+    }
+  }
+  return { pids, depthByPid, parentInView };
+}
+
+let viewMode = "rows"; // "rows" | "tree"
+
+function visiblePids() {
+  if (viewMode === "tree") {
+    return treeOrderedPids().pids;
+  }
+  return baseVisiblePids();
+}
+
 function effectiveDurationMs() {
   if (document.getElementById("boot-only").checked) return BOOT_WINDOW_MS;
   return DATA.duration_ms;
@@ -600,12 +1069,22 @@ function effectiveDurationMs() {
 function render() {
   rowsHost.innerHTML = "";
   axisHost.innerHTML = "";
-  // also clear any old snap-lines
-  chartInner.querySelectorAll(".snap-line").forEach(n => n.remove());
+  // also clear any old snap-lines + connectors
+  chartInner.querySelectorAll(".snap-line, #tree-connectors").forEach(n => n.remove());
 
-  const pids = visiblePids();
+  const labelWidth = getLabelWidth();
+  // Compute pids + (if tree mode) depth + parent-in-view map
+  let pids, depthByPid = null, parentInView = null;
+  if (viewMode === "tree") {
+    const t = treeOrderedPids();
+    pids = t.pids;
+    depthByPid = t.depthByPid;
+    parentInView = t.parentInView;
+  } else {
+    pids = baseVisiblePids();
+  }
   const totalMs = effectiveDurationMs();
-  const chartWidth = TARGETS.LABEL_WIDTH + totalMs * pxPerMs + 60;
+  const chartWidth = labelWidth + totalMs * pxPerMs + 60;
   chartInner.style.width = `${chartWidth}px`;
   chartInner.style.height = `${TARGETS.AXIS_HEIGHT + pids.length * TARGETS.ROW_HEIGHT + 40}px`;
 
@@ -615,7 +1094,7 @@ function render() {
   for (let t = 0; t <= totalMs; t += tickStep) {
     const tick = document.createElement("div");
     tick.className = "axis-tick";
-    tick.style.left = `${TARGETS.LABEL_WIDTH + t * pxPerMs}px`;
+    tick.style.left = `${labelWidth + t * pxPerMs}px`;
     tick.textContent = formatMs(t);
     axisHost.appendChild(tick);
   }
@@ -627,9 +1106,16 @@ function render() {
     eventsByPid.get(ev.pid).push(ev);
   }
 
+  const rowIndexByPid = new Map();
   pids.forEach((p, idx) => {
+    rowIndexByPid.set(p.pid, idx);
     const row = document.createElement("div");
-    row.className = "row" + (idx % 2 ? " alt" : "");
+    let cls = "row" + (idx % 2 ? " alt" : "");
+    if (depthByPid) {
+      const d = Math.min(8, depthByPid.get(p.pid) || 0);
+      cls += ` tree-depth-${d}`;
+    }
+    row.className = cls;
     row.style.top = `${idx * TARGETS.ROW_HEIGHT}px`;
     row.style.position = "absolute";
     row.style.left = "0";
@@ -643,7 +1129,7 @@ function render() {
 
     const lane = document.createElement("div");
     lane.className = "lane";
-    lane.style.left = `${TARGETS.LABEL_WIDTH}px`;
+    lane.style.left = `${labelWidth}px`;
     lane.style.width = `${DATA.duration_ms * pxPerMs + 60}px`;
 
     const span = document.createElement("div");
@@ -679,6 +1165,52 @@ function render() {
     rowsHost.appendChild(row);
   });
 
+  // tree-mode connectors: SVG paths from parent → child at the spawn x
+  if (viewMode === "tree" && parentInView && parentInView.size > 0) {
+    const SVG_NS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(SVG_NS, "svg");
+    svg.id = "tree-connectors";
+    svg.setAttribute("width", String(chartWidth));
+    svg.setAttribute("height", String(pids.length * TARGETS.ROW_HEIGHT));
+    svg.style.top = `${TARGETS.AXIS_HEIGHT}px`;
+    svg.style.left = "0";
+    for (const [childPid, parentPid] of parentInView.entries()) {
+      const childIdx = rowIndexByPid.get(childPid);
+      const parentIdx = rowIndexByPid.get(parentPid);
+      const child = pids[childIdx];
+      const parent = pids[parentIdx];
+      if (!child || !parent) continue;
+      const x = labelWidth + child.first_ms * pxPerMs;
+      const py = parentIdx * TARGETS.ROW_HEIGHT + TARGETS.ROW_HEIGHT / 2;
+      const cy = childIdx * TARGETS.ROW_HEIGHT + TARGETS.ROW_HEIGHT / 2;
+      // L-shape: down from parent's bar (slight curve at the corner)
+      // Path: M (x-6, py) → curve to (x, py+8) → vertical down to (x, cy-2) → curve right
+      const path = document.createElementNS(SVG_NS, "path");
+      const r = 6; // corner radius
+      const dy = cy - py;
+      const dir = dy >= 0 ? 1 : -1;
+      const d = [
+        `M ${x - 12} ${py}`,
+        `L ${x - r} ${py}`,
+        `Q ${x} ${py} ${x} ${py + r * dir}`,
+        `L ${x} ${cy - r * dir}`,
+        `Q ${x} ${cy} ${x + r} ${cy}`,
+        `L ${x + 4} ${cy}`,
+      ].join(" ");
+      path.setAttribute("d", d);
+      path.setAttribute("stroke", scriptColor(parent.script));
+      path.setAttribute("opacity", "0.45");
+      svg.appendChild(path);
+      // Small arrowhead at child end (a tiny triangle pointing right)
+      const arrow = document.createElementNS(SVG_NS, "polygon");
+      arrow.setAttribute("points", `${x + 4},${cy - 3} ${x + 9},${cy} ${x + 4},${cy + 3}`);
+      arrow.setAttribute("fill", scriptColor(parent.script));
+      arrow.setAttribute("opacity", "0.55");
+      svg.appendChild(arrow);
+    }
+    chartInner.appendChild(svg);
+  }
+
   // overlay snapshots as vertical lines
   rowsHost.style.position = "absolute";
   rowsHost.style.top = `${TARGETS.AXIS_HEIGHT}px`;
@@ -692,7 +1224,7 @@ function render() {
     const line = document.createElement("div");
     const present = snap.env && snap.env.has_VADE_RUNTIME_DIR;
     line.className = "snap-line " + (snap.env ? (present ? "has-rt" : "no-rt") : "");
-    line.style.left = `${TARGETS.LABEL_WIDTH + snap.ts_ms * pxPerMs}px`;
+    line.style.left = `${labelWidth + snap.ts_ms * pxPerMs}px`;
     line.style.top = `${TARGETS.AXIS_HEIGHT}px`;
     line.style.height = `${pids.length * TARGETS.ROW_HEIGHT}px`;
     const marker = document.createElement("div");
@@ -747,18 +1279,131 @@ function moveTooltip(e) {
 }
 function hideTooltip() { tooltip.style.display = "none"; }
 
+// Lookup helper: find a PID's full record by pid number
+function findPid(pidNum) {
+  return DATA.pids.find(p => p.pid === pidNum);
+}
+
+// Jump to a PID: scroll its row into view, highlight, populate detail
+function jumpToPid(pidNum) {
+  const target = findPid(pidNum);
+  if (target) {
+    showProcDetail(target);
+    // Scroll the chart vertically so the target row is in view
+    const visible = visiblePids();
+    const idx = visible.findIndex(p => p.pid === pidNum);
+    if (idx >= 0) {
+      scroll.scrollTop = Math.max(0, idx * TARGETS.ROW_HEIGHT - 80);
+    } else {
+      // Not in current view (filtered out) — surface a note
+      const body = document.getElementById("detail-body");
+      const note = document.createElement("div");
+      note.style.color = "var(--muted)";
+      note.style.marginTop = "8px";
+      note.style.fontSize = "10px";
+      note.textContent = "(this PID is filtered out of the current view — toggle hide-wrappers or boot-only to see its row)";
+      body.appendChild(note);
+    }
+  }
+}
+
+function pidLinkHtml(linkObj) {
+  // linkObj: {pid, script, tracked} from parent_label OR {pid} from a bare child
+  if (!linkObj) return "<i>none (process root)</i>";
+  const tracked = linkObj.tracked !== false && findPid(linkObj.pid);
+  const colorStyle = tracked ? `color:${scriptColor(linkObj.script)}` : `color:var(--muted)`;
+  const cls = tracked ? "pid-link" : "pid-link-untracked";
+  const label = linkObj.script ? `${linkObj.pid} · ${escapeHtml(linkObj.script)}` : `${linkObj.pid}`;
+  if (tracked) {
+    return `<a href="#" class="${cls}" data-pid="${linkObj.pid}" style="${colorStyle}; text-decoration: underline dotted; cursor: pointer">${label}</a>`;
+  }
+  return `<span style="${colorStyle}">${label}</span>`;
+}
+
 function showProcDetail(p) {
   const title = document.getElementById("detail-title");
   const body = document.getElementById("detail-body");
   title.textContent = `Process · PID ${p.pid}`;
   body.classList.remove("hint");
+
+  // Build ancestor chain as readable cards (root → immediate parent)
+  let ancestorsHtml;
+  if (!p.ancestors || p.ancestors.length === 0) {
+    ancestorsHtml = "<i>none (process root)</i>";
+  } else {
+    // Reverse so the most distant ancestor is at the top
+    const reversed = [...p.ancestors].reverse();
+    ancestorsHtml = '<div class="anc-list">' + reversed.map((a, i) => {
+      const tracked = a.tracked && findPid(a.pid);
+      const cls = tracked ? "tracked" : "untracked";
+      const arrow = i > 0 ? '<span class="anc-arrow">↳</span>' : '';
+      const color = tracked ? `color:${scriptColor(a.script)}` : `color:var(--muted)`;
+      const clickAttr = tracked ? ` data-pid="${a.pid}"` : "";
+      return `<div class="anc-row ${cls}"${clickAttr}>
+        ${arrow}<span class="anc-pid">PID ${a.pid}</span><span class="anc-script" style="${color}">${escapeHtml(a.script)}</span>
+      </div>`;
+    }).join("") + '</div>';
+  }
+
+  // Build children block (tracked only) — use vertical card stack
+  let childrenHtml;
+  if (!p.children || p.children.length === 0) {
+    childrenHtml = "<i>none</i>";
+  } else {
+    childrenHtml = '<div class="children-list">' + p.children.map(cpid => {
+      const c = findPid(cpid);
+      return pidLinkHtml(c ? {pid: c.pid, script: c.script, tracked: true} : {pid: cpid, script: "(not traced)", tracked: false});
+    }).join("") + '</div>';
+  }
+
+  // Build command log
+  let cmdLogHtml = "";
+  if (p.commands && p.commands.length > 0) {
+    const rows = p.commands.map(c => `
+      <div class="cmd-row">
+        <span class="cmd-ts">${formatMs(c.ts_ms)}</span>
+        <span class="cmd-loc">${escapeHtml(c.script)}${c.line ? ":" + c.line : ""}${c.fn !== "MAIN" ? " · " + escapeHtml(c.fn) : ""}</span>
+        <div class="cmd-text">${escapeHtml(c.cmd)}</div>
+      </div>
+    `).join("");
+    const truncNote = p.commands_truncated
+      ? `<div class="cmd-trunc">… showing first ${p.commands.length} of ${p.count} commands (rest elided to keep file size bounded)</div>`
+      : "";
+    cmdLogHtml = `
+      <details class="cmd-log" open>
+        <summary>command log (${p.commands.length}${p.commands_truncated ? "/" + p.count : ""})</summary>
+        <div class="cmd-list">${rows}${truncNote}</div>
+      </details>
+    `;
+  } else {
+    cmdLogHtml = `<details class="cmd-log"><summary>command log</summary><div class="hint" style="padding:6px 0">No commands captured (PID was a brief subprocess with only noise commands).</div></details>`;
+  }
+
   body.innerHTML = `<dl>
     <dt>script</dt><dd style="color:${scriptColor(p.script)}">${escapeHtml(p.script)}</dd>
     <dt>first seen</dt><dd>${formatMs(p.first_ms)}</dd>
     <dt>last seen</dt><dd>${formatMs(p.last_ms)}</dd>
     <dt>lifespan</dt><dd>${(p.last_ms - p.first_ms).toFixed(1)} ms</dd>
     <dt>commands in xtrace</dt><dd>${p.count}</dd>
-  </dl>`;
+    <dt>ancestor chain</dt><dd>${ancestorsHtml}</dd>
+    <dt>children (traced)</dt><dd>${childrenHtml}</dd>
+    ${p.ps_cmd ? `<dt>ps cmd</dt><dd style="color:var(--muted); font-size:10px">${escapeHtml(p.ps_cmd)}</dd>` : ""}
+  </dl>${cmdLogHtml}`;
+
+  // Wire up pid-link and ancestor-card clicks
+  body.querySelectorAll(".pid-link").forEach(el => {
+    el.addEventListener("click", (e) => {
+      e.preventDefault();
+      jumpToPid(parseInt(el.dataset.pid, 10));
+    });
+  });
+  body.querySelectorAll(".anc-row.tracked").forEach(el => {
+    el.addEventListener("click", () => {
+      jumpToPid(parseInt(el.dataset.pid, 10));
+    });
+  });
+
+  openDetail();
 }
 
 function showEventDetail(ev, p) {
@@ -775,6 +1420,7 @@ function showEventDetail(ev, p) {
     ${ev.detail ? `<dt>detail</dt><dd>${escapeHtml(ev.detail)}</dd>` : ""}
     <dt>raw command</dt><dd style="white-space:pre-wrap">${escapeHtml(ev.cmd)}</dd>
   </dl>`;
+  openDetail();
 }
 
 function showSnapDetail(snap) {
@@ -792,6 +1438,7 @@ function showSnapDetail(snap) {
     <dt>VADE_CLOUD_STATE_DIR</dt><dd style="color:${e.has_VADE_CLOUD_STATE_DIR ? '#4ad06a' : '#ff4a4a'}">${e.has_VADE_CLOUD_STATE_DIR ? "present" : "missing"}</dd>
     <dt>snapshot dir</dt><dd>${escapeHtml(snap.dir)}</dd>
   </dl>`;
+  openDetail();
 }
 
 function typeColor(t) {
@@ -805,49 +1452,241 @@ function typeColor(t) {
 // Zoom controls
 const zoomInput = document.getElementById("zoom");
 zoomInput.addEventListener("input", () => { pxPerMs = parseFloat(zoomInput.value); render(); });
-document.getElementById("fit").addEventListener("click", () => {
-  const usable = scroll.clientWidth - TARGETS.LABEL_WIDTH - 60;
-  pxPerMs = Math.max(TARGETS.MIN_PX_PER_MS, Math.min(TARGETS.MAX_PX_PER_MS, usable / effectiveDurationMs()));
+function fitToWindow(targetMs) {
+  const usable = scroll.clientWidth - getLabelWidth() - 60;
+  pxPerMs = Math.max(TARGETS.MIN_PX_PER_MS, Math.min(TARGETS.MAX_PX_PER_MS, usable / targetMs));
   zoomInput.value = pxPerMs;
   render();
   scroll.scrollLeft = 0;
-});
-document.getElementById("boot-zoom").addEventListener("click", () => {
-  const usable = scroll.clientWidth - TARGETS.LABEL_WIDTH - 60;
-  pxPerMs = Math.max(TARGETS.MIN_PX_PER_MS, Math.min(TARGETS.MAX_PX_PER_MS, usable / 5000));
-  zoomInput.value = pxPerMs;
-  render();
-  scroll.scrollLeft = 0;
-});
+}
+document.getElementById("fit").addEventListener("click", () => fitToWindow(effectiveDurationMs()));
+document.getElementById("boot-zoom").addEventListener("click", () => fitToWindow(5000));
 document.getElementById("filter").addEventListener("input", render);
 document.getElementById("hide-noise").addEventListener("change", render);
 document.getElementById("boot-only").addEventListener("change", render);
+
+// View-mode toggle
+const VIEW_KEY = "vade-trace-view";
+function setViewMode(mode) {
+  viewMode = mode;
+  localStorage.setItem(VIEW_KEY, mode);
+  document.getElementById("view-rows").classList.toggle("active", mode === "rows");
+  document.getElementById("view-tree").classList.toggle("active", mode === "tree");
+  render();
+}
+document.getElementById("view-rows").addEventListener("click", () => setViewMode("rows"));
+document.getElementById("view-tree").addEventListener("click", () => setViewMode("tree"));
+// Restore preference
+viewMode = localStorage.getItem(VIEW_KEY) || "rows";
+document.getElementById("view-rows").classList.toggle("active", viewMode === "rows");
+document.getElementById("view-tree").classList.toggle("active", viewMode === "tree");
+
+// --- Zoom around a focal point (used by wheel + pinch) ---
+function zoomAround(clientX, factor) {
+  const labelWidth = getLabelWidth();
+  const rect = scroll.getBoundingClientRect();
+  const xInChart = scroll.scrollLeft + (clientX - rect.left) - labelWidth;
+  const msAtPointer = xInChart / pxPerMs;
+  const next = Math.max(TARGETS.MIN_PX_PER_MS, Math.min(TARGETS.MAX_PX_PER_MS, pxPerMs * factor));
+  if (next === pxPerMs) return false;
+  pxPerMs = next;
+  zoomInput.value = pxPerMs;
+  render();
+  scroll.scrollLeft = msAtPointer * pxPerMs - (clientX - rect.left - labelWidth);
+  return true;
+}
 
 // wheel zoom (ctrl/cmd)
 scroll.addEventListener("wheel", (e) => {
   if (!(e.ctrlKey || e.metaKey)) return;
   e.preventDefault();
-  const rect = scroll.getBoundingClientRect();
-  const xInChart = scroll.scrollLeft + (e.clientX - rect.left) - TARGETS.LABEL_WIDTH;
-  const msAtPointer = xInChart / pxPerMs;
   const factor = e.deltaY < 0 ? 1.2 : 1 / 1.2;
-  const next = Math.max(TARGETS.MIN_PX_PER_MS, Math.min(TARGETS.MAX_PX_PER_MS, pxPerMs * factor));
-  if (next === pxPerMs) return;
-  pxPerMs = next;
-  zoomInput.value = pxPerMs;
-  render();
-  scroll.scrollLeft = msAtPointer * pxPerMs + (e.clientX - rect.left - TARGETS.LABEL_WIDTH) * 0 + TARGETS.LABEL_WIDTH - (e.clientX - rect.left);
-  scroll.scrollLeft = msAtPointer * pxPerMs - (e.clientX - rect.left - TARGETS.LABEL_WIDTH);
+  zoomAround(e.clientX, factor);
 }, { passive: false });
+
+// --- iOS Safari pinch zoom on the chart area ---
+// `gesturestart`/`gesturechange`/`gestureend` give us a `scale` ratio.
+// We project that onto pxPerMs and keep the pinch midpoint anchored.
+let gestureBasePx = pxPerMs;
+let gestureCenterX = 0;
+const chartArea = document.getElementById("chart-area");
+chartArea.addEventListener("gesturestart", (e) => {
+  e.preventDefault();
+  gestureBasePx = pxPerMs;
+  // approximate midpoint from clientX/clientY (Safari sets these on gesture)
+  gestureCenterX = (e.clientX != null) ? e.clientX : (chartArea.getBoundingClientRect().left + chartArea.clientWidth / 2);
+}, { passive: false });
+chartArea.addEventListener("gesturechange", (e) => {
+  e.preventDefault();
+  const target = Math.max(TARGETS.MIN_PX_PER_MS, Math.min(TARGETS.MAX_PX_PER_MS, gestureBasePx * e.scale));
+  if (Math.abs(target - pxPerMs) < 1e-4) return;
+  const factor = target / pxPerMs;
+  zoomAround(gestureCenterX, factor);
+}, { passive: false });
+chartArea.addEventListener("gestureend", (e) => { e.preventDefault(); }, { passive: false });
+
+// --- Fallback pinch zoom for browsers without iOS gesture events ---
+// Use Pointer Events to track two simultaneous touches.
+const activePointers = new Map();
+let pinchInitialDist = 0;
+let pinchBasePx = pxPerMs;
+let pinchCenterX = 0;
+scroll.addEventListener("pointerdown", (e) => {
+  if (e.pointerType !== "touch") return;
+  activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+  if (activePointers.size === 2) {
+    const [a, b] = [...activePointers.values()];
+    pinchInitialDist = Math.hypot(a.x - b.x, a.y - b.y);
+    pinchBasePx = pxPerMs;
+    pinchCenterX = (a.x + b.x) / 2;
+  }
+});
+scroll.addEventListener("pointermove", (e) => {
+  if (e.pointerType !== "touch" || !activePointers.has(e.pointerId)) return;
+  activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+  if (activePointers.size === 2 && pinchInitialDist > 0) {
+    const [a, b] = [...activePointers.values()];
+    const dist = Math.hypot(a.x - b.x, a.y - b.y);
+    const scaleRatio = dist / pinchInitialDist;
+    const target = Math.max(TARGETS.MIN_PX_PER_MS, Math.min(TARGETS.MAX_PX_PER_MS, pinchBasePx * scaleRatio));
+    if (Math.abs(target - pxPerMs) > 1e-4) {
+      const factor = target / pxPerMs;
+      zoomAround(pinchCenterX, factor);
+    }
+    e.preventDefault();
+  }
+}, { passive: false });
+function endPointer(e) {
+  if (activePointers.has(e.pointerId)) activePointers.delete(e.pointerId);
+  if (activePointers.size < 2) pinchInitialDist = 0;
+}
+scroll.addEventListener("pointerup", endPointer);
+scroll.addEventListener("pointercancel", endPointer);
+scroll.addEventListener("pointerleave", endPointer);
+
+// --- Detail-area open/close on narrow screens ---
+function isNarrow() { return window.matchMedia("(max-width: 900px)").matches; }
+function openDetail() {
+  if (isNarrow()) detailArea.classList.add("open");
+}
+function closeDetail() {
+  detailArea.classList.remove("open");
+}
+detailClose.addEventListener("click", closeDetail);
+
+// --- Controls toggle on narrow screens ---
+controlsToggle.addEventListener("click", () => {
+  controlsEl.classList.toggle("open");
+});
+// Close controls panel when tapping outside (on narrow screens)
+document.addEventListener("click", (e) => {
+  if (!isNarrow()) return;
+  if (controlsEl.contains(e.target) || controlsToggle.contains(e.target)) return;
+  controlsEl.classList.remove("open");
+});
+
+// --- Header/legend chrome toggle (claims vertical space in cut-off viewers) ---
+const chromeToggle = document.getElementById("chrome-toggle");
+const CHROME_KEY = "vade-trace-chrome";
+function applyChrome() {
+  const state = localStorage.getItem(CHROME_KEY) || "visible";
+  document.body.dataset.chrome = state;
+  chromeToggle.textContent = state === "hidden" ? "▾" : "▴";
+  chromeToggle.title = state === "hidden"
+    ? "Show header (currently hidden)"
+    : "Hide header — claim ~70px of vertical space if your viewer is cutting off the top";
+  // After toggling chrome, re-fit because #main height just changed
+  setTimeout(() => render(), 0);
+}
+chromeToggle.addEventListener("click", () => {
+  const next = (localStorage.getItem(CHROME_KEY) || "visible") === "visible" ? "hidden" : "visible";
+  localStorage.setItem(CHROME_KEY, next);
+  applyChrome();
+});
+applyChrome();
+
+// --- Manual top-offset nudge (▲/▼). Pushes the layout down so an
+// overlapping app toolbar (iPad Files viewer, etc.) stops cutting the top.
+// Persists per-device via localStorage so the user only tunes it once.
+const OFFSET_KEY = "vade-trace-offset";
+const OFFSET_STEP = 20;
+const OFFSET_MAX = 500;
+function getOffset() { return parseInt(localStorage.getItem(OFFSET_KEY) || "0", 10) || 0; }
+function setOffset(v) {
+  v = Math.max(0, Math.min(OFFSET_MAX, v));
+  localStorage.setItem(OFFSET_KEY, String(v));
+  document.documentElement.style.setProperty("--manual-offset", v + "px");
+  setTimeout(() => render(), 0);
+}
+document.getElementById("pad-down").addEventListener("click", () => setOffset(getOffset() + OFFSET_STEP));
+document.getElementById("pad-up").addEventListener("click", () => setOffset(getOffset() - OFFSET_STEP));
+setOffset(getOffset());
+
+// --- Resizable detail sidebar (desktop / wide-viewport only) ---
+const detailResize = document.getElementById("detail-resize");
+const DETAIL_WIDTH_KEY = "vade-trace-detail-width";
+const initialDetailWidth = parseInt(localStorage.getItem(DETAIL_WIDTH_KEY) || "340", 10);
+document.documentElement.style.setProperty("--detail-width", initialDetailWidth + "px");
+(function wireDetailResize() {
+  let dragging = false;
+  let startX = 0;
+  let startW = 0;
+  function pxFromEvent(e) {
+    return (e.touches && e.touches[0]) ? e.touches[0].clientX : e.clientX;
+  }
+  function onMove(e) {
+    if (!dragging) return;
+    const dx = startX - pxFromEvent(e); // drag left = larger
+    const next = Math.max(280, Math.min(window.innerWidth * 0.7, startW + dx));
+    document.documentElement.style.setProperty("--detail-width", next + "px");
+    if (e.cancelable) e.preventDefault();
+  }
+  function onEnd() {
+    if (!dragging) return;
+    dragging = false;
+    detailResize.classList.remove("dragging");
+    const w = parseInt(getComputedStyle(detailArea).width, 10);
+    localStorage.setItem(DETAIL_WIDTH_KEY, String(w));
+    // re-fit chart after width change
+    render();
+  }
+  detailResize.addEventListener("pointerdown", (e) => {
+    dragging = true;
+    startX = pxFromEvent(e);
+    startW = parseInt(getComputedStyle(detailArea).width, 10);
+    detailResize.classList.add("dragging");
+    detailResize.setPointerCapture(e.pointerId);
+  });
+  detailResize.addEventListener("pointermove", onMove);
+  detailResize.addEventListener("pointerup", onEnd);
+  detailResize.addEventListener("pointercancel", onEnd);
+})();
+
+// --- Touch hint swap ---
+if (IS_TOUCH) {
+  document.querySelectorAll(".touch-hint").forEach(n => n.style.display = "");
+  document.querySelectorAll(".mouse-hint").forEach(n => n.style.display = "none");
+  const ht = document.getElementById("hint-text");
+  if (ht) ht.textContent = "drag = pan · pinch = zoom · tap event/snapshot for detail";
+}
 
 setMeta();
 // initial fit
-window.addEventListener("load", () => {
-  const usable = scroll.clientWidth - TARGETS.LABEL_WIDTH - 60;
+function initialFit() {
+  const usable = scroll.clientWidth - getLabelWidth() - 60;
   pxPerMs = Math.max(TARGETS.MIN_PX_PER_MS, Math.min(TARGETS.MAX_PX_PER_MS, usable / Math.min(5000, BOOT_WINDOW_MS)));
   zoomInput.value = pxPerMs;
   render();
+}
+window.addEventListener("load", initialFit);
+
+// --- Re-render on resize / orientation change so label-width media query takes effect ---
+let resizeTimer = 0;
+window.addEventListener("resize", () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => render(), 100);
 });
+window.addEventListener("orientationchange", () => setTimeout(initialFit, 200));
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Promotes the iPad-tuning + observability features developed in interactive `/debug-mode` sessions today so they reproduce in fresh containers, until the proper VADE Console (briefing-33 / vade-app/vade-coo-memory#800) replaces this static HTML viewer.

Closes vade-app/vade-runtime#283.

## What changed

**iPad / touch** — viewport-fit cover, safe-area-inset, visualViewport-based vh; two-finger pinch zoom (iOS gesture + pointer-event fallback); slide-in detail sheet on narrow viewports; collapsible controls; larger tap targets; top-right `⇕` / `▲` / `▼` escape hatches for in-app WebViews whose toolbar overlays the page (Files-app, Documents, etc.) — all persist via localStorage.

**Detail panel** — resizable right sidebar (drag left edge); ancestor chain as readable cards (no mid-word wrapping); traced-children list; expandable per-PID command log (up to ~80 commands · script:line · function · raw bash; noise scripts suppressed).

**Tree view** — new `rows` / `tree` toggle in the controls bar. Tree mode reorders by parent→child preorder, indents labels by depth, draws SVG L-shaped connectors with arrowheads from each parent's bar at the child's spawn-x down/up to the child's row.

**Parser** — captures per-PID command logs (capped, noise-filtered); scans `snapshots/*/metadata/processes.txt` for PID→PPID; `ancestor_chain()` prefers ps-side identity over xtrace identity (clean handling of PID reuse — e.g. PID 2213 starts as `claude` per ps but our xtrace re-uses 2213 for a later bash subprocess; the chain shows `claude` at PID 2213).

**SKILL.md** — updated orientation, capability list, and "what the timeline can/can't answer" tables to reflect the new affordances.

## Reproducing in a fresh session

After this merges, any session that invokes the `trace-timeline` skill on a captured run gets the full feature set out of the box — no manual edits. Use case: `/debug-mode` flagged something interesting, you want to visualize on iPad.

## Lifecycle

Bridging changes. The proper home for this work is briefing-33's VADE Console v0. When that lands:
- The Python renderer flips from "emit HTML" to "emit JSON" only.
- The UI moves to a React app served at `console.vade-app.dev`.
- This skill flips to "open the URL with the right run-id".

## Test plan

- [x] Renderer produces valid HTML (~4 MB) without errors on the current trace
- [x] iPad layout fixes verified by user on iPadOS file viewer in interactive session
- [x] Tree view produces sensible connectors and depth labels
- [ ] Verified in a fresh session by re-rendering against a captured run (post-merge)

https://claude.ai/code/session_011hi9AEPZshgF6QMjmLx48e