### PR TITLE
boot-digest: flag D4 as known transient race in degraded-boot banner

### DIFF
--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -129,6 +129,10 @@ if [ "$_integrity_ok" = "false" ] || [ -f "$SKIP_SENTINEL" ]; then
   echo "    2) VADE_COO_MODE=1 bash /home/user/coo-harness/scripts/coo-bootstrap.sh"
   echo "    3) set -a; source \$HOME/.vade/coo-env; set +a"
   echo "    4) bash /home/user/coo-harness/scripts/integrity-check.sh"
+  if [[ ",$_integrity_degraded," == *",D4,"* ]]; then
+    echo ""
+    echo "  D4 is a known transient race error. Follow the recovery steps above."
+  fi
   echo ""
   echo "  CLAUDE.md step 1 (conditional gate): surface to BDFL, do no other work."
   echo "═══════════════════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Adds a one-line conditional note after the proven-recovery block in `coo-identity-digest.sh`'s degraded-boot banner: when `D4` appears in the integrity-check degraded list, print

```
  D4 is a known transient race error. Follow the recovery steps above.
```

so a fresh-session reader knows the failure is a known intermittent (the settings.json env is populated by `session-start-sync` racing the integrity-check write) and the documented 4-step recovery is sufficient — no escalation needed.

Closes: n/a

## Why this matters

D4 ("settings.json env missing: VADE_RUNTIME_DIR" or similar) shows up periodically on otherwise-healthy boots. The proven-recovery block already documents the fix, but the banner doesn't tell the reader *D4 in particular is transient and the recovery resolves it*. Without that signal, an instance reading a degraded boot can't tell whether to escalate or run the recovery.

## Implementation

```sh
if [[ ",$_integrity_degraded," == *",D4,"* ]]; then
  echo ""
  echo "  D4 is a known transient race error. Follow the recovery steps above."
fi
```

Substring-matched on the comma-padded degraded list. Verified against 9 edge cases (matches `D4`, `A1,D4`, `D4,A1`, `A1,D4,E5`; does not match empty, `D`, `D4X`, `A1`, `C1,D5`).

End-to-end render tested with a synthesized D4-failure `integrity-check.json` (digest's internal `integrity-check.sh` call stubbed so the synthetic state survives). D4 case shows the new line in the correct place between the recovery steps and the CLAUDE.md gate line; non-D4 degraded boots (e.g. A1-only) do not show it.

## Boot-impact assessment

Modifies a SessionStart hook script — technically a boot-impacting change. **No handoff prompt** because the change is:

- Additive text inside an already-degraded-boot output path
- Conditional on D4 being present in `_integrity_degraded`; doesn't touch the success-path render
- Cannot induce a boot failure that wasn't already there
- Not artificially triggerable in a fresh container (clean boots don't exercise this code path)

## Test plan

- [x] Substring match correct on all 9 edge cases
- [x] D4 case renders the new line between recovery steps and CLAUDE.md gate
- [x] Non-D4 degraded case does not render the new line
- [ ] CI green

https://claude.ai/code/session_012qtsAaWVdETRNjqE4fjqPP