### PR TITLE
F8: canonical ISSUE_TEMPLATE sync — vrt → 8 consumers

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,27 @@
+# F8 template centralization — auto-sync manifest for BetaHuhn/repo-file-sync-action.
+#
+# Canonical: vade-coo-memory#938 (F8). Operations doc lives in vcm:
+# vade-coo-memory/coo/operations/template-centralization.md.
+#
+# Source repo: vade-app/vade-runtime. Sources listed below are repo-relative
+# paths in this repo; dest paths are the same-shape paths in each consumer.
+# `deleteOrphaned: true` enforces full parity — a template removed here is
+# removed in consumers. No consumer has a `config.yml` chooser today, so the
+# orphan-delete is safe across all 8 consumers.
+#
+# Auth + workflow definition: .github/workflows/sync-issue-templates.yml.
+
+group:
+  repos: |
+    vade-app/vade-coo-memory
+    vade-app/vade-core
+    vade-app/vade-agent-logs
+    vade-app/tjsonl
+    vade-app/coo-console
+    vade-app/skills
+    vade-app/coo4one
+    vade-app/vade-site
+  files:
+    - source: .github/ISSUE_TEMPLATE/
+      dest: .github/ISSUE_TEMPLATE/
+      deleteOrphaned: true

--- a/.github/workflows/sync-issue-templates.yml
+++ b/.github/workflows/sync-issue-templates.yml
@@ -1,0 +1,75 @@
+name: Sync issue templates
+
+# Canonical for the org's per-type ISSUE_TEMPLATE inventory. Fires on push to
+# main when .github/ISSUE_TEMPLATE/** or the sync config changes; opens a sync
+# PR in each of the 8 consumer repos listed in .github/sync.yml.
+#
+# Centralization: vade-coo-memory#938 (F8). Mechanism rationale (sync-action
+# vs symlink vs build-time): vade-coo-memory/coo/audits/2026-05-24_org-infrastructure-audit/
+# f7-f8-centralization-design.md §"Issue templates". Operations doc:
+# vade-coo-memory/coo/operations/template-centralization.md.
+#
+# Canonical-host pivot (vcm → vrt): vrt aligns with the F7 pattern — harness
+# owns operational infrastructure; ops doc + case-law live in vcm. The
+# sync-action mechanism does not have F7's public→private constraint (it runs
+# entirely in the source repo + writes via PAT), so the choice is principled
+# rather than mechanically forced. Templates are bridge surface; their natural
+# home is alongside the bridge workflow already in vrt.
+#
+# Auth: secrets.VADE_FIELDS_ADMIN_PAT (org-secret mirror of GITHUB_MCP_PAT,
+# visibility=all, fine-grained, contents:write + pull-requests:write on all
+# vade-app/* repos per the secrets schema entry for `vade-coo-self-2026-04`).
+# Same secret bridge-form-fields-to-natives.yml uses.
+#
+# Action pinning: BetaHuhn/repo-file-sync-action SHA-pinned to the v1.21.1
+# release commit (the action's last release, 2024-05-05). Staleness is a known
+# risk; fallback is a custom gh-CLI workflow. See template-centralization.md
+# §"Action staleness".
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/sync.yml'
+      - '.github/workflows/sync-issue-templates.yml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run (no PRs opened in consumers)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-issue-templates
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync ISSUE_TEMPLATE/ to consumers
+        uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619  # v1.21.1
+        with:
+          GH_PAT: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}
+          IS_FINE_GRAINED: true
+          CONFIG_PATH: .github/sync.yml
+          PR_LABELS: 'sync,sync:templates'
+          BRANCH_PREFIX: sync/issue-templates
+          COMMIT_PREFIX: 'sync(templates):'
+          PR_BODY: |
+            Auto-synced from `vade-app/vade-runtime` canonical issue templates (F8).
+
+            **Edit the canonical**, not this PR: [`vade-runtime/.github/ISSUE_TEMPLATE/`](https://github.com/vade-app/vade-runtime/tree/main/.github/ISSUE_TEMPLATE). Changes there auto-propagate here on next push to `main`.
+
+            - Canonical issue: [vade-coo-memory#938](https://github.com/vade-app/vade-coo-memory/issues/938)
+            - Operations doc: [`coo/operations/template-centralization.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/template-centralization.md)
+            - Mechanism survey: [`f7-f8-centralization-design.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/audits/2026-05-24_org-infrastructure-audit/f7-f8-centralization-design.md)
+
+            `deleteOrphaned: true` is in effect — files deleted from the canonical are deleted here too.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}


### PR DESCRIPTION
Implementation half of [F8 (vade-coo-memory#938)](https://github.com/vade-app/vade-coo-memory/issues/938). Pivots the canonical host from `vade-coo-memory` to `vade-runtime` per the F7 precedent — harness owns operational infrastructure; ops doc + case-law live in vcm.

Supersedes the earlier draft at [vade-coo-memory#978](https://github.com/vade-app/vade-coo-memory/pull/978) (closed in favor of this pivot).

## Closing keywords

Closes: n/a

## Summary

- \`.github/sync.yml\` — manifest: 8 consumers (vcm + 6 others; vrt itself as source). \`deleteOrphaned: true\` for full parity.
- \`.github/workflows/sync-issue-templates.yml\` — push-triggered on \`.github/ISSUE_TEMPLATE/**\` + sync config + the workflow itself; \`workflow_dispatch\` with \`dry_run\` input default \`true\` for safe first-touch validation.

Templates already live in \`vrt/.github/ISSUE_TEMPLATE/\` byte-identical to vcm's, so no file moves needed — only the canonical assignment flips. After this lands, vcm becomes a normal consumer of its own templates via the first sync run.

## Why the pivot

The trigger argument for vrt-as-canonical was conditional on templates moving with the workflow. With templates already in vrt and byte-identical, \`push: paths: .github/ISSUE_TEMPLATE/**\` watches vrt's filesystem — same clean trigger, no relay, no split-brain.

Principle alignment:
- vcm's role: COO memory, identity, case-law. The case-law about templates (\`coo/operations/issue-fields-and-types.md\`, the F7/F8 design dossier) stays in vcm.
- vrt's role: harness — operational infrastructure. F7 reusables already live here; the \`bridge-form-fields-to-natives.yml\` workflow that operates on these templates already lives here; the templates themselves are the bridge surface, not the case-law about it.
- Post-rename arc: vcm → \`coo-memory\` (memory), vrt → \`coo-harness\` (kernel). Templates fit the harness.

The previous vcm placement was historical accident (templates were authored alongside the case-law and never migrated). F8 is the right moment to fix it.

## Mechanism (unchanged from vcm#978's design)

- **Sync-action** (\`BetaHuhn/repo-file-sync-action\`, SHA-pinned to v1.21.1) — the only mechanism that reaches GitHub's path-literal template discovery. Symlinks + build-time + org-default-fallback all ruled out in the mechanism survey.
- **Auth** — \`secrets.VADE_FIELDS_ADMIN_PAT\` (org-secret mirror of \`GITHUB_MCP_PAT\`, same as bridge-form-fields). No new rotation surface.
- **Orphan policy** — \`deleteOrphaned: true\`. Verified no consumer has a \`config.yml\` chooser.

## Calibrated risks

**Action staleness.** \`BetaHuhn/repo-file-sync-action\` last released 2024-05-05. Not archived, not actively maintained. SHA-pinned eliminates supply-chain drift; a future runner change could still break it. Fallback documented in the ops doc: ~60-line custom workflow using \`gh\` CLI.

**First sync deltas** (predicted):
- vcm / core / agent-logs: zero-diff (already in lockstep)
- tjsonl: +2 (\`epic.yml\`, \`skill.yml\`)
- coo-console / skills / coo4one / vade-site: +10 each (new template dirs)

## Cross-repo references

- [vade-coo-memory#938](https://github.com/vade-app/vade-coo-memory/issues/938) — F8 issue (acceptance criteria + post-merge follow-ups)
- [vade-coo-memory#978](https://github.com/vade-app/vade-coo-memory/pull/978) — earlier vcm-canonical draft (closed for this pivot)
- vcm follow-up PR — adds \`coo/operations/template-centralization.md\` (ops doc with vrt-as-canonical wording) + updates \`coo/operations/issue-fields-and-types.md\`

## Post-merge handoff

1. **DRY_RUN validation.** After merge, manually run the workflow via Actions UI with \`dry_run: true\` to validate auth + manifest before live propagation. Output \`pull_request_urls\` should be \`[]\` in dry-run mode.
2. **Live run.** Re-dispatch with \`dry_run: false\` (or push a no-op comment to \`bug.yml\` to fire the push trigger). Expect 5 consumer PRs (the 3 in-lockstep consumers get no PR).
3. **Enable auto-merge on consumers.** Per the ops doc §"Auto-merge in consumers".
4. **Close [#896](https://github.com/vade-app/vade-coo-memory/issues/896)** (org-wide parity) once pilot is green.

https://claude.ai/code/session_01M1XipbZh1gNg7rn6Tpkart