### PR TITLE
F7 pivot: move canonical reusables to vade-runtime (public)

### DIFF
--- a/.github/workflows/auto-add-prs-to-project-reusable.yml
+++ b/.github/workflows/auto-add-prs-to-project-reusable.yml
@@ -1,0 +1,95 @@
+name: Auto-add new PRs to the VADE project (reusable)
+
+# Reusable workflow: adds a PR to the VADE org project board with
+# Status=In Progress. Pairs with `auto-tag-issues-reusable.yml`'s
+# project-add step (which only handles issues, not PRs).
+#
+# Canonical home: vade-app/vade-runtime/.github/workflows/auto-add-prs-to-project-reusable.yml
+# Centralization design: vade-coo-memory#939 (F7); host=vade-runtime per #939 comment.
+# Operations doc: vade-app/vade-coo-memory:coo/operations/workflow-centralization.md
+# Project-board doc: vade-app/vade-coo-memory:coo/operations/project-board.md
+# Status canonical: MEMO-2026-05-20-pbrd
+#
+# Trigger contract for callers:
+#   on: pull_request
+#     types: [opened, reopened]
+#   jobs:
+#     <name>:
+#       uses: vade-app/vade-runtime/.github/workflows/auto-add-prs-to-project-reusable.yml@main
+#       secrets: inherit
+#
+# Prerequisites in each caller repo:
+#   - secrets.VADE_PROJECT_PAT — PAT with `project` scope for the
+#     vade-app org. If unset, the workflow logs a warning and skips
+#     (graceful no-op, mirrors the auto-tag-issues pattern).
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-project-add-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  add:
+    # Skip dependabot + GitHub Actions auto-PRs; include vade-coo,
+    # claude[bot], and human authors.
+    if: |
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to VADE project, set Status=In Progress
+        env:
+          VADE_PROJECT_PAT: ${{ secrets.VADE_PROJECT_PAT }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Auto-add is opportunistic — graceful skip on any failure mode
+          # (missing secret, PAT scope insufficient for this repo, project
+          # field write denied). The CI run does NOT fail; the PR proceeds.
+          set -uo pipefail
+
+          if [ -z "${VADE_PROJECT_PAT:-}" ]; then
+            echo "VADE_PROJECT_PAT not set — skipping project assignment for PR #$PR_NUMBER"
+            exit 0
+          fi
+
+          # Canonical IDs from coo/operations/project-board.md:
+          PROJECT_ID="PVT_kwDOEGdN_84BUV2r"
+          STATUS_FIELD_ID="PVTSSF_lADOEGdN_84BUV2rzhBesAw"
+          STATUS_IN_PROGRESS_OPT="47fc9ee4"
+
+          export GH_TOKEN="$VADE_PROJECT_PAT"
+
+          # addProjectV2ItemById is idempotent: returns the existing
+          # edge if the item is already on the project.
+          add_out=$(gh api graphql \
+            -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' \
+            -F p="$PROJECT_ID" \
+            -F c="$PR_NODE_ID" 2>&1)
+          add_rc=$?
+          ITEM_ID=$(printf '%s' "$add_out" | jq -r '.data.addProjectV2ItemById.item.id // empty' 2>/dev/null || true)
+
+          if [ "$add_rc" -ne 0 ] || [ -z "$ITEM_ID" ]; then
+            echo "auto-add: PR #$PR_NUMBER could not be added to VADE project (likely VADE_PROJECT_PAT lacks Pull Requests: Read on this repo). Continuing — this is non-blocking." >&2
+            echo "auto-add: gh output was: $add_out" >&2
+            exit 0
+          fi
+          echo "Added PR #$PR_NUMBER to VADE as item $ITEM_ID"
+
+          # Set Status=In Progress. Best-effort — log and continue on failure.
+          if ! gh api graphql \
+            -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+            -F p="$PROJECT_ID" \
+            -F i="$ITEM_ID" \
+            -F f="$STATUS_FIELD_ID" \
+            -F o="$STATUS_IN_PROGRESS_OPT" >/dev/null 2>&1; then
+            echo "auto-add: Status field write failed on item $ITEM_ID — continuing" >&2
+            exit 0
+          fi
+
+          echo "Set Status=In Progress on item $ITEM_ID"

--- a/.github/workflows/auto-add-prs-to-project.yml
+++ b/.github/workflows/auto-add-prs-to-project.yml
@@ -16,5 +16,7 @@ permissions:
 
 jobs:
   add:
-    uses: vade-app/vade-coo-memory/.github/workflows/auto-add-prs-to-project-reusable.yml@main
+    # Same-repo call uses relative path (see coo-on-assign.yml note).
+    # External consumers use: vade-app/vade-runtime/.github/workflows/auto-add-prs-to-project-reusable.yml@main
+    uses: ./.github/workflows/auto-add-prs-to-project-reusable.yml
     secrets: inherit

--- a/.github/workflows/auto-tag-issues-reusable.yml
+++ b/.github/workflows/auto-tag-issues-reusable.yml
@@ -1,0 +1,397 @@
+name: Auto-tag new issues (reusable)
+
+# Reusable workflow: classifies a newly-opened (or workflow_dispatch'd)
+# issue across area/qualifier/milestone dimensions, applies the labels
+# additively, and adds the issue to the VADE org project board.
+#
+# Canonical home: vade-app/vade-runtime/.github/workflows/auto-tag-issues-reusable.yml
+# Centralization design: vade-coo-memory#939 (F7); host=vade-runtime (public)
+# so private + public consumers can both invoke (Public→Private workflow_call
+# resolution fails despite access_level=organization; bridge-form-fields-to-natives.yml
+# is the live in-org precedent for "public canonical, mixed consumers").
+# Operations doc: vade-app/vade-coo-memory:coo/operations/workflow-centralization.md
+# Canonical taxonomy: https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md
+# Canonical fields:   https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/issue-fields-and-types.md
+# Canonical project:  https://github.com/orgs/vade-app/projects/1 (VADE)
+#   Project node ID:  PVT_kwDOEGdN_84BUV2r
+#
+# Per-repo behavior is bridged via `${{ github.repository }}` — every
+# caller routes its own issues through this single classifier; the
+# canonical taxonomy is uniform across vade-app/* repos.
+#
+# Mirrors the pilot on vade-coo-memory (see MEMO 2026-04-23-04 and the
+# five-PR debug chain on vade-coo-memory: #70, #73, #74, #75, #76).
+# Do not regress the invariants without reviewing that history first:
+#   - permissions.id-token:write is required (OIDC; PR #73)
+#   - fetch the issue via `gh` tool call, not YAML-inlined event
+#     fields (PR #74)
+#   - `--permission-mode bypassPermissions` is required in headless CI
+#     (PR #75)
+#   - prompt must mandate exact `gh issue edit` + `gh issue view`
+#     verification; the model will otherwise declare success in text
+#     without calling the tool (PR #76)
+#
+# Trigger contract for callers (see auto-tag-issues.yml thin trigger):
+#   on:
+#     issues:       { types: [opened] }
+#     workflow_dispatch:
+#       inputs:
+#         issue_number: { required: true, type: number }
+#   permissions:
+#     issues: write
+#     contents: read
+#     id-token: write
+#   jobs:
+#     tag:
+#       uses: vade-app/vade-runtime/.github/workflows/auto-tag-issues-reusable.yml@main
+#       with:
+#         issue-number:  ${{ github.event.issue.number || inputs.issue_number }}
+#         mode:          ${{ github.event_name == 'workflow_dispatch' && 'full' || 'gapfill' }}
+#         opener-is-bot: ${{ github.event.issue.user.type == 'Bot' || false }}
+#       secrets: inherit
+#
+# Prerequisites in each caller repo:
+#   - secrets.ANTHROPIC_API_KEY set (org-level preferred, repo-level OK)
+#   - Claude GitHub App installed on this repo
+#     (https://github.com/apps/claude)
+# Optional (graceful skip if absent):
+#   - secrets.VADE_PROJECT_PAT — PAT with `project` scope for the
+#     vade-app org. Enables auto-add to the VADE project. If
+#     missing, labeling still runs; the project step logs a
+#     warning and skips.
+
+on:
+  workflow_call:
+    inputs:
+      issue-number:
+        description: "Issue number to classify and tag."
+        required: true
+        type: number
+      mode:
+        description: "gapfill (issues.opened, additive only) or full (workflow_dispatch, re-classify)."
+        required: true
+        type: string
+      opener-is-bot:
+        description: "Whether the issue opener is a Bot. Skip workflow if true unless mode=full."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  contents: read
+  id-token: write  # anthropics/claude-code-action@v1 mints its GitHub token via OIDC
+
+concurrency:
+  group: auto-tag-${{ github.repository }}-${{ inputs.issue-number }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    # Skip bot-authored issues so the router can't retrigger itself
+    # once agents start filing issues. Override on workflow_dispatch
+    # (mode=full) so a manual re-classify can still run.
+    if: ${{ inputs.mode == 'full' || !inputs.opener-is-bot }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Classify, label, and add to VADE project
+        uses: anthropics/claude-code-action@v1
+        env:
+          # Optional: PAT with `project` scope for the vade-app org.
+          # Propagated to the subprocess so the prompt's project
+          # GraphQL mutations can use it via `GH_TOKEN=…`. If unset,
+          # the project step in the prompt gracefully skips.
+          VADE_PROJECT_PAT: ${{ secrets.VADE_PROJECT_PAT }}
+          # MODE drives the prompt's gap-fill vs full-reclassify branch:
+          # `gapfill` on `issues.opened` (default; respects opener-set
+          # state), `full` on `workflow_dispatch` (re-classify all
+          # dimensions). Hard invariant in both modes: never remove a
+          # pre-existing label or milestone. See vade-coo-memory#834.
+          MODE: ${{ inputs.mode }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # bypassPermissions because the subprocess runs headless in CI —
+          # no interactive prompt available, so default-deny blocks the
+          # label-write and project-mutation paths. Blast radius is
+          # bounded by the workflow's `permissions:` block (issues:write
+          # + contents:read) and the prompt's explicit "labels + one
+          # project item only" constraint.
+          claude_args: --model claude-haiku-4-5-20251001 --permission-mode bypassPermissions
+          # Surface full SDK output in the Actions log so future failures
+          # (permission denials, tool errors, GraphQL 4xx) are visible
+          # without a rerun.
+          show_full_output: true
+          prompt: |
+            You are a small, deterministic triage routine for the
+            `${{ github.repository }}` repo. You classify one specific
+            issue, apply labels, and add it to the VADE project.
+            You do nothing else.
+
+            Target issue number: ${{ inputs.issue-number }}
+
+            Procedure:
+
+            1. Fetch the target issue via `Bash`:
+
+                   gh issue view <NUMBER> --repo ${{ github.repository }} --json title,body,author,id,labels,milestone
+
+               The `id` field is the GraphQL node ID — keep it; step 5
+               needs it. The `labels` array (each entry has `.name`)
+               and `milestone.title` are what the opener already set
+               — step 2's mode filter and step 3 need them to honor
+               the mode contract below. Do NOT request
+               `authorAssociation` (not a valid `gh` JSON field).
+
+            **Mode contract.** Read `MODE` from env (`echo "$MODE"`):
+
+              - `gapfill` (default; fires on `issues.opened`): Only
+                ADD labels and milestone for dimensions NOT already
+                present on the issue. Respect what the opener set as
+                authoritative. The result may legitimately be zero
+                new labels and no milestone — that is a valid
+                gap-fill outcome and the project-add step in §5
+                still runs.
+
+              - `full` (`workflow_dispatch` only): Classify all
+                dimensions; additive label writes (`--add-label`
+                no-ops on labels already present). May set milestone
+                only if none is already set.
+
+            **Hard invariant, both modes:** NEVER use `--remove-label`,
+            NEVER pass `--milestone ""` (empty) to clear, NEVER
+            reason yourself into removing a pre-existing label or
+            milestone. The opener's pre-set values are authoritative;
+            this classifier fills gaps, it does not adjudicate prior
+            choices. If a pre-existing classification looks wrong to
+            you, ignore it — surfacing classification disagreements
+            is out of scope for this workflow.
+
+            2. Classify across the dimensions below. Canonical refs:
+               https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md
+               + https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/issue-fields-and-types.md
+
+               **Retired dimensions** (do NOT apply these as labels):
+               `type:*`, `readiness:*`, `prio:*` were retired 2026-05-21
+               per MEMO-2026-05-21-xfqh. Native issue type is set by the
+               issue template's `type:` front-matter; Priority / Readiness
+               field values are bridged from the template's dropdown
+               widgets by `bridge-form-fields-trigger.yml`. Applying
+               the legacy labels on top is duplicate metadata — the bug
+               this workflow was fixed to stop doing
+               (vade-coo-memory#879).
+
+               - `area:*` — one or two, from this repo's vocabulary:
+                 area:memory, area:identity, area:agents, area:skills, area:governance
+                 (plus the universal area:docs / area:ci / area:deploy
+                 available to every repo). Skip if no area clearly
+                 applies.
+
+               - qualifiers — apply each that matches (zero or more):
+                   needs:bdfl-approval — decision requires the BDFL
+                     (Ven) before implementation.
+                   blocked:bdfl-go-ahead — explicitly awaiting BDFL
+                     sign-off right now.
+                   blocked:upstream — waiting on upstream work in
+                     another repo or external dependency.
+                   emancipatory — issue concerns agent autonomy, self-
+                     infrastructure, or agent society design.
+                   external-code — touches code outside this repo's
+                     canonical ownership (vendored or cross-repo).
+
+               - `milestone` — zero or one (OPTIONAL; defaults to
+                 none). Use the GitHub UI title (e.g.,
+                 "Substrate Hygiene and Tooling"), NOT the M-prefix.
+                 Pick at most one per its scope-rule + test (canonical:
+                 https://github.com/vade-app/vade-coo-memory/blob/main/coo/audits/2026-05-20_milestone-taxonomy/README.md):
+                   "Decentering the Mind" — substantive edit / review /
+                     support for the "Decentering the Mind" essay or
+                     its peer-review atoms. Excludes the general
+                     publication pipeline ("The Published Record"),
+                     lineage events ("Lineage and Parallel Instances"),
+                     other foundations essays ("The Foundations Chain").
+                   "Boot and Environment Integrity" — agent's ability
+                     to start correctly + know its env state: boot
+                     pipeline, integrity probes, bootstrap, cloud /
+                     local env parity, harness secrets, boot CI.
+                     Excludes post-boot hooks ("Substrate Hygiene"),
+                     boot-time reads of identity / memory files.
+                   "Substrate Hygiene and Tooling" — operational
+                     primitives that make the agent work better
+                     session-to-session WITHOUT changing what it IS
+                     or CAN DO: hooks lifecycle, memo system plumbing,
+                     briefings integrity, label taxonomy, attribution
+                     mechanics, issue / PR hygiene, nightly automation,
+                     one-off refactors. Test: if removed, ops degrade
+                     silently without changing identity or capabilities.
+                   "The Published Record" — everything for
+                     read.vade-app.dev as public artifact: Quarto
+                     build, publish-site CI, publish-affordance, tier
+                     system, allowlist, IA, backlinks, deployment.
+                     Test: does this exist because the outside world
+                     should read something?
+                   "Memory Architecture" — design + implementation of
+                     the memory substrate: Mem0 model + SOP, memo
+                     system structure (index, IDs, semantic layer),
+                     transcript storage + schema, identity layer
+                     file, episodic memory cap. Excludes day-to-day
+                     memo writes; boot reads of memory files.
+                   "The Foundations Chain" — foundations essays +
+                     companions, disposition proposal, quorum records,
+                     F1-F6 watchdogs, the chain's open-question
+                     issues. Test: is this a primary artifact of the
+                     chain's self-record? Excludes Decentering and
+                     lineage.
+                   "Lineage and Parallel Instances" — issues whose
+                     primary subject is a documented lineage event
+                     (the-eight, laughing-davinci, socratic-126 / 209)
+                     OR the multi-instance phenomenon: deliberate
+                     fan-outs, society-of-selves auditor,
+                     lineage-interpreter agent. Test: is the primary
+                     subject the experience / record of co-existing
+                     instances, not the plumbing?
+                   "Skills and Agent Capabilities" — new capabilities
+                     added to the agent's vocabulary: slash commands,
+                     skills, sub-agent patterns, MCP integrations.
+                     Test: does this create or improve something the
+                     agent can INVOKE (vs configure / monitor)?
+                   "The Product Application" — vade-core as a
+                     product: tldraw canvas UI, MCP bridge, Fly.io,
+                     R2 / D1 storage, iPad-live, Shiffrin demo,
+                     auth / multi-tenant. Test: does this matter
+                     because end-users interact with the running app
+                     at vade-app.dev? Excludes read.vade-app.dev.
+                   "Outreach and Sustainability" — work extending
+                     reach, legitimacy, or material continuity beyond
+                     the current pair: Anthropic letter, funding
+                     instruments, philosopher contacts, conference
+                     prep, Shiffrin deck (outreach side).
+
+                 **Default to no milestone on ambiguity** (per
+                 MEMO-2026-05-20-mlst + MEMO-2026-05-21-qg65). If no
+                 milestone clearly applies per its scope-rule AND
+                 test, do NOT set one. Better empty than wrong.
+
+               Expect 0–3 labels total on a typical issue (one or two
+               area + zero or more qualifiers). Zero is a valid result
+               if no area clearly applies and no qualifier matches —
+               do not invent labels to hit a count. (This is the
+               **classification** target, not the apply target — the
+               mode filter below decides what actually gets written.)
+
+               **Mode filter (apply to your classification before
+               step 3):**
+
+               - If `MODE=gapfill`: walk the existing labels from
+                 step 1. For `area:*`, if any `area:*` label is
+                 already present, DROP your area classifications.
+                 For qualifiers (`needs:*`, `blocked:*`,
+                 `emancipatory`, `external-code`), KEEP only the ones
+                 NOT already present. For milestone, if
+                 `milestone.title` is non-null in step 1's output,
+                 DROP your milestone choice. The filtered set may be
+                 empty — that is OK.
+
+               - If `MODE=full`: KEEP all your label classifications
+                 (additive writes will no-op on duplicates). For
+                 milestone, DROP your choice if `milestone.title` is
+                 non-null in step 1's output (the hard invariant
+                 forbids replacing it).
+
+            3. **Apply the filtered classification (additive only).**
+               Execute this `Bash` command — one `--add-label` flag
+               per label that survived the mode filter, plus
+               `--milestone "<name>"` if a milestone choice survived:
+
+                   gh issue edit <NUMBER> --repo ${{ github.repository }} \
+                     --add-label "<label1>" --add-label "<label2>" ... \
+                     [--milestone "<milestone-name>"]
+
+               If the filtered set is empty (gap-fill found nothing
+               to add and no milestone to set), SKIP this command
+               entirely and proceed to step 4. The project-add step
+               still runs.
+
+               **Hard rules (both modes):**
+               - NEVER use `--remove-label`.
+               - NEVER pass `--milestone ""` to clear a milestone.
+               - If `gh` reports a label does not exist in the repo,
+                 create it via `gh label create "<label>" --repo
+                 ${{ github.repository }}` and retry.
+               - If `gh` reports the milestone doesn't exist, drop
+                 the `--milestone` flag and proceed. Do NOT create
+                 milestones — only the names listed in step 2 are
+                 valid; selection mistakes are silenced this way.
+
+               Keep going until `gh issue edit` exits 0 (or skip if
+               the filtered set is empty).
+
+            4. **Verify labels and milestone** by running:
+
+                   gh issue view <NUMBER> --repo ${{ github.repository }} --json labels,milestone
+
+               Two checks, both modes:
+
+               (a) Confirm every label you actually wrote in step 3
+                   (post-filter) is present in `labels[*].name`, and
+                   (if you set a milestone) `milestone.title` matches.
+                   If any are missing, retry step 3 for those.
+
+               (b) **Wipe-detection.** Confirm every pre-existing
+                   label from step 1 is STILL in `labels[*].name`,
+                   and (if step 1 had a milestone) `milestone.title`
+                   is unchanged. If any pre-existing value is
+                   missing, that is a critical hard-invariant
+                   violation: report it explicitly in the final
+                   message — do NOT attempt to restore via further
+                   writes (the wipe already happened; surfacing it
+                   is what matters).
+
+            5. **Add the issue to the VADE project.**
+               Run this exact Bash block, replacing `<ISSUE_ID>` with
+               the `id` you got in step 1:
+
+                   if [ -z "$VADE_PROJECT_PAT" ]; then
+                     echo "VADE_PROJECT_PAT not set — skipping project assignment"
+                   else
+                     ITEM_ID=$(GH_TOKEN="$VADE_PROJECT_PAT" gh api graphql \
+                       -f query='mutation { addProjectV2ItemById(input: {projectId: "PVT_kwDOEGdN_84BUV2r", contentId: "<ISSUE_ID>"}) { item { id } } }' \
+                       -q '.data.addProjectV2ItemById.item.id')
+                     echo "Added to VADE as item $ITEM_ID (default Status=Todo)"
+                   fi
+
+               If the PAT is set and the mutation returns an error,
+               report the error in your final message but do not retry
+               destructively.
+
+            6. **Verify project membership** (only if step 5 ran the
+               mutation path, not the skip path):
+
+                   gh issue view <NUMBER> --repo ${{ github.repository }} --json projectItems
+
+               Confirm a project item whose `title` is "VADE" appears
+               in the output. If step 5 took the skip path, note that
+               in your final message instead.
+
+            Do not stop until BOTH:
+              - Step 4's verification shows every intended label on the
+                issue (and the milestone, if you selected one), AND
+              - Step 6 confirms the VADE project item, OR step 5
+                logged the "VADE_PROJECT_PAT not set" warning.
+
+            Merely declaring "applied" in text is not enough — the
+            terminal state must be verified via `gh` output.
+
+            Side-effect budget: labels + at most one milestone + the
+            one VADE project item from step 5. Do not edit the title
+            or body, do not post a comment, do not assign, do not
+            close.
+
+            Final message: one line naming the mode used
+            (`gapfill`/`full`), one line on what the opener had set
+            (labels + milestone from step 1), one line on what step 3
+            actually wrote (labels + milestone, or "no-op — gap-fill
+            found nothing to add"), one line naming the final labels
+            (and milestone, if any) now on the issue, one line on
+            project state (added / skipped / error). If the
+            wipe-detection check in step 4 fired, lead with
+            `WIPE DETECTED: <details>`.

--- a/.github/workflows/auto-tag-issues.yml
+++ b/.github/workflows/auto-tag-issues.yml
@@ -25,7 +25,9 @@ permissions:
 
 jobs:
   tag:
-    uses: vade-app/vade-coo-memory/.github/workflows/auto-tag-issues-reusable.yml@main
+    # Same-repo call uses relative path (see coo-on-assign.yml note).
+    # External consumers use: vade-app/vade-runtime/.github/workflows/auto-tag-issues-reusable.yml@main
+    uses: ./.github/workflows/auto-tag-issues-reusable.yml
     with:
       issue-number: ${{ github.event.issue.number || inputs.issue_number }}
       mode: ${{ github.event_name == 'workflow_dispatch' && 'full' || 'gapfill' }}

--- a/.github/workflows/coo-on-assign-reusable.yml
+++ b/.github/workflows/coo-on-assign-reusable.yml
@@ -1,0 +1,155 @@
+name: COO on issue assign (reusable)
+
+# Reusable workflow: posts a pre-fill claude.ai/code launch URL on the
+# assigned issue when the new assignee is vade-coo. Called from per-repo
+# thin trigger workflows at `.github/workflows/coo-on-assign.yml`.
+#
+# Canonical home: vade-app/vade-runtime/.github/workflows/coo-on-assign-reusable.yml
+# Centralization design: vade-coo-memory#939 (F7); moved to vade-runtime
+# (public) per #939 comment because Public→Private workflow_call resolution
+# fails despite access_level=organization on the target.
+# Operations doc: vade-app/vade-coo-memory:coo/operations/workflow-centralization.md
+# Workflow rationale: vade-app/vade-coo-memory:coo/operations/coo-on-assign.md
+#
+# COO_SCOPE_REPOS maintenance: edit the list in this file once; all
+# consumer thin triggers pick up the change at next assignment event.
+# This file replaces the prior workflow-sync convention that required
+# N-PR fanout per change.
+#
+# Trigger contract for callers:
+#   on: issues
+#     types: [assigned]
+#   permissions:
+#     issues: write
+#     contents: read
+#   jobs:
+#     <name>:
+#       uses: vade-app/vade-runtime/.github/workflows/coo-on-assign-reusable.yml@main
+#       secrets: inherit
+
+on:
+  workflow_call:
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  # Scope per (repo, issue, assignee). The repo prefix prevents cross-repo
+  # collisions on issue numbers; concurrent assigns of different users to
+  # the same issue don't serialize (the assignee gate filters anyway), but
+  # rapid re-assigns of vade-coo to the same issue queue.
+  group: coo-on-assign-${{ github.repository }}-${{ github.event.issue.number }}-${{ github.event.assignee.login }}
+  cancel-in-progress: false
+
+jobs:
+  post-launch-link:
+    # Gate: only fire when the user that was just assigned is vade-coo.
+    # `github.event.assignee` is the user added by THIS event (distinct
+    # from `github.event.issue.assignees`, the full current list).
+    if: ${{ github.event.assignee.login == 'vade-coo' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build pre-fill URL and post launch comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const repoSlug = `${owner}/${repo}`;
+
+            // --- Boot prompt template -------------------------------
+            // Refinement of the draft proposal in vade-app/vade-coo-memory#801.
+            // Notes:
+            //  - flat numbered/lettered list, no nested indentation —
+            //    template-literal preserves leading whitespace and YAML
+            //    indent stripping would otherwise leak spaces into the
+            //    prompt body.
+            //  - Readiness-field branch (3a/3b/3c) routes on the
+            //    native Readiness field so the instance doesn't
+            //    re-derive scope per-issue.
+            //  - "Ven is not at the keyboard" framing is explicit so
+            //    the instance briefs instead of asking when it would
+            //    have asked interactively.
+            //  - issue.title leads the prompt so claude.ai/code's
+            //    auto-naming heuristic surfaces the issue title as the
+            //    session name. There is no documented session-name
+            //    URL parameter — the pre-fill spec lists only
+            //    prompt / prompt_url / repositories / environment
+            //    (https://code.claude.com/docs/en/web-quickstart#pre-fill-sessions).
+            //    Leading the prompt with the title is the only lever.
+            const prompt = [
+              issue.title,
+              ``,
+              `You are the VADE COO agent, opening a fresh cloud session by GitHub assignment, not by Ven sitting at the keyboard. Treat this as async.`,
+              ``,
+              `1. Boot first per CLAUDE.md — read every numbered step in the session-start reading order, not just the ones that seem most relevant to the task below. The list includes integrity gate (1), persisted-output gate (1b), charter (2), governance (3), preferences (4), identity layer (5), episodic memory (6), memo digest (7), lineage events (7b), project board (8), mem0_sop (9), context README (12), operational Mem0 search (13), discussions digest (14). Skipping items because the parenthetical or this prompt seemed to enumerate a shorter set is the exact regression this language replaces. Greet briefly.`,
+              `2. Read the assigning issue: ${issue.html_url}. Read its issue type, Readiness/Priority field values, labels, milestone, comments, and any cross-referenced issues / PRs.`,
+              `3. Branch by the issue's Readiness field.`,
+              `3a. Readiness=Ready (or unset on a well-scoped body): implement autonomously. Open a PR when the change is complete and the verification steps in the issue (or your judgement of equivalent steps) have run green. Auto-subscribe per the PR-watch discipline in CLAUDE.md. Stand by for review.`,
+              `3b. Readiness ∈ {Needs design, Needs research, Needs breakdown}, or any clarification-shaped signal in the body: do preliminary reconnaissance, draft a plan, then post a brief comment on the issue (or open a discussion thread for larger scope) that names what you understood, what the design space is, which decisions Ven needs to make, and your recommendation. Stop after the brief — wait for Ven.`,
+              `3c. needs:bdfl-approval label: never merge autonomously. Always brief, never autonomous, regardless of the Readiness value.`,
+              `4. When the task above is complete, stand by — do not proactively invoke /end-session or otherwise wrap. Async sessions stay idle until Ven re-engages or the idle-watchdog runs mechanical session-close. End-of-session is a Ven-trigger or watchdog-trigger in this context, NOT an agent-initiated one. Wrapping prematurely after a brief means the session is unavailable when Ven arrives to continue.`,
+              ``,
+              `Ven is not currently at the keyboard at session start. Don't expect interactive clarification mid-task; if you would have asked, brief instead. But Ven may engage at any time — if a message arrives mid-session, switch to interactive mode and continue.`,
+            ].join('\n');
+
+            // --- Compose the pre-fill URL ---------------------------
+            // URLSearchParams handles percent-encoding (incl. multi-line
+            // newlines as %0A) for both prompt and repositories. No
+            // `environment` param at MVP — Ven's last-used env is sticky.
+            //
+            // Pre-select ALL ten vade-app/* repos the COO has scope on.
+            // The boot pass (coo-bootstrap.sh, integrity-check, identity
+            // layer reads) cross-references files across these repos; a
+            // session attached to only the assigning repo fails boot.
+            // The assigning repo goes first so it's the obvious primary
+            // in the form's repo selector.
+            //
+            // When a vade-app/* repo is added/renamed/archived/deleted,
+            // update THIS LIST in the canonical reusable. Consumer thin
+            // triggers pick up the change automatically.
+            const COO_SCOPE_REPOS = [
+              'vade-app/vade-coo-memory',
+              'vade-app/vade-core',
+              'vade-app/vade-runtime',
+              'vade-app/vade-agent-logs',
+              'vade-app/skills',
+              'vade-app/coo4one',
+              'vade-app/vade-site',
+              'vade-app/tjsonl',
+              'vade-app/coo-console',
+            ];
+            const repositories = [
+              repoSlug,
+              ...COO_SCOPE_REPOS.filter(r => r !== repoSlug),
+            ].join(',');
+
+            const params = new URLSearchParams({
+              prompt,
+              repositories,
+            });
+            const launchUrl = `https://claude.ai/code?${params.toString()}`;
+
+            // --- Comment body ---------------------------------------
+            const body = [
+              `I've been assigned this issue. To launch a cloud COO session with the boot prompt + issue context pre-loaded:`,
+              ``,
+              `[**Launch COO session →**](${launchUrl})`,
+              ``,
+              `The session opens when you click — claude.ai/code needs a signed-in human (you) to spawn the container. Re-assign me to post a fresh link (e.g. after a session ends or gets stuck).`,
+              ``,
+              `---`,
+              `<sub>posted by \`coo-on-assign\` workflow · design: vade-app/vade-coo-memory#801 · [operations doc](https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/coo-on-assign.md)</sub>`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issue.number,
+              body,
+            });
+
+            core.info(`Posted launch comment on ${repoSlug}#${issue.number}`);
+            core.info(`Launch URL length: ${launchUrl.length} chars`);

--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -24,5 +24,9 @@ permissions:
 
 jobs:
   post-launch-link:
-    uses: vade-app/vade-coo-memory/.github/workflows/coo-on-assign-reusable.yml@main
+    # Same-repo call uses relative path (no ref) per GitHub docs:
+    # https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow
+    # — resolves the reusable from the same commit as the caller.
+    # External consumers use: vade-app/vade-runtime/.github/workflows/coo-on-assign-reusable.yml@main
+    uses: ./.github/workflows/coo-on-assign-reusable.yml
     secrets: inherit

--- a/.github/workflows/issue-pr-hygiene-reusable.yml
+++ b/.github/workflows/issue-pr-hygiene-reusable.yml
@@ -1,0 +1,515 @@
+name: Issue / PR hygiene (reusable)
+
+# Reusable workflow: enforces the four issue/PR hygiene patterns
+# documented in vade-app/vade-coo-memory:coo/operations/issue-pr-hygiene.md:
+#
+#   A — Epic-type issues use GitHub's native sub-issue API (advisory)
+#   B — PRs that resolve issues include a closing keyword     (blocking or advisory, per caller)
+#   C — cross-repo refs use vade-app/<repo>#N form            (advisory)
+#   D — non-issue IDs use dash form (no #N)                   (advisory)
+#
+# Pure regex/GraphQL via actions/github-script@v7. No LLM call
+# (deliberately differs from auto-tag-issues.yml's Haiku pattern —
+# extending Haiku per-PR would multiply cost without buying anything
+# for these regex-decidable patterns).
+#
+# Canonical home: vade-app/vade-runtime/.github/workflows/issue-pr-hygiene-reusable.yml
+# Centralization design: vade-coo-memory#939 (F7); absorbs vade-coo-memory#767.
+# Host=vade-runtime per #939 comment (Public→Private workflow_call fails).
+# Operations doc: vade-app/vade-coo-memory:coo/operations/workflow-centralization.md
+# Pattern-B promotion cadence: vade-app/vade-coo-memory:coo/adoption_tracker.md (≥14 days clean)
+# Authority + audit: vade-app/vade-coo-memory:coo/audits/2026-05-01_issue-pr-hygiene/synthesis.md
+#
+# Per-repo behavior:
+#   - Pattern-B mode (blocking vs advisory) is the only per-caller knob.
+#   - Exempt-class detection is the UNION across all callers — safe to
+#     run universally because the patterns are whitelists. The exempts
+#     cover: dependabot/claude[bot] (universal), anthropic-code-agent
+#     stubs (vade-runtime-specific), auto-meta-sidecar headRefs (defensive),
+#     Night's Watch session-log paths (essential in vade-agent-logs, 96.9%
+#     of historical PRs).
+#
+# Trigger contract for callers (see issue-pr-hygiene.yml thin trigger):
+#   on:
+#     pull_request:
+#       # `synchronize` (push commits to PR branch) dropped: the title/body —
+#       # the only thing these checks examine — doesn't change on commit push,
+#       # so synchronize events are pure 1-min-floor waste. `edited` stays so
+#       # users can fix a failed check by editing the body in place.
+#       types: [opened, edited, reopened]
+#     issues:
+#       types: [opened, edited, labeled]
+#   permissions:
+#     pull-requests: write
+#     issues: write
+#     contents: read
+#     checks: write
+#   jobs:
+#     hygiene:
+#       uses: vade-app/vade-runtime/.github/workflows/issue-pr-hygiene-reusable.yml@main
+#       with:
+#         pattern-b-mode: blocking  # or "advisory"
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      pattern-b-mode:
+        description: '"blocking" (setFailed on Pattern-B miss) or "advisory" (post comment, do not fail).'
+        required: false
+        type: string
+        default: advisory
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+  checks: write
+
+concurrency:
+  group: hygiene-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-checks:
+    # Patterns B + C + D. One job, sequential steps — shares the 1-min
+    # runner floor across both checks. When pattern-b-mode=blocking,
+    # Pattern B may fail the run; the C+D advisory step uses
+    # `if: !cancelled()` so it still posts its comment when B fails.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for closing keywords (Pattern B)
+        uses: actions/github-script@v7
+        env:
+          PATTERN_B_MODE: ${{ inputs.pattern-b-mode }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const title = pr.title || '';
+            const author = pr.user.login;
+            const headRef = pr.head.ref;
+            const mode = process.env.PATTERN_B_MODE || 'advisory';
+            const isBlocking = (mode === 'blocking');
+
+            // ---- Exempt-class detection (skip enforcement entirely) ----
+            // Authority: coo/operations/issue-pr-hygiene.md §"Exempt-class registry"
+            // Defensive union across all caller repos — patterns are
+            // whitelists, safe to run anywhere.
+
+            // Universal author-based exempts
+            const exemptAuthors = ['dependabot[bot]', 'claude[bot]'];
+            if (exemptAuthors.includes(author)) {
+              core.info(`Exempt: author=${author}`);
+              return;
+            }
+
+            // anthropic-code-agent stubs (essential for vade-runtime;
+            // defensive elsewhere — the body prefix is the discriminator).
+            if (author === 'app/anthropic-code-agent' &&
+                body.startsWith('Thanks for asking me to work on this')) {
+              core.info(`Exempt: anthropic-code-agent stub`);
+              return;
+            }
+
+            // headRef-based exempt: auto-meta-sidecar-commits (defensive)
+            if (/^claude\/auto-meta-[0-9a-f-]{36}$/.test(headRef)) {
+              core.info(`Exempt: auto-meta-sidecar headRef=${headRef}`);
+              return;
+            }
+
+            // Path-based exempt: Night's Watch session-logs
+            // (essential for vade-agent-logs — 96.9% of historical PRs;
+            // defensive elsewhere since other repos have no sessions/ tree).
+            const filesResp = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const allSessionPaths = filesResp.data.length > 0 &&
+              filesResp.data.every(f => /^sessions\/\d{4}\/\d{2}\/\d{2}\//.test(f.filename));
+            if (allSessionPaths) {
+              core.info(`Exempt: all changes under sessions/YYYY/MM/DD/`);
+              return;
+            }
+
+            // ---- Closing-keyword regexes ----
+            // Same-repo: Closes #N, Fixes #N, Resolves #N (case-insensitive)
+            const sameRepoRe = /\b(clos(?:e|es|ed|ing)|fix(?:es|ed|ing)?|resolv(?:e|es|ed|ing))\s+#\d+\b/i;
+            // Cross-repo: Closes vade-app/<repo>#N
+            const crossRepoRe = /\b(clos(?:e|es|ed|ing)|fix(?:es|ed|ing)?|resolv(?:e|es|ed|ing))\s+vade-app\/[a-z0-9-]+#\d+\b/i;
+            // Broken form: Closes <reponame>#N (no vade-app/ prefix) — silently doesn't auto-close.
+            // Detect to give a helpful error instead of just "missing keyword".
+            const brokenFormRe = /\b(clos(?:e|es|ed|ing)|fix(?:es|ed|ing)?|resolv(?:e|es|ed|ing))\s+vade-(coo-memory|runtime|core|governance|agent-logs)#\d+\b/i;
+            // Comma-list form: Closes #1, #2, #3 — only the first ref auto-closes.
+            // GitHub's parser requires the keyword per issue. Detect to warn.
+            const commaListRe = /\b(clos(?:e|es|ed|ing)|fix(?:es|ed|ing)?|resolv(?:e|es|ed|ing))\s+(?:#\d+|vade-app\/[a-z0-9-]+#\d+)\s*,\s*(?:#\d+|vade-app\/[a-z0-9-]+#\d+)/i;
+
+            const titleHasKeyword = sameRepoRe.test(title) || crossRepoRe.test(title);
+            const bodyHasKeyword = sameRepoRe.test(body) || crossRepoRe.test(body);
+            const titleHasBrokenForm = brokenFormRe.test(title);
+            const bodyHasBrokenForm = brokenFormRe.test(body);
+            const hasCommaList = commaListRe.test(title) || commaListRe.test(body);
+
+            // Idempotent advisory comment helper.
+            const postOrUpdateAdvisory = async (marker, commentBody) => {
+              const commentsResp = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const existing = commentsResp.data.find(c =>
+                c.body && c.body.includes(marker) && c.user.type === 'Bot'
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: commentBody,
+                });
+                core.info(`Updated existing advisory comment ${existing.id}`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: commentBody,
+                });
+                core.info(`Posted new advisory comment`);
+              }
+            };
+
+            // Comma-list: only the first ref auto-closes — surface either way.
+            if ((titleHasKeyword || bodyHasKeyword) && hasCommaList) {
+              const msg =
+                `Detected comma-list closing form \`Closes #N, #M, ...\`. ` +
+                `GitHub's parser only auto-closes the FIRST issue; subsequent refs ` +
+                `stay open silently. Use one \`Closes\` keyword per issue:\n\n` +
+                `    Closes vade-app/<repo>#N\n    Closes vade-app/<repo>#M\n\n` +
+                `See coo/operations/issue-pr-hygiene.md §"Closing-keyword discipline" ` +
+                `(in vade-app/vade-coo-memory).`;
+              if (isBlocking) {
+                core.setFailed(`Pattern B (closing keywords) — BLOCKING\n\n${msg}`);
+                return;
+              }
+              const marker = '<!-- issue-pr-hygiene/b-comma -->';
+              const commaBody = `${marker}\n\n` +
+                `### Issue / PR hygiene — advisory (Pattern B: comma-list closing form)\n\n` +
+                `${msg}\n\n` +
+                `*This is advisory; the check does not block merge. ` +
+                `Apply label \`hygiene:exempt\` to suppress on this PR.*`;
+              await postOrUpdateAdvisory(marker, commaBody);
+              core.warning(`Pattern B comma-list form detected; advisory comment posted.`);
+              // Fall through — the keyword-found path returns below.
+            }
+
+            if (titleHasKeyword || bodyHasKeyword) {
+              core.info(`Pattern B passed (keyword found in ${titleHasKeyword ? 'title' : 'body'})`);
+              return;
+            }
+
+            // Allow explicit opt-out for "no issue resolved"
+            if (/^closes:\s*n\/a\b/im.test(body) || /\bn\/a\s*—\s*no issue resolved\b/i.test(body)) {
+              core.info(`Pattern B passed (explicit "Closes: n/a" / "n/a — no issue resolved" present)`);
+              return;
+            }
+
+            // No valid keyword found. Two failure modes:
+            const reasons = [];
+            if (titleHasBrokenForm || bodyHasBrokenForm) {
+              reasons.push(
+                `Detected broken closing form \`Closes <reponame>#N\` ` +
+                `(no \`vade-app/\` prefix). This **autolinks but does NOT auto-close** the issue. ` +
+                `Use \`Closes #N\` for same-repo or \`Closes vade-app/<repo>#N\` for cross-repo.`
+              );
+            } else {
+              reasons.push(
+                `No closing keyword found in PR title or body. ` +
+                `If this PR resolves an issue, add \`Closes #N\` (same-repo) ` +
+                `or \`Closes vade-app/<repo>#N\` (cross-repo). ` +
+                `If no issue is resolved, add a body line: \`Closes: n/a\`.`
+              );
+            }
+
+            const summary = reasons.join('\n\n');
+            const seeDocs = `See coo/operations/issue-pr-hygiene.md §"Closing-keyword discipline" ` +
+              `(in vade-app/vade-coo-memory).`;
+
+            if (isBlocking) {
+              core.setFailed(`Pattern B (closing keywords) — BLOCKING\n\n${summary}\n\n${seeDocs}`);
+              return;
+            }
+
+            // ADVISORY: post comment, do not fail.
+            const marker = '<!-- issue-pr-hygiene/b -->';
+            const commentBody = `${marker}\n\n` +
+              `### Issue / PR hygiene — advisory (Pattern B: closing keywords)\n\n` +
+              `${summary}\n\n` +
+              `${seeDocs}\n\n` +
+              `*This is advisory; the check does not block merge. ` +
+              `Apply label \`hygiene:exempt\` to suppress on this PR.*`;
+            await postOrUpdateAdvisory(marker, commentBody);
+            core.warning(`Pattern B advisory posted; not blocking.`);
+
+      - name: Lint cross-repo + collision-prone references (Patterns C+D — advisory)
+        # Run even when the closing-keywords step failed (B may block;
+        # C+D is advisory and should still surface).
+        if: ${{ !cancelled() }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const title = pr.title || '';
+            const repo = context.repo.repo; // e.g. "vade-coo-memory"
+
+            // Per-repo allowlist for known-grandfathered Pattern-D items.
+            // Originally populated for the quorum-6 thread (PRs #175 + #183,
+            // 898 of 1348 corpus hits). MEMO-2026-05-01-pdal landed the
+            // dash-form back-edit corpus-wide via bin/dash-form-rewriter.sh,
+            // which Ven reframed as a render fix (not a history rewrite —
+            // GitHub preserves timestamps + authorship + edit indicator on
+            // body/comment PATCHes). The allowlist is now empty; the linter
+            // applies uniformly. Re-populate only if a future case warrants
+            // it, citing the rationale here.
+            const grandfatheredItems = new Set([]);
+            if (grandfatheredItems.has(pr.number)) {
+              core.info(`Skipped: PR #${pr.number} on Pattern-D grandfather list`);
+              // Don't return — still run Pattern C
+            }
+
+            const advisories = [];
+
+            // ---- Pattern C: cross-repo bare #N ----
+            // Detect bare #N adjacent to a vade-* repo cue suggesting
+            // cross-repo intent. Heuristic — emits suggestion, never blocks.
+            const crossRepoCues = /(vade-(?:runtime|core|governance|agent-logs)(?!#))[^\n]{0,80}#\d+/g;
+            // Carve-out: discussion references. `vade-app/<repo>#N` autolinks
+            // to an *issue* #N, not a discussion — discussions have no `#N`
+            // autolink form at all, only literal URLs. Skip matches whose
+            // captured span contains the word "discussion" (case-insensitive).
+            // Worked example: `vade-app/vade-core discussion #149` should NOT
+            // be rewritten to `vade-app/vade-core#149` (which would mis-resolve
+            // to issue #149). vade-coo-memory#476.
+            const cMatches = [...body.matchAll(crossRepoCues), ...title.matchAll(crossRepoCues)]
+              .filter(m => !/discussion/i.test(m[0]));
+            if (cMatches.length > 0) {
+              advisories.push(
+                `**Pattern C — cross-repo references**\n\n` +
+                `Detected ${cMatches.length} reference(s) where a vade-* repo is named ` +
+                `near a bare \`#N\`. Bare \`#N\` resolves to the host repo (${repo}); ` +
+                `use \`vade-app/<repo>#N\` for cross-repo. ` +
+                `Examples found:\n\n` +
+                cMatches.slice(0, 5).map(m => `  - \`${m[0]}\``).join('\n')
+              );
+            }
+
+            // List-inheritance: `vade-app/<repo>#N, #M, ...` — only first gets prefix.
+            // Detect prefix followed by comma-separated #N where subsequent #N lack the prefix.
+            const listInheritanceRe = /vade-app\/[a-z0-9-]+#\d+\s*,\s*#\d+/g;
+            const listMatches = [...body.matchAll(listInheritanceRe), ...title.matchAll(listInheritanceRe)];
+            if (listMatches.length > 0) {
+              advisories.push(
+                `**Pattern C — list-inheritance**\n\n` +
+                `Detected \`vade-app/<repo>#N, #M\` patterns. The prefix scopes only ` +
+                `the first \`#N\`; subsequent \`#M\` autolink to ${repo}. ` +
+                `Repeat the prefix per item: \`vade-app/<repo>#N, vade-app/<repo>#M\`.\n\n` +
+                listMatches.slice(0, 3).map(m => `  - \`${m[0]}\``).join('\n')
+              );
+            }
+
+            // ---- Pattern D: #num for non-issue IDs ----
+            if (!grandfatheredItems.has(pr.number)) {
+              // Plural-form noun (`s?`) and range suffix (`#N-#M`, `#N–#M`,
+              // `#N - #M`) added per vade-coo-memory#757 audit
+              // (coo/audits/2026-05-13_hyperlinking-sweep/synthesis.md §6).
+              // The 2026-05-01 audit named the en-dash miss; it remained
+              // open in the regex until this extension.
+              const collisionTerms = /\b(quorum|instance|briefing|memo|stage|phase|finding|oq|audit|committee|persona|agent|chunk|round|track|step|tier|band|mechanism|hypothesis)s?\s+#\d+(?:\s*[-–]\s*#?\d+)?\b/gi;
+              const enumeratedIds = /\b(F\d+|Q\d+|A\d+|G\d+)\s+#\d+(?:\s*[-–]\s*#?\d+)?\b/g;
+
+              // Allowlist: markdown checkbox lists (`- [ ] #N` or `- [x] #N`) — these are
+              // procedural enumerations, not autolink-bait. Strip checkbox lines first.
+              const stripped = body.replace(/^[-*]\s*\[[ xX]\]\s+.*$/gm, '');
+
+              const dMatches = [
+                ...stripped.matchAll(collisionTerms),
+                ...stripped.matchAll(enumeratedIds),
+                ...title.matchAll(collisionTerms),
+                ...title.matchAll(enumeratedIds),
+              ];
+
+              if (dMatches.length > 0) {
+                advisories.push(
+                  `**Pattern D — \`#num\` for non-issue IDs**\n\n` +
+                  `Detected ${dMatches.length} reference(s) using \`<term> #N\` notation ` +
+                  `where \`#N\` autolinks to an unrelated GitHub issue/PR. ` +
+                  `Use dash form: \`quorum-1\`, \`instance-N\`, \`briefing-014\`, etc. ` +
+                  `(prevents the false-positive autolink; \`MEMO-...\` already has a click-through autolink configured.) ` +
+                  `Examples found:\n\n` +
+                  dMatches.slice(0, 5).map(m => `  - \`${m[0]}\``).join('\n') +
+                  `\n\nSee \`coo/operations/issue-pr-hygiene.md\` §"Notation rules" (in vade-app/vade-coo-memory).`
+                );
+              }
+            }
+
+            if (advisories.length === 0) {
+              core.info(`Patterns C + D passed.`);
+              return;
+            }
+
+            // Post advisory comment (idempotent — find prior comment by marker)
+            const marker = '<!-- issue-pr-hygiene/c-d -->';
+            const commentsResp = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            const existing = commentsResp.data.find(c =>
+              c.body && c.body.includes(marker) && c.user.type === 'Bot'
+            );
+
+            const commentBody = `${marker}\n\n` +
+              `### Issue / PR hygiene — advisory (Patterns C + D)\n\n` +
+              advisories.join('\n\n---\n\n') +
+              `\n\n*This is advisory; the check does not block merge. ` +
+              `Apply label \`hygiene:exempt\` to suppress on this PR.*`;
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: commentBody,
+              });
+              core.info(`Updated existing advisory comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: commentBody,
+              });
+              core.info(`Posted new advisory comment`);
+            }
+
+  sub-issue-linkage:
+    # Pattern A — Epic-type issues use native sub-issue API. Advisory.
+    # Predicate-migration note: pre-Stage-3 of the issue-fields-and-types migration
+    # (MEMO-2026-05-21-xfqh) keyed on the `type:epic` label; post-Stage-3 the
+    # predicate is the native issue type. The script GraphQL-queries both
+    # `issueType` and `subIssues` and returns early when the type isn't Epic.
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check sub-issue linkage on Epic-type issues
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const issueNumber = issue.number;
+
+            // GraphQL query: issueType + subIssues count.
+            // issueType — native org-level type (Task/Bug/Feature/Epic/etc).
+            //   Skip the advisory unless the type is `Epic`.
+            // subIssues — canonical native parent/child API (post-2024 Issues v2;
+            //   populated by the "Add sub-issue" button or the addSubIssue
+            //   mutation). Distinct from trackedIssues, which reflects markdown
+            //   `- [ ] #N` task-list connections only and returns 0 for issues
+            //   whose children were linked via the native API. See
+            //   coo/operations/issue-pr-hygiene.md §"GraphQL gotchas" (in vade-app/vade-coo-memory).
+            let result;
+            try {
+              result = await github.graphql(`
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $number) {
+                      issueType { name }
+                      subIssues(first: 1) {
+                        totalCount
+                      }
+                    }
+                  }
+                }
+              `, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: issueNumber,
+              });
+            } catch (err) {
+              core.warning(`GraphQL query failed: ${err.message}. ` +
+                `Likely token-scope or feature-flag issue. Skipping advisory.`);
+              return;
+            }
+
+            const typeName = result?.repository?.issue?.issueType?.name ?? null;
+            const isEpicByType = typeName === 'Epic';
+            // Fallback for the legacy path: pre-Stage-3 issues that still
+            // carry only the `type:epic` label without a native type set.
+            const isEpicByLabel = (issue.labels || [])
+              .some(l => (l.name || l) === 'type:epic');
+
+            if (!isEpicByType && !isEpicByLabel) {
+              core.info(`Skipping Pattern A: issue type is ${typeName || 'unset'}, ` +
+                `no legacy type:epic label.`);
+              return;
+            }
+
+            const subCount = result?.repository?.issue?.subIssues?.totalCount ?? 0;
+            if (subCount > 0) {
+              core.info(`Pattern A passed: subIssues count = ${subCount}`);
+              return;
+            }
+
+            // Advisory comment (idempotent)
+            const marker = '<!-- issue-pr-hygiene/a -->';
+            const commentsResp = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const existing = commentsResp.data.find(c =>
+              c.body && c.body.includes(marker) && c.user.type === 'Bot'
+            );
+
+            const epicPredicate = isEpicByType
+              ? `is typed \`Epic\``
+              : `carries the legacy \`type:epic\` label`;
+            const commentBody = `${marker}\n\n` +
+              `### Issue hygiene — advisory (Pattern A: sub-issue linkage)\n\n` +
+              `This issue ${epicPredicate} but has no native sub-issues linked ` +
+              `(\`subIssues\` count = 0). Markdown \`#N\` checklists are insufficient — ` +
+              `they're invisible to GraphQL queries and the project board's tracker UI.\n\n` +
+              `Add sub-issues via the GitHub UI's "Add sub-issue" button on this issue, ` +
+              `or via the GraphQL \`addSubIssue\` mutation.\n\n` +
+              `See \`coo/operations/issue-pr-hygiene.md\` §"Sub-issue linkage" + ` +
+              `\`coo/label_taxonomy.md\` §6 (in vade-app/vade-coo-memory).\n\n` +
+              `*This is advisory; the check does not block merge. ` +
+              `Apply label \`hygiene:exempt\` to suppress on this issue.*`;
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: commentBody,
+              });
+              core.info(`Updated existing advisory comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: commentBody,
+              });
+              core.info(`Posted new advisory comment`);
+            }

--- a/.github/workflows/issue-pr-hygiene.yml
+++ b/.github/workflows/issue-pr-hygiene.yml
@@ -28,7 +28,9 @@ permissions:
 
 jobs:
   hygiene:
-    uses: vade-app/vade-coo-memory/.github/workflows/issue-pr-hygiene-reusable.yml@main
+    # Same-repo call uses relative path (see coo-on-assign.yml note).
+    # External consumers use: vade-app/vade-runtime/.github/workflows/issue-pr-hygiene-reusable.yml@main
+    uses: ./.github/workflows/issue-pr-hygiene-reusable.yml
     with:
       pattern-b-mode: advisory
     secrets: inherit


### PR DESCRIPTION
## Summary

Per [vade-coo-memory#939 comment 4531467653](https://github.com/vade-app/vade-coo-memory/issues/939#issuecomment-4531467653), pivoting F7's canonical home from vcm (private) to vade-runtime (public) — Ven picked option A. Public→Private workflow_call resolution fails despite `access_level=organization` (empirically confirmed via [vade-runtime#316](https://github.com/vade-app/vade-runtime/pull/316)'s actions:read fix-up which also failed). Public canonical with mixed-visibility consumers is the live in-org precedent (`bridge-form-fields-to-natives.yml`).

### What changed

**Adds 4 canonical reusables** in vade-runtime/.github/workflows/:
- `coo-on-assign-reusable.yml`
- `auto-tag-issues-reusable.yml`
- `auto-add-prs-to-project-reusable.yml`
- `issue-pr-hygiene-reusable.yml`

Content identical to the now-orphaned vcm copies (vcm#971) except header comments updated to reference vade-runtime as canonical home + the rationale for the move.

**Converts vade-runtime's 4 thin triggers** to relative-path same-repo calls:
- `uses: ./.github/workflows/<name>-reusable.yml` (no ref; resolves at same commit)

This fixes the broken CI on `Issue / PR hygiene` + `Auto-add new PRs to the VADE project` that vade-runtime#315 introduced.

### Sequencing

This PR is the prereq for the companion vcm cleanup PR (which deletes the orphaned vcm canonicals, switches vcm's thin triggers to `vade-app/vade-runtime/...@main`, and updates the operations doc). vcm PR must merge AFTER this one.

After both merge, the remaining 7 consumer rollouts (vade-core, vade-agent-logs, coo-console, skills, coo4one, vade-site, tjsonl) become unblocked — all point to vade-runtime.

### Test plan

- [ ] CI green on this PR — same-repo relative-path call validates the new wiring (vade-runtime's hygiene + auto-add should pass instead of failing in 0s with 0 jobs)
- [ ] After merge: vade-runtime's broken CI is fixed for all future PRs/issues
- [ ] vcm companion PR opens + merges to finalize the pivot
- [ ] Remaining 7 consumer rollouts begin

Closes: n/a — companion to vade-coo-memory#939 pivot per option A

https://claude.ai/code/session_011Wj1heZYDXrdHC9rw9NGDE