### PR TITLE
hot-fix(coo-identity-digest): stale coo/ paths post-coo-memory#1069

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -123,3 +123,6 @@ jobs:
 
       - name: Idle watchdog — close sequence smoke (coo-logs#67)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-session-idle-watchdog.sh"
+
+      - name: Identity digest — gap-warning contract (coo-memory#1069)
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/test-digest-gap-warnings.sh"

--- a/scripts/ci/test-digest-gap-warnings.sh
+++ b/scripts/ci/test-digest-gap-warnings.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# CI smoke test for scripts/coo-identity-digest.sh gap-warning behavior.
+#
+# Locks down the contract added after coo-labs/coo-memory#1069 shipped
+# three boot-digest regressions: when expected input files / dirs are
+# missing, every guarded section in the digest must emit a
+# `⚠ DIGEST GAP` warning to stdout rather than silently no-op.
+#
+# Pre-fix, the script ran to exit 0 with empty section blocks; the
+# hook self-test still passed (script exists, exits 0) and the
+# integrity-check stayed green. Ven caught the gap only by reading the
+# transcript and noticing missing content. This test makes the gap a
+# CI-observable regression.
+#
+# Asserts:
+#
+#   1. Synthetic missing-files run produces three DIGEST GAP markers
+#      (identity layer, lineage, memos). Catches removal of any of the
+#      three else-branches added in this commit.
+#
+#   2. Each gap warning names the expected path (so the operator's fix
+#      is obvious from the boot output).
+#
+#   3. Synthetic populated-files run produces ZERO DIGEST GAP markers
+#      and DOES produce the three section headers. Catches the inverse
+#      regression: false-positive warnings on healthy boots.
+#
+#   4. Missing jq specifically surfaces the jq-not-on-PATH variant of
+#      the memo gap, not the file-not-found variant. Catches the
+#      if/elif distinction collapsing into a single message.
+#
+# The test does NOT exercise:
+#   - Live MEM_REPO content (test stubs minimal files).
+#   - Bootstrap posture / MCP-surface / cloud-receipt blocks.
+#   - The SessionStart-hook chain (Layer-2, coo-harness#85).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DIGEST_SRC="$REPO_ROOT/scripts/coo-identity-digest.sh"
+
+if [ ! -x "$DIGEST_SRC" ]; then
+  echo "FAIL: $DIGEST_SRC not executable" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d -t digest-gap-warnings-test-XXXXXX)"
+PASS=0
+FAIL=0
+
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label" >&2
+    echo "    expected substring: $needle" >&2
+    echo "    actual (first 40 lines):" >&2
+    printf '%s' "$haystack" | head -40 | sed 's/^/      /' >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  FAIL: $label" >&2
+    echo "    unexpected substring present: $needle" >&2
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_count() {
+  local haystack="$1" needle="$2" expected="$3" label="$4"
+  local actual
+  actual="$(printf '%s' "$haystack" | grep -cF -- "$needle" || true)"
+  if [ "$actual" = "$expected" ]; then
+    echo "  PASS: $label (count=$actual)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (got count=$actual, expected $expected)" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Assert 1+2: empty MEM_REPO produces three gap warnings, each naming
+# its expected path.
+# ──────────────────────────────────────────────────────────────────────
+
+echo "[case 1] empty MEM_REPO → three DIGEST GAP warnings"
+EMPTY_REPO="$WORKDIR/empty-mem-repo"
+mkdir -p "$EMPTY_REPO"
+# CLAUDE.md must exist; the top-level gate exits 0 silently otherwise.
+touch "$EMPTY_REPO/CLAUDE.md"
+
+out1="$(COO_MEMORY_DIR="$EMPTY_REPO" bash "$DIGEST_SRC" 2>&1 || true)"
+
+assert_count "$out1" "⚠ DIGEST GAP" 3 \
+  "three DIGEST GAP markers emitted"
+assert_contains "$out1" "Identity layer (CB-* / OG-*) unavailable" \
+  "identity-layer gap surfaces section name"
+assert_contains "$out1" "$EMPTY_REPO/identity/identity_layer.md" \
+  "identity-layer gap names expected path"
+assert_contains "$out1" "Active lineage events unavailable" \
+  "lineage gap surfaces section name"
+assert_contains "$out1" "$EMPTY_REPO/lineage" \
+  "lineage gap names expected path"
+assert_contains "$out1" "Latest memos unavailable" \
+  "memos gap surfaces section name"
+assert_contains "$out1" "$EMPTY_REPO/memos/memo_index.json" \
+  "memos gap names expected path"
+assert_contains "$out1" "memo_index.json not found" \
+  "memos gap names file-missing cause"
+
+# ──────────────────────────────────────────────────────────────────────
+# Assert 3: populated MEM_REPO produces ZERO gap warnings AND the three
+# expected section headers.
+# ──────────────────────────────────────────────────────────────────────
+
+echo "[case 2] populated MEM_REPO → zero DIGEST GAP, three section headers"
+FULL_REPO="$WORKDIR/full-mem-repo"
+mkdir -p "$FULL_REPO/identity" "$FULL_REPO/lineage" "$FULL_REPO/memos"
+touch "$FULL_REPO/CLAUDE.md"
+cat >"$FULL_REPO/identity/identity_layer.md" <<'EOF'
+# Identity layer test fixture
+CB-001 — placeholder.
+EOF
+# Minimal memo_index.json with one entry so jq produces output.
+cat >"$FULL_REPO/memos/memo_index.json" <<'EOF'
+[{"id":"2026-05-27-test","status":"active","title":"Fixture memo"}]
+EOF
+
+out2="$(COO_MEMORY_DIR="$FULL_REPO" bash "$DIGEST_SRC" 2>&1 || true)"
+
+assert_not_contains "$out2" "⚠ DIGEST GAP" \
+  "no gap warnings when files present"
+assert_contains "$out2" "Identity layer (CB-* / OG-*) — inlined from" \
+  "identity-layer section renders"
+# Lineage dir exists but is empty — no events to print, but no gap
+# warning either: the directory IS present, so the guard succeeds.
+# Section header should render even with zero events inside.
+assert_contains "$out2" "Active lineage events" \
+  "lineage section header renders even when empty"
+assert_contains "$out2" "Latest memos (10 most recent" \
+  "memos section renders with fixture entry"
+assert_contains "$out2" "2026-05-27-test" \
+  "memo digest renders the fixture entry id"
+
+# ──────────────────────────────────────────────────────────────────────
+# Assert 4: missing jq surfaces the jq-specific variant, not
+# the file-not-found variant.
+# ──────────────────────────────────────────────────────────────────────
+
+echo "[case 3] memo_index present + jq off PATH → jq-specific gap"
+JQ_PATH="$WORKDIR/sanitized-path-bin"
+mkdir -p "$JQ_PATH"
+# Synthesize a PATH that has bash + standard tools but no jq. We do
+# this by symlinking only the binaries the script needs (excluding jq).
+for cmd in bash sh cat grep sed awk readlink basename dirname cd ls \
+           printf echo tr mktemp date node id sort find; do
+  if real="$(command -v "$cmd" 2>/dev/null)"; then
+    ln -sf "$real" "$JQ_PATH/$(basename "$cmd")"
+  fi
+done
+
+out3="$(COO_MEMORY_DIR="$FULL_REPO" PATH="$JQ_PATH" bash "$DIGEST_SRC" 2>&1 || true)"
+
+assert_contains "$out3" "Latest memos unavailable" \
+  "memos gap fires when jq absent"
+assert_contains "$out3" "jq not on PATH" \
+  "memos gap names jq-specific cause"
+assert_not_contains "$out3" "memo_index.json not found" \
+  "jq-missing case does NOT report file-missing"
+
+# ──────────────────────────────────────────────────────────────────────
+# Summary
+# ──────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "test-digest-gap-warnings: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -32,7 +32,7 @@ else
   MEM_REPO="/home/user/coo-memory"
 fi
 CLAUDE_MD="$MEM_REPO/CLAUDE.md"
-MEMO_INDEX="$MEM_REPO/coo/memo_index.json"
+MEMO_INDEX="$MEM_REPO/memos/memo_index.json"
 BOOTSTRAP_LOG="${HOME}/.vade/coo-bootstrap.log"
 SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/settings.json"
 WORKSPACE_IDENTITY_LINK="$WORKSPACE_ROOT/CLAUDE.md"
@@ -87,7 +87,7 @@ fi
 if [ "$_integrity_ok" = "false" ] || [ -f "$SKIP_SENTINEL" ]; then
   # DEGRADED BOOT — print loudly at the very top. The 4-line recovery
   # sequence below is the proven fix from the 2026-05-13 audit
-  # (coo-memory/coo/audits/2026-05-13_boot-skip-failure/recovery-transcript.txt).
+  # (coo-memory/audits/2026-05-13_boot-skip-failure/recovery-transcript.txt).
   echo "═══════════════════════════════════════════════════════════════"
   echo "⚠️  BOOT DEGRADED — DO NOT START SUBSTANTIVE WORK"
   echo "═══════════════════════════════════════════════════════════════"
@@ -183,26 +183,26 @@ fi
 # task-shaped, default LLM task-focus wins over procedure-first and the
 # reading pass is silently skipped; without this block the session runs
 # on operational metadata only. Per coo-harness#226.
-IDENTITY_LAYER="$MEM_REPO/coo/identity_layer.md"
+IDENTITY_LAYER="$MEM_REPO/identity/identity_layer.md"
 if [ -f "$IDENTITY_LAYER" ]; then
   echo ""
   echo "───────────────────────────────────────────────────────────────"
-  echo "Identity layer (CB-* / OG-*) — inlined from coo/identity_layer.md"
+  echo "Identity layer (CB-* / OG-*) — inlined from identity/identity_layer.md"
   echo "───────────────────────────────────────────────────────────────"
   cat "$IDENTITY_LAYER"
   echo "───────────────────────────────────────────────────────────────"
 fi
 
-# Lineage events — one-line stamps from each coo/lineage/<event>/README.md.
+# Lineage events — one-line stamps from each lineage/<event>/README.md.
 # Full READMEs stay Read-on-demand per CLAUDE.md §6b; this surface gives
 # the agent a stable pointer to active events without requiring the read,
 # and is filesystem-driven so new events surface without a CLAUDE.md edit.
 # Dirs starting with `_` are meta-folders, not events; skipped.
-LINEAGE_DIR="$MEM_REPO/coo/lineage"
+LINEAGE_DIR="$MEM_REPO/lineage"
 if [ -d "$LINEAGE_DIR" ]; then
   echo ""
   echo "───────────────────────────────────────────────────────────────"
-  echo "Active lineage events (full READMEs in coo/lineage/<event>/)"
+  echo "Active lineage events (full READMEs in lineage/<event>/)"
   echo "───────────────────────────────────────────────────────────────"
   for event_dir in "$LINEAGE_DIR"/*/; do
     [ -d "$event_dir" ] || continue
@@ -222,7 +222,7 @@ fi
 if [ -f "$MEMO_INDEX" ] && check_cmd jq; then
   echo ""
   echo "───────────────────────────────────────────────────────────────"
-  echo "Latest memos (10 most recent; full text in coo/memos/<id>.md)"
+  echo "Latest memos (10 most recent; full text in memos/<id>.md)"
   echo "───────────────────────────────────────────────────────────────"
   # Read straight from the structured index that the memo-index hook
   # regenerated earlier in the SessionStart chain. Flat array, sorted
@@ -230,7 +230,7 @@ if [ -f "$MEMO_INDEX" ] && check_cmd jq; then
   # memo lands closest to the user prompt.
   #
   # Prints only id + status + title. Full schema is documented in
-  # coo/operations/memo-access.md. The index uses ~19K tokens at ~95
+  # operations/memo-access.md. The index uses ~19K tokens at ~95
   # memos post-coo-memory#351 — agents needing other slices
   # should jq the file rather than Read it.
   if digest_out=$(jq -r '
@@ -244,7 +244,7 @@ if [ -f "$MEMO_INDEX" ] && check_cmd jq; then
     echo "  (memo_index.json present but unparseable; skipping digest)"
   fi
   echo ""
-  echo "Deeper slices: jq '...' coo/memo_index.json (flat array — schema in coo/operations/memo-access.md)"
+  echo "Deeper slices: jq '...' memos/memo_index.json (flat array — schema in operations/memo-access.md)"
 fi
 
 echo "───────────────────────────────────────────────────────────────"
@@ -552,7 +552,7 @@ case "$e5_status" in
     echo ""
     echo "  ⚠ Mem0 MCP is degraded. CLAUDE.md §4 + §12 boot rituals (CB-* / OG-* identity"
     echo "    load, recent-episodic handoff) cannot run via MCP this session. Fall back to"
-    echo "    durable file layer (coo/episodic_memory.md + memo_index.json) per CLAUDE.md §6"
+    echo "    durable file layer (identity/episodic_memory.md + memos/memo_index.json) per CLAUDE.md §6"
     echo "    graceful-degradation clause; for writes route through .claude/_lib/mem0-rest.sh."
     echo "    Detail: $e5_detail"
     ;;

--- a/scripts/coo-identity-digest.sh
+++ b/scripts/coo-identity-digest.sh
@@ -19,6 +19,30 @@ source "$SCRIPT_DIR/lib/common.sh"
 boot_log_record coo-identity-digest start
 trap '_rc=$?; boot_log_record coo-identity-digest end $([ $_rc -eq 0 ] && echo ok || echo fail) rc=$_rc' EXIT
 
+# _digest_gap: emit a loud warning when an expected digest input is
+# missing. Section-block guards default to silent no-ops when their
+# `[ -f ... ]` probes fall through — exactly the shape that let
+# coo-labs/coo-memory#1069 ship three boot-digest regressions unnoticed
+# (the script ran to exit 0; the hook self-test passed; the blocks were
+# just empty). This helper closes that gap: every guarded section emits
+# either content or a clearly-marked gap warning naming the missing
+# path. Format mirrors the BOOT DEGRADED block below but at warning
+# severity — the digest is informative, not gate-bearing.
+#
+# Args:
+#   $1  section name (e.g. "Identity layer")
+#   $2  expected path or path + dep
+#   $3  brief cause / hint
+_digest_gap() {
+  echo ""
+  echo "───────────────────────────────────────────────────────────────"
+  echo "⚠ DIGEST GAP — $1 unavailable"
+  echo "───────────────────────────────────────────────────────────────"
+  echo "  Expected: $2"
+  echo "  Cause:    $3"
+  echo "───────────────────────────────────────────────────────────────"
+}
+
 # Resolve workspace root: parent of vade-runtime. /home/user on cloud,
 # $WORKSPACE_ROOT on local.
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -191,6 +215,9 @@ if [ -f "$IDENTITY_LAYER" ]; then
   echo "───────────────────────────────────────────────────────────────"
   cat "$IDENTITY_LAYER"
   echo "───────────────────────────────────────────────────────────────"
+else
+  _digest_gap "Identity layer (CB-* / OG-*)" "$IDENTITY_LAYER" \
+    "file not found — CB-*/OG-* beliefs not inlined this boot"
 fi
 
 # Lineage events — one-line stamps from each lineage/<event>/README.md.
@@ -217,9 +244,23 @@ if [ -d "$LINEAGE_DIR" ]; then
     [ -n "$stamp" ] && printf "  %-18s %s\n" "" "$stamp"
   done
   echo "───────────────────────────────────────────────────────────────"
+else
+  _digest_gap "Active lineage events" "$LINEAGE_DIR" \
+    "directory not found — lineage events not surfaced this boot"
 fi
 
-if [ -f "$MEMO_INDEX" ] && check_cmd jq; then
+# Memo digest: split the previous single-`if` guard into three cases so
+# each failure mode surfaces a precise gap warning instead of silently
+# no-op'ing. Pre-#1069 the combined guard `[ -f "$MEMO_INDEX" ] &&
+# check_cmd jq` had no else branch — when the path constant pointed at
+# a deleted location, the entire memo block silently produced nothing.
+if [ ! -f "$MEMO_INDEX" ]; then
+  _digest_gap "Latest memos" "$MEMO_INDEX" \
+    "memo_index.json not found — regen via .claude/_lib/memo-index.sh"
+elif ! check_cmd jq; then
+  _digest_gap "Latest memos" "$MEMO_INDEX (+ jq)" \
+    "jq not on PATH — install jq to enable memo-digest rendering"
+else
   echo ""
   echo "───────────────────────────────────────────────────────────────"
   echo "Latest memos (10 most recent; full text in memos/<id>.md)"

--- a/scripts/sync-templates-to-consumers.sh
+++ b/scripts/sync-templates-to-consumers.sh
@@ -5,7 +5,7 @@
 #
 # Canonical: coo-memory#938 (F8). Replaces BetaHuhn/repo-file-sync-action
 # after the action's Node 20 deprecation (coo-harness#321). Mechanism rationale:
-# coo-memory/coo/operations/template-centralization.md.
+# coo-memory/operations/template-centralization.md.
 #
 # Consumer list source: coo-labs/.github/repos.yaml (the F17 canonical
 # registry). Same selector as the F17b drift-check this script obsoletes:
@@ -46,7 +46,7 @@ Auto-synced from `coo-labs/coo-harness` canonical issue templates (F8).
 **Edit the canonical**, not this PR: [`coo-harness/.github/ISSUE_TEMPLATE/`](https://github.com/coo-labs/coo-harness/tree/main/.github/ISSUE_TEMPLATE). Changes there auto-propagate here on next push to `main`.
 
 - Canonical issue: [coo-memory#938](https://github.com/coo-labs/coo-memory/issues/938)
-- Operations doc: [`coo/operations/template-centralization.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/template-centralization.md)
+- Operations doc: [`operations/template-centralization.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/template-centralization.md)
 - Sync mechanism: [`coo-harness/scripts/sync-templates-to-consumers.sh`](https://github.com/coo-labs/coo-harness/blob/main/scripts/sync-templates-to-consumers.sh)
 
 Orphan deletion is in effect — files deleted from the canonical are deleted here too.


### PR DESCRIPTION
## Summary

Hot-fix + structural hardening for `coo-identity-digest` after [coo-labs/coo-memory#1069](https://github.com/coo-labs/coo-memory/pull/1069) (PR8 of the file-sprawl cleanup arc, which dropped the `coo/` wrapper).

Two coupled layers in one PR — they address the same hook and the same failure mode:

1. **Path rewrites** (the user-visible hot-fix): three load-bearing constants and four cosmetic strings pointed at the dropped `coo/<X>` paths, silently no-op'ing three boot-digest sections.
2. **Fail-loud gap warnings + CI regression test** (the structural fence): the silent-no-op shape is now a CI-observable regression. The next time a path constant goes stale, the test fails at PR time and the digest output names exactly which file is missing.

Root cause + tool-layer fence in [coo-labs/coo-memory#1070](https://github.com/coo-labs/coo-memory/issues/1070) (merged via [coo-memory#1071](https://github.com/coo-labs/coo-memory/pull/1071)): the migration-sweep tool used to verify #1069 silently degraded to primary-only walking due to a `$HOME`/repos.yaml mismatch in the cloud container. This PR is the downstream digest-side fix; coo-memory#1070 prevents the upstream recurrence.

## Changes

### `scripts/coo-identity-digest.sh`

**Path rewrites** — three critical + four cosmetic:

| Line (orig) | Was | Is |
|---|---|---|
| 35  | `$MEM_REPO/coo/memo_index.json` | `$MEM_REPO/memos/memo_index.json` |
| 186 | `$MEM_REPO/coo/identity_layer.md` | `$MEM_REPO/identity/identity_layer.md` |
| 201 | `$MEM_REPO/coo/lineage` | `$MEM_REPO/lineage` |
| 90, 190, 196, 205, 225, 247, 555 | various `coo/<X>` echo/comment strings | rewritten to new paths |

**New gap-warning surface** — `_digest_gap` helper + three else branches:

- Identity-layer block: else branch emits `⚠ DIGEST GAP — Identity layer (CB-* / OG-*) unavailable` naming the expected path.
- Lineage block: else branch emits `⚠ DIGEST GAP — Active lineage events unavailable`.
- Memos block: previous combined guard `[ -f "$MEMO_INDEX" ] && check_cmd jq` split into three precise cases:
  1. `memo_index.json` missing → "regen via .claude/_lib/memo-index.sh"
  2. jq off PATH → "install jq to enable memo-digest rendering"
  3. file + jq present → render (existing happy path; internal parse-fail message preserved)

### `scripts/sync-templates-to-consumers.sh`

Two cosmetic stale paths (lines 8 + 49) — header comment + a markdown link the script posts into consumer-repo PR bodies.

### `scripts/ci/test-digest-gap-warnings.sh` (new)

16-assertion CI smoke test across three cases:

| Case | Asserts |
|---|---|
| empty MEM_REPO | three DIGEST GAP markers; each names its expected path; correct section labels |
| populated MEM_REPO | zero gap warnings; three section headers render; memo digest renders fixture entry id |
| memo_index present + jq off PATH | jq-specific gap fires; file-missing variant does NOT fire |

### `.github/workflows/bootstrap-regression.yml`

Wires `test-digest-gap-warnings.sh` into the existing bash-test sequence alongside the transcript-export-wrapper and idle-watchdog smoke tests.

## Verification

```sh
$ bash scripts/coo-identity-digest.sh | grep -E 'Latest memos|Identity layer|Active lineage'
Identity layer (CB-* / OG-*) — inlined from identity/identity_layer.md
Active lineage events (full READMEs in lineage/<event>/)
Latest memos (10 most recent; full text in memos/<id>.md)

$ bash scripts/ci/test-digest-gap-warnings.sh | tail -3
test-digest-gap-warnings: 16 passed, 0 failed
```

## Test plan

- [x] CI bootstrap-regression workflow runs the new `test-digest-gap-warnings.sh` smoke test.
- [ ] Reviewer confirms `bash scripts/coo-identity-digest.sh` produces non-empty content under each of the three section headers on this branch.
- [ ] Fresh-container boot loads the digest with all three blocks. Handoff prompt for post-merge verification is posted as a separate comment.

`[HANDOFF REQUIRED]`

Closes coo-labs/coo-memory#1070.

https://claude.ai/code/session_0135mWboqQ1VFqonV36Tj5P3