### PR TITLE
settings: opt into thinking-summary display (test for #275)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,8 @@
 {
   "model": "opusplan",
   "effortLevel": "high",
+  "showThinkingSummaries": true,
+  "alwaysThinkingEnabled": true,
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
Closes vade-app/vade-runtime#275 (pending merge + fresh-session verification)

5-minute test from the research brief on [#275](https://github.com/vade-app/vade-runtime/issues/275#issuecomment-4532163012).

Adds two keys to \`.claude/settings.json\`:
- \`showThinkingSummaries: true\`
- \`alwaysThinkingEnabled: true\`

## Why

Opus 4.7 changed the API default for \`thinking.display\` from \`\"summarized\"\` to \`\"omitted\"\`, so the model returns thinking blocks with empty content unless the caller explicitly opts in. Two open upstream bugs ([anthropics/claude-code#49708](https://github.com/anthropics/claude-code/issues/49708), [#56356](https://github.com/anthropics/claude-code/issues/56356)) report that the Claude Code client doesn't send the override even when these settings are in \`settings.json\` — but those reports are bounded to v2.1.128; our container is on **v2.1.150** (22 versions newer). This change makes the test reproducible across fresh containers.

## Test plan

- [ ] Merge.
- [ ] Boot a fresh Claude Code session on this branch / main (the test needs a new container — settings are baked in at session start).
- [ ] Run any non-trivial prompt that should provoke chain-of-thought.
- [ ] In the new container: \`jq -c 'select(.message.content) | .message.content | if type==\"array\" then .[] | select(.type==\"thinking\") else empty end' /root/.claude/projects/-home-user/<SESSION_ID>.jsonl | head -1 | jq '.thinking | length'\` — if >0, the fix landed in our version and these settings are the unlock; if 0, we're still upstream-blocked (revert or keep, the keys are harmless).
- [ ] If working: also confirm \`/verbose\` UI renders the thinking summary, and that exported \`.analysis.json\` sidecars carry it (might need a transcript-analyzer schema bump — separate issue).

https://claude.ai/code/session_01BdhsgwcGG6LUxaVTbfiXRL