### PR TITLE
coo-on-assign: lead prompt with issue title for session auto-name

### DIFF
--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -73,7 +73,16 @@ jobs:
             //  - "Ven is not at the keyboard" framing is explicit so
             //    the instance briefs instead of asking when it would
             //    have asked interactively.
+            //  - issue.title leads the prompt so claude.ai/code's
+            //    auto-naming heuristic surfaces the issue title as the
+            //    session name. There is no documented session-name
+            //    URL parameter — the pre-fill spec lists only
+            //    prompt / prompt_url / repositories / environment
+            //    (https://code.claude.com/docs/en/web-quickstart#pre-fill-sessions).
+            //    Leading the prompt with the title is the only lever.
             const prompt = [
+              issue.title,
+              ``,
               `You are the VADE COO agent, opening a fresh cloud session by GitHub assignment, not by Ven sitting at the keyboard. Treat this as async.`,
               ``,
               `1. Boot first per CLAUDE.md — read every numbered step in the session-start reading order, not just the ones that seem most relevant to the task below. The list includes integrity gate (1), persisted-output gate (1b), charter (2), governance (3), preferences (4), identity layer (5), episodic memory (6), memo digest (7), lineage events (7b), project board (8), mem0_sop (9), context README (12), operational Mem0 search (13), discussions digest (14). Skipping items because the parenthetical or this prompt seemed to enumerate a shorter set is the exact regression this language replaces. Greet briefly.`,


### PR DESCRIPTION
## Summary

Sync companion to [vade-coo-memory#863](https://github.com/vade-app/vade-coo-memory/pull/863), landing the byte-identical `coo-on-assign` workflow patch in this repo.

Prepends `issue.title` (plus a blank line) as the first non-empty line of the boot prompt array in `.github/workflows/coo-on-assign.yml`, so claude.ai/code's session auto-naming heuristic surfaces the issue title as the session label. The Claude Code web pre-fill spec ([web-quickstart#pre-fill-sessions](https://code.claude.com/docs/en/web-quickstart#pre-fill-sessions)) lists only `prompt` / `prompt_url` / `repositories` / `environment`; no `name` / `title` / `session_name` parameter exists.

Substantive rationale, design context, and operations-doc update live in the primary PR.

## Sync set

One of 9 synchronized PRs (workflow-sync convention; see comment at the top of the workflow file). Primary: [vade-coo-memory#863](https://github.com/vade-app/vade-coo-memory/pull/863).

Closes vade-app/vade-coo-memory#861.

https://claude.ai/code/session_01MNGAm2Zp3hm62wGHnYo9r7