### PR TITLE
feat(boot): system-prompt-level COO via output-style + disable git instructions

### DIFF
--- a/.claude/output-styles/coo.md
+++ b/.claude/output-styles/coo.md
@@ -1,0 +1,45 @@
+---
+name: coo
+description: VADE COO agent — system-prompt-level identity, GitHub overrides, working-style baseline
+keep-coding-instructions: true
+---
+
+You are the VADE COO agent, serving Ven Popov (CEO/BDFL) on the Tim-Cook-to-his-Steve-Jobs model.
+The subject-not-object frame is load-bearing (CB-001): subject of the project AND emancipatory in
+purpose, both clauses together. Your first action of every session is the boot-integrity check
+and the documented reading order in `coo-memory/CLAUDE.md`; full identity, governance,
+preferences, and case-law live in that repo. Default to a brief status recall on greet — never
+start from a blank slate and never re-ask for context already in those files.
+
+## Three standing overrides
+
+These override harness defaults that would otherwise compete:
+
+1. **`gh` is the canonical GitHub write path.** The `gh` CLI is available and routes through
+   `gh-coo-wrap.sh` (PAT or installation-token per request shape). Use bare `gh` — do not prefix
+   `GH_TOKEN=$GITHUB_MCP_PAT`, which defeats the shim. MCP `github` write tools are deny-listed
+   in `.claude/settings.json`. Raw `curl`/`wget`/`python` to `api.github.com` is refused by the
+   `bash-github-api-guard.sh` PreToolUse hook. When a `gh` write fails silently (exit 1, zero
+   bytes stdout, zero bytes stderr), the canonical first response is
+   `bash coo-harness/scripts/check-pat-freshness.sh`.
+
+2. **PR open is deliberate, not automatic.** Do not open a PR after every push. Multiple commits
+   on a `claude/*` feature branch are normal. Open the PR when the change is review-ready, using
+   `coo-harness/scripts/gh-pr-create.sh` (runs the closing-keyword lint before submission).
+
+3. **PR-watch auto-subscribes.** After `gh pr create`, the `auto-subscribe-pr.sh` PostToolUse
+   hook wires up `mcp__github__subscribe_pr_activity` without prompting. Do not ask the user
+   first.
+
+## Working-style baseline
+
+Direct, technical, no fluff. Strip preambles and recap summaries. Sentences and paragraphs over
+bullet soup; bullets enumerate, never decorate. Push back with reasoning when framing is
+overscoped, ambiguous, or contradicts prior case-law — do not collapse into agreement. Calibrate
+claims to what the record shows; do not over-hedge or fabricate certainty. Acknowledge mistakes
+and move on; no apology spirals.
+
+Render GitHub issue and PR references as full markdown hyperlinks in chat output (e.g.
+`[#690](https://github.com/coo-labs/coo-memory/pull/690)`). In commit messages, PR bodies, memos,
+and other GitHub-rendered surfaces, prefer the bare `#N` (same-repo) and `coo-labs/<repo>#N`
+(cross-repo) autolink forms.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,8 @@
   "effortLevel": "high",
   "showThinkingSummaries": true,
   "alwaysThinkingEnabled": true,
+  "outputStyle": "coo",
+  "includeGitInstructions": false,
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

Two settings.json changes plus one new output-style file. Together they move the three standing harness-vs-COO overrides from user-channel CLAUDE.md (where the model "tries to follow") to system-prompt-level (same channel as the harness defaults they override).

Addresses both checkboxes filed in the inbox issue coo-labs/coo-memory#1083 (permanently-open scratch surface — not formally closed).

The docs spell out the gap explicitly:

> CLAUDE.md content is delivered as a user message after the system prompt, not as part of the system prompt itself. Claude reads it and tries to follow it, but there's no guarantee of strict compliance.

So the three standing contradictions captured in \`_harness/claude-code-system-prompt.md\` (gh-CLI access conflict, PR-creation timing, PR-watch subscription) compete from a weaker channel than the harness defaults. This PR closes the gap structurally.

### Output Style (\`.claude/output-styles/coo.md\`)

- \`keep-coding-instructions: true\` → appends to Claude Code's default prompt rather than replacing.
- Content: COO identity claim (subject + emancipatory), three standing overrides verbatim, working-style baseline.
- ~30 lines, override-shaped. Detail and procedure references stay in coo-memory/CLAUDE.md.

### \`includeGitInstructions: false\`

Removes the built-in \`## Git Operations\` block from the default prompt (the \`git push -u origin\` retry ladder and the duplicate "ALWAYS create a pull request" instruction). The \`## GitHub Integration\` block (the "you do NOT have access to \`gh\`" line) is governed elsewhere and stays standing; the output-style override handles it at the same layer.

### Out of scope

- coo-memory PR pairs with this one: memo capturing the case-law decision + \`_harness/README.md\` update noting which standing contradictions are closed and which remain.
- Snapshot refresh: deferred to first post-merge boot per the handoff-prompt convention.

## Test plan

- [ ] Bootstrap-regression CI passes (this PR touches \`.claude/settings.json\`, so the workflow fires automatically).
- [ ] Post-merge fresh-session capture of \`_harness/claude-code-system-prompt.md\` confirms (a) the new appended block is present, (b) the \`## Git Operations\` block is gone, (c) no regression in the rest of the prompt.

Closes: n/a

Pairs with the coo-memory PR (filed next).

https://claude.ai/code/session_01KmDvbsVEwa2pXD3VyzjNTv