### PR TITLE
F7 follow-up: add actions:read for cross-repo workflow_call to private vcm

### DIFF
--- a/.github/workflows/auto-add-prs-to-project.yml
+++ b/.github/workflows/auto-add-prs-to-project.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  actions: read  # required to resolve a workflow_call ref in a private repo (vcm)
 
 jobs:
   add:

--- a/.github/workflows/auto-tag-issues.yml
+++ b/.github/workflows/auto-tag-issues.yml
@@ -22,6 +22,7 @@ permissions:
   issues: write
   contents: read
   id-token: write  # anthropics/claude-code-action@v1 mints its GitHub token via OIDC
+  actions: read  # required to resolve a workflow_call ref in a private repo (vcm)
 
 jobs:
   tag:

--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   issues: write
   contents: read
+  actions: read  # required to resolve a workflow_call ref in a private repo (vcm)
 
 jobs:
   post-launch-link:

--- a/.github/workflows/issue-pr-hygiene.yml
+++ b/.github/workflows/issue-pr-hygiene.yml
@@ -25,6 +25,7 @@ permissions:
   issues: write
   contents: read
   checks: write
+  actions: read  # required to resolve a workflow_call ref in a private repo (vcm)
 
 jobs:
   hygiene:


### PR DESCRIPTION
## Summary

Follow-up to [vade-runtime#315](https://github.com/vade-app/vade-runtime/pull/315) (F7 pilot consumer). The 4 thin triggers were missing `actions: read` at the caller's permissions block — required when invoking a reusable workflow stored in a **private** repository (vcm is private; vade-runtime is public). Without it, the workflow loader can't resolve the `@main` ref and the run fails in 0 seconds with 0 jobs — which is exactly what vade-runtime#315's hygiene + auto-add CI checks did, even after vcm#971 landed.

Confirmed by the post-merge re-trigger that still failed:
- [Hygiene run on vade-runtime#315 after vcm#971 merged](https://github.com/vade-app/vade-runtime/actions/runs/26382813352) — failure in 0s, 0 jobs.

This PR adds `actions: read` to all 4 thin triggers. The PR's own CI runs the fixed thin triggers on the head branch — if the hypothesis is right, hygiene + auto-add will pass on this PR.

### What changed

```diff
 permissions:
   ... (existing) ...
+  actions: read  # required to resolve a workflow_call ref in a private repo (vcm)
```

Applied to: `coo-on-assign.yml`, `auto-tag-issues.yml`, `auto-add-prs-to-project.yml`, `issue-pr-hygiene.yml`. 4 files, +4 / -0 lines.

### Test plan

- [ ] CI green on this PR (`Issue / PR hygiene` + `Auto-add new PRs to the VADE project` succeed instead of fail-in-0s)
- [ ] Operations doc updated separately in vcm to document the `actions: read` requirement
- [ ] Same fix baked into the rollout PRs for the other 7 consumer repos (vade-core, vade-agent-logs, coo-console, skills, coo4one, vade-site, tjsonl)

Closes: n/a — fix-up for vade-coo-memory#939's pilot landing

https://claude.ai/code/session_011Wj1heZYDXrdHC9rw9NGDE