### PR TITLE
tagging-taxonomy: add ops doc reference to skill description

### DIFF
--- a/.claude/skills/tagging-taxonomy/SKILL.md
+++ b/.claude/skills/tagging-taxonomy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tagging-taxonomy
-description: Apply or look up VADE issue metadata. Use when filing, triaging, or searching issues across vade-app repos by dimension (issue type, area, Readiness field, Priority field, needs/blocked). Native types + Issue fields are the primary metadata layer per MEMO-2026-05-21-xfqh; `area:*` and qualifier labels are what remains label-encoded.
+description: "Apply or look up VADE issue metadata. Use when filing, triaging, or searching issues across vade-app repos by dimension (issue type, area, Readiness field, Priority field, needs/blocked). Native types + Issue fields are the primary metadata layer per MEMO-2026-05-21-xfqh; operational reference: `coo/operations/issue-fields-and-types.md` (field list, pinning matrix, API surface). `area:*` and qualifier labels are what remains label-encoded."
 ---
 
 # VADE issue tagging taxonomy


### PR DESCRIPTION
## Summary

Companion to vade-app/vade-coo-memory#984 (closes vade-app/vade-coo-memory#909).

Updates the `tagging-taxonomy` skill frontmatter description to cite `coo/operations/issue-fields-and-types.md` as the operational reference alongside MEMO-2026-05-21-xfqh. The ops doc already appears in the Canonical sources section of the skill body; this makes it visible at the listing level so agents see it without invoking the skill first.

## Test plan

- [ ] Check that the skill listing description includes the ops doc path
- [ ] Confirm no functional change to the skill body taxonomy content

https://claude.ai/code/session_018QMsAyUnW2zXy2dXaTfqW7