### PR TITLE
Adopt /skill-name: title convention in skill.yml + tagging-taxonomy

### DIFF
--- a/.claude/skills/tagging-taxonomy/SKILL.md
+++ b/.claude/skills/tagging-taxonomy/SKILL.md
@@ -66,7 +66,7 @@ type picker. Retires the `type:*` label dimension as of 2026-05-21.
 | `Test` | `type:test` | Test coverage, fixtures, harness |
 | `Research` | `type:research` | Spike or investigation |
 | `Epic` | `type:epic` | Parent issue covering multiple implementable children |
-| `Skill` | (no prior label) | Skill lifecycle work (idea / implement / review / revise / evaluate) |
+| `Skill` | (no prior label) | Skill lifecycle work (idea / implement / review / revise / evaluate). **Title form**: `/<skill-name>: <short description>` (e.g. `/peer-review: tighten Phase 2 ingest`). The slash-prefix makes board scan-ability immediate; the `Skill kind` and `Skill name` native fields carry the lifecycle phase + canonical name. |
 
 The retired `type:*` labels remain on historical issues for
 record-keeping; do NOT apply them to new issues. GitHub default

--- a/.github/ISSUE_TEMPLATE/skill.yml
+++ b/.github/ISSUE_TEMPLATE/skill.yml
@@ -1,6 +1,6 @@
 name: Skill
 description: Skill lifecycle work (implement / review / revise / evaluate / idea).
-title: "Skill: <skill-name> — <phase>"
+title: "/<skill-name>: <short description>"
 type: Skill
 body:
   - type: markdown


### PR DESCRIPTION
## Summary

Mirror of the vade-coo-memory PR. Two changes:

- `.github/ISSUE_TEMPLATE/skill.yml` title default → `"/<skill-name>: <short description>"`.
- `.claude/skills/tagging-taxonomy/SKILL.md` §"The dimensions" §1 Skill row: add the title-form rule naming the slash-prefix convention.

## Test plan

- [x] Template title default updated
- [x] tagging-taxonomy SKILL.md carries the convention in the Skill native-type row
- [ ] Sibling PRs in vade-coo-memory / vade-core / vade-agent-logs land the same template change

Refs vade-app/vade-coo-memory#802

Closes: n/a

https://claude.ai/code/session_015nu8GL4c1BdNerKhxFrq9o