### PR TITLE
fix(#335): heal /root/.claude hooks at resume — close B4 drift

### DIFF
--- a/scripts/session-start-sync.sh
+++ b/scripts/session-start-sync.sh
@@ -43,6 +43,22 @@ fi
 
 boot_log_record session-start-sync start
 sync_claude_config "$SCRIPT_DIR/../.claude" "$WORKSPACE_ROOT_DERIVED/.claude"
+# Heal $HOME/.claude/settings.json hooks block on cloud only — never on
+# Mac. Cloud build-time (cloud-setup.sh:41) bakes the hooks here once at
+# snapshot creation; without this resume-time re-sync, hooks-block commits
+# landing between bake and resume leave the user-scope settings frozen at
+# bake-time SHA. integrity-check B4 trips, and any future config that
+# Claude Code merges user-scope-precedent goes stale. The VADE_COO_MODE
+# gate matches the pattern in _write_claude_settings_* (common.sh:1717,
+# 1845, 1915, 1952, 1987) per coo-harness#262: Mac sessions don't set the
+# flag, so the personal ~/.claude/settings.json stays untouched. The
+# path-inequality clause is defense-in-depth — on cloud $HOME=/root and
+# $WORKSPACE_ROOT_DERIVED=/home/user diverge; if they ever converge (or
+# VADE_COO_MODE leaks onto a local Mac) we still no-op. First tripped
+# by coo-memory#781 / coo-harness#334; audit-input for coo-memory#762.
+if [ "${VADE_COO_MODE:-0}" = "1" ] && [ "$HOME" != "$WORKSPACE_ROOT_DERIVED" ]; then
+  sync_claude_config "$SCRIPT_DIR/../.claude" "$HOME/.claude"
+fi
 # Aggregate per-repo primitives from data-owning repos. Per the
 # data-ownership rule (MEMO 2026-04-25-02), slash commands and skills
 # live in the repo whose data they manipulate; the aggregator surfaces


### PR DESCRIPTION
Closes #335

## Summary

\`session-start-sync.sh\` syncs the hooks block to \`\$WORKSPACE_ROOT/.claude\` (= \`/home/user/.claude\` on cloud) but never to \`\$HOME/.claude\` (= \`/root/.claude\` on cloud — the user-scope settings that \`integrity-check\` B4 reads). The env-merge calls already target \`\$HOME/.claude\`, so env keys stay fresh — but the hooks block stays frozen at snapshot-bake SHA. When a hooks-block commit lands between snapshot bake and a session resume on that snapshot, B4 trips.

#334 (agent-model-guard PreToolUse matcher) is the first hooks-block commit since #262 wired the two-mechanism path-selection asymmetry; B4 has been latent since 2026-05-13. Full root-cause walk-through in #335.

**Fix.** Add one \`VADE_COO_MODE\`-gated \`sync_claude_config\` call after the existing one, targeting \`\$HOME/.claude\`. Matches the gate pattern at \`lib/common.sh:1717,1845,1915,1952,1987\`. \`_sync_claude_settings\` preserves the env block during the re-sync, so secrets survive.

## Context — why the wiring is currently asymmetric

**PR #262 (\`2704330\`, 2026-05-13)** introduced two-mechanism Mac protection:
1. \`VADE_COO_MODE\` gate on all four \`_write_claude_settings_*\` writers (early-return when unset; Mac's \`local-setup.sh\` doesn't set it).
2. \`CLAUDE_CONFIG_DIR\`-aware default \`dst\` for \`sync_claude_config\` (Mac's \`claude-coo\` wrapper redirects to \`~/.claude-coo\`).

But \`session-start-sync.sh:45\` calls \`sync_claude_config\` with **explicit dst** = \`\$WORKSPACE_ROOT_DERIVED/.claude\`, which bypasses both defenses. The call stayed safe-on-Mac by deliberately targeting workspace-scope rather than user-scope — a third, implicit mechanism that wasn't unified with the writer-side defenses.

This fix engages mechanism (1) explicitly: \`VADE_COO_MODE\`-gated, plus a \`\$HOME\`/\`\$WORKSPACE_ROOT_DERIVED\` inequality clause as defense-in-depth. The deeper unification belongs in coo-labs/coo-memory#762.

## In-container verification (this session, before push)

\`/root/.claude/settings.json\` PreToolUse matchers:
- Before fix: \`["Bash"]\`
- After running modified \`session-start-sync.sh\`: \`["Bash","Agent"]\` — matches repo HEAD

Env block: 23 keys preserved (\`GITHUB_MCP_PAT\`, \`MEM0_API_KEY\`, \`CLOUDFLARE_*\`, \`VADE_COO_MODE\`, etc.).

\`integrity-check.sh\`: \`summary.ok: true\`, 29/29 invariants pass, B4 flipped to \`settings.json hooks section matches repo\`.

## Test plan

- [x] In-container verification (above): B4 flips \`ok\` after modified sync runs against the live drift state. This is the strongest available test — a fresh-container post-merge boot will not exhibit the drift (the rebake will pick up HEAD), so the post-merge confirmation uses a synthetic edit. See PR comment for the handoff prompt.
- [ ] Post-merge handoff verification (see comment).

## Related

- #334 — first hooks-block commit to trip the latent B4 drift
- #262 (\`2704330\`) — wired the two-mechanism path-selection asymmetry this fix engages with
- coo-labs/coo-memory#762 — boot-architecture audit epic
- coo-labs/coo-memory#1020 — audit-input issue (sub-issue of #762)

https://claude.ai/code/session_01Y1obbe5ybdeA5S6NxAdPHf