### PR TITLE
feat: GitHub App routing for org-admin endpoints (vade-coo-memory#837)

### DIFF
--- a/scripts/ci/mocks/op
+++ b/scripts/ci/mocks/op
@@ -82,6 +82,23 @@ case "${1:-}" in
       "op://COO/vade-coo-sign/public key")
         cat "$KEYDIR/vade-coo-sign.pub"
         ;;
+      "op://COO/vade-coo-app/app_id")
+        # GitHub App ID (vade-coo-memory#837) — canned numeric for the
+        # CI mode. Real value is set in production via Ven's UI work
+        # (Phase 1) and stored in op://COO/vade-coo-app/app_id.
+        echo "999000"
+        ;;
+      "op://COO/vade-coo-app/installation_id")
+        echo "888777"
+        ;;
+      "op://COO/vade-coo-app/private_key")
+        # Placeholder PEM-shaped string for CI. fetch_coo_secrets only
+        # checks for non-empty; the minter (gh-app-token.sh) is not on
+        # the bootstrap-regression hot path, so this body is never
+        # parsed by openssl in CI. Production reads the real key from
+        # 1Password on demand at mint time.
+        echo "-----BEGIN RSA PRIVATE KEY----- CIMOCK00000000000000000000= -----END RSA PRIVATE KEY-----"
+        ;;
       *)
         echo "[mock op] unknown op:// ref: $ref" >&2
         exit 2

--- a/scripts/ci/test-gh-coo-wrap.sh
+++ b/scripts/ci/test-gh-coo-wrap.sh
@@ -321,6 +321,95 @@ assert_contains "gh repo list <owner>: keeps MCP_PAT (uncovered action)" "$out" 
 out="$("$WRAPPER" release create v1.0.0)"
 assert_contains "gh release create: keeps MCP_PAT (uncovered)" "$out" "GH_TOKEN=MCP_PAT_TESTING"
 
+# ============================================================
+# App-token routing tests (vade-coo-memory#837).
+# ============================================================
+# Org-admin REST endpoints (issue-types, properties, custom roles)
+# get routed to a GitHub App installation token, minted via
+# $VADE_RUNTIME_DIR/scripts/gh-app-token.sh, bypassing the
+# identity-vs-token rule (MEMO-2026-05-21-w6qz) that 403s the
+# fine-grained PAT on org-admin operations.
+
+printf '\nApp-token routing tests:\n'
+
+# Stand up a mock minter under a fake $VADE_RUNTIME_DIR so the wrapper
+# can invoke it without reading 1Password or hitting GitHub. The mock
+# prints a known sentinel token (or exits non-zero for failure-mode
+# coverage).
+FAKE_RUNTIME="$WORK/fake-runtime"
+mkdir -p "$FAKE_RUNTIME/scripts"
+cat > "$FAKE_RUNTIME/scripts/gh-app-token.sh" <<'EOF'
+#!/usr/bin/env bash
+if [ "${MOCK_MINTER_FAIL:-0}" = "1" ]; then
+  echo "mock minter: deliberate failure" >&2
+  exit 3
+fi
+echo "APP_TOKEN_TESTING"
+EOF
+chmod +x "$FAKE_RUNTIME/scripts/gh-app-token.sh"
+export VADE_RUNTIME_DIR="$FAKE_RUNTIME"
+export GITHUB_APP_ID="999000"
+export GITHUB_APP_INSTALLATION_ID="888777"
+
+# --- org-admin auto-routes ---
+
+out="$("$WRAPPER" api orgs/vade-app/issue-types)"
+assert_contains "gh api orgs/vade-app/issue-types: mints App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api orgs/vade-app/issue-types/123)"
+assert_contains "gh api orgs/vade-app/issue-types/<id>: mints App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api -X PUT orgs/vade-app/issue-types/123)"
+assert_contains "gh api -X PUT orgs/vade-app/issue-types/<id>: mints App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api orgs/vade-app/properties/values)"
+assert_contains "gh api orgs/vade-app/properties/values: mints App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api orgs/vade-app/custom-repository-roles)"
+assert_contains "gh api orgs/vade-app/custom-repository-roles: mints App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+# --- non-org-admin paths stay on MCP_PAT (regression coverage) ---
+
+out="$("$WRAPPER" api orgs/vade-app/repos)"
+assert_contains "gh api orgs/vade-app/repos: keeps MCP_PAT (not org-admin)" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+out="$("$WRAPPER" api repos/vade-app/vade-coo-memory)"
+assert_contains "gh api repos/vade-app/...: keeps MCP_PAT (not org-admin)" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# --- explicit opt-in via GH_USE_APP_TOKEN=1 ---
+
+out="$(GH_USE_APP_TOKEN=1 "$WRAPPER" api user)"
+assert_contains "GH_USE_APP_TOKEN=1: mints App token regardless of path" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$(GH_USE_APP_TOKEN=1 "$WRAPPER" api graphql -f query=foo)"
+assert_contains "GH_USE_APP_TOKEN=1 + graphql: mints App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+# --- GITHUB_APP_ID unset: routing falls through (no App-token attempt) ---
+
+out="$(env -u GITHUB_APP_ID -u GITHUB_APP_INSTALLATION_ID \
+  GITHUB_MCP_PAT="$GITHUB_MCP_PAT" GITHUB_PUBLIC_PAT="$GITHUB_PUBLIC_PAT" \
+  GH_TOKEN="$GH_TOKEN" CLAUDE_CODE_REMOTE_SESSION_ID="$CLAUDE_CODE_REMOTE_SESSION_ID" \
+  COO_GH_REAL="$WORK/gh-real" VADE_RUNTIME_DIR="$VADE_RUNTIME_DIR" \
+  "$WRAPPER" api orgs/vade-app/issue-types)"
+assert_contains "GITHUB_APP_ID unset: org-admin path keeps MCP_PAT (no mint)" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# --- minter failure: warn + fall back to PAT (no silent 403 swap) ---
+
+out="$(MOCK_MINTER_FAIL=1 "$WRAPPER" api orgs/vade-app/issue-types 2>&1)"
+assert_contains "minter failure: warns" "$out" "App-token mint failed"
+assert_contains "minter failure: falls back to MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# --- minter missing: warn + fall back to PAT ---
+
+out="$(VADE_RUNTIME_DIR="/nonexistent-vade-runtime" \
+  GITHUB_APP_ID="$GITHUB_APP_ID" GITHUB_APP_INSTALLATION_ID="$GITHUB_APP_INSTALLATION_ID" \
+  GITHUB_MCP_PAT="$GITHUB_MCP_PAT" GITHUB_PUBLIC_PAT="$GITHUB_PUBLIC_PAT" \
+  GH_TOKEN="$GH_TOKEN" CLAUDE_CODE_REMOTE_SESSION_ID="$CLAUDE_CODE_REMOTE_SESSION_ID" \
+  COO_GH_REAL="$WORK/gh-real" \
+  "$WRAPPER" api orgs/vade-app/issue-types 2>&1)"
+assert_contains "minter missing: warns" "$out" "minter not found"
+assert_contains "minter missing: falls back to MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
 printf '\n'
 printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"
 if [ "$FAIL" -gt 0 ]; then

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# gh-app-token.sh — mint a GitHub App installation token for vade-coo-app.
+#
+# Authenticates as the App's *installation*, not as a user — bypasses the
+# user-elevation rule (MEMO-2026-05-21-w6qz) that blocks `vade-coo` PAT
+# from org-admin endpoints (createIssueType, createIssueField, project
+# writes, custom-property admin).
+#
+# Reads creds from env (preferred) or 1Password fallback. Caches the
+# installation token in $VADE_CLOUD_STATE_DIR/gh-app-token-cache.json
+# (TTL ~55 min — GitHub mints tokens valid for 1 h).
+#
+# Usage:
+#   gh-app-token.sh                       # print token to stdout
+#   gh-app-token.sh --refresh             # ignore cache, mint fresh
+#   gh-app-token.sh --jwt                 # print the App JWT (debug)
+#
+# Env consumed:
+#   GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY
+#   (populated by fetch_coo_secrets at boot; falls back to op:// reads).
+#
+# Exit codes: 0 ok | 2 missing creds | 3 mint failure | 4 malformed response
+
+set -euo pipefail
+
+CACHE_FILE="${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state}/gh-app-token-cache.json"
+MIN_TTL_SEC=300
+
+refresh=0
+mode=token
+for arg in "$@"; do
+  case "$arg" in
+    --refresh) refresh=1 ;;
+    --jwt) mode=jwt ;;
+    -h|--help)
+      sed -n '2,18p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "gh-app-token: unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# Cache hit path
+if [ "$mode" = token ] && [ "$refresh" -eq 0 ] && [ -f "$CACHE_FILE" ]; then
+  now=$(date +%s)
+  cached_exp=$(jq -r '.expires_at_unix // 0' "$CACHE_FILE" 2>/dev/null || echo 0)
+  if [ "$cached_exp" -gt $((now + MIN_TTL_SEC)) ]; then
+    jq -r '.token' "$CACHE_FILE"
+    exit 0
+  fi
+fi
+
+# Fetch creds (env preferred, op:// fallback)
+app_id="${GITHUB_APP_ID:-}"
+install_id="${GITHUB_APP_INSTALLATION_ID:-}"
+private_key="${GITHUB_APP_PRIVATE_KEY:-}"
+
+if [ -z "$app_id" ]; then
+  app_id="$(op read 'op://COO/vade-coo-app/app_id' 2>/dev/null || true)"
+fi
+if [ -z "$install_id" ]; then
+  install_id="$(op read 'op://COO/vade-coo-app/installation_id' 2>/dev/null || true)"
+fi
+if [ -z "$private_key" ]; then
+  private_key="$(op read 'op://COO/vade-coo-app/private_key' 2>/dev/null || true)"
+fi
+
+if [ -z "$app_id" ] || [ -z "$install_id" ] || [ -z "$private_key" ]; then
+  echo "gh-app-token: missing creds (app_id=${app_id:+set} install_id=${install_id:+set} private_key=${private_key:+set})" >&2
+  exit 2
+fi
+
+# Normalize PEM. 1Password text-field paste flattens newlines in PEM-shaped
+# multi-line content into spaces; openssl rejects the result. Recover by
+# re-wrapping the base64 body at 64 chars between the BEGIN/END markers.
+PEM_FILE="$(mktemp)"
+trap 'rm -f "$PEM_FILE"' EXIT
+python3 - "$private_key" > "$PEM_FILE" <<'PY'
+import sys, re
+raw = sys.argv[1].rstrip('\n')
+m = re.match(r'^(-----BEGIN [^-]+-----)\s*(.+?)\s*(-----END [^-]+-----)\s*$', raw, re.DOTALL)
+if not m:
+    sys.stderr.write("gh-app-token: PEM pattern mismatch\n")
+    sys.exit(2)
+header, body, footer = m.groups()
+body = re.sub(r'\s+', '', body)
+wrapped = '\n'.join(body[i:i+64] for i in range(0, len(body), 64))
+sys.stdout.write(f"{header}\n{wrapped}\n{footer}\n")
+PY
+chmod 600 "$PEM_FILE"
+
+# Build JWT (RS256). iat backdated by 60s for clock-skew tolerance per
+# GitHub's own recommendation.
+now=$(date +%s)
+iat=$((now - 60))
+exp=$((now + 540))
+header_b64=$(printf '{"alg":"RS256","typ":"JWT"}' | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+payload_b64=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$iat" "$exp" "$app_id" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+unsigned="$header_b64.$payload_b64"
+sig_b64=$(printf '%s' "$unsigned" | openssl dgst -sha256 -sign "$PEM_FILE" -binary | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+jwt="$unsigned.$sig_b64"
+
+if [ "$mode" = jwt ]; then
+  echo "$jwt"
+  exit 0
+fi
+
+# Exchange for installation token
+response="$(curl -sS -w '\n%{http_code}' -X POST \
+  -H "Authorization: Bearer $jwt" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/app/installations/$install_id/access_tokens" 2>&1)"
+
+http_code="$(echo "$response" | tail -1)"
+body="$(echo "$response" | sed '$d')"
+
+if [ "$http_code" != "201" ]; then
+  echo "gh-app-token: mint failed (HTTP $http_code): $body" >&2
+  exit 3
+fi
+
+token="$(echo "$body" | jq -r '.token // empty')"
+expires_at="$(echo "$body" | jq -r '.expires_at // empty')"
+
+if [ -z "$token" ] || [ -z "$expires_at" ]; then
+  echo "gh-app-token: malformed response: $body" >&2
+  exit 4
+fi
+
+# Cache
+mkdir -p "$(dirname "$CACHE_FILE")"
+expires_unix="$(python3 -c "from datetime import datetime; print(int(datetime.fromisoformat('$expires_at'.replace('Z', '+00:00')).timestamp()))")"
+jq -n --arg t "$token" --arg ea "$expires_at" --argjson eu "$expires_unix" \
+  '{token: $t, expires_at: $ea, expires_at_unix: $eu, minted_at: (now | floor)}' > "$CACHE_FILE"
+chmod 600 "$CACHE_FILE"
+
+echo "$token"

--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -244,10 +244,92 @@ extract_owner_positional() {
   return 0
 }
 
-target_owner="$(extract_owner "$@")"
-[ -z "$target_owner" ] && target_owner="$(extract_owner_positional "$@")"
-if [ -n "$target_owner" ] && [ "$target_owner" != "vade-app" ] && [ -n "${GITHUB_PUBLIC_PAT:-}" ]; then
-  export GH_TOKEN="$GITHUB_PUBLIC_PAT"
+# is_org_admin_api: returns 0 iff the argv parses as `gh api <path>` where
+# <path> matches a known org-admin REST surface (issue-types, custom
+# properties, properties, custom-repository-roles under any org). These
+# endpoints 403 for fine-grained PATs whose underlying user is not an org
+# admin (identity-vs-token rule, MEMO-2026-05-21-w6qz) — App installation
+# tokens authenticate as the installation, bypassing the user-elevation
+# gate. Scope intentionally narrow: only auto-route surfaces known to
+# require org-admin + currently in use. Other surfaces opt in explicitly
+# via GH_USE_APP_TOKEN=1.
+#
+# GraphQL bodies (gh api graphql -f query=…) are not parsed here — set
+# GH_USE_APP_TOKEN=1 at the callsite for org-admin GraphQL mutations
+# (e.g. addProjectV2ItemById on org-owned ProjectV2 items).
+is_org_admin_api() {
+  local sub=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --) shift ;;
+      --*=*) shift ;;
+      -R|--repo|--hostname) shift; [ $# -gt 0 ] && shift ;;
+      -*) shift ;;
+      *)
+        sub="$1"; shift; break ;;
+    esac
+  done
+  [ "$sub" = "api" ] || return 1
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --*=*) shift ;;
+      --*|-*)
+        if __gh_valued_flag "$1"; then
+          shift; [ $# -gt 0 ] && shift
+        else
+          shift
+        fi
+        ;;
+      *)
+        local path="${1#/}"
+        case "$path" in
+          orgs/*/issue-types|orgs/*/issue-types/*) return 0 ;;
+          orgs/*/properties/*) return 0 ;;
+          orgs/*/custom-repository-roles|orgs/*/custom-repository-roles/*) return 0 ;;
+        esac
+        return 1
+        ;;
+    esac
+  done
+  return 1
+}
+
+# Routing precedence:
+#   1. GH_USE_APP_TOKEN=1 → mint App token (explicit opt-in; for GraphQL).
+#   2. `gh api <org-admin-path>` → mint App token (auto).
+#   3. owner != vade-app + GITHUB_PUBLIC_PAT → public PAT (cross-org).
+#   4. default → $GITHUB_MCP_PAT via gh's auth context (no override here).
+#
+# App-token routing is attempted only when GITHUB_APP_ID is set in env
+# (the boot-time signal that Phase 1 of vade-coo-memory#837 has been
+# completed). When unset (App not yet provisioned), routing falls through
+# to the cross-org branch and the org-admin call lands on the PAT — which
+# 403s with the same error class the App fixes. Failure mode is symmetric
+# with the pre-App state, not silently wrong.
+if [ -n "${GITHUB_APP_ID:-}" ] && { [ "${GH_USE_APP_TOKEN:-0}" = "1" ] || is_org_admin_api "$@"; }; then
+  # The minter lives in vade-runtime/scripts/, not next to this wrapper.
+  # ensure_gh_coo_wrap (lib/common.sh) installs *only* gh-coo-wrap.sh to
+  # ~/.local/bin/gh — the minter stays canonical at its repo path. Locate
+  # via $VADE_RUNTIME_DIR (set in settings.json env at boot per D4
+  # integrity-check); fall back to a hard-coded path for the in-cloud
+  # default layout if the env var is missing.
+  minter="${VADE_RUNTIME_DIR:-/home/user/vade-runtime}/scripts/gh-app-token.sh"
+  if [ -x "$minter" ]; then
+    app_token="$("$minter" 2>/dev/null || true)"
+    if [ -n "$app_token" ]; then
+      export GH_TOKEN="$app_token"
+    else
+      echo "gh-coo-wrap: WARN: App-token mint failed for org-admin path; falling back to default auth (likely 403)." >&2
+    fi
+  else
+    echo "gh-coo-wrap: WARN: minter not found at $minter; org-admin path will use default auth." >&2
+  fi
+else
+  target_owner="$(extract_owner "$@")"
+  [ -z "$target_owner" ] && target_owner="$(extract_owner_positional "$@")"
+  if [ -n "$target_owner" ] && [ "$target_owner" != "vade-app" ] && [ -n "${GITHUB_PUBLIC_PAT:-}" ]; then
+    export GH_TOKEN="$GITHUB_PUBLIC_PAT"
+  fi
 fi
 
 # Resolve issue/PR shape-check script. Advisory only; missing-tolerant.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1406,6 +1406,7 @@ fetch_coo_secrets() {
   local github_pat="" github_public_pat="" agentmail_key="" mem0_key=""
   local r2_access_key_id="" r2_secret_access_key="" age_identity=""
   local vade_auth_token="" cloudflare_api_token="" cloudflare_account_id=""
+  local github_app_id="" github_app_installation_id=""
   local got=0
 
   if github_pat="$(retry 3 op read 'op://COO/vade-coo-self-2026-04/token')" && [ -n "$github_pat" ]; then
@@ -1517,6 +1518,33 @@ fetch_coo_secrets() {
     log "  WARN: op://COO/cloudflare-api-token-vade-coo/account_id unavailable; CLOUDFLARE_ACCOUNT_ID will be unset (E9 probe will skip; wrangler may prompt for account selection)"
   fi
 
+  # vade-coo-app GitHub App identifiers (MEMO-2026-05-21 vade-coo-memory#837).
+  # Public values only: app_id and installation_id propagate to env so the
+  # `gh-app-token.sh` minter skips two op reads per fresh-token mint. The
+  # private key (op://COO/vade-coo-app/private_key) intentionally stays in
+  # 1Password — the minter reads it on cache miss only (tokens cached
+  # ~55 min in $VADE_CLOUD_STATE_DIR/gh-app-token-cache.json), so the
+  # sensitive material never lands in settings.json env. Best-effort
+  # fetch: missing item warns and leaves both unset; the minter then
+  # falls back to op reads for the IDs too, but with two extra round-
+  # trips per mint. Both unset = App not yet provisioned (Phase 1 not
+  # done); gh-coo-wrap routing simply skips the App-token branch.
+  if github_app_id="$(retry 3 op read 'op://COO/vade-coo-app/app_id')" && [ -n "$github_app_id" ]; then
+    log "  read GitHub App ID (len=${#github_app_id})"
+    got=$((got+1))
+  else
+    github_app_id=""
+    log "  WARN: op://COO/vade-coo-app/app_id unavailable; GITHUB_APP_ID will be unset (gh-coo-wrap org-admin routing will fall back to op reads or pass through)"
+  fi
+
+  if github_app_installation_id="$(retry 3 op read 'op://COO/vade-coo-app/installation_id')" && [ -n "$github_app_installation_id" ]; then
+    log "  read GitHub App installation ID (len=${#github_app_installation_id})"
+    got=$((got+1))
+  else
+    github_app_installation_id=""
+    log "  WARN: op://COO/vade-coo-app/installation_id unavailable; GITHUB_APP_INSTALLATION_ID will be unset"
+  fi
+
   if [ "$got" -eq 0 ]; then
     log "  no COO secrets could be fetched; skipping env file write"
     return 1
@@ -1544,6 +1572,8 @@ fetch_coo_secrets() {
       if [ -n "$vade_auth_token" ];      then echo "export VADE_AUTH_TOKEN='$vade_auth_token'"; fi
       if [ -n "$cloudflare_api_token" ]; then echo "export CLOUDFLARE_API_TOKEN='$cloudflare_api_token'"; fi
       if [ -n "$cloudflare_account_id" ]; then echo "export CLOUDFLARE_ACCOUNT_ID='$cloudflare_account_id'"; fi
+      if [ -n "$github_app_id" ];               then echo "export GITHUB_APP_ID='$github_app_id'"; fi
+      if [ -n "$github_app_installation_id" ];  then echo "export GITHUB_APP_INSTALLATION_ID='$github_app_installation_id'"; fi
     } > "$env_file"
   )
   chmod 600 "$env_file"
@@ -1564,6 +1594,8 @@ fetch_coo_secrets() {
   if [ -n "$vade_auth_token" ];      then export VADE_AUTH_TOKEN="$vade_auth_token"; fi
   if [ -n "$cloudflare_api_token" ]; then export CLOUDFLARE_API_TOKEN="$cloudflare_api_token"; fi
   if [ -n "$cloudflare_account_id" ]; then export CLOUDFLARE_ACCOUNT_ID="$cloudflare_account_id"; fi
+  if [ -n "$github_app_id" ];                then export GITHUB_APP_ID="$github_app_id"; fi
+  if [ -n "$github_app_installation_id" ];   then export GITHUB_APP_INSTALLATION_ID="$github_app_installation_id"; fi
   return 0
 }
 
@@ -1586,7 +1618,9 @@ merge_coo_settings_env() {
     "${VADE_MCP_URL:-}" \
     "${CLOUDFLARE_API_TOKEN:-}" \
     "${CLOUDFLARE_ACCOUNT_ID:-}" \
-    "${GITHUB_PUBLIC_PAT:-}"
+    "${GITHUB_PUBLIC_PAT:-}" \
+    "${GITHUB_APP_ID:-}" \
+    "${GITHUB_APP_INSTALLATION_ID:-}"
 }
 
 # Persist non-secret bootstrap-derived path state into ~/.claude/settings.json
@@ -1656,6 +1690,7 @@ _write_claude_settings_env() {
   local vade_bearer_token="${8:-}" vade_mcp_url="${9:-}"
   local cloudflare_api_token="${10:-}" cloudflare_account_id="${11:-}"
   local github_public_pat="${12:-}"
+  local github_app_id="${13:-}" github_app_installation_id="${14:-}"
   if ! check_cmd node; then
     log "Warning: node missing; skipping ~/.claude/settings.json env merge"
     return 0
@@ -1680,6 +1715,8 @@ _write_claude_settings_env() {
   CLOUDFLARE_API_TOKEN="$cloudflare_api_token" \
   CLOUDFLARE_ACCOUNT_ID="$cloudflare_account_id" \
   GITHUB_PUBLIC_PAT="$github_public_pat" \
+  GITHUB_APP_ID="$github_app_id" \
+  GITHUB_APP_INSTALLATION_ID="$github_app_installation_id" \
   NODE_PATH="$node_path" PLAYWRIGHT_BROWSERS_PATH="$pw_browsers" node -e '
     const fs = require("fs");
     const path = process.argv[1];
@@ -1701,6 +1738,12 @@ _write_claude_settings_env() {
     }
     if (process.env.GITHUB_PUBLIC_PAT) {
       merged.GITHUB_PUBLIC_PAT = process.env.GITHUB_PUBLIC_PAT;
+    }
+    if (process.env.GITHUB_APP_ID) {
+      merged.GITHUB_APP_ID = process.env.GITHUB_APP_ID;
+    }
+    if (process.env.GITHUB_APP_INSTALLATION_ID) {
+      merged.GITHUB_APP_INSTALLATION_ID = process.env.GITHUB_APP_INSTALLATION_ID;
     }
     if (process.env.AGENTMAIL_API_KEY) {
       merged.AGENTMAIL_API_KEY = process.env.AGENTMAIL_API_KEY;

--- a/scripts/lib/transcript-redaction.json
+++ b/scripts/lib/transcript-redaction.json
@@ -101,6 +101,20 @@
       "notes": "Cloudflare account UUID (32-char lowercase hex). Not strictly secret (appears in committed wrangler.jsonc and Cloudflare URLs throughout the platform), but the Secret Registration Rule requires every fetch_coo_secrets export to have a pattern. Context-scoped to accounts/<id> URL paths to avoid false positives against arbitrary 32-char hex (commit SHAs, file hashes, etc)."
     },
     {
+      "id": "github-app-id",
+      "regex": "\\bGITHUB_APP_ID(?:[=:][\"']?|\" *: *[\"']?)\\d+\\b",
+      "replacement": "GITHUB_APP_ID=[REDACTED:github-app-id]",
+      "secret_var": "GITHUB_APP_ID",
+      "notes": "vade-coo-app numeric App ID. Public value (shown on the App's settings page) but registered for defense-in-depth: redacts the env-shape assignment so a leaked transcript doesn't ship the exact ID alongside other operational config. Context-scoped to the assignment shape (=, :, JSON-key form) to avoid false positives against arbitrary 6-7-digit numbers (commit-counts, line numbers, etc). vade-coo-memory#837."
+    },
+    {
+      "id": "github-app-installation-id",
+      "regex": "\\bGITHUB_APP_INSTALLATION_ID(?:[=:][\"']?|\" *: *[\"']?)\\d+\\b|/app/installations/\\d+/access_tokens",
+      "replacement": "GITHUB_APP_INSTALLATION_ID=[REDACTED:github-app-installation-id]",
+      "secret_var": "GITHUB_APP_INSTALLATION_ID",
+      "notes": "vade-coo-app installation ID. Same posture as GITHUB_APP_ID: public but registered. Also matches the /app/installations/<id>/access_tokens endpoint URL where the ID appears bare (the minter's exchange endpoint)."
+    },
+    {
       "id": "stripe-key",
       "regex": "\\b(?:sk|rk)_live_[A-Za-z0-9]{24,}\\b",
       "replacement": "[REDACTED:stripe-key]",


### PR DESCRIPTION
## Summary

Phase 2 of [vade-coo-memory#837](https://github.com/vade-app/vade-coo-memory/issues/837) — wires a GitHub App installation-token path through `gh-coo-wrap.sh` to bypass the identity-vs-token rule ([MEMO-2026-05-21-w6qz](https://github.com/vade-app/vade-coo-memory/blob/main/coo/memos/2026-05-21-w6qz.md)) that 403s `vade-coo`'s PAT on org-admin REST endpoints (`createIssueType`, `updateIssueField`, custom-property admin, etc.).

- **`scripts/gh-app-token.sh`** — new. Mints an installation token (RS256 JWT → installation access token exchange) from `op://COO/vade-coo-app/{app_id, installation_id, private_key}`. Caches in `$VADE_CLOUD_STATE_DIR/gh-app-token-cache.json` (TTL ~55 min). Tolerates 1Password text-field paste flattening — normalizes the PEM body by rewrapping at 64 chars between BEGIN/END.
- **`scripts/gh-coo-wrap.sh`** — extends routing with two new branches:
  1. `gh api <org-admin-path>` (issue-types, properties, custom-repository-roles under any `orgs/<org>/`) → auto-routes to App installation token via the minter.
  2. `GH_USE_APP_TOKEN=1 gh …` → explicit opt-in (for GraphQL mutations like `addProjectV2ItemById` that aren't URL-pattern-matchable).
  Existing branches (`vade-app/*` → `GITHUB_MCP_PAT`; cross-org → `GITHUB_PUBLIC_PAT`) unchanged. App-token routing only fires when `GITHUB_APP_ID` is in env (the boot signal that Phase 1 has been done); when unset, falls through to the original behavior.
- **`scripts/lib/common.sh`** — extends `fetch_coo_secrets()` to read `op://COO/vade-coo-app/app_id` + `installation_id` (public values; the private key stays in 1P and is read by the minter on cache miss only), writes them to `~/.vade/coo-env` and propagates through `merge_coo_settings_env` into `~/.claude/settings.json` env. Both vars best-effort; missing item warns and routing falls back to PAT (same failure mode as pre-App).
- **`scripts/ci/test-gh-coo-wrap.sh`** — adds 14 routing tests covering all four branches + minter failure modes + env-unset fallthrough.
- **`scripts/ci/mocks/op`** — canned values for the new `op://` refs so CI exercises the App-configured path.

## Smoke test results (live, against `vade-coo-app` installed on `vade-app`)

```
$ rm -f $VADE_CLOUD_STATE_DIR/gh-app-token-cache.json

# Auto-routed org-admin read
$ gh api orgs/vade-app/issue-types --jq '.[].name'
Task / Bug / Feature / Epic / Chore / Docs / Refactor / Test / Research / Skill
✓ cache file created (TTL ~55 min)

# Non-org-admin path — no mint, uses PAT
$ gh api repos/vade-app/vade-coo-memory --jq '.full_name'
vade-app/vade-coo-memory
✓ cache absent (mint not triggered)

# Cross-org — uses public PAT, no mint
$ gh api repos/anthropics/claude-code --jq '.full_name'
anthropics/claude-code
✓ cache absent

# Explicit opt-in to App-identity surface
$ GH_USE_APP_TOKEN=1 gh api /installation/repositories --jq '.repositories | length'
11
✓ cache created

# The original blocker — org-admin WRITE
$ gh api -X PUT -H 'X-GitHub-Api-Version: 2022-11-28' --input - orgs/vade-app/issue-types/32706191 \
  <<< '{"name":"Task","description":"A specific piece of work","color":"yellow","is_enabled":true}'
✓ WRITE OK: Task updated_at=2026-04-11T01:08:17Z  (was 403 with vade-coo PAT pre-elevation)
```

## Test plan

- [x] `bash scripts/ci/test-gh-coo-wrap.sh` — 65 pass, 0 fail (51 pre-existing + 14 new App-token routing).
- [x] Local end-to-end smoke against the real `vade-coo-app` installation (above).
- [ ] CI: `bootstrap-regression.yml` runs on push — verifies fetch_coo_secrets + merge_coo_settings_env path in fake-env mode.
- [ ] Boot validation on fresh container after merge (see handoff prompt below).

## Pre-merge gating

This change touches `fetch_coo_secrets()` (boot path) and `gh-coo-wrap.sh` (sole-write-surface). Verification per `coo/operations/handoff-prompts.md`:

- Spin a fresh container (or `bash $HOME/.claude/vade-hooks/dispatch.sh session-start-sync` if reproducible without rebuild).
- Confirm boot integrity check passes: `cat ${VADE_CLOUD_STATE_DIR}/integrity-check.json | jq .summary.ok` → `true`.
- Confirm new env vars persisted: `jq '.env | {GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID}' ~/.claude/settings.json` (both should be non-null).
- Confirm an org-admin write works through bare `gh`:
  ```sh
  gh api orgs/vade-app/issue-types --jq '.[0].name'  # should print a name; cache file created
  ls $VADE_CLOUD_STATE_DIR/gh-app-token-cache.json
  ```

## Out of scope (deferred)

- **App-actor commits** — would require revising [CB-005](https://github.com/vade-app/vade-coo-memory/blob/main/coo/identity_layer.md#cb-005). Issue body explicitly defers.
- **Pre-mint at boot** — minter is on-demand; cache amortizes the 1Password + JWT cost across the hour. Pre-mint would shave ~500 ms off the first call per session. Defer unless latency becomes annoying.
- **Phase 3** (workflow migration — `auto-add-prs-to-project.yml` + `auto-tag-issues.yml` → `actions/create-github-app-token@v1`) — follow-up PR after this lands.
- **Phase 4** (de-elevate `vade-coo` from org-owner) — gated on Stage 2 [vade-coo-memory#808](https://github.com/vade-app/vade-coo-memory/issues/808) done.
- **`coo/operations/attribution.md` + memo** documenting the new routing rule — follow-up PR in `vade-coo-memory` after this lands.

Closes: n/a — Phase 2 of an epic (vade-coo-memory#837 stays open through Phase 4).

https://claude.ai/code/session_01Dk3B7HziaZ6KtrWz3rEXqk