### PR TITLE
F17b: COO_SCOPE_REPOS + sync.yml derive from canonical registry

### DIFF
--- a/.github/workflows/coo-on-assign-reusable.yml
+++ b/.github/workflows/coo-on-assign-reusable.yml
@@ -11,10 +11,11 @@ name: COO on issue assign (reusable)
 # Operations doc: coo-labs/coo-memory:coo/operations/workflow-centralization.md
 # Workflow rationale: coo-labs/coo-memory:coo/operations/coo-on-assign.md
 #
-# COO_SCOPE_REPOS maintenance: edit the list in this file once; all
-# consumer thin triggers pick up the change at next assignment event.
-# This file replaces the prior workflow-sync convention that required
-# N-PR fanout per change.
+# COO_SCOPE_REPOS source: fetched at job time from the canonical registry
+# at coo-labs/.github/repos.yaml (status == "active" filter; meta tier
+# excluded). Adding/archiving a repo there auto-propagates to every
+# consumer thin trigger on next assignment event — no edit needed in
+# this file. F17b migration: coo-memory#999.
 #
 # Trigger contract for callers:
 #   on: issues
@@ -50,8 +51,33 @@ jobs:
     if: ${{ github.event.assignee.login == 'vade-coo' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Load active repos from canonical registry
+        id: registry
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Read coo-labs/.github/repos.yaml; emit active non-meta repos as
+          # a JSON array of fully-qualified slugs for github-script to consume.
+          # `.github` is public so github.token can read it without elevated
+          # perms. Failure here fails the job loudly (set -e) rather than
+          # silently falling back to a hardcoded list.
+          repos_json="$(gh api repos/coo-labs/.github/contents/repos.yaml --jq '.content | @base64d' \
+            | yq -r '.repos[] | select(.status == "active" and .tier != "meta") | "coo-labs/" + .name' \
+            | jq -R . | jq -s .)"
+          if [ -z "$repos_json" ] || [ "$repos_json" = "[]" ]; then
+            echo "::error::registry returned empty active-repo list; bailing rather than posting a launch URL with no repos pre-selected"
+            exit 1
+          fi
+          {
+            echo "active_repos<<EOF"
+            echo "$repos_json"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build pre-fill URL and post launch comment
         uses: actions/github-script@v7
+        env:
+          COO_SCOPE_REPOS_JSON: ${{ steps.registry.outputs.active_repos }}
         with:
           script: |
             const issue = context.payload.issue;
@@ -107,20 +133,11 @@ jobs:
             // The assigning repo goes first so it's the obvious primary
             // in the form's repo selector.
             //
-            // When a coo-labs/* repo is added/renamed/archived/deleted,
-            // update THIS LIST in the canonical reusable. Consumer thin
-            // triggers pick up the change automatically.
-            const COO_SCOPE_REPOS = [
-              'coo-labs/coo-memory',
-              'coo-labs/vade-canvas',
-              'coo-labs/coo-harness',
-              'coo-labs/coo-logs',
-              'coo-labs/skills',
-              'coo-labs/coo4one',
-              'coo-labs/site',
-              'coo-labs/tjsonl',
-              'coo-labs/coo-console',
-            ];
+            // Loaded from the canonical registry at coo-labs/.github/repos.yaml
+            // in the prior step (filter: status == "active" and tier != "meta").
+            // Adding/archiving a repo there auto-propagates to every consumer
+            // thin trigger on next assignment event. F17b: coo-memory#999.
+            const COO_SCOPE_REPOS = JSON.parse(process.env.COO_SCOPE_REPOS_JSON);
             const repositories = [
               repoSlug,
               ...COO_SCOPE_REPOS.filter(r => r !== repoSlug),

--- a/.github/workflows/sync-issue-templates.yml
+++ b/.github/workflows/sync-issue-templates.yml
@@ -53,6 +53,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # F17b drift-check (coo-memory#999): the BetaHuhn sync action reads
+      # .github/sync.yml as a static config file (no env substitution), so
+      # we keep the consumer list committed but assert it matches the
+      # canonical registry at coo-labs/.github/repos.yaml. Fails CI if a
+      # repo was added/archived in the registry but not reflected here.
+      - name: Verify sync.yml repos list matches registry
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          expected="$(gh api repos/coo-labs/.github/contents/repos.yaml --jq '.content | @base64d' \
+            | yq -r '.repos[] | select(.status == "active" and .tier != "meta" and .name != "coo-harness") | "coo-labs/" + .name' \
+            | sort)"
+          actual="$(yq -r '.group.repos' .github/sync.yml | grep -v '^[[:space:]]*$' | sort)"
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::.github/sync.yml repos list drifted from coo-labs/.github/repos.yaml — update sync.yml to match active non-meta repos minus coo-harness"
+            echo "--- expected (from registry) ---"
+            echo "$expected"
+            echo "--- actual (sync.yml) ---"
+            echo "$actual"
+            echo "--- diff ---"
+            diff <(echo "$expected") <(echo "$actual") || true
+            exit 1
+          fi
+          echo "sync.yml repos list matches registry ($(echo "$expected" | wc -l | tr -d ' ') consumers)."
+
       - name: Sync ISSUE_TEMPLATE/ to consumers
         uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619  # v1.21.1
         with:

--- a/scripts/registry-check.sh
+++ b/scripts/registry-check.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# registry-check: assert coo-labs/.github/repos.yaml matches live org state.
+#
+# Reads the canonical registry and the live `gh api orgs/coo-labs/repos`
+# output; fails non-zero on any drift in:
+#   - membership (repo in one list, missing from the other)
+#   - visibility (public/private)
+#   - status (registry.status vs live.archived)
+#
+# Designed for two invocation contexts:
+#   - PR check in coo-labs/.github when repos.yaml changes
+#   - Nightly schedule (catches drift introduced via the GitHub UI)
+#
+# Source: coo-memory#999 (F17b drift-check, load-bearing — without this the
+# registry becomes a quieter drift problem than the literals it replaced).
+#
+# Portability: uses only `yq -r` with `+`-concat filter syntax; works on
+# both mikefarah yq v4 (GitHub-hosted runners) and kislyuk yq (Python
+# wrapper used in dev containers). Same compatibility surface as
+# coo-memory/bin/configure-memo-autolinks.sh.
+#
+# Usage:
+#   bash scripts/registry-check.sh           # exits 0 on clean, 1 on drift
+#   bash scripts/registry-check.sh --quiet   # output only on drift
+
+set -euo pipefail
+
+OWNER="coo-labs"
+QUIET=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --quiet)   QUIET=1; shift ;;
+    -h|--help) sed -n '2,26p' "$0"; exit 0 ;;
+    *) echo "registry-check: unknown flag '$1'" >&2; exit 2 ;;
+  esac
+done
+
+: "${GH_TOKEN:=${GITHUB_MCP_PAT:-}}"
+if [ -z "$GH_TOKEN" ]; then
+  echo "registry-check: GH_TOKEN / GITHUB_MCP_PAT not set; cannot authenticate." >&2
+  exit 2
+fi
+export GH_TOKEN
+
+for tool in gh yq jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "registry-check: $tool not on PATH." >&2
+    exit 2
+  fi
+done
+
+# --- Fetch registry --------------------------------------------------------
+registry_yaml="$(gh api "repos/$OWNER/.github/contents/repos.yaml" --jq '.content | @base64d')"
+if [ -z "$registry_yaml" ]; then
+  echo "registry-check: empty registry response from $OWNER/.github/repos.yaml" >&2
+  exit 2
+fi
+
+# Tab-separated lines: name<TAB>visibility<TAB>status
+registry_lines="$(yq -r '.repos[] | .name + "\t" + .visibility + "\t" + .status' <<<"$registry_yaml" | sort)"
+
+# --- Fetch live list -------------------------------------------------------
+# `gh api orgs/<org>/repos?type=all` includes archived repos when authenticated.
+# coo-labs has ~12 repos; --paginate is cheap insurance against future growth.
+live_lines="$(gh api "orgs/$OWNER/repos?type=all&per_page=100" --paginate \
+  | jq -r '.[] | .name + "\t" + .visibility + "\t" + (if .archived then "archived" else "active" end)' \
+  | sort)"
+
+# --- Diff ------------------------------------------------------------------
+registry_names="$(echo "$registry_lines" | cut -f1)"
+live_names="$(echo "$live_lines" | cut -f1)"
+
+only_registry="$(comm -23 <(echo "$registry_names") <(echo "$live_names"))"
+only_live="$(comm -13 <(echo "$registry_names") <(echo "$live_names"))"
+
+drift=0
+report=()
+
+if [ -n "$only_registry" ]; then
+  drift=1
+  report+=("Registry has repos not present in live org:")
+  while IFS= read -r r; do report+=("  - $r"); done <<<"$only_registry"
+fi
+
+if [ -n "$only_live" ]; then
+  drift=1
+  report+=("Live org has repos not in registry:")
+  while IFS= read -r r; do report+=("  - $r"); done <<<"$only_live"
+fi
+
+common="$(comm -12 <(echo "$registry_names") <(echo "$live_names"))"
+while IFS= read -r repo; do
+  [ -z "$repo" ] && continue
+  reg_line="$(echo "$registry_lines" | awk -v r="$repo" -F'\t' '$1==r')"
+  liv_line="$(echo "$live_lines"     | awk -v r="$repo" -F'\t' '$1==r')"
+  if [ "$reg_line" != "$liv_line" ]; then
+    drift=1
+    reg_rest="$(echo "$reg_line" | cut -f2-)"
+    liv_rest="$(echo "$liv_line" | cut -f2-)"
+    report+=("$repo: drift — registry=[$reg_rest] live=[$liv_rest]")
+  fi
+done <<<"$common"
+
+if [ "$drift" -eq 0 ]; then
+  if [ "$QUIET" -eq 0 ]; then
+    count="$(echo "$registry_names" | wc -l | tr -d ' ')"
+    echo "registry-check: clean ($count repos match)"
+  fi
+  exit 0
+fi
+
+echo "registry-check: drift detected between $OWNER/.github/repos.yaml and live org state" >&2
+for line in "${report[@]}"; do
+  echo "$line" >&2
+done
+exit 1


### PR DESCRIPTION
## Summary

Migrates the two list-shape consumer literals identified in coo-labs/coo-memory#999 to read from `coo-labs/.github/repos.yaml` rather than carrying hardcoded repo lists, and adds the load-bearing `scripts/registry-check.sh` drift-checker.

- `coo-on-assign-reusable.yml` — `COO_SCOPE_REPOS` JS array replaced by a pre-step that fetches active non-meta repos from the registry and exposes them via `$GITHUB_OUTPUT` for the github-script step to `JSON.parse`. Adding/archiving a repo in the registry now auto-propagates to every consumer thin trigger on next issue-assignment event.

- `sync-issue-templates.yml` — keeps `.github/sync.yml` committed (the BetaHuhn action reads it as a static config; no env substitution available), but adds a drift-check step that fails CI if `group.repos:` diverges from the registry's `active` non-meta repos minus `coo-harness` (the source).

- `scripts/registry-check.sh` — new. Asserts registry matches live `gh api orgs/coo-labs/repos` on membership, visibility, status. Will be wired into a PR check + nightly schedule in `coo-labs/.github` (follow-up PR).

## Scope refinement vs. original issue

The original issue body enumerated ~8 in-scope sites. Investigation showed two categories:

| Site type | Migration |
|---|---|
| **List-shape** (`COO_SCOPE_REPOS`, `sync.yml group.repos:`) | migrated here |
| **Single org-name string** (`gh-coo-wrap.sh` sentinel, `git-push-with-fallback.sh`, `project-board-digest.sh --owner`, `bridge-form-fields-to-natives.py:40` ORG, `bin/{external-touch,dash-form-rewriter,backfill-file-links,add-sub-issues}` `OWNER_DEFAULT`/`REPO_OWNER`) | left as-is |

The single org-name constants change ~once per org lifetime (we just did it; next one is years away). Replacing them with runtime registry reads trades zero risk for some risk (network call, yq dep, registry-vs-runtime drift) for zero gain. The list-shape literals were the F17b cost driver.

Also: three of the issue's named sites moved to `coo-harness/scripts/` during the F11 kernel divorce; the issue body is pre-divorce. No functional impact.

## Verification

- `bash scripts/registry-check.sh` against live state: clean (11 repos match).
- Drift-check filter on `sync.yml` produces identical sorted output to the expected registry-derived list.
- Both edited YAML files parse via `yq '.'`.

## Test plan

- [ ] `coo-on-assign-reusable.yml` — exercise by assigning `@vade-coo` to a test issue once merged; verify the launch URL pre-selects the same 9 repos as the prior hardcoded list.
- [ ] `sync-issue-templates.yml` — exercise on next `.github/ISSUE_TEMPLATE/**` change; verify the drift-check step passes.
- [ ] `bootstrap-regression` CI is expected to pass — `registry-check.sh` is not invoked by `cloud-setup.sh` / `session-start-sync.sh` / `integrity-check.sh`.

Closes coo-labs/coo-memory#999.

https://claude.ai/code/session_01C5mjAFbQWEUcaLxUBXV27H