### PR TITLE
fix(git-push): surface rc=1 errors; ensure fallback fires on proxy rejection (closes #280)

### DIFF
--- a/scripts/ci/test-git-push-fallback.sh
+++ b/scripts/ci/test-git-push-fallback.sh
@@ -191,6 +191,175 @@ assert_match "fallback push args contain direct vade-coo URL" 'vade-coo:test_pat
 assert_no_match ".git/config contains no PAT" 'test_pat_DO_NOT_LEAK_2222' \
   "$(cat "$REPO/.git/config")"
 
+echo "== silent-failure hardening: workflow-scope rejection (#280) =="
+
+# Repro the #280 case directly: proxy rejects with the workflow-scope
+# OAuth message that should trip PROXY_FAILURE_PATTERNS=workflow.*scope.
+# The fix has to (a) match the marker, (b) fire the fallback, (c) leave
+# a diagnostic trail when the fallback itself fails so the next session
+# isn't stuck with rc=1 and zero output.
+
+WORKFLOW_WORK="$(mktemp -d)"
+WORKFLOW_LOG="$WORKFLOW_WORK/git-mock.log"
+WORKFLOW_STATE="$WORKFLOW_WORK/state"
+WORKFLOW_WRAPPER_LOG="$WORKFLOW_WORK/wrapper.log"
+
+cat > "$WORKFLOW_WORK/git" <<MOCKEOF
+#!/usr/bin/env bash
+case "\$1" in
+  push)
+    {
+      printf 'MOCK PUSH ARGS:'
+      for a in "\$@"; do printf ' [%s]' "\$a"; done
+      printf '\n'
+    } >> "$WORKFLOW_LOG"
+    if [ -f "$WORKFLOW_STATE" ]; then
+      # Fallback push: succeed.
+      exit 0
+    fi
+    : > "$WORKFLOW_STATE"
+    # Primary push: emit the canonical workflow-scope rejection.
+    cat >&2 <<'ERR'
+remote: refusing to allow an OAuth App to create or update workflow \`.github/workflows/foo.yml\` without \`workflow\` scope
+To http://127.0.0.1:35033/git/vade-app/vade-runtime
+ ! [remote rejected] claude/foo -> claude/foo (refusing to allow an OAuth App to create or update workflow without workflow scope)
+error: failed to push some refs to 'http://127.0.0.1:35033/git/vade-app/vade-runtime'
+ERR
+    exit 1
+    ;;
+  *)
+    exec $REAL_GIT "\$@"
+    ;;
+esac
+MOCKEOF
+chmod +x "$WORKFLOW_WORK/git"
+
+WORKFLOW_REPO="$WORKFLOW_WORK/repo"
+mkdir -p "$WORKFLOW_REPO"
+(
+  cd "$WORKFLOW_REPO"
+  $REAL_GIT init -q -b main >/dev/null 2>&1
+  $REAL_GIT -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
+  $REAL_GIT checkout -q -b claude/workflow-test
+  $REAL_GIT remote add origin "http://local_proxy@127.0.0.1:8080/git/vade-app/vade-runtime"
+)
+
+WORKFLOW_STUB_HOME="$WORKFLOW_WORK/stub-home"
+mkdir -p "$WORKFLOW_STUB_HOME"
+
+(
+  cd "$WORKFLOW_REPO"
+  PATH="$WORKFLOW_WORK:$PATH"
+  HOME="$WORKFLOW_STUB_HOME" \
+  GITHUB_MCP_PAT="test_pat_workflow_280" \
+  VADE_GIT_PUSH_FALLBACK_LOG="$WORKFLOW_WRAPPER_LOG" \
+    bash "$WRAPPER" -u origin claude/workflow-test
+) > "$WORKFLOW_WORK/wrapper.out" 2>&1
+workflow_rc=$?
+
+workflow_out="$(cat "$WORKFLOW_WORK/wrapper.out")"
+
+assert_eq "workflow-scope: wrapper exits 0 after fallback rescue" "0" "$workflow_rc"
+assert_match "workflow-scope: stderr surfaced 'retrying via' message" \
+  'retrying via https://vade-coo:\*\*\*@github\.com' "$workflow_out"
+assert_match "workflow-scope: stderr surfaced the workflow-scope marker" \
+  'workflow.*scope' "$workflow_out"
+
+# Mock saw two pushes (primary proxy attempt + direct-URL fallback).
+workflow_push_count="$(grep -c '^MOCK PUSH ARGS:' "$WORKFLOW_LOG" 2>/dev/null || echo 0)"
+assert_eq "workflow-scope: mock saw two push attempts" "2" "$workflow_push_count"
+
+# Durable log was written.
+assert_match "workflow-scope: durable log records 'wrapper start'" \
+  'wrapper start: args=' "$(cat "$WORKFLOW_WRAPPER_LOG" 2>/dev/null || true)"
+assert_match "workflow-scope: durable log records 'proxy-failure marker matched'" \
+  'proxy-failure marker matched' "$(cat "$WORKFLOW_WRAPPER_LOG" 2>/dev/null || true)"
+assert_match "workflow-scope: durable log records fallback rc=0" \
+  'fallback push: rc=0' "$(cat "$WORKFLOW_WRAPPER_LOG" 2>/dev/null || true)"
+
+echo "== silent-failure hardening: fallback also fails, forensic trail (#280) =="
+
+# Both pushes fail. Without #280's fix, this is exactly the silent-rc=1
+# case observed twice in production. Now: wrapper still exits non-zero
+# but the durable log MUST contain both push outputs for triage.
+
+DOUBLE_FAIL_WORK="$(mktemp -d)"
+DOUBLE_FAIL_LOG="$DOUBLE_FAIL_WORK/git-mock.log"
+DOUBLE_FAIL_WRAPPER_LOG="$DOUBLE_FAIL_WORK/wrapper.log"
+
+cat > "$DOUBLE_FAIL_WORK/git" <<MOCKEOF
+#!/usr/bin/env bash
+case "\$1" in
+  push)
+    {
+      printf 'MOCK PUSH ARGS:'
+      for a in "\$@"; do printf ' [%s]' "\$a"; done
+      printf '\n'
+    } >> "$DOUBLE_FAIL_LOG"
+    # Determine which attempt this is by checking arg list for a github.com URL.
+    is_fallback=0
+    for a in "\$@"; do
+      case "\$a" in
+        *github.com*) is_fallback=1; break ;;
+      esac
+    done
+    if [ "\$is_fallback" -eq 1 ]; then
+      printf 'remote: fallback also rejected (auth or network)\n' >&2
+      exit 1
+    else
+      printf 'remote: HTTP 403\n' >&2
+      exit 1
+    fi
+    ;;
+  *)
+    exec $REAL_GIT "\$@"
+    ;;
+esac
+MOCKEOF
+chmod +x "$DOUBLE_FAIL_WORK/git"
+
+DOUBLE_FAIL_REPO="$DOUBLE_FAIL_WORK/repo"
+mkdir -p "$DOUBLE_FAIL_REPO"
+(
+  cd "$DOUBLE_FAIL_REPO"
+  $REAL_GIT init -q -b main >/dev/null 2>&1
+  $REAL_GIT -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
+  $REAL_GIT checkout -q -b claude/double-fail
+  $REAL_GIT remote add origin "http://local_proxy@127.0.0.1:8080/git/vade-app/vade-runtime"
+)
+
+DOUBLE_FAIL_STUB_HOME="$DOUBLE_FAIL_WORK/stub-home"
+mkdir -p "$DOUBLE_FAIL_STUB_HOME"
+
+(
+  cd "$DOUBLE_FAIL_REPO"
+  PATH="$DOUBLE_FAIL_WORK:$PATH"
+  HOME="$DOUBLE_FAIL_STUB_HOME" \
+  GITHUB_MCP_PAT="test_pat_double_fail_280" \
+  VADE_GIT_PUSH_FALLBACK_LOG="$DOUBLE_FAIL_WRAPPER_LOG" \
+    bash "$WRAPPER" -u origin claude/double-fail
+) > "$DOUBLE_FAIL_WORK/wrapper.out" 2>&1
+double_fail_rc=$?
+
+assert_eq "double-fail: wrapper exits non-zero" "1" "$double_fail_rc"
+
+# CRITICAL: the durable log must contain forensics for both pushes.
+double_fail_log="$(cat "$DOUBLE_FAIL_WRAPPER_LOG" 2>/dev/null || true)"
+assert_match "double-fail: durable log dumps primary push output" \
+  '\-\-\- primary push \(rc=1\) \-\-\-' "$double_fail_log"
+assert_match "double-fail: durable log dumps fallback push output" \
+  '\-\-\- fallback push \(rc=1\) \-\-\-' "$double_fail_log"
+assert_match "double-fail: durable log captures the original 'HTTP 403'" \
+  'HTTP 403' "$double_fail_log"
+assert_match "double-fail: durable log captures the fallback rejection" \
+  'fallback also rejected' "$double_fail_log"
+
+# Durable log MUST NOT contain the PAT.
+assert_no_match "double-fail: durable log contains no PAT" \
+  'test_pat_double_fail_280' "$double_fail_log"
+
+rm -rf "$WORKFLOW_WORK" "$DOUBLE_FAIL_WORK"
+
 echo
 printf 'Results: %d pass, %d fail\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/git-push-with-fallback.sh
+++ b/scripts/git-push-with-fallback.sh
@@ -33,6 +33,17 @@
 #       after the push lands;
 #     · pipes fallback push output through a sed redactor that masks
 #       any `<user>:<password>@` URL.
+#
+# Silent-failure hardening (vade-app/vade-runtime#280):
+#   The wrapper writes every state transition (entry, primary push rc,
+#   marker-match decision, fallback push rc) to a durable log at
+#   ~/.vade/git-push-fallback.log so cases where stderr is swallowed
+#   by an outer harness (bootstrap-trace, captured CI runner, etc.)
+#   leave a recoverable forensic trail. The fallback push output is
+#   also tee'd to a tmp file and dumped to the log on rc!=0, so the
+#   PAT-redacted git stderr is available for triage even when the
+#   interactive stream was empty. Set VADE_GIT_PUSH_FALLBACK_LOG=<path>
+#   to override the log location.
 
 set -uo pipefail
 
@@ -105,43 +116,103 @@ parse_push_refspec() {
 }
 
 PUSH_OUT_TMP=""
-cleanup() { [ -n "${PUSH_OUT_TMP:-}" ] && rm -f "$PUSH_OUT_TMP"; }
+FALLBACK_OUT_TMP=""
+cleanup() {
+  [ -n "${PUSH_OUT_TMP:-}" ] && rm -f "$PUSH_OUT_TMP"
+  [ -n "${FALLBACK_OUT_TMP:-}" ] && rm -f "$FALLBACK_OUT_TMP"
+}
 trap cleanup EXIT
 
+# Surface a line to BOTH stderr and the durable wrapper log under
+# ~/.vade/git-push-fallback.log. Bug #280: under the bootstrap-trace
+# harness and in some cloud-sandbox conditions, stderr from a piped
+# `git push` got eaten before reaching the user — leaving rc=1 with no
+# visible diagnostic. Tagging every important state transition through
+# this helper guarantees there is *always* a durable trail on disk even
+# when the interactive stderr stream is closed/redirected/swallowed.
+WRAPPER_LOG="${VADE_GIT_PUSH_FALLBACK_LOG:-${HOME}/.vade/git-push-fallback.log}"
+log_both() {
+  local msg="$*"
+  log_err "$msg"
+  mkdir -p "$(dirname "$WRAPPER_LOG")" 2>/dev/null || return 0
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo)"
+  printf '%s [pid=%d] %s\n' "$ts" "$$" "$msg" >> "$WRAPPER_LOG" 2>/dev/null || true
+  # Bounded retention.
+  if [ "$(wc -l < "$WRAPPER_LOG" 2>/dev/null || echo 0)" -gt 500 ]; then
+    tail -n 500 "$WRAPPER_LOG" > "${WRAPPER_LOG}.tmp" 2>/dev/null \
+      && mv -f "${WRAPPER_LOG}.tmp" "$WRAPPER_LOG" 2>/dev/null
+  fi
+}
+
+# Tee variant of log_both that also dumps the underlying push output
+# file to the wrapper log. Used when the wrapper returns non-zero so
+# the next session's investigator has the raw git stderr/stdout on
+# disk even if stderr was swallowed at runtime.
+dump_to_log() {
+  local label="$1" file="$2"
+  [ -f "$file" ] || return 0
+  mkdir -p "$(dirname "$WRAPPER_LOG")" 2>/dev/null || return 0
+  {
+    printf -- '--- %s ---\n' "$label"
+    cat "$file" 2>/dev/null || true
+    printf -- '--- end %s ---\n' "$label"
+  } >> "$WRAPPER_LOG" 2>/dev/null || true
+}
+
 main() {
+  log_both "wrapper start: args=[$*]"
+
   if ! PUSH_OUT_TMP="$(mktemp 2>/dev/null)"; then
-    log_err "mktemp failed; running git push directly with no fallback"
+    log_both "mktemp failed; running git push directly with no fallback"
     exec git push "$@"
   fi
   local tmp="$PUSH_OUT_TMP"
 
+  # Run the primary push. Two output sinks for resilience against the
+  # symptom in #280 where stderr from a piped invocation was swallowed:
+  # (a) tee to the user's terminal as before, (b) the always-present
+  # $tmp file we grep against, (c) appended into $WRAPPER_LOG after
+  # rc!=0 so a silent stderr is recoverable post-hoc.
   local rc=0
+  # `2>&1 | tee` is the canonical capture-and-display pattern.
+  # PIPESTATUS[0] is the only correct way to read git's exit under
+  # `set -o pipefail`; assign immediately on the next line — any
+  # intervening command (including a conditional branch on $?) will
+  # overwrite it.
   git push "$@" 2>&1 | tee "$tmp"
-  rc="${PIPESTATUS[0]}"
+  rc="${PIPESTATUS[0]:-1}"
+  log_both "primary push: rc=$rc bytes_captured=$(wc -c < "$tmp" 2>/dev/null || echo 0)"
   if [ "$rc" -eq 0 ]; then
     return 0
   fi
 
+  # Non-zero. From here on every return path must (1) emit a stderr
+  # line via log_both, (2) include the captured git output in the
+  # wrapper log so a silent-stderr session leaves a forensic trail.
+  dump_to_log "primary push (rc=$rc)" "$tmp"
+
   if ! grep -qE "$PROXY_FAILURE_PATTERNS" "$tmp"; then
-    log_err "git push failed (rc=$rc) with no proxy-failure marker; passing through"
+    log_both "git push failed (rc=$rc) with no proxy-failure marker; passing through"
     return "$rc"
   fi
+  log_both "proxy-failure marker matched; preparing fallback"
 
   local remote current_url repo_path repo_owner
   remote="$(resolve_remote_from_args "$@")"
   if ! current_url="$(git remote get-url "$remote" 2>/dev/null)" || [ -z "$current_url" ]; then
-    log_err "could not resolve remote '$remote'; not falling back"
+    log_both "could not resolve remote '$remote'; not falling back"
     return "$rc"
   fi
   case "$current_url" in
     *github.com*)
-      log_err "remote '$remote' already targets github.com; failure is not proxy-related"
+      log_both "remote '$remote' already targets github.com; failure is not proxy-related"
       return "$rc"
       ;;
   esac
   repo_path="$(extract_repo_path "$current_url")"
   if [ -z "$repo_path" ]; then
-    log_err "could not extract owner/repo from '$current_url'; not falling back"
+    log_both "could not extract owner/repo from '$current_url'; not falling back"
     return "$rc"
   fi
   repo_owner="${repo_path%%/*}"
@@ -162,14 +233,14 @@ main() {
     fallback_pat_name="GITHUB_MCP_PAT"
     fallback_user="vade-coo"
   else
-    log_err "git proxy push failed but no GitHub PAT is set (GITHUB_MCP_PAT, GITHUB_PUBLIC_PAT); cannot fall back"
-    log_err "  run scripts/coo-bootstrap.sh (or source ~/.vade/coo-env) to populate them"
+    log_both "git proxy push failed but no GitHub PAT is set (GITHUB_MCP_PAT, GITHUB_PUBLIC_PAT); cannot fall back"
+    log_both "  run scripts/coo-bootstrap.sh (or source ~/.vade/coo-env) to populate them"
     return "$rc"
   fi
 
   local direct_url="https://${fallback_user}:${fallback_pat}@github.com/${repo_path}.git"
   local masked_url="https://${fallback_user}:***@github.com/${repo_path}.git"
-  log_err "git proxy push failed; retrying via $masked_url (using $fallback_pat_name)"
+  log_both "git proxy push failed; retrying via $masked_url (using $fallback_pat_name)"
 
   # Build fallback args: substitute direct_url for the remote token, and
   # drop -u / --set-upstream (the upstream-tracking config gets written
@@ -191,20 +262,44 @@ main() {
     local current_branch
     current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
     if [ -z "$current_branch" ]; then
-      log_err "no remote in args and detached HEAD; cannot construct fallback push"
+      log_both "no remote in args and detached HEAD; cannot construct fallback push"
       return "$rc"
     fi
     new_args+=("$direct_url" "HEAD:refs/heads/$current_branch")
   fi
 
-  # Pipe push output through a redactor as belt-and-suspenders against
-  # any URL leak from git itself. PIPESTATUS preserves git's exit code.
+  # Fallback push: same belt-and-suspenders treatment as the primary —
+  # capture to a tmp file for forensics, run output through the PAT
+  # redactor, AND tee to stdout/stderr. The prior implementation piped
+  # straight through `sed` with no separate capture; if sed exited
+  # non-zero (e.g., SIGPIPE on closed terminal) or stderr was swallowed,
+  # there was no recoverable diagnostic. Now the raw (post-redaction)
+  # output lands in $FALLBACK_OUT_TMP and gets dumped to $WRAPPER_LOG
+  # whenever the fallback returns non-zero.
   local fallback_rc
-  git push "${new_args[@]}" 2>&1 | sed -E "$PAT_REDACT_SED"
-  fallback_rc="${PIPESTATUS[0]}"
+  if ! FALLBACK_OUT_TMP="$(mktemp 2>/dev/null)"; then
+    # Degraded path: lose the forensic dump but still run the fallback.
+    log_both "fallback mktemp failed; running fallback push without capture"
+    git push "${new_args[@]}" 2>&1 | sed -E "$PAT_REDACT_SED"
+    fallback_rc="${PIPESTATUS[0]:-1}"
+  else
+    local ftmp="$FALLBACK_OUT_TMP"
+    # The pipeline: git → sed (redactor) → tee (sink to file + stdout).
+    # PIPESTATUS[0] still captures git's exit code; tee's exit
+    # ($PIPESTATUS[2]) and sed's ($PIPESTATUS[1]) are non-fatal for
+    # routing purposes.
+    git push "${new_args[@]}" 2>&1 | sed -E "$PAT_REDACT_SED" | tee "$ftmp"
+    fallback_rc="${PIPESTATUS[0]:-1}"
+    log_both "fallback push: rc=$fallback_rc bytes_captured=$(wc -c < "$ftmp" 2>/dev/null || echo 0)"
+    if [ "$fallback_rc" -ne 0 ]; then
+      dump_to_log "fallback push (rc=$fallback_rc)" "$ftmp"
+    fi
+  fi
   if [ "$fallback_rc" -ne 0 ]; then
+    log_both "fallback push failed; rc=$fallback_rc (forensic trail: $WRAPPER_LOG)"
     return "$fallback_rc"
   fi
+  log_both "fallback push succeeded"
 
   # Restore upstream tracking via the symbolic remote so .git/config
   # stays free of the credential URL. Skip silently if the user didn't
@@ -222,7 +317,7 @@ main() {
       git config "branch.${local_branch}.remote" "$remote"
       git config "branch.${local_branch}.merge" "$merge_ref"
     else
-      log_err "fallback push succeeded but could not parse refspec; upstream not restored — run 'git push -u $remote <branch>' manually if needed"
+      log_both "fallback push succeeded but could not parse refspec; upstream not restored — run 'git push -u $remote <branch>' manually if needed"
     fi
   fi
 }


### PR DESCRIPTION
## Summary

Closes #280. The `git-push-with-fallback.sh` wrapper was observed twice exiting rc=1 with **zero stdout, zero stderr** — once in `run-2026-05-20T181315` under the bootstrap-trace harness ([#280 OP](https://github.com/vade-app/vade-runtime/issues/280#issue-)), then again in `run-2026-05-21T024648` while pushing a workflow-file commit ([#280 comment 2](https://github.com/vade-app/vade-runtime/issues/280#issuecomment-)). In both, the safety-net script became indistinguishable from "git is broken" to the next session.

The triggering case in observation 2 was the proxy emitting `refusing to allow an OAuth App ... workflow scope`, which **does** match `PROXY_FAILURE_PATTERNS` — so the fallback condition was satisfied. The reporter could not confirm whether (a) the rescue never fired, or (b) the rescue's output was also swallowed; from the user's seat both look identical.

## Root cause (best-supported reading)

stderr from the wrapper's `git push ... 2>&1 | tee/sed` invocations is routed through pipelines whose `sed`/`tee` ends can themselves be killed by SIGPIPE, closed fds, or harness-installed file-descriptor wrappers (the bootstrap-trace harness uses `exec {fd}>>...` to set up `BASH_XTRACEFD`). When stderr disappears from the user's view, the wrapper's existing `log_err` lines disappear with it, and the wrapper looks silent. The fallback push had no separate capture file at all (line was `git push ... 2>&1 | sed -E "$PAT_REDACT_SED"` with no tee), so even post-hoc inspection had nothing to read.

## Fix

Two changes, both in `scripts/git-push-with-fallback.sh`:

1. **Durable forensic log.** Every state transition (entry, primary push rc + byte-count, marker-match decision, fallback push rc, every error path) writes to `~/.vade/git-push-fallback.log` (overridable via `VADE_GIT_PUSH_FALLBACK_LOG`). When stderr is swallowed by an outer harness, the log preserves the boot-time history. Bounded retention (500 lines).
2. **Fallback push also tees.** The fallback pipeline gains a `| tee \"$ftmp\"` sink so the PAT-redacted output of a failed fallback lands in the durable log. Previously, double-fail cases (proxy + direct-URL both refused) left **no forensic trail at all**.

Additional hardening:
- `PIPESTATUS[0]:-1` default in case the shell handed back an empty value (paranoia, not a confirmed bug — see "remaining open questions").
- Every `return` path is now preceded by a `log_both` call (was previously `log_err`-only, easy to grep for). Naming `log_both` makes the durability contract explicit at the call site.
- Wrapper comment block documents the silent-failure hardening alongside the existing credential-leak hardening note.

## Verification

`scripts/ci/test-git-push-fallback.sh` is extended with two new test groups (13 new asserts, 31 total):

- **workflow-scope rejection (#280 observation 2).** Reproduces the proxy emitting the exact `refusing to allow an OAuth App ... workflow scope` string. Asserts: wrapper exits 0 after fallback rescue; stderr surfaces both the workflow-scope marker and the `retrying via https://vade-coo:***@github.com` message; the durable log records wrapper start, marker-match, and fallback rc=0.
- **double-fail forensic trail.** Both pushes fail. Asserts: wrapper exits 1; durable log dumps both pushes' raw output between `--- primary push ---` / `--- fallback push ---` fences; log captures `HTTP 403` and `fallback also rejected` content; log contains zero PAT material.

```
$ bash scripts/ci/test-git-push-fallback.sh
...
Results: 31 pass, 0 fail

$ bash scripts/ci/test-git-shim.sh
...
=== results: 13 passed, 0 failed ===
```

## Remaining open questions

- **The exact mechanism behind the swallowed stderr.** The hypothesis above (`BASH_XTRACEFD` / pipeline SIGPIPE / harness `exec` fd manipulation) is plausible but I could not reproduce the silent-stderr case in isolation — the workflow-scope rejection reproducer surfaces stderr cleanly. The fix is defensive (write to disk on every transition) rather than diagnostic of the exact stderr-disappearance route. If a future occurrence still surfaces silent stderr at the terminal, the `~/.vade/git-push-fallback.log` will at least say "wrapper start" + the rc + the captured push output, which is a 100% diagnostic improvement over the current "no output, exit 1" symptom.
- **Whether the bootstrap-trace harness in #273 ever needs to be told about this wrapper specifically.** If trace-mode output ends up routed via `BASH_XTRACEFD` and never reaches the user, that's an upstream harness concern (#273), not a wrapper concern. Filed as a "to consider" if #280 recurs after this fix.

## Test plan

- [x] `bash scripts/ci/test-git-push-fallback.sh` — 31/31 pass.
- [x] `bash scripts/ci/test-git-shim.sh` — 13/13 pass (no regressions).
- [x] `bash -n scripts/git-push-with-fallback.sh` — clean syntax.
- [x] This branch's own push surfaced `wrapper start` and `primary push: rc=0` lines, confirming the durable log + transition tracing fire on the happy path.
- [ ] Post-merge: on the next workflow-file push attempt, confirm `~/.vade/git-push-fallback.log` shows the wrapper's state transitions.

https://claude.ai/code/session_011dTuSjsfYFazcEecjpsHKR