### PR TITLE
boot-digest: correct mem0-rest.sh path — `.claude/_lib/` not `bin/`

### DIFF
--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -546,14 +546,14 @@ else
 fi
 printf "  %-25s %s\n" "MEM0_API_KEY:" "settings.json env=$mem0_key"
 printf "  %-25s %s\n" "integrity-check E5:" "$e5_status"
-echo "  REST fallback (writes):   bin/mem0-rest.sh; canonical for memo_pointer (MEMO 2026-04-24-07)"
+echo "  REST fallback (writes):   .claude/_lib/mem0-rest.sh; canonical for memo_pointer (MEMO 2026-04-24-07)"
 case "$e5_status" in
   degraded)
     echo ""
     echo "  ⚠ Mem0 MCP is degraded. CLAUDE.md §4 + §12 boot rituals (CB-* / OG-* identity"
     echo "    load, recent-episodic handoff) cannot run via MCP this session. Fall back to"
     echo "    durable file layer (coo/episodic_memory.md + memo_index.json) per CLAUDE.md §6"
-    echo "    graceful-degradation clause; for writes route through bin/mem0-rest.sh."
+    echo "    graceful-degradation clause; for writes route through .claude/_lib/mem0-rest.sh."
     echo "    Detail: $e5_detail"
     ;;
   skip)


### PR DESCRIPTION
Paired with [coo-labs/coo-memory#1036](https://github.com/coo-labs/coo-memory/issues/1036) (PR5 of the file-sprawl cleanup arc). Single-cutover per migration-protocol §10 — both PRs merge in one window.

Closes: n/a (paired with the coo-memory PR closing coo-labs/coo-memory#1036)

## Why

`scripts/coo-identity-digest.sh` prints \"REST fallback (writes): bin/mem0-rest.sh\" at every session boot, and the graceful-degradation message echoed the same stale path. The script actually lives at `.claude/_lib/mem0-rest.sh` (in coo-memory), co-located with the 4 skills that consume it (memo-query, memo-audit, memo-sync, memo-search) per the canonical-layout convention 4 \"Shared helpers across multiple skills go in a single `.claude/_lib/` per repo\".

## What

Two `echo` strings updated:

- Line 549: \"REST fallback (writes): bin/mem0-rest.sh; …\" → \"… .claude/_lib/mem0-rest.sh; …\"
- Line 556: \"… route through bin/mem0-rest.sh.\" → \"… route through .claude/_lib/mem0-rest.sh.\"

No behavior change — informational text only.

## Boot impact

Yes — the digest is the first thing a fresh session sees post-integrity-check. The output text changes; the surfaced path now resolves. Handoff prompt posted on the coo-memory PR.

## Test plan

- [ ] Reviewer confirms the script's two echo strings now say `.claude/_lib/mem0-rest.sh`.
- [ ] Bootstrap-regression CI passes.
- [ ] Verify in a fresh container that the boot surface now shows `.claude/_lib/mem0-rest.sh`.

https://claude.ai/code/session_011pLXLQ7S3hckxasB8MiicE