### PR TITLE
chore(coo-memory#910): clean cut in canonical workflows + skill

### DIFF
--- a/.claude/skills/tagging-taxonomy/SKILL.md
+++ b/.claude/skills/tagging-taxonomy/SKILL.md
@@ -154,7 +154,7 @@ When asked to tag a new issue, run this in order:
 
 ## Search recipes — "what should I work on?"
 
-**Layer rule** (canonical: [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md) §"API surface"): issue fields live on a dedicated REST endpoint (`/repos/<o>/<r>/issues/<n>/issue-field-values`), not on the search API. GitHub issue-search qualifiers (`gh issue list --search`) honor `type:<Type>` but **do not** honor `readiness:*` / `priority:*` / `effort:*` — those silently fall back to text matching and return wrong results. Filter on issue-field values via REST iteration or the project board, not via `--search`.
+**Layer rule** (canonical: [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md) §"API surface"): issue fields live on a dedicated API surface — REST `/repos/<o>/<r>/issues/<n>/issue-field-values` per-issue, or GraphQL `issueFieldValues` connection on the `Issue` type. GitHub issue-search qualifiers (`gh issue list --search`) honor `type:<Type>` but **do not** honor `readiness:*` / `priority:*` / `effort:*` — those silently fall back to text matching and return wrong results. The VADE project board does not expose issue fields on `gh project item-list` JSON either (Status / Owner / Milestone are project-item fields, a different layer). Filter on issue-field values via GraphQL or per-issue REST, not via `--search` or `gh project`.
 
 What works on `--search`:
 - `type:<Type>` — native issue type (works since 2026-03)

--- a/.claude/skills/tagging-taxonomy/SKILL.md
+++ b/.claude/skills/tagging-taxonomy/SKILL.md
@@ -154,21 +154,79 @@ When asked to tag a new issue, run this in order:
 
 ## Search recipes — "what should I work on?"
 
-Native fields are searchable as first-class GitHub search
-qualifiers (case-insensitive on org-level Issue-field entities).
-Find issues a coding agent can take:
+**Layer rule** (canonical: [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md) §"API surface"): issue fields live on a dedicated REST endpoint (`/repos/<o>/<r>/issues/<n>/issue-field-values`), not on the search API. GitHub issue-search qualifiers (`gh issue list --search`) honor `type:<Type>` but **do not** honor `readiness:*` / `priority:*` / `effort:*` — those silently fall back to text matching and return wrong results. Filter on issue-field values via REST iteration or the project board, not via `--search`.
+
+What works on `--search`:
+- `type:<Type>` — native issue type (works since 2026-03)
+- `label:<label>` — labels
+- `milestone:<title>` — milestones
+- All standard qualifiers (`is:open`, `assignee:`, `author:`, etc.)
+
+What does NOT work on `--search`:
+- `readiness:<value>`, `priority:<value>`, `effort:<value>` — silently fuzzy-match issue body text; results are wrong
+- Any non-type issue-field qualifier
+
+### Find issues a coding agent can take (Readiness=Ready)
+
+GraphQL — one query per repo, return number+title for all Ready issues:
 
 ```bash
-gh issue list --repo coo-labs/coo-memory \
-  --search "readiness:Ready" --state open
+gh api graphql -f query='
+  query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+      issues(first: 100, states: OPEN) {
+        nodes {
+          number title
+          issueFieldValues(first: 25) {
+            nodes {
+              ... on IssueFieldSingleSelectValue {
+                name
+                field { ... on IssueFieldCommon { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -F owner=coo-labs -F repo=coo-memory \
+  --jq '.data.repository.issues.nodes
+        | map(select(.issueFieldValues.nodes
+                     | any(.field.name == "Readiness" and .name == "Ready")))
+        | .[] | "#\(.number) \(.title)"'
 ```
 
-Find the research queue:
+REST per-issue is the fallback when GraphQL paging is awkward (>100 open):
 
 ```bash
-gh issue list --repo coo-labs/coo-memory \
-  --search "readiness:'Needs research'" --state open
+REPO=coo-labs/coo-memory; READINESS_FIELD_ID=42387399
+for n in $(gh issue list --repo $REPO --state open --limit 500 --json number --jq '.[].number'); do
+  v=$(gh api repos/$REPO/issues/$n/issue-field-values 2>/dev/null \
+    | jq -r ".[] | select(.issue_field_id == $READINESS_FIELD_ID) | .single_select_option.name // empty")
+  [ "$v" = "Ready" ] && echo "#$n"
+done
 ```
+
+Field IDs (from canonical ops doc): Priority `41357630`, Effort `41357633`, Readiness `42387399`. See [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md) §"API surface" for the full table + REST shape gotchas.
+
+### Find the research queue (Readiness="Needs research")
+
+Same GraphQL shape — substitute `.name == "Ready"` → `.name == "Needs research"`.
+
+### Find Feature-typed work that's Ready
+
+Combine `type:` (works on `--search`) with the field check (GraphQL or REST):
+
+```bash
+gh issue list --repo coo-labs/coo-memory --search "type:Feature" --state open \
+  --json number --jq '.[].number' \
+  | while read n; do
+      v=$(gh api repos/coo-labs/coo-memory/issues/$n/issue-field-values 2>/dev/null \
+        | jq -r '.[] | select(.issue_field_id == 42387399) | .single_select_option.name // empty')
+      [ "$v" = "Ready" ] && echo "#$n"
+    done
+```
+
+### Label-based filters (these still use `--search` / `--label`)
 
 Blocked on BDFL (anywhere):
 
@@ -178,13 +236,6 @@ for r in coo-memory coo-harness vade-canvas coo-logs; do
 done
 ```
 
-Issues that need breakdown before anyone picks them up:
-
-```bash
-gh issue list --repo coo-labs/<repo> \
-  --search "readiness:'Needs breakdown'" --state open
-```
-
 Active work in a specific area across repos:
 
 ```bash
@@ -192,18 +243,6 @@ for r in coo-memory coo-harness vade-canvas coo-logs; do
   gh issue list --repo coo-labs/$r --label "area:memory" --state open
 done
 ```
-
-Ready feature work in vade-canvas:
-
-```bash
-gh issue list --repo coo-labs/vade-canvas \
-  --search "type:Feature readiness:Ready" --state open
-```
-
-The `priority:` qualifier does not yet resolve in `gh issue list
---search` (REST/GraphQL only). Use the side-panel Priority filter
-on the project board, or `gh api graphql -f query='{ ... issueFieldValues ... }'`
-for programmatic access.
 
 ## Routing hints (for future agent routers)
 

--- a/.claude/skills/tagging-taxonomy/SKILL.md
+++ b/.claude/skills/tagging-taxonomy/SKILL.md
@@ -1,43 +1,36 @@
 ---
 name: tagging-taxonomy
-description: "Apply or look up VADE issue metadata. Use when filing, triaging, or searching issues across coo-labs repos by dimension (issue type, area, Readiness field, Priority field, needs/blocked). Native types + Issue fields are the primary metadata layer per MEMO-2026-05-21-xfqh; operational reference: `coo/operations/issue-fields-and-types.md` (field list, pinning matrix, API surface). `area:*` and qualifier labels are what remains label-encoded."
+description: "Apply or look up VADE issue metadata. Use when filing, triaging, or searching issues across coo-labs repos by dimension (issue type, area, Readiness field, Priority field, needs/blocked). Native types + Issue fields are the primary metadata layer; operational reference: `coo/operations/issue-fields-and-types.md` (field list, pinning matrix, API surface). `area:*` and qualifier labels are what remains label-encoded."
 ---
 
 # VADE issue tagging taxonomy
 
 The coo-labs repos share metadata across two layers:
 
-1. **Native issue types + Issue fields** (org-wide; primary as of
-   2026-05-21 per MEMO-2026-05-21-xfqh) — handles the `Type`,
+1. **Native issue types + Issue fields** (org-wide) — handles `Type`,
    `Priority`, `Readiness`, `Effort`, and per-type fields
    (`Output kind`, `Research question`, `Skill kind`, `Skill name`).
    Set via issue templates + the `bridge-form-fields-trigger.yml`
    workflow on `issues.opened`.
-2. **Labels** (per-repo or org-wide) — handles what remains
-   label-encoded: `area:*`, qualifiers (`needs:*`, `blocked:*`),
-   semantic tags (`emancipatory`, `external-code`, `publish`,
-   `permanently-open`), and discussion-specific labels.
+2. **Labels** (per-repo or org-wide) — handles `area:*`, qualifiers
+   (`needs:*`, `blocked:*`), semantic tags (`emancipatory`,
+   `external-code`, `publish`, `permanently-open`), and
+   discussion-specific labels.
 
-Canonical refs:
-- `vade-coo-memory/coo/operations/issue-fields-and-types.md` —
-  field list, pinning matrix, API surface, migration stages.
-- `vade-coo-memory/coo/label_taxonomy.md` — surviving label
-  dimensions + the retired `type:*`/`readiness:*`/`prio:*` history.
+Canonical reference: `coo-labs/coo-memory/coo/operations/issue-fields-and-types.md` —
+field list, pinning matrix, API surface, label vocabulary.
 
-Read the canonical refs when the digest below looks stale.
+Read the canonical when the digest below looks stale.
 
 ## When to use this skill
 
 Invoke when you need to:
 
-- Apply labels (`area:*` + qualifiers) to an issue you are filing
-  or triaging.
-- Pick the "next task to work on" — filter by the native Readiness
-  field (`gh issue list --search "readiness:Ready"`).
-- Route an issue to the right agent profile via native issue type +
-  `area:*`.
+- Apply labels (`area:*` + qualifiers) to an issue you are filing or triaging.
+- Pick the "next task to work on" — filter by the native Readiness field
+  (`gh issue list --search "readiness:Ready"`).
+- Route an issue to the right agent profile via native issue type + `area:*`.
 - Decide whether something is gated (`needs:*`, `blocked:*`).
-- Check whether a label is valid, deprecated, or missing.
 
 Don't invoke for: PR-level review labels (none defined), project-board
 `Status` / `Owner` fields (those live on the project, not on labels —
@@ -46,61 +39,51 @@ see `coo/operations/project-board.md`), or commit-message conventions
 
 ## The dimensions
 
-Each issue carries metadata from each dimension independently.
-Some are native fields (Type / Priority / Readiness / Effort); others
-are labels (`area:*`, qualifiers).
-
 ### 1. Native issue type — kind of work (exactly one)
 
-Set via the issue template's `type:` front-matter or the GitHub UI
-type picker. Retires the `type:*` label dimension as of 2026-05-21.
+Set via the issue template's `type:` front-matter or the GitHub UI type picker.
 
-| Native type | Replaces label | Meaning |
-|---|---|---|
-| `Task` | (default) | Default kind of implementable work |
-| `Bug` | `type:bug` | Defect; behaviour diverges from intended |
-| `Feature` | `type:feat` | New capability or user-facing behaviour |
-| `Chore` | `type:chore` | Build, tooling, infra, housekeeping |
-| `Docs` | `type:docs` | Documentation-only change |
-| `Refactor` | `type:refactor` | Internal restructure, no behaviour change |
-| `Test` | `type:test` | Test coverage, fixtures, harness |
-| `Research` | `type:research` | Spike or investigation |
-| `Epic` | `type:epic` | Parent issue covering multiple implementable children |
-| `Skill` | (no prior label) | Skill lifecycle work (idea / implement / review / revise / evaluate). **Title form**: `/<skill-name>: <short description>` (e.g. `/peer-review: tighten Phase 2 ingest`). The slash-prefix makes board scan-ability immediate; the `Skill kind` and `Skill name` native fields carry the lifecycle phase + canonical name. |
+| Native type | Meaning |
+|---|---|
+| `Task` | Default kind of implementable work |
+| `Bug` | Defect; behaviour diverges from intended |
+| `Feature` | New capability or user-facing behaviour |
+| `Chore` | Build, tooling, infra, housekeeping |
+| `Docs` | Documentation-only change |
+| `Refactor` | Internal restructure, no behaviour change |
+| `Test` | Test coverage, fixtures, harness |
+| `Research` | Spike or investigation |
+| `Epic` | Parent issue covering multiple implementable children |
+| `Skill` | Skill lifecycle work (idea / implement / review / revise / evaluate). **Title form**: `/<skill-name>: <short description>` (e.g. `/peer-review: tighten Phase 2 ingest`). The slash-prefix makes board scan-ability immediate; the `Skill kind` and `Skill name` native fields carry the lifecycle phase + canonical name. |
 
-The retired `type:*` labels remain on historical issues for
-record-keeping; do NOT apply them to new issues. GitHub default
-labels `bug` / `enhancement` / `documentation` are present but the
-native type is canonical when both apply.
+GitHub default labels `bug` / `enhancement` / `documentation` are
+present but the native type is canonical when both apply.
 
 ### 2. `area:*` — where in the system (one or two; LABEL)
 
 Prefix is universal; value list is per-repo. Adding a new `area:*`
 value is unilateral — just create the label. `area:*` stays a label
-because the per-repo vocabulary fights org-wide field scope (the
-field would either flatten the vocabulary or require per-type
-duplication).
+because the per-repo vocabulary fights org-wide field scope.
 
 | Repo | Values |
 |---|---|
 | **Universal** (any repo) | `area:docs`, `area:ci`, `area:deploy` |
-| `vade-coo-memory` | `area:memory`, `area:identity`, `area:agents`, `area:skills`, `area:governance` |
-| `vade-runtime` | `area:cloud-env`, `area:mcp`, `area:bootstrap`, `area:hooks` |
-| `vade-core` | `area:canvas`, `area:mcp`, `area:storage`, `area:auth`, `area:ui`, `area:cloud` |
-| `vade-governance` | `area:authority`, `area:policy` |
-| `vade-agent-logs` | `area:sessions`, `area:schema` |
+| `coo-memory` | `area:memory`, `area:identity`, `area:agents`, `area:skills`, `area:governance` |
+| `coo-harness` | `area:cloud-env`, `area:mcp`, `area:bootstrap`, `area:hooks`, `area:transcripts` |
+| `vade-canvas` | `area:canvas`, `area:mcp`, `area:storage`, `area:auth`, `area:ui`, `area:cloud`, `area:agents` |
+| `coo-logs` | `area:sessions`, `area:schema` |
 
 ### 3. `Readiness` field — agent-routable? (single-select)
 
 **The headline dimension.** Drives agent assignment. Pinned to all
 types except Docs / Refactor.
 
-| Field value | Replaces label | Agent-routable? |
-|---|---|---|
-| `Ready` | `readiness:ready` | **yes** |
-| `Needs design` | `readiness:needs-design` | no |
-| `Needs research` | `readiness:needs-research` | research agent |
-| `Needs breakdown` | `readiness:needs-breakdown` | no |
+| Field value | Agent-routable? |
+|---|---|
+| `Ready` | **yes** |
+| `Needs design` | no |
+| `Needs research` | research agent |
+| `Needs breakdown` | no |
 
 Set via the issue template's Readiness dropdown (bridged) or the
 side-panel field on existing issues. Transitions: `Needs research`
@@ -112,12 +95,12 @@ itself `Ready` or worked.
 
 Pinned to all types.
 
-| Field value | Replaces label | Meaning |
-|---|---|---|
-| `P0` | `prio:P0` | Blocker; drop other work |
-| `P1` | `prio:P1` | High; next in queue |
-| `P2` | `prio:P2` | Normal; scheduled in current horizon |
-| `P3` | `prio:P3` | Backlog; someday/maybe |
+| Field value | Meaning |
+|---|---|
+| `P0` | Blocker; drop other work |
+| `P1` | High; next in queue |
+| `P2` | Normal; scheduled in current horizon |
+| `P3` | Backlog; someday/maybe |
 
 Default is P2 if absent. Set via the issue template's Priority
 dropdown (bridged) or the side-panel field.
@@ -129,18 +112,11 @@ dropdown (bridged) or the side-panel field.
 | `needs:bdfl-approval` | Decision gate pending BDFL ack |
 | `blocked:bdfl-go-ahead` | Externally blocked on BDFL before work starts |
 | `blocked:upstream` | Blocked on a third-party change |
-| `emancipatory` | Lowers the barrier for other humans/agents (MEMO 2026-04-20-01) |
+| `emancipatory` | Lowers the barrier for other humans/agents (MEMO-2026-04-20-01) |
 | `external-code` | Integrates, audits, or cherry-picks third-party code |
+| `permanently-open` | Intentionally kept open as a record or settled-but-open artifact |
 | `good first issue` | GitHub default; genuinely approachable by a newcomer |
 | `help wanted` | GitHub default; explicit ask for external contributions |
-
-### Legacy — `proj:*` (retained, not extended)
-
-`vade-coo-memory` has `proj:bootstrap`, `proj:pm-migration`,
-`proj:workspace-relocate`, `proj:skills-research`, `proj:coo-identity`,
-`proj:proposed-epic`. **Don't create new `proj:*` labels.** Use
-native issue type `Epic` + GitHub sub-issues for new parent/child
-linkage.
 
 ## Classification checklist
 
@@ -150,8 +126,8 @@ When asked to tag a new issue, run this in order:
    template (`bug.yml`, `feature.yml`, `chore.yml`, etc.) sets the
    native type via `type:` front-matter. If the issue was opened
    with the wrong template, the type can be reassigned via the
-   GitHub UI's type picker or `updateIssueIssueType` GraphQL
-   mutation.
+   GitHub UI's type picker or `updateIssue` GraphQL mutation
+   (with `issueTypeId`).
 2. **Pick one or two `area:*`** from the repo's vocabulary. If
    none fit, create a new `area:*` label rather than force-fitting,
    or leave area off if the issue genuinely spans no clear area.
@@ -171,9 +147,10 @@ When asked to tag a new issue, run this in order:
      --add-label "area:agents,needs:bdfl-approval"
    ```
 
-   For native fields, use the GitHub UI side-panel, or the
-   `setIssueFieldValue` GraphQL mutation. Per-issue field-value
-   setting works with the standard fine-grained PAT.
+   For native fields, use the GitHub UI side-panel, or the REST
+   `POST /repos/<o>/<r>/issues/<n>/issue-field-values` endpoint
+   (works with the standard fine-grained PAT — see canonical doc
+   §"API surface" for the exact shape).
 
 ## Search recipes — "what should I work on?"
 
@@ -182,21 +159,21 @@ qualifiers (case-insensitive on org-level Issue-field entities).
 Find issues a coding agent can take:
 
 ```bash
-gh issue list --repo coo-labs/vade-coo-memory \
+gh issue list --repo coo-labs/coo-memory \
   --search "readiness:Ready" --state open
 ```
 
 Find the research queue:
 
 ```bash
-gh issue list --repo coo-labs/vade-coo-memory \
+gh issue list --repo coo-labs/coo-memory \
   --search "readiness:'Needs research'" --state open
 ```
 
 Blocked on BDFL (anywhere):
 
 ```bash
-for r in vade-coo-memory vade-runtime vade-core vade-governance vade-agent-logs; do
+for r in coo-memory coo-harness vade-canvas coo-logs; do
   gh issue list --repo coo-labs/$r --label "needs:bdfl-approval" --state open
 done
 ```
@@ -211,29 +188,22 @@ gh issue list --repo coo-labs/<repo> \
 Active work in a specific area across repos:
 
 ```bash
-for r in vade-coo-memory vade-runtime vade-core vade-governance vade-agent-logs; do
+for r in coo-memory coo-harness vade-canvas coo-logs; do
   gh issue list --repo coo-labs/$r --label "area:memory" --state open
 done
 ```
 
-Ready feature work in vade-core:
+Ready feature work in vade-canvas:
 
 ```bash
-gh issue list --repo coo-labs/vade-core \
+gh issue list --repo coo-labs/vade-canvas \
   --search "type:Feature readiness:Ready" --state open
 ```
 
 The `priority:` qualifier does not yet resolve in `gh issue list
---search` (REST/GraphQL only as of 2026-05-21). Use the side-panel
-Priority filter on the project board, or
-`gh api graphql -f query='{ ... issueFieldValues ... }'` for
-programmatic access.
-
-For historical issues that pre-date the migration, the retired
-`type:*`, `readiness:*`, `prio:*` labels still match via `--label`
-— the backfill set both label + native field on those, so either
-filter works for closed issues. New issues only carry the native
-field.
+--search` (REST/GraphQL only). Use the side-panel Priority filter
+on the project board, or `gh api graphql -f query='{ ... issueFieldValues ... }'`
+for programmatic access.
 
 ## Routing hints (for future agent routers)
 
@@ -248,27 +218,7 @@ native type + `area:*`:
 | `Docs` | any | Haiku-class model (cheap, fast) |
 | `Refactor` | any | `claude-code` + repo-aware `simplify` skill |
 
-Gates: `needs:bdfl-approval` is a handshake; `blocked:*` is a hard
-stop.
-
-## Deprecated labels (do not apply to new issues)
-
-Kept to avoid breaking closed-issue references. Map forward as shown:
-
-| Old | New |
-|---|---|
-| `track:memory` | `area:memory` |
-| `track:boot-opt` | `area:agents` (or `area:memory` by scope) |
-| `track:orchestration` | `area:agents` |
-| `track:self-assess` | `area:agents` |
-| `docs-only` | `type:docs` |
-| `canvas` (vade-core) | `area:canvas` |
-| `feat` (vade-core) | `type:feat` |
-| `milestone-1` (vade-core) | GitHub milestones |
-| `Strategy` (vade-agent-logs) | `type:research` |
-| `epic:ipad-live` | `type:epic` + sub-issues |
-| `phase:3-pilot` | no replacement; use milestones |
-| `Discussion-update`, `COO essay` | ad-hoc; consider retiring |
+Gates: `needs:bdfl-approval` is a handshake; `blocked:*` is a hard stop.
 
 ## Maintenance — what requires a memo
 
@@ -286,9 +236,8 @@ cross-repo invariant.
 ## Canonical sources
 
 ```text
-vade-coo-memory/coo/operations/issue-fields-and-types.md   # primary
-vade-coo-memory/coo/label_taxonomy.md                       # label scheme
-vade-coo-memory/coo/memos/2026-05-21-xfqh.md                # adoption memo
+coo-labs/coo-memory/coo/operations/issue-fields-and-types.md
+coo-labs/coo-memory/coo/memos/2026-05-21-xfqh.md
 ```
 
 When this digest and the canonical docs disagree, the canonical

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -13,8 +13,7 @@ body:
         each child issue (or use the GraphQL `addSubIssue` mutation).
 
         Native sub-issue linkage is **required** for Epic-type issues per
-        [`coo/operations/issue-pr-hygiene.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-pr-hygiene.md)
-        + [`coo/label_taxonomy.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/label_taxonomy.md) §6 —
+        [`coo/operations/issue-pr-hygiene.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-pr-hygiene.md) —
         markdown checklists of `#N` references in the epic body are insufficient
         because they're invisible to GraphQL queries and the project board's
         tracker UI.
@@ -33,8 +32,8 @@ body:
       label: Summary
       description: One-paragraph description of what this epic is about and what shipping it looks like.
       placeholder: |
-        e.g., "Migrate the five repos from `proj:*` labels to GitHub native
-        sub-issues so the project board's tracker UI reflects real progress."
+        e.g., "Migrate the four primary repos from markdown-checklist sub-issue tracking
+        to GitHub's native sub-issue API so the project board's tracker UI reflects real progress."
     validations:
       required: true
 

--- a/.github/workflows/auto-tag-issues-reusable.yml
+++ b/.github/workflows/auto-tag-issues-reusable.yml
@@ -10,8 +10,7 @@ name: Auto-tag new issues (reusable)
 # resolution fails despite access_level=organization; bridge-form-fields-to-natives.yml
 # is the live in-org precedent for "public canonical, mixed consumers").
 # Operations doc: coo-labs/coo-memory/coo/operations/workflow-centralization.md
-# Canonical taxonomy: https://github.com/coo-labs/coo-memory/blob/main/coo/label_taxonomy.md
-# Canonical fields:   https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md
+# Canonical taxonomy: https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md
 # Canonical project:  https://github.com/orgs/coo-labs/projects/1 (VADE)
 #   Project node ID:  PVT_kwDOEGdN_84BUV2r
 #
@@ -166,19 +165,14 @@ jobs:
             you, ignore it — surfacing classification disagreements
             is out of scope for this workflow.
 
-            2. Classify across the dimensions below. Canonical refs:
-               https://github.com/coo-labs/coo-memory/blob/main/coo/label_taxonomy.md
-               + https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md
+            2. Classify across the dimensions below. Canonical ref:
+               https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md
 
-               **Retired dimensions** (do NOT apply these as labels):
-               `type:*`, `readiness:*`, `prio:*` were retired 2026-05-21
-               per MEMO-2026-05-21-xfqh. Native issue type is set by the
-               issue template's `type:` front-matter; Priority / Readiness
-               field values are bridged from the template's dropdown
-               widgets by `bridge-form-fields-trigger.yml`. Applying
-               the legacy labels on top is duplicate metadata — the bug
-               this workflow was fixed to stop doing
-               (coo-memory#879).
+               Issue type is set by the issue template's `type:`
+               front-matter; Priority / Readiness / Effort field values
+               are bridged from the template's dropdown widgets by
+               `bridge-form-fields-trigger.yml`. This workflow only
+               applies labels (`area:*`, qualifiers) and milestone.
 
                - `area:*` — one or two, from this repo's vocabulary:
                  area:memory, area:identity, area:agents, area:skills, area:governance

--- a/.github/workflows/issue-pr-hygiene-reusable.yml
+++ b/.github/workflows/issue-pr-hygiene-reusable.yml
@@ -417,10 +417,7 @@ jobs:
 
   sub-issue-linkage:
     # Pattern A — Epic-type issues use native sub-issue API. Advisory.
-    # Predicate-migration note: pre-Stage-3 of the issue-fields-and-types migration
-    # (MEMO-2026-05-21-xfqh) keyed on the `type:epic` label; post-Stage-3 the
-    # predicate is the native issue type. The script GraphQL-queries both
-    # `issueType` and `subIssues` and returns early when the type isn't Epic.
+    # Predicate is the native issue type (queried via GraphQL).
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
@@ -466,15 +463,8 @@ jobs:
             }
 
             const typeName = result?.repository?.issue?.issueType?.name ?? null;
-            const isEpicByType = typeName === 'Epic';
-            // Fallback for the legacy path: pre-Stage-3 issues that still
-            // carry only the `type:epic` label without a native type set.
-            const isEpicByLabel = (issue.labels || [])
-              .some(l => (l.name || l) === 'type:epic');
-
-            if (!isEpicByType && !isEpicByLabel) {
-              core.info(`Skipping Pattern A: issue type is ${typeName || 'unset'}, ` +
-                `no legacy type:epic label.`);
+            if (typeName !== 'Epic') {
+              core.info(`Skipping Pattern A: issue type is ${typeName || 'unset'}.`);
               return;
             }
 
@@ -496,18 +486,15 @@ jobs:
               c.body && c.body.includes(marker) && c.user.type === 'Bot'
             );
 
-            const epicPredicate = isEpicByType
-              ? `is typed \`Epic\``
-              : `carries the legacy \`type:epic\` label`;
             const commentBody = `${marker}\n\n` +
               `### Issue hygiene — advisory (Pattern A: sub-issue linkage)\n\n` +
-              `This issue ${epicPredicate} but has no native sub-issues linked ` +
+              `This issue is typed \`Epic\` but has no native sub-issues linked ` +
               `(\`subIssues\` count = 0). Markdown \`#N\` checklists are insufficient — ` +
               `they're invisible to GraphQL queries and the project board's tracker UI.\n\n` +
               `Add sub-issues via the GitHub UI's "Add sub-issue" button on this issue, ` +
               `or via the GraphQL \`addSubIssue\` mutation.\n\n` +
-              `See \`coo/operations/issue-pr-hygiene.md\` §"Sub-issue linkage" + ` +
-              `\`coo/label_taxonomy.md\` §6 (in coo-labs/coo-memory).\n\n` +
+              `See \`coo/operations/issue-pr-hygiene.md\` §"Sub-issue linkage" ` +
+              `(in coo-labs/coo-memory).\n\n` +
               `*This is advisory; the check does not block merge. ` +
               `Apply label \`hygiene:exempt\` to suppress on this issue.*`;
 


### PR DESCRIPTION
## Summary

Per [coo-memory#910](https://github.com/coo-labs/coo-memory/issues/910) + [MEMO-2026-05-25-abbh](https://github.com/coo-labs/coo-memory/blob/main/coo/memos/2026-05-25-abbh.md): clean cut on the canonical issue-tagging surface (sync-propagates to all 8 consumer repos) + the Pattern-A `type:epic` predicate regression.

- **`tagging-taxonomy` SKILL.md** — drop "Replaces label" columns, drop the deprecated-labels table, drop the legacy `proj:*` section, reframe lede. Update cross-repo paths to `coo-labs/*`.
- **`auto-tag-issues-reusable.yml`** — drop the "Retired dimensions" paragraph; the labels are about to be deleted, so the negative-guard is redundant. Point only at consolidated taxonomy doc.
- **`issue-pr-hygiene-reusable.yml`** — Pattern-A predicate becomes `issueType.name === 'Epic'` only; drop the legacy `type:epic` label fallback (closes [coo-labs/coo-memory#906](https://github.com/coo-labs/coo-memory/issues/906)).
- **`epic.yml` ISSUE_TEMPLATE** — drop `label_taxonomy.md` cross-reference and deprecated-label example from placeholder text. Auto-syncs to 8 consumers.

Companion PR: [coo-memory PR #998](https://github.com/coo-labs/coo-memory/pull/998) — doc consolidation, archive, umbrella memo, supersession.

Closes coo-labs/coo-memory#906.
Refs coo-labs/coo-memory#910.
Refs MEMO-2026-05-25-abbh.

## Test plan

- [ ] Read `issue-pr-hygiene-reusable.yml` Pattern-A: confirms `typeName !== 'Epic'` early-return + no label fallback.
- [ ] Open a test Epic-typed issue in any consumer repo: confirm Pattern-A advisory fires.
- [ ] Open a test issue with the legacy `type:epic` label only (no native type): confirm Pattern-A correctly skips (the legacy fallback is gone).
- [ ] Confirm `sync-issue-templates` workflow propagates the `epic.yml` change to 8 consumers.
- [ ] CI bootstrap-regression passes (no boot-touching changes here, but confirm).

https://claude.ai/code/session_01Qw1XCqgkyVa33rdoaokuwY