### PR TITLE
fix: reusable YAML syntax + trigger sync (vade-coo-memory#811)

### DIFF
--- a/.github/workflows/bridge-form-fields-to-natives.yml
+++ b/.github/workflows/bridge-form-fields-to-natives.yml
@@ -42,7 +42,7 @@ on:
         default: false
     secrets:
       VADE_FIELDS_ADMIN_PAT:
-        description: PAT with org-level Issue fields write scope. Resolved from `secrets: inherit` in caller workflows (same-named org secret with selected-repo visibility scoped to the four primary repos).
+        description: "PAT with org-level Issue fields write scope. Resolved from secrets-inherit in caller workflows (same-named org secret with selected-repo visibility scoped to the four primary repos)."
         required: true
 
 permissions:

--- a/.github/workflows/bridge-form-fields-trigger.yml
+++ b/.github/workflows/bridge-form-fields-trigger.yml
@@ -27,12 +27,14 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   bridge:
     uses: vade-app/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml@main
     with:
       issue-number: ${{ github.event.issue.number || inputs.issue_number }}
       repo-full-name: ${{ github.repository }}
-      dry-run: ${{ inputs.dry_run || false }}
-    secrets:
-      ISSUE_FIELDS_ADMIN_PAT: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Root cause + sibling sync.

The bridge runs since #297 merged were all failing with `conclusion=failure` but zero jobs / zero referenced_workflows / 0s runtime. The reusable workflow file had an unquoted `secrets: inherit` in a description field — YAML scanner error at line 45 col 89 ("mapping values are not allowed here"). GitHub's runner couldn't parse the reusable, so the trigger couldn't resolve it, and the run terminated immediately.

This PR:
1. Quotes the description string so it parses.
2. Brings vade-runtime's own bridge trigger workflow into parity with vade-coo-memory canonical (`secrets: inherit` + drop dry-run pass-through).

Sibling sync PRs land in vade-core / vade-agent-logs in parallel.

## Test plan

- [ ] After merge: create a fresh test issue in vade-coo-memory; bridge should resolve the reusable + run the script + populate native fields.

Closes: n/a — debug iteration for vade-app/vade-coo-memory#811.

https://claude.ai/code/session_013zXPvSRbF9Nf4F1H5S2zhK