### PR TITLE
hotfix(PR9a): integrity-check.sh path in coo-identity-digest

### DIFF
--- a/scripts/lifecycle/coo-identity-digest.sh
+++ b/scripts/lifecycle/coo-identity-digest.sh
@@ -77,7 +77,7 @@ SKIP_SENTINEL="${HOME}/.vade/.coo-bootstrap-skip-reason"
 # Run integrity-check FIRST so the file we read below reflects this
 # session. Original position (after Mem0 banner) eliminated to avoid
 # duplication.
-bash "$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true
+bash "$VADE_RUNTIME_DIR/scripts/boot/integrity-check.sh" || true
 
 _integrity_ok="unknown"
 _integrity_passed="?"
@@ -359,7 +359,7 @@ else
   echo ""
   echo "  WARN: identity is degraded — required env vars are missing."
   echo "  Inspect $BOOTSTRAP_LOG for the failing step, then re-run:"
-  echo "    VADE_FORCE_COO_BOOTSTRAP=1 bash \"${SCRIPT_DIR}/coo-bootstrap.sh\""
+  echo "    VADE_FORCE_COO_BOOTSTRAP=1 bash \"\$VADE_RUNTIME_DIR/scripts/boot/coo-bootstrap.sh\""
 fi
 
 # Classify OP_SERVICE_ACCOUNT_TOKEN visibility across build/session. The


### PR DESCRIPTION
## Summary

Post-merge verification of [coo-labs/coo-harness#344](https://github.com/coo-labs/coo-harness/pull/344) caught a residual sibling-relative path bug. `scripts/lifecycle/coo-identity-digest.sh` calls `integrity-check.sh` via `\$SCRIPT_DIR` — but `\$SCRIPT_DIR` is now `scripts/lifecycle/` (post-PR9a), while `integrity-check.sh` moved to `scripts/boot/`. The `2>/dev/null` swallowed the resulting "No such file" failure silently, so:

- integrity-check.json never got written at session-start
- The digest banner showed `E5: unknown` instead of a real status
- Manual invocation worked (kernel itself was healthy) — only the auto-wire was broken

The other session running the post-merge handoff checklist diagnosed it precisely; this PR is the one-line fix.

### Changes

`scripts/lifecycle/coo-identity-digest.sh`:

1. **Line 80** (the actual bug): `bash "\$SCRIPT_DIR/integrity-check.sh" 2>/dev/null || true` → `bash "\$VADE_RUNTIME_DIR/scripts/boot/integrity-check.sh" || true`. Drops the `2>/dev/null` per the other session's recommendation — future path bugs should be loud. Keeps `|| true` because the digest is informative, not gate-bearing.

2. **Line 362** (same class, in a recovery-instruction echo): `\${SCRIPT_DIR}/coo-bootstrap.sh` → `\$VADE_RUNTIME_DIR/scripts/boot/coo-bootstrap.sh`. Wouldn't trip runtime but would print a wrong path to the operator on the BOOTSTRAP_LOG-fallback branch.

### Verification

Local run:
```
$ bash scripts/lifecycle/coo-identity-digest.sh
VADE integrity: 29/29 OK — /home/user/.vade-cloud-state/integrity-check.json
Boot integrity: summary.ok=true  (29/29)
```

integrity-check.json gets the fresh write the digest is supposed to trigger.

Closes: n/a (residual fix to coo-labs/coo-memory#1066, not a separate scope)

Part of coo-labs/coo-memory#917 (file-sprawl cleanup arc).

https://claude.ai/code/session_01KQ2ymnaR6CoshwcP1e2St9