### PR TITLE
feat(workflows): vade-coo-app token for project auto-add + auto-tag (Phase 3, vade-coo-memory#837)

### DIFF
--- a/.github/workflows/auto-add-prs-to-project.yml
+++ b/.github/workflows/auto-add-prs-to-project.yml
@@ -12,9 +12,17 @@ name: Auto-add new PRs to the VADE project
 # When the VADE project is rebuilt or its fields change, batch-update
 # all 4 repos' workflows together.
 #
-# Prerequisites:
-#   - secrets.VADE_PROJECT_PAT — PAT with `project` scope for the
-#     vade-app org. If unset, the workflow logs a warning and skips
+# Prerequisites (one of, in preference order — first available wins):
+#   - vars.VADE_COO_APP_ID + secrets.VADE_COO_APP_PRIVATE_KEY — the
+#     vade-coo-app GitHub App credentials (MEMO-2026-05-21-4wgy +
+#     vade-app/vade-coo-memory#837 Phase 2). Installation-token auth;
+#     bypasses the identity-vs-token rule that 403s a user PAT on
+#     org-admin endpoints.
+#   - secrets.VADE_PROJECT_PAT — legacy PAT with `project` scope for
+#     the vade-app org. Used as fallback while the App secrets are
+#     being provisioned across the org. Will be retired in a follow-up
+#     once Ven confirms App secrets are live on every relevant repo.
+#   - If neither is set, the workflow logs a warning and skips
 #     (graceful no-op, mirrors the auto-tag-issues.yml pattern).
 
 on:
@@ -37,8 +45,18 @@ jobs:
       github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Mint vade-coo-app installation token (optional)
+        id: app-token
+        if: vars.VADE_COO_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.VADE_COO_APP_ID }}
+          private-key: ${{ secrets.VADE_COO_APP_PRIVATE_KEY }}
+          owner: vade-app
+
       - name: Add PR to VADE project, set Status=In Progress
         env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           VADE_PROJECT_PAT: ${{ secrets.VADE_PROJECT_PAT }}
           PR_NODE_ID: ${{ github.event.pull_request.node_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -48,8 +66,16 @@ jobs:
           # field write denied). The CI run does NOT fail; the PR proceeds.
           set -uo pipefail
 
-          if [ -z "${VADE_PROJECT_PAT:-}" ]; then
-            echo "VADE_PROJECT_PAT not set — skipping project assignment for PR #$PR_NUMBER"
+          # Prefer the App installation token; fall back to the legacy
+          # PAT during the migration window (Phase 3 of #837).
+          if [ -n "${APP_TOKEN:-}" ]; then
+            export GH_TOKEN="$APP_TOKEN"
+            echo "auth source: vade-coo-app installation token"
+          elif [ -n "${VADE_PROJECT_PAT:-}" ]; then
+            export GH_TOKEN="$VADE_PROJECT_PAT"
+            echo "auth source: VADE_PROJECT_PAT (legacy fallback)"
+          else
+            echo "no auth source available — skipping project assignment for PR #$PR_NUMBER"
             exit 0
           fi
 
@@ -57,8 +83,6 @@ jobs:
           PROJECT_ID="PVT_kwDOEGdN_84BUV2r"
           STATUS_FIELD_ID="PVTSSF_lADOEGdN_84BUV2rzhBesAw"
           STATUS_IN_PROGRESS_OPT="47fc9ee4"
-
-          export GH_TOKEN="$VADE_PROJECT_PAT"
 
           # addProjectV2ItemById is idempotent: returns the existing
           # edge if the item is already on the project.

--- a/.github/workflows/auto-tag-issues.yml
+++ b/.github/workflows/auto-tag-issues.yml
@@ -22,11 +22,14 @@ name: Auto-tag new issues
 #   - secrets.ANTHROPIC_API_KEY set (org-level preferred, repo-level OK)
 #   - Claude GitHub App installed on this repo
 #     (https://github.com/apps/claude)
-# Optional (graceful skip if absent):
-#   - secrets.VADE_PROJECT_PAT — PAT with `project` scope for the
-#     vade-app org. Enables auto-add to the VADE project. If
-#     missing, labeling still runs; the project step logs a
-#     warning and skips.
+# Optional auth for project-add step (one of, in preference order):
+#   - vars.VADE_COO_APP_ID + secrets.VADE_COO_APP_PRIVATE_KEY — the
+#     vade-coo-app GitHub App credentials (MEMO-2026-05-21-4wgy +
+#     vade-app/vade-coo-memory#837 Phase 2). Preferred.
+#   - secrets.VADE_PROJECT_PAT — legacy PAT with `project` scope for
+#     the vade-app org. Fallback during the migration window.
+#   - If neither is set, labeling still runs; the project step in
+#     the prompt logs a warning and skips.
 
 on:
   issues:
@@ -55,14 +58,25 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.issue.user.type != 'Bot' && github.event.issue.user.login != 'vade-coo') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Mint vade-coo-app installation token (optional)
+        id: app-token
+        if: vars.VADE_COO_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.VADE_COO_APP_ID }}
+          private-key: ${{ secrets.VADE_COO_APP_PRIVATE_KEY }}
+          owner: vade-app
+
       - name: Classify, label, and add to VADE project
         uses: anthropics/claude-code-action@v1
         env:
-          # Optional: PAT with `project` scope for the vade-app org.
-          # Propagated to the subprocess so the prompt's project
-          # GraphQL mutations can use it via `GH_TOKEN=…`. If unset,
-          # the project step in the prompt gracefully skips.
-          VADE_PROJECT_PAT: ${{ secrets.VADE_PROJECT_PAT }}
+          # Auth for the subprocess's project-add step. Variable name
+          # stays VADE_PROJECT_PAT for prompt compatibility, but the
+          # value preferred is the App installation token (Phase 3 of
+          # vade-coo-memory#837); legacy PAT is fallback during the
+          # migration window. If both are empty, the prompt's project
+          # step skips gracefully.
+          VADE_PROJECT_PAT: ${{ steps.app-token.outputs.token || secrets.VADE_PROJECT_PAT }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # bypassPermissions because the subprocess runs headless in CI —


### PR DESCRIPTION
## Summary

Phase 3 of [vade-app/vade-coo-memory#837](https://github.com/vade-app/vade-coo-memory/issues/837) — migrates the two workflows that hit org-level project mutations to mint a `vade-coo-app` installation token via `actions/create-github-app-token@v1`.

- **`.github/workflows/auto-add-prs-to-project.yml`** — adds an optional preceding `Mint vade-coo-app installation token` step; the subsequent `Add PR to VADE project` step prefers the App token and falls back to `VADE_PROJECT_PAT` if the App secrets aren't set.
- **`.github/workflows/auto-tag-issues.yml`** — same shape; the Claude Code subprocess receives the App token (or PAT fallback) under the existing `VADE_PROJECT_PAT` env var name, so the inline prompt is unchanged.

Migration shape is **fallback-chain**, not hard cutover:

```
App token (preferred) → VADE_PROJECT_PAT (legacy) → skip
```

This keeps the workflow operational through the org-secret provisioning window with no UX gap. The legacy PAT can be retired in a follow-up commit once Ven confirms the org-level App credentials are live.

## Required Ven follow-up (Phase 3.5)

Add to **vade-app org settings** at https://github.com/organizations/vade-app/settings:

- **Variables → Actions** → New organization variable:
  - Name: `VADE_COO_APP_ID`
  - Value: the numeric App ID from `op://COO/vade-coo-app/app_id`
  - Repository access: All repositories
- **Secrets → Actions** → New organization secret:
  - Name: `VADE_COO_APP_PRIVATE_KEY`
  - Value: the full PEM contents from `op://COO/vade-coo-app/private_key` (paste the multi-line text; the action handles whitespace tolerantly, but for cleanest behavior re-derive newlines from 1Password's text using `op read | python -c "..."` and paste the output)
  - Repository access: All repositories

App ID is public (visible on the App settings page), so it's stored as a **variable** rather than a secret — vars work in `if:` expressions, secrets don't. The gating `if: vars.VADE_COO_APP_ID != ''` cleanly skips the mint step when the org variable isn't set, which is the substrate signal that Phase 3.5 hasn't been done yet.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; ..."` on both files).
- [ ] CI on push: workflow lint / syntax checks.
- [ ] After Ven adds the org vars/secrets, a fresh PR or issue should log `auth source: vade-coo-app installation token` in the workflow output.
- [ ] Without the org vars/secrets set (pre-Phase-3.5 state), the workflow should log `auth source: VADE_PROJECT_PAT (legacy fallback)` and continue functioning identically to today.

## Refs

Refs: vade-app/vade-coo-memory#837 (parent epic) · MEMO-2026-05-21-4wgy (routing rule) · [vade-app/vade-coo-memory#819](https://github.com/vade-app/vade-coo-memory/issues/819) (fully retires once Ven flips off `VADE_PROJECT_PAT` in a follow-up).

Closes: n/a — Phase 3 of an epic; the parent #837 stays open through Phase 4.

https://claude.ai/code/session_01Dk3B7HziaZ6KtrWz3rEXqk