### PR TITLE
feat: bridge workflow + mirrored templates (vade-coo-memory#811)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,76 @@
+name: Bug
+description: A defect — existing behavior diverges from intended.
+title: "Bug: <short description>"
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Bug
+
+        Existing behavior diverges from what's intended. Use this template
+        for regressions, broken features, and unexpected outputs.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Steps to reproduce the bug. Be specific enough that someone else can hit the same state.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-observed
+    attributes:
+      label: Expected vs observed
+      description: What you expected to happen, and what actually happened.
+      placeholder: |
+        **Expected:** ...
+
+        **Observed:** ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Environment, recent changes, related issues. Use hyphenated MEMO
+        autolink form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,61 @@
+name: Chore
+description: Build, tooling, infra, housekeeping.
+title: "Chore: <short description>"
+type: Chore
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Chore
+
+        Housekeeping: build, tooling, infrastructure, dependency updates,
+        substrate hygiene. Use for work that doesn't ship user-facing
+        behavior but keeps the system running.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-paragraph description of what needs doing and why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,59 @@
+name: Docs
+description: Documentation-only change.
+title: "Docs: <short description>"
+type: Docs
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Docs
+
+        Documentation-only changes — new operations docs, foundation
+        essays, retrospective entries, README updates, or memo paired
+        files. For code changes that include incidental doc updates use
+        the corresponding code type instead.
+
+        Only the Priority widget bridges to a native field; Docs are not
+        pinned to a Readiness field (they ship when written).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What documentation needs writing / changing, and where it should live.
+    validations:
+      required: true
+
+  - type: textarea
+    id: source-of-truth
+    attributes:
+      label: Source-of-truth pointer
+      description: |
+        Is there an existing file this doc supersedes or paired with? If yes, name it.
+        For new memos / operations docs, list the memo IDs / paired artifacts.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,18 +1,18 @@
 name: Epic
 description: A parent issue that tracks multiple implementable child issues.
 title: "Epic: <short description>"
-labels: ["type:epic", "readiness:needs-breakdown"]
+type: Epic
 body:
   - type: markdown
     attributes:
       value: |
-        # Epic creation
+        # Epic
 
         Epics organize multi-issue work. After creating this issue, use the
         GitHub UI's **"Add sub-issue"** button on this issue to formally link
         each child issue (or use the GraphQL `addSubIssue` mutation).
 
-        Native sub-issue linkage is **required** for `type:epic` issues per
+        Native sub-issue linkage is **required** for Epic-type issues per
         [`coo/operations/issue-pr-hygiene.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/issue-pr-hygiene.md)
         + [`coo/label_taxonomy.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md) §6 —
         markdown checklists of `#N` references in the epic body are insufficient
@@ -20,13 +20,21 @@ body:
         tracker UI.
 
         The hygiene workflow will emit an advisory comment if no native
-        sub-issues are linked once you label this issue `type:epic`.
+        sub-issues are linked once this issue is given the Epic type.
+
+        Native-field widgets at the bottom are bridged to the issue's
+        native fields by a workflow on creation. Start date / Target date
+        are not pre-elicited here; set them in the issue's side panel
+        once the epic is scheduled.
 
   - type: textarea
     id: summary
     attributes:
       label: Summary
       description: One-paragraph description of what this epic is about and what shipping it looks like.
+      placeholder: |
+        e.g., "Migrate the five repos from `proj:*` labels to GitHub native
+        sub-issues so the project board's tracker UI reflects real progress."
     validations:
       required: true
 
@@ -35,6 +43,10 @@ body:
     attributes:
       label: Success criteria
       description: How we'll know this epic is done. Specific and falsifiable.
+      placeholder: |
+        - All 18 currently-non-compliant epics across the five repos have at
+          least one sub-issue linked via the native API.
+        - The project board's tracker column reflects native sub-issue counts.
     validations:
       required: true
 
@@ -45,8 +57,9 @@ body:
       description: |
         After creating this epic, click "Add sub-issue" on this issue's right-side
         panel to formally link each child. Use this textarea ONLY for a working
-        scratchpad of sub-issue candidates BEFORE they become real sub-issues.
-        Native sub-issues are the source-of-truth.
+        scratchpad of sub-issue candidates BEFORE they become real sub-issues
+        (e.g., "we'll need an issue for X"). Native sub-issues are the
+        source-of-truth.
       placeholder: |
         Working scratch — replace with native sub-issue links once filed:
           - [ ] Stream 1: <description>
@@ -63,7 +76,7 @@ body:
         form `vade-app/<repo>#N` for cross-repo references (NEVER bare `#N` —
         that autolinks to the wrong issue).
       placeholder: |
-        - vade-app/vade-coo-memory#NNN — describe dependency
+        - vade-app/vade-runtime#NNN — describe dependency
         - vade-app/vade-core#NNN — describe dependency
     validations:
       required: false
@@ -76,5 +89,48 @@ body:
         Background, prior memos, related epics. Use hyphenated MEMO autolink
         form (`MEMO-YYYY-MM-DD-<suffix>`) and dash form for non-issue IDs
         (`quorum-N`, `briefing-N`, `instance-N`).
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Needs breakdown
+        - Ready
+        - Needs design
+        - Needs research
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      description: Estimated effort. XS → XL. Bridged to the native Effort field.
+      options:
+        - L
+        - XS
+        - S
+        - M
+        - XL
+      default: 0
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,71 @@
+name: Feature
+description: New user-facing capability.
+title: "Feature: <short description>"
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Feature
+
+        A new user-facing capability. For internal restructuring use
+        **Refactor**; for housekeeping use **Chore**.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+
+  - type: textarea
+    id: user-capability
+    attributes:
+      label: User capability
+      description: What can the user do after this ships that they couldn't do before? Frame from the user's perspective.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Specific, falsifiable conditions for completion.
+      placeholder: |
+        - [ ] <condition 1>
+        - [ ] <condition 2>
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,76 @@
+name: Refactor
+description: Internal restructuring without behavior change.
+title: "Refactor: <short description>"
+type: Refactor
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Refactor
+
+        Internal restructuring that does not change observable behavior.
+        Pure code/data re-arrangement. If behavior changes — even
+        slightly — use **Feature** or **Bug** instead.
+
+        Native-field widgets at the bottom (Priority, Effort) are
+        bridged to the issue's native fields by a workflow on creation.
+        Refactor is not pinned to Readiness (it's typically picked up
+        opportunistically).
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What's being restructured. Files, modules, packages, or conceptual layers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior-unchanged
+    attributes:
+      label: Behavior-unchanged check
+      description: |
+        How you'll verify external behavior didn't change. Existing tests
+        passing is usually sufficient; for boundary cases, name the
+        specific behaviors you've confirmed remain equivalent.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      description: Estimated effort. XS → XL. Bridged to the native Effort field.
+      options:
+        - M
+        - XS
+        - S
+        - L
+        - XL
+      default: 0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/research.yml
+++ b/.github/ISSUE_TEMPLATE/research.yml
@@ -1,0 +1,119 @@
+name: Research
+description: Spike, investigation, deep-dive — produces findings, not merged code.
+title: "Research: <short description>"
+type: Research
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Research
+
+        Spikes, investigations, deep-dives that produce findings (memos,
+        foundation essays, operations docs, briefings, or scoped
+        code-spikes). The deliverable is **understanding made durable**,
+        not a feature ship.
+
+        Native-field widgets at the bottom are bridged to the issue's
+        native fields by a workflow on creation. The custom fields
+        `Research question` and `Output kind` are pinned to Research.
+
+  - type: textarea
+    id: research-question
+    attributes:
+      label: Research question
+      description: The specific question to investigate. One sentence; bridged to the native `Research question` field.
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Approach
+      description: How you plan to investigate. Sources to read, experiments to run, instances/agents to consult.
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected-output
+    attributes:
+      label: Expected output
+      description: What artifact this will produce — memo, foundation essay, operations doc, briefing, or code-spike. Match the `Output kind` selection below.
+    validations:
+      required: false
+
+  - type: textarea
+    id: done-when
+    attributes:
+      label: Done when
+      description: Specific, falsifiable conditions for closing this issue. Research issues benefit from a clear close-when since they can drift.
+      placeholder: |
+        - [ ] <finding 1 reached>
+        - [ ] <artifact 1 published>
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      description: Estimated effort. XS → XL. Bridged to the native Effort field.
+      options:
+        - M
+        - XS
+        - S
+        - L
+        - XL
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: output-kind
+    attributes:
+      label: Output kind
+      description: Type of artifact this research will produce. Bridged to the native Output kind field.
+      options:
+        - memo
+        - foundation-essay
+        - operations-doc
+        - briefing
+        - code-spike
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/skill.yml
+++ b/.github/ISSUE_TEMPLATE/skill.yml
@@ -1,0 +1,109 @@
+name: Skill
+description: Skill lifecycle work (implement / review / revise / evaluate / idea).
+title: "Skill: <skill-name> — <phase>"
+type: Skill
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Skill
+
+        Skill lifecycle work — the new axis surfaced by issue fields.
+        Use this for any work on a `.claude/skills/<name>/` skill:
+        ideating, implementing, reviewing the SKILL.md, revising after
+        usage, or evaluating effectiveness.
+
+        Native-field widgets at the bottom are bridged to the issue's
+        native fields by a workflow on creation. The custom fields
+        `Skill kind` and `Skill name` are pinned to Skill.
+
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill name
+      description: Canonical skill name (e.g. `memo-search`, `debug-mode`, `peer-review`). Matches the directory name under `.claude/skills/`. Bridged to the native `Skill name` field.
+      placeholder: <skill-name>
+    validations:
+      required: true
+
+  - type: dropdown
+    id: skill-kind
+    attributes:
+      label: Skill kind
+      description: Lifecycle phase. Bridged to the native `Skill kind` field.
+      options:
+        - idea
+        - implement
+        - review
+        - revise
+        - evaluate
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope of this phase
+      description: What this specific lifecycle step accomplishes. For `idea`, sketch the trigger and shape. For `implement`, the deliverable file path. For `review`/`revise`, what's being evaluated against what.
+    validations:
+      required: true
+
+  - type: textarea
+    id: adoption-test
+    attributes:
+      label: Adoption test
+      description: How will we know this skill is actually used? Or for `idea`-phase, what signals would trigger its use?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior skill versions, related issues. Use hyphenated MEMO
+        autolink form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      description: Estimated effort. XS → XL. Bridged to the native Effort field.
+      options:
+        - M
+        - XS
+        - S
+        - L
+        - XL
+      default: 0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,74 @@
+name: Task
+description: Default kind of implementable work that doesn't fit another type.
+title: "Task: <short description>"
+type: Task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Task
+
+        Use this template for default implementable work. For multi-step
+        parent issues use the **Epic** template instead. For defects use
+        **Bug**; for new user-facing capabilities use **Feature**.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+        See [`coo/operations/issue-fields-and-types.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/issue-fields-and-types.md).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-paragraph description of what this task is and what shipping looks like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Specific, falsifiable conditions for completion.
+      placeholder: |
+        - [ ] <condition 1>
+        - [ ] <condition 2>
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form (`MEMO-YYYY-MM-DD-<suffix>`) and full cross-repo form
+        (`vade-app/<repo>#N`) for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -1,0 +1,72 @@
+name: Test
+description: Test coverage, fixtures, harness work.
+title: "Test: <short description>"
+type: Test
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Test
+
+        Test coverage additions, fixture management, harness work. For
+        the actual bug being tested use **Bug** with a linked Test issue,
+        not this template.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+
+  - type: textarea
+    id: what-being-tested
+    attributes:
+      label: What's being tested
+      description: The component, behavior, regression, or boundary case this test covers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: linked-issue
+    attributes:
+      label: Linked issue
+      description: |
+        The bug or feature this test addresses. Use full cross-repo form
+        (`vade-app/<repo>#N`) for cross-repo references; bare `#N` resolves
+        wrong.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/workflows/bridge-form-fields-to-natives.yml
+++ b/.github/workflows/bridge-form-fields-to-natives.yml
@@ -1,0 +1,68 @@
+name: Bridge issue-form widgets to native fields (reusable)
+
+# Reusable workflow that parses an issue body for `### <Label>\n\n<value>`
+# sections produced by the issue-form templates (`task.yml`, `bug.yml`, etc.
+# in vade-app/vade-coo-memory and mirrored across the four primary repos)
+# and writes the corresponding native Issue field values via the
+# `setIssueFieldValue` GraphQL mutation.
+#
+# Called from per-repo trigger workflows (`bridge-form-fields-trigger.yml`)
+# in vade-coo-memory / vade-runtime / vade-core / vade-agent-logs.
+#
+# Canonical design: vade-app/vade-coo-memory#811 + MEMO-2026-05-21-xfqh.
+# Pinning matrix + field IDs: coo/operations/issue-fields-and-types.md.
+#
+# Fires only on `issues.opened` (one-shot bridging at creation time).
+# Body-edits do not re-trigger — users update native fields via the
+# issue's side panel after creation, not by editing body sections.
+#
+# Prerequisites in each caller repo:
+#   - `secrets.GITHUB_MCP_PAT` — fine-grained PAT with org-level Issue
+#     fields write scope (the same PAT the COO sessions use).
+#
+# Cross-repo workflow access requires vade-app/vade-runtime's
+# Settings → Actions → General → Access set to
+# "Accessible from repositories in the 'vade-app' organization".
+
+on:
+  workflow_call:
+    inputs:
+      issue-number:
+        description: Issue number to bridge.
+        type: number
+        required: true
+      repo-full-name:
+        description: Full owner/repo of the calling repository (e.g. vade-app/vade-coo-memory).
+        type: string
+        required: true
+      dry-run:
+        description: If true, print intended mutations without applying.
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      ISSUE_FIELDS_ADMIN_PAT:
+        description: PAT with org-level Issue fields write scope.
+        required: true
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  bridge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout vade-runtime (script source)
+        uses: actions/checkout@v4
+        with:
+          repository: vade-app/vade-runtime
+          ref: main
+
+      - name: Run bridge
+        env:
+          GH_TOKEN: ${{ secrets.ISSUE_FIELDS_ADMIN_PAT }}
+          REPO_FULL_NAME: ${{ inputs.repo-full-name }}
+          ISSUE_NUMBER: ${{ inputs.issue-number }}
+          DRY_RUN: ${{ inputs.dry-run && '1' || '0' }}
+        run: python3 scripts/bridge-form-fields-to-natives.py

--- a/.github/workflows/bridge-form-fields-trigger.yml
+++ b/.github/workflows/bridge-form-fields-trigger.yml
@@ -1,0 +1,38 @@
+name: Bridge issue-form widgets to native fields (trigger)
+
+# Triggers the bridge reusable workflow at
+# vade-app/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml
+# whenever an issue is opened in this repository.
+#
+# This file is hand-mirrored across vade-coo-memory / vade-runtime /
+# vade-core / vade-agent-logs. Edit canonical in vade-coo-memory and
+# port to siblings (workflow-sync convention; see
+# coo/operations/issue-pr-hygiene.md).
+#
+# Bridge design + script source: vade-app/vade-runtime#TBD.
+# Stage 2 design: vade-app/vade-coo-memory#811.
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to re-bridge.
+        required: true
+        type: number
+      dry_run:
+        description: Dry-run (print intended mutations without applying).
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  bridge:
+    uses: vade-app/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml@main
+    with:
+      issue-number: ${{ github.event.issue.number || inputs.issue_number }}
+      repo-full-name: ${{ github.repository }}
+      dry-run: ${{ inputs.dry_run || false }}
+    secrets:
+      ISSUE_FIELDS_ADMIN_PAT: ${{ secrets.GITHUB_MCP_PAT }}

--- a/scripts/bridge-form-fields-to-natives.py
+++ b/scripts/bridge-form-fields-to-natives.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""bridge-form-fields-to-natives.py
+
+Parse a GitHub issue body for `### <Label>\\n\\n<value>` sections produced
+by issue-form templates, look up the corresponding org-level Issue field
+in the `vade-app` organization, and call `setIssueFieldValue` to populate
+the native field.
+
+Invoked from `.github/workflows/bridge-form-fields-to-natives.yml`
+(reusable workflow in vade-runtime) on `issues.opened` events in
+caller repos. Stage 2 of the issue-fields-and-types migration
+(MEMO-2026-05-21-xfqh + vade-coo-memory#811).
+
+Inputs (env):
+    GH_TOKEN          PAT with org-level Issue field admin scope.
+    REPO_FULL_NAME    e.g. "vade-app/vade-coo-memory".
+    ISSUE_NUMBER      Numeric issue number.
+    DRY_RUN           If "1", print intended mutations without applying.
+
+Exit codes:
+    0 — success (mutations applied, or nothing to do)
+    1 — fatal error (token missing, issue not found, GraphQL failure)
+
+The script is intentionally fail-loud rather than fail-silent: when an
+option name in the body doesn't match any field option, it logs the
+mismatch and continues (the other matched sections still apply).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+from typing import Any
+
+ORG = "vade-app"
+GRAPHQL_URL = "https://api.github.com/graphql"
+REST_BASE = "https://api.github.com"
+
+
+def env(name: str, *, required: bool = True, default: str | None = None) -> str:
+    val = os.environ.get(name, default)
+    if required and not val:
+        sys.stderr.write(f"[bridge] missing required env: {name}\n")
+        sys.exit(1)
+    return val or ""
+
+
+def gh_rest(path: str) -> dict[str, Any]:
+    req = urllib.request.Request(
+        f"{REST_BASE}/{path.lstrip('/')}",
+        headers={
+            "Authorization": f"Bearer {GH_TOKEN}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read())
+
+
+def gh_graphql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+    body = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        GRAPHQL_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {GH_TOKEN}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as r:
+        result = json.loads(r.read())
+    if result.get("errors"):
+        sys.stderr.write(f"[bridge] graphql errors: {json.dumps(result['errors'])}\n")
+        sys.exit(1)
+    return result["data"]
+
+
+def parse_body(body: str) -> dict[str, str]:
+    """Parse issue-form-rendered body into {label: value} sections.
+
+    Issue forms render each non-markdown widget as:
+        ### <Label>
+
+        <value>
+
+    Multi-line textareas get multi-line values. Unfilled widgets render
+    `_No response_`, which we skip.
+    """
+    if not body:
+        return {}
+    sections: dict[str, str] = {}
+    pattern = re.compile(r"^### (.+?)$\n+(.*?)(?=\n### |\Z)", re.M | re.S)
+    for match in pattern.finditer(body):
+        label = match.group(1).strip()
+        value = match.group(2).strip()
+        if value in ("_No response_", "", "_No response_."):
+            continue
+        sections[label] = value
+    return sections
+
+
+def fetch_org_fields() -> dict[str, dict[str, Any]]:
+    """Fetch all org-level Issue fields, return name -> spec dict."""
+    query = """
+    query($org: String!) {
+      organization(login: $org) {
+        issueFields(first: 50) {
+          nodes {
+            ... on IssueFieldSingleSelect {
+              id
+              name
+              dataType
+              singleSelectOptions { id name }
+            }
+            ... on IssueFieldText {
+              id
+              name
+              dataType
+            }
+            ... on IssueFieldDate {
+              id
+              name
+              dataType
+            }
+            ... on IssueFieldNumber {
+              id
+              name
+              dataType
+            }
+          }
+        }
+      }
+    }
+    """
+    data = gh_graphql(query, {"org": ORG})
+    nodes = data["organization"]["issueFields"]["nodes"]
+    fields: dict[str, dict[str, Any]] = {}
+    for node in nodes:
+        if not node or "name" not in node:
+            continue
+        spec = {
+            "id": node["id"],
+            "dataType": node["dataType"],
+        }
+        if node["dataType"] == "SINGLE_SELECT":
+            spec["options"] = {opt["name"]: opt["id"] for opt in node.get("singleSelectOptions", [])}
+        fields[node["name"]] = spec
+    return fields
+
+
+def resolve_mutation_inputs(
+    sections: dict[str, str], fields: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Map parsed body sections to setIssueFieldValue input shapes.
+
+    Returns a list of IssueFieldCreateOrUpdateInput dicts ready to pass
+    as the `issueFields` array argument.
+    """
+    inputs: list[dict[str, Any]] = []
+    for label, value in sections.items():
+        field = fields.get(label)
+        if not field:
+            continue  # body section is content, not a native-field bridge
+        field_id = field["id"]
+        dtype = field["dataType"]
+        if dtype == "SINGLE_SELECT":
+            option_id = field["options"].get(value)
+            if not option_id:
+                sys.stderr.write(
+                    f"[bridge] {label}: value {value!r} not in options "
+                    f"{list(field['options'])} — skipping\n"
+                )
+                continue
+            inputs.append({"fieldId": field_id, "singleSelectOptionId": option_id})
+        elif dtype == "TEXT":
+            inputs.append({"fieldId": field_id, "textValue": value})
+        elif dtype == "DATE":
+            try:
+                datetime.strptime(value, "%Y-%m-%d")
+            except ValueError:
+                sys.stderr.write(
+                    f"[bridge] {label}: {value!r} not YYYY-MM-DD — skipping\n"
+                )
+                continue
+            inputs.append({"fieldId": field_id, "dateValue": value})
+        elif dtype == "NUMBER":
+            try:
+                num = float(value)
+            except ValueError:
+                sys.stderr.write(
+                    f"[bridge] {label}: {value!r} not numeric — skipping\n"
+                )
+                continue
+            inputs.append({"fieldId": field_id, "numberValue": num})
+    return inputs
+
+
+def apply_mutations(issue_node_id: str, mutation_inputs: list[dict[str, Any]]) -> None:
+    """Call setIssueFieldValue once with the full list of field updates."""
+    if not mutation_inputs:
+        print("[bridge] no native-field sections matched — nothing to apply")
+        return
+    mutation = """
+    mutation($input: SetIssueFieldValueInput!) {
+      setIssueFieldValue(input: $input) {
+        issue { id number }
+      }
+    }
+    """
+    variables = {
+        "input": {
+            "issueId": issue_node_id,
+            "issueFields": mutation_inputs,
+        }
+    }
+    if DRY_RUN:
+        print(f"[bridge] DRY_RUN — would set {len(mutation_inputs)} fields:")
+        print(json.dumps(mutation_inputs, indent=2))
+        return
+    gh_graphql(mutation, variables)
+    print(f"[bridge] set {len(mutation_inputs)} field values on issue {issue_node_id}")
+
+
+def main() -> int:
+    repo = env("REPO_FULL_NAME")
+    issue_number = env("ISSUE_NUMBER")
+    owner, name = repo.split("/", 1)
+
+    issue = gh_rest(f"repos/{owner}/{name}/issues/{issue_number}")
+    body = issue.get("body") or ""
+    issue_node_id = issue["node_id"]
+
+    sections = parse_body(body)
+    if not sections:
+        print("[bridge] no parseable form sections in body — exiting")
+        return 0
+
+    fields = fetch_org_fields()
+    mutation_inputs = resolve_mutation_inputs(sections, fields)
+    apply_mutations(issue_node_id, mutation_inputs)
+    return 0
+
+
+if __name__ == "__main__":
+    GH_TOKEN = env("GH_TOKEN")
+    DRY_RUN = os.environ.get("DRY_RUN") == "1"
+    try:
+        sys.exit(main())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        sys.stderr.write(f"[bridge] HTTP {e.code}: {body}\n")
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Sibling PR to vade-app/vade-coo-memory#846 (Stage 2 of the issue-fields-and-types migration per [MEMO-2026-05-21-xfqh](https://github.com/vade-app/vade-coo-memory/blob/main/coo/memos/2026-05-21-xfqh.md)).

This repo carries:
- **The bridge logic** (reusable workflow + Python parser) — called by trigger workflows in the four primary repos.
  - `.github/workflows/bridge-form-fields-to-natives.yml` — reusable workflow (`on: workflow_call`).
  - `scripts/bridge-form-fields-to-natives.py` — stdlib-only parser. Reads `### <Label>\n\n<value>` sections from the issue body, looks up org-level fields, calls `setIssueFieldValue` once with the full list of mutations. Fail-loud on unknown single-select option values; skips body sections that don't match any org-field name.
- **Mirrored per-type issue templates** (10) — canonical in vade-coo-memory; this repo carries the mirror.
- **Local caller workflow** (`bridge-form-fields-trigger.yml`) — same as the one in the other primary repos.

## Prerequisites surfaced in vade-coo-memory's PR

1. Pin the 4 new custom fields to Research / Skill via the UI.
2. `secrets.GITHUB_MCP_PAT` accessible to caller repos.
3. **This repo's setting**: Settings → Actions → General → Access → "Accessible from repositories in the 'vade-app' organization" (required for the cross-org reusable workflow to fire from caller repos).

## Test plan

- [ ] After merge: trigger the bridge via `workflow_dispatch` on a test issue in vade-coo-memory; confirm the script runs end-to-end.
- [ ] Verify the cross-org reusable-workflow access setting is in effect by triggering from a caller repo.

Closes: n/a — sub-deliverable of vade-app/vade-coo-memory#811.

https://claude.ai/code/session_013zXPvSRbF9Nf4F1H5S2zhK