### PR TITLE
fix: reusable bridge — match secret name to caller's namespace (vade-coo-memory#811)

### DIFF
--- a/.github/workflows/bridge-form-fields-to-natives.yml
+++ b/.github/workflows/bridge-form-fields-to-natives.yml
@@ -41,8 +41,8 @@ on:
         required: false
         default: false
     secrets:
-      ISSUE_FIELDS_ADMIN_PAT:
-        description: PAT with org-level Issue fields write scope.
+      VADE_FIELDS_ADMIN_PAT:
+        description: PAT with org-level Issue fields write scope. Resolved from `secrets: inherit` in caller workflows (same-named org secret with selected-repo visibility scoped to the four primary repos).
         required: true
 
 permissions:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run bridge
         env:
-          GH_TOKEN: ${{ secrets.ISSUE_FIELDS_ADMIN_PAT }}
+          GH_TOKEN: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}
           REPO_FULL_NAME: ${{ inputs.repo-full-name }}
           ISSUE_NUMBER: ${{ inputs.issue-number }}
           DRY_RUN: ${{ inputs.dry-run && '1' || '0' }}

--- a/.github/workflows/bridge-form-fields-trigger.yml
+++ b/.github/workflows/bridge-form-fields-trigger.yml
@@ -35,4 +35,4 @@ jobs:
       repo-full-name: ${{ github.repository }}
       dry-run: ${{ inputs.dry_run || false }}
     secrets:
-      ISSUE_FIELDS_ADMIN_PAT: ${{ secrets.GITHUB_MCP_PAT }}
+      ISSUE_FIELDS_ADMIN_PAT: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}


### PR DESCRIPTION
## Summary

Reusable workflow's `secrets.ISSUE_FIELDS_ADMIN_PAT` reference didn't resolve under `secrets: inherit` from caller workflows — `inherit` only passes same-named secrets through, and the caller's namespace has `VADE_FIELDS_ADMIN_PAT` (the org secret). The required-secret check failed at job-setup time (job conclusion: `failure`, no steps recorded).

Renames the reusable workflow's secret declaration + env reference from `ISSUE_FIELDS_ADMIN_PAT` to `VADE_FIELDS_ADMIN_PAT`. After this lands the bridge should fire end-to-end on the next test issue.

## Test plan

- [ ] After merge: create a fresh test issue in vade-coo-memory; verify the workflow runs to completion + sets native field values via `setIssueFieldValue`.

Closes: n/a — debug iteration for vade-app/vade-coo-memory#811.

https://claude.ai/code/session_013zXPvSRbF9Nf4F1H5S2zhK