### PR TITLE
fix(#320): drop implementation paths from sync trigger filter

### DIFF
--- a/.github/workflows/sync-issue-templates.yml
+++ b/.github/workflows/sync-issue-templates.yml
@@ -25,14 +25,20 @@ name: Sync issue templates
 # (coo-harness#321). Consumer list is read at job-time from
 # coo-labs/.github/repos.yaml (the F17 canonical registry); the previous
 # .github/sync.yml + drift-check were vestigial after the action removal.
+#
+# Trigger-path principle (coo-harness#320): fire on output changes (the
+# templates) only — not on implementation changes (this workflow file or
+# the sync script). Implementation edits should be tested via
+# workflow_dispatch with dry_run=true, not by force-merging through 8
+# consumer repos. The original incident: vrt#319's second sync wave at
+# 2026-05-25T10:44 fired purely on a workflow-file edit during the F9
+# rename (a no-content change), opening 8 live PRs across consumers.
 
 on:
   push:
     branches: [main]
     paths:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/sync-issue-templates.yml'
-      - 'scripts/sync-templates-to-consumers.sh'
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Summary

Removes the workflow-file and sync-script paths from the push-trigger's `paths:` filter. After this change, the sync only fires on actual template content changes (`.github/ISSUE_TEMPLATE/**`) — not on implementation refactors of the workflow or the script that implements it.

## Reframe vs. the issue title

The issue title — *"DRY_RUN gate is unreachable on push events"* — is literally correct but misframes the fix. A DRY_RUN gate on every push would break the F8 ergonomic contract: edit canonical template → push → consumers sync. The actual foot-gun is narrower:

> The path-filter fired on implementation changes (the workflow file itself + the sync script), so any no-content refactor of the implementation triggered a live sync wave across 8 consumer repos.

Concrete past evidence: [coo-harness#319](https://github.com/coo-labs/coo-harness/pull/319)'s second sync wave at 2026-05-25T10:44 fired purely on a workflow-file edit during the F9 org rename (a no-content change for the templates themselves), opening 8 live consumer PRs. Predicted deltas matched, no damage — but the foot-gun is the same shape that could later cause damage on a less-benign edit.

## The fix

Trigger-path principle: fire on output changes (templates) only, not on implementation changes (workflow + script). Implementation edits get tested via `workflow_dispatch` with `dry_run=true`, which is the right path for that class of change anyway.

```diff
   paths:
     - '.github/ISSUE_TEMPLATE/**'
-    - '.github/workflows/sync-issue-templates.yml'
-    - 'scripts/sync-templates-to-consumers.sh'
```

Plus a comment-block at the top of the workflow naming the principle and citing the original incident.

## What's unchanged

- F8 ergonomic contract: editing a canonical template still auto-syncs to consumers on push.
- `workflow_dispatch` with `dry_run=true` still works for previewing.
- DRY_RUN-on-push semantics: unchanged (live, as before).
- The post-#321 sync script and its consumer-list reading from `coo-labs/.github/repos.yaml`: unchanged.

## Test plan

- [ ] Merge this PR. The merge itself touches only the workflow file — under the new filter this should NOT trigger a sync wave (no change to `.github/ISSUE_TEMPLATE/**`).
- [ ] After merge, a separate trivial edit to any `ISSUE_TEMPLATE/*.yml` should still trigger the sync (the production path works).
- [ ] `workflow_dispatch` with `dry_run=true` should still run end-to-end against consumers without opening PRs.

Closes coo-labs/coo-harness#320.

https://claude.ai/code/session_01C5mjAFbQWEUcaLxUBXV27H