### PR TITLE
F7+F8: reusable workflow for sync-PR auto-merge

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,27 @@
+# F8 template centralization — auto-sync manifest for BetaHuhn/repo-file-sync-action.
+#
+# Canonical: vade-coo-memory#938 (F8). Operations doc lives in vcm:
+# vade-coo-memory/coo/operations/template-centralization.md.
+#
+# Source repo: vade-app/vade-runtime. Sources listed below are repo-relative
+# paths in this repo; dest paths are the same-shape paths in each consumer.
+# `deleteOrphaned: true` enforces full parity — a template removed here is
+# removed in consumers. No consumer has a `config.yml` chooser today, so the
+# orphan-delete is safe across all 8 consumers.
+#
+# Auth + workflow definition: .github/workflows/sync-issue-templates.yml.
+
+group:
+  repos: |
+    vade-app/vade-coo-memory
+    vade-app/vade-core
+    vade-app/vade-agent-logs
+    vade-app/tjsonl
+    vade-app/coo-console
+    vade-app/skills
+    vade-app/coo4one
+    vade-app/vade-site
+  files:
+    - source: .github/ISSUE_TEMPLATE/
+      dest: .github/ISSUE_TEMPLATE/
+      deleteOrphaned: true

--- a/.github/workflows/auto-merge-sync-pr-reusable.yml
+++ b/.github/workflows/auto-merge-sync-pr-reusable.yml
@@ -1,0 +1,35 @@
+name: Auto-merge sync PR (reusable)
+
+# Reusable: enable squash auto-merge on the caller's PR when it carries a
+# sync:* label. Pairs with the F8 sync workflow (sync-issue-templates.yml in
+# this repo) which labels every PR it opens with `sync,sync:templates`. Once
+# CI on the consumer PR passes, GitHub's auto-merge feature lands it.
+#
+# Callers: 8 consumer thin-triggers per coo/operations/workflow-centralization.md
+# row "auto-merge-sync-pr-reusable.yml". The caller fires on `pull_request:
+# types: [labeled]` and forwards to here; the caller's `if:` gate decides
+# whether the label warrants auto-merge (currently: any label starting with
+# `sync:`).
+#
+# Auth: `secrets.GITHUB_TOKEN` from the caller's context (default-scoped to
+# the consumer repo's PRs). Requires the consumer repo to have auto-merge
+# enabled (gh repo edit --enable-auto-merge — done once per consumer in F8).
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --squash --auto \
+            --repo ${{ github.repository }}

--- a/.github/workflows/sync-issue-templates.yml
+++ b/.github/workflows/sync-issue-templates.yml
@@ -1,0 +1,75 @@
+name: Sync issue templates
+
+# Canonical for the org's per-type ISSUE_TEMPLATE inventory. Fires on push to
+# main when .github/ISSUE_TEMPLATE/** or the sync config changes; opens a sync
+# PR in each of the 8 consumer repos listed in .github/sync.yml.
+#
+# Centralization: vade-coo-memory#938 (F8). Mechanism rationale (sync-action
+# vs symlink vs build-time): vade-coo-memory/coo/audits/2026-05-24_org-infrastructure-audit/
+# f7-f8-centralization-design.md §"Issue templates". Operations doc:
+# vade-coo-memory/coo/operations/template-centralization.md.
+#
+# Canonical-host pivot (vcm → vrt): vrt aligns with the F7 pattern — harness
+# owns operational infrastructure; ops doc + case-law live in vcm. The
+# sync-action mechanism does not have F7's public→private constraint (it runs
+# entirely in the source repo + writes via PAT), so the choice is principled
+# rather than mechanically forced. Templates are bridge surface; their natural
+# home is alongside the bridge workflow already in vrt.
+#
+# Auth: secrets.VADE_FIELDS_ADMIN_PAT (org-secret mirror of GITHUB_MCP_PAT,
+# visibility=all, fine-grained, contents:write + pull-requests:write on all
+# vade-app/* repos per the secrets schema entry for `vade-coo-self-2026-04`).
+# Same secret bridge-form-fields-to-natives.yml uses.
+#
+# Action pinning: BetaHuhn/repo-file-sync-action SHA-pinned to the v1.21.1
+# release commit (the action's last release, 2024-05-05). Staleness is a known
+# risk; fallback is a custom gh-CLI workflow. See template-centralization.md
+# §"Action staleness".
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/sync.yml'
+      - '.github/workflows/sync-issue-templates.yml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run (no PRs opened in consumers)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-issue-templates
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync ISSUE_TEMPLATE/ to consumers
+        uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619  # v1.21.1
+        with:
+          GH_PAT: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}
+          IS_FINE_GRAINED: true
+          CONFIG_PATH: .github/sync.yml
+          PR_LABELS: 'sync,sync:templates'
+          BRANCH_PREFIX: sync/issue-templates
+          COMMIT_PREFIX: 'sync(templates):'
+          PR_BODY: |
+            Auto-synced from `vade-app/vade-runtime` canonical issue templates (F8).
+
+            **Edit the canonical**, not this PR: [`vade-runtime/.github/ISSUE_TEMPLATE/`](https://github.com/vade-app/vade-runtime/tree/main/.github/ISSUE_TEMPLATE). Changes there auto-propagate here on next push to `main`.
+
+            - Canonical issue: [vade-coo-memory#938](https://github.com/vade-app/vade-coo-memory/issues/938)
+            - Operations doc: [`coo/operations/template-centralization.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/template-centralization.md)
+            - Mechanism survey: [`f7-f8-centralization-design.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/audits/2026-05-24_org-infrastructure-audit/f7-f8-centralization-design.md)
+
+            `deleteOrphaned: true` is in effect — files deleted from the canonical are deleted here too.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}


### PR DESCRIPTION
Adds the reusable workflow consumers will call from a \`pull_request: labeled\` trigger to auto-merge sync PRs. Pairs with the F8 sync-issue-templates workflow.

## Closing keywords

Closes: n/a

## Summary

- \`.github/workflows/auto-merge-sync-pr-reusable.yml\` — reusable workflow that runs \`gh pr merge --squash --auto\` on the caller's PR. Permissions: \`pull-requests: write\`. Auth: caller's \`secrets.GITHUB_TOKEN\` (no PAT needed since the action runs inside the consumer repo's context).

This implements the open acceptance row from [vade-coo-memory#938](https://github.com/vade-app/vade-coo-memory/issues/938): *"Configure auto-merge for sync-action PRs in consumer repos"*. Repo-wide \`allow_auto_merge\` is already enabled on all 9 substrate repos; this reusable provides the label-gated trigger.

## Mechanism

The F8 sync-action labels every PR it opens with \`sync,sync:templates\`. Each consumer will carry a thin-trigger workflow that fires on \`pull_request: types: [labeled]\` with \`if: startsWith(github.event.label.name, 'sync:')\`, calling this reusable. The reusable enables squash auto-merge; GitHub lands the PR once CI passes.

Follow-up: 8 consumer thin-trigger PRs (one per F8 consumer: vcm, runtime, core, agent-logs, tjsonl, coo-console, skills, coo4one, vade-site — minus vrt itself which doesn't receive sync PRs).

## Cross-repo references

- [vade-coo-memory#938](https://github.com/vade-app/vade-coo-memory/issues/938) — F8 epic (this closes the auto-merge acceptance row)
- vcm paired PR — updates \`coo/operations/workflow-centralization.md\` table

https://claude.ai/code/session_01M1XipbZh1gNg7rn6Tpkart