### PR TITLE
workflows: correct bridge prereq comment (VADE_FIELDS_ADMIN_PAT, not GITHUB_MCP_PAT)

### DIFF
--- a/.github/workflows/bridge-form-fields-to-natives.yml
+++ b/.github/workflows/bridge-form-fields-to-natives.yml
@@ -18,12 +18,13 @@ name: Bridge issue-form widgets to native fields (reusable)
 #
 # Prerequisites in each caller repo:
 #   - `secrets.VADE_FIELDS_ADMIN_PAT` — fine-grained PAT with
-#     org-level Issue fields write scope. Org-level secret; distinct
-#     from the container's `GITHUB_MCP_PAT` (which is not in org
-#     secrets). The `secrets:` block in the reusable workflow below
-#     names it explicitly; this prerequisite comment exists so caller
-#     repos know what to wire up. Naming-drift correction:
-#     MEMO-2026-05-21-zf7d.
+#     org-level Issue fields write scope. Org-level secret slot;
+#     holds the same value as the COO's `GITHUB_MCP_PAT` env var
+#     (the COO PAT at `op://COO/vade-coo-self-2026-04/token`),
+#     renamed around the GitHub Actions reserved `GITHUB_*` prefix
+#     per vade-coo-memory#848. When the COO PAT rotates, this org
+#     secret slot needs the new value pasted in too (third rotation
+#     surface; see MEMO-2026-05-21-zf7d).
 #
 # Cross-repo workflow access requires vade-app/vade-runtime's
 # Settings → Actions → General → Access set to

--- a/.github/workflows/bridge-form-fields-to-natives.yml
+++ b/.github/workflows/bridge-form-fields-to-natives.yml
@@ -17,8 +17,13 @@ name: Bridge issue-form widgets to native fields (reusable)
 # issue's side panel after creation, not by editing body sections.
 #
 # Prerequisites in each caller repo:
-#   - `secrets.GITHUB_MCP_PAT` — fine-grained PAT with org-level Issue
-#     fields write scope (the same PAT the COO sessions use).
+#   - `secrets.VADE_FIELDS_ADMIN_PAT` — fine-grained PAT with
+#     org-level Issue fields write scope. Org-level secret; distinct
+#     from the container's `GITHUB_MCP_PAT` (which is not in org
+#     secrets). The `secrets:` block in the reusable workflow below
+#     names it explicitly; this prerequisite comment exists so caller
+#     repos know what to wire up. Naming-drift correction:
+#     MEMO-2026-05-21-zf7d.
 #
 # Cross-repo workflow access requires vade-app/vade-runtime's
 # Settings → Actions → General → Access set to


### PR DESCRIPTION
## Summary

The bridge-form-fields-to-natives workflow's 'Prerequisites' comment block named `secrets.GITHUB_MCP_PAT` but the actual `env:` block on row 64 reads `${{ secrets.VADE_FIELDS_ADMIN_PAT }}`. `GITHUB_MCP_PAT` is the container's PAT identifier and is not in org secrets at all (org secrets are `ANTHROPIC_API_KEY`, `VADE_COO_APP_PRIVATE_KEY`, `VADE_FIELDS_ADMIN_PAT`, `VADE_PROJECT_PAT`).

This fixes the doc drift. No behavior change — the workflow has been reading the right secret all along.

Found while diagnosing why bridge runs 401'd after today's 2026-05-21 PAT rotation; the misnamed prereq led the originating session to brief Ven about the wrong org secret. Context: [MEMO-2026-05-21-zf7d](https://github.com/vade-app/vade-coo-memory/blob/main/coo/memos/2026-05-21-zf7d.md) (patched in [vade-app/vade-coo-memory#883](https://github.com/vade-app/vade-coo-memory/pull/883)).

## Test plan

- [x] grep confirms comment + env now use the same name
- [x] no behavior change (env: block unchanged)

Closes: n/a — comment-drift fix.

https://claude.ai/code/session_01PnJiksBdhSpkwhZuPEmbXf