### PR TITLE
sync-issue-templates: auto-merge consumer PRs from source side

### DIFF
--- a/.github/workflows/sync-issue-templates.yml
+++ b/.github/workflows/sync-issue-templates.yml
@@ -73,3 +73,25 @@ jobs:
 
             `deleteOrphaned: true` is in effect — files deleted from the canonical are deleted here too.
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+
+      # Enable squash auto-merge on each sync PR from the source side. The
+      # auto-merge-sync-pr-reusable.yml thin-trigger pattern in consumers
+      # cannot succeed because the default GITHUB_TOKEN lacks
+      # mergePullRequest permission (coo-harness#326). Driving the merge
+      # from here with VADE_FIELDS_ADMIN_PAT closes that gap with a single
+      # source-side change rather than 9 cross-repo edits.
+      - name: Enable auto-merge on consumer sync PRs
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        env:
+          GH_TOKEN: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}
+        run: |
+          consumers="$(yq '.group.repos' .github/sync.yml)"
+          for repo in $consumers; do
+            [ -z "$repo" ] && continue
+            pr="$(gh pr list -R "$repo" --label sync:templates --state open --json number --jq '.[0].number // empty')"
+            if [ -n "$pr" ]; then
+              echo "::notice::Enabling squash auto-merge: $repo#$pr"
+              gh pr merge "$pr" --squash --auto --repo "$repo" \
+                || echo "::warning::Failed to enable auto-merge on $repo#$pr"
+            fi
+          done


### PR DESCRIPTION
## Summary

`auto-merge-sync-pr-reusable.yml` thin-trigger chain in consumers cannot enable auto-merge because the default `GITHUB_TOKEN` lacks `mergePullRequest` permission (`graphql: Resource not accessible by integration`). Root cause noted in MEMO-2026-05-25-4fkg; surfaced as a failure in today's F11 verification when the 8 sync PRs from the F11 (12:42 UTC) re-fire stalled indefinitely (manually merged in this session).

This drives the merge from the **source** workflow instead — `VADE_FIELDS_ADMIN_PAT` is already in scope here and has `contents:write` + `pull-requests:write` across all 8 consumers. One source-side change replaces what would otherwise be a 9-cross-repo fix (1 reusable + 8 thin callers).

After this lands, the thin-trigger workflow + reusable in coo-harness + 8 consumers become dead code; they can be removed in a follow-up cleanup.

## How it works

After the BetaHuhn sync step, the new step reads `.github/sync.yml` for the consumer list, finds the open `sync:templates`-labeled PR per consumer, and calls `gh pr merge --squash --auto`. Skipped on dry-run dispatches to match the BetaHuhn `DRY_RUN` branch above.

## Test plan

- [ ] Land this PR + verify next sync workflow run executes the new step without error
- [ ] Trigger a no-op canonical template change after merge; observe the resulting sync PR(s) auto-merge within seconds rather than stalling

Closes #326.

https://claude.ai/code/session_01Y3Tmx5L4cckhe1MqAjzHoi