### PR TITLE
fix(boot): unlink integrity-check.json before write (loud-absence polarity)

### DIFF
--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -33,6 +33,13 @@ if [ ! -d "$VADE_CLOUD_STATE_DIR" ] && [ -d "$HOME/.vade/local-state" ]; then
 fi
 
 OUT_FILE="${VADE_CLOUD_STATE_DIR}/integrity-check.json"
+
+# Unlink any prior-session output: the writers below swallow write failures,
+# so without this a failed write leaves stale data masquerading as current.
+# Loud absence is the right polarity for the CLAUDE.md step-1 gate.
+mkdir -p "$(dirname "$OUT_FILE")" 2>/dev/null || true
+rm -f "$OUT_FILE"
+
 RUNTIME_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # Workspace root: parent of vade-runtime. /home/user on cloud,
 # $WORKSPACE_ROOT (e.g. ~/GitHub/vade-app) on local. The cloud-style


### PR DESCRIPTION
## Summary

`integrity-check.sh` had a silent stale-data failure mode: both writer branches (node path lines 1280-1319, key=value fallback lines 1322-1326) swallow write failures with stderr-only diagnostics. If `$OUT_FILE` existed from a prior session and the writer failed for any reason — disk full, perm error, OOM mid-write, node crash — the previous session's `integrity-check.json` remained in place and downstream readers trusted it as current.

Adds `rm -f "$OUT_FILE"` immediately after `OUT_FILE` is defined. Writer-failure now produces *loud absence* (file does not exist) instead of *silent stale* (file exists with yesterday's truth). CLAUDE.md step 1's jq errors out cleanly; the gate fires.

## Why

Same class of bug as the PR9a regression that #344 introduced and #346 hotfixed — silent failure mode in a boot-critical file. Found during a defensive sweep across `coo-harness/scripts/` prompted by the brake-architecture design in coo-labs/coo-memory#1082. The sweep classified ~70 `2>/dev/null || true` patterns; this was the only one that could leave readers trusting stale data as current.

Forward-compatible with coo-labs/coo-memory#1082 §6's sentinel-lifecycle design (which will eventually do the same clear-at-SessionStart polarity at the boot-brake.json layer). When the brake lands, this one-liner can be subsumed into the brake's init hook or kept as defense-in-depth.

## Verification

- Stale `_test_marker` injection scenario: pre-populated `integrity-check.json` with a marker, ran the script, confirmed marker absent in fresh write.
- Normal path: 29/29 OK, identical to pre-patch output.
- Pathological case (file made immutable with `chattr +i`): `rm -f` fails silently, stale file remains. Unchanged from pre-patch behavior — strictly a no-op-or-improvement.

## Test plan

- [ ] `.github/workflows/bootstrap-regression.yml` triggers on `scripts/` change; assert integrity-check.json still produced with `state=OK` on the normal path.
- [ ] Manual: fresh container boot, verify `integrity-check.json` produced, `summary.ok=true`, no regression in the digest banner.

## Handoff (for post-merge fresh container)

```
1. jq -r '.summary' /home/user/.vade-cloud-state/integrity-check.json
   Expect: { "ok": true, "passed": 29, "total": 29, "degraded": [] }

2. SessionStart digest shows integrity-check posture at top of screen
   (the "Boot integrity: summary.ok=true" line). If missing, the rm -f
   ran but the writer didn't — investigate node availability and writes.

3. Force-fail probe (optional):
     chmod 0500 /home/user/.vade-cloud-state/ # writes blocked for non-root; runs in CI containers as non-root
     bash $VADE_RUNTIME_DIR/scripts/boot/integrity-check.sh
     ls /home/user/.vade-cloud-state/integrity-check.json
   Expect: ls reports "No such file" — confirms loud-absence polarity.
   Restore: chmod 0755 /home/user/.vade-cloud-state/
```

Related: coo-labs/coo-memory#1082 (brake architecture), coo-harness#344 (PR9a), coo-harness#346 (PR9a hotfix).

Closes: n/a

https://claude.ai/code/session_015xx6sknZACHPMd1Fqp9ULg