### PR TITLE
add(hooks): skill-yaml-guard — PreToolUse strict-YAML validator for SKILL.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,6 +91,15 @@
             "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/agent-model-guard.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/skill-yaml-guard.sh\""
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/scripts/ci/test-skill-yaml-guard.sh
+++ b/scripts/ci/test-skill-yaml-guard.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# test-skill-yaml-guard: smoke-test scripts/hooks/skill-yaml-guard.sh.
+#
+# Mirrors test-bash-github-api-guard.sh: pipe PreToolUse JSON
+# envelopes into the hook, assert block / allow per case.
+#
+# Run: bash scripts/ci/test-skill-yaml-guard.sh
+# Exit: 0 on all pass, 1 otherwise.
+#
+# Reference: coo-labs/coo-memory#1088, coo-labs/skills#26.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/skill-yaml-guard.sh"
+
+[ -x "$HOOK" ] || { echo "FAIL: hook not executable at $HOOK"; exit 1; }
+command -v jq >/dev/null || { echo "FAIL: jq required"; exit 1; }
+command -v python3 >/dev/null || { echo "FAIL: python3 required"; exit 1; }
+python3 -c "import yaml" 2>/dev/null || { echo "FAIL: python3-yaml required"; exit 1; }
+
+TMP="$(mktemp -d -t skill-yaml-guard-test.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+# run_hook_write <file_path> <content>
+run_hook_write() {
+  jq -n --arg fp "$1" --arg c "$2" \
+    '{tool_name: "Write", tool_input: {file_path: $fp, content: $c}}' \
+    | "$HOOK" 2>/dev/null
+}
+
+# run_hook_edit <file_path> <old_string> <new_string> [replace_all]
+run_hook_edit() {
+  local fp="$1" old="$2" new="$3" all="${4:-false}"
+  jq -n --arg fp "$fp" --arg o "$old" --arg n "$new" --argjson all "$all" \
+    '{tool_name: "Edit", tool_input: {file_path: $fp, old_string: $o, new_string: $n, replace_all: $all}}' \
+    | "$HOOK" 2>/dev/null
+}
+
+# run_hook_raw <stdin-json>
+run_hook_raw() {
+  printf '%s' "$1" | "$HOOK" 2>/dev/null
+}
+
+assert_block() {
+  local name="$1" out="$2"
+  if printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  BLOCK: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("BLOCK: $name")
+    printf '  FAIL  BLOCK: %s\n' "$name"
+    printf '         hook output: %s\n' "${out:-<empty>}"
+  fi
+}
+
+assert_allow() {
+  local name="$1" out="$2"
+  if [ -z "$out" ] || ! printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  ALLOW: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("ALLOW: $name")
+    printf '  FAIL  ALLOW: %s\n' "$name"
+    printf '         hook output: %s\n' "$out"
+  fi
+}
+
+# --- fixtures ---
+
+# Frontmatter that violates strict YAML: unquoted colon-space in
+# description value (the 2026-05-30 batch root cause).
+BAD_FM_COLON='---
+name: example
+description: Use when X. Dont invoke for: case Y.
+---
+body
+'
+
+# Frontmatter with unquoted bracket flow-sequence in argument-hint
+# (the day-overview class of bug).
+BAD_FM_FLOW='---
+name: example
+description: a single short sentence.
+argument-hint: [--date YYYY-MM-DD] [--end YYYY-MM-DD]
+---
+body
+'
+
+# Same descriptions, but properly double-quoted — must pass.
+GOOD_FM_COLON='---
+name: example
+description: "Use when X. Dont invoke for: case Y."
+---
+body
+'
+GOOD_FM_FLOW='---
+name: example
+description: a single short sentence.
+argument-hint: "[--date YYYY-MM-DD] [--end YYYY-MM-DD]"
+---
+body
+'
+
+NO_FM='# just a markdown file, no frontmatter
+some prose.
+'
+
+# --- Write fixtures ---
+
+printf 'Write cases:\n'
+
+assert_allow "valid frontmatter (quoted)" \
+  "$(run_hook_write /tmp/x/SKILL.md "$GOOD_FM_COLON")"
+
+assert_allow "valid frontmatter (quoted flow)" \
+  "$(run_hook_write /tmp/x/SKILL.md "$GOOD_FM_FLOW")"
+
+assert_block "invalid frontmatter — unquoted colon-space" \
+  "$(run_hook_write /tmp/x/SKILL.md "$BAD_FM_COLON")"
+
+assert_block "invalid frontmatter — unquoted flow sequence in argument-hint" \
+  "$(run_hook_write /tmp/x/SKILL.md "$BAD_FM_FLOW")"
+
+assert_allow "no frontmatter at all" \
+  "$(run_hook_write /tmp/x/SKILL.md "$NO_FM")"
+
+assert_allow "non-SKILL.md path (would be invalid YAML, but path doesn't match)" \
+  "$(run_hook_write /tmp/notes.md "$BAD_FM_COLON")"
+
+assert_allow "non-SKILL.md path, deep nested" \
+  "$(run_hook_write /tmp/.claude/skills/x/README.md "$BAD_FM_COLON")"
+
+# --- Edit fixtures (need on-disk files) ---
+
+printf '\nEdit cases:\n'
+
+EDIT_DIR="$TMP/edit"
+mkdir -p "$EDIT_DIR"
+
+# Valid file, edit introduces invalid YAML in frontmatter -> BLOCK.
+printf '%s' "$GOOD_FM_COLON" > "$EDIT_DIR/SKILL.md"
+assert_block "edit a valid file introducing colon-space" \
+  "$(run_hook_edit "$EDIT_DIR/SKILL.md" \
+      'description: "Use when X. Dont invoke for: case Y."' \
+      'description: Use when X. Dont invoke for: case Y.')"
+
+# Valid file, edit touches body only -> still valid -> ALLOW.
+printf '%s' "$GOOD_FM_COLON" > "$EDIT_DIR/SKILL.md"
+assert_allow "edit a valid file, body only, still valid" \
+  "$(run_hook_edit "$EDIT_DIR/SKILL.md" 'body' 'new body content')"
+
+# Already-broken file, edit touches body only -> ALLOW (pre-existing rule).
+printf '%s' "$BAD_FM_COLON" > "$EDIT_DIR/SKILL.md"
+assert_allow "edit a pre-existing-broken file, body only — pre-existing rule" \
+  "$(run_hook_edit "$EDIT_DIR/SKILL.md" 'body' 'new body content')"
+
+# Already-broken file, edit FIXES the frontmatter -> post is valid -> ALLOW.
+printf '%s' "$BAD_FM_COLON" > "$EDIT_DIR/SKILL.md"
+assert_allow "edit fixes a broken frontmatter (post-state valid)" \
+  "$(run_hook_edit "$EDIT_DIR/SKILL.md" \
+      'description: Use when X. Dont invoke for: case Y.' \
+      'description: "Use when X. Dont invoke for: case Y."')"
+
+# Edit whose old_string doesn't match -> Edit will error itself; don't block.
+printf '%s' "$GOOD_FM_COLON" > "$EDIT_DIR/SKILL.md"
+assert_allow "edit with non-matching old_string" \
+  "$(run_hook_edit "$EDIT_DIR/SKILL.md" 'this-string-is-not-in-the-file' 'whatever')"
+
+# Edit on a non-existent file -> Edit will error itself; don't block.
+assert_allow "edit on non-existent file" \
+  "$(run_hook_edit "$EDIT_DIR/does-not-exist/SKILL.md" 'old' 'new')"
+
+# replace_all: introduce invalidity at multiple sites.
+printf -- '---\nname: x\ndescription: "ok"\nfoo: "ok"\n---\nbody\n' > "$EDIT_DIR/SKILL.md"
+assert_block "replace_all introduces invalidity (foo: -> foo: bad: pair)" \
+  "$(run_hook_edit "$EDIT_DIR/SKILL.md" '"ok"' 'use for: bad' true)"
+
+# --- Wrong-matcher and bypass ---
+
+printf '\nMatcher + bypass cases:\n'
+
+assert_allow "Bash tool envelope is inert" \
+  "$(run_hook_raw '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}')"
+
+assert_allow "MultiEdit tool envelope is inert (not currently in matcher)" \
+  "$(run_hook_raw '{"tool_name":"MultiEdit","tool_input":{"file_path":"/tmp/SKILL.md"}}')"
+
+assert_allow "Read tool envelope is inert" \
+  "$(run_hook_raw '{"tool_name":"Read","tool_input":{"file_path":"/tmp/SKILL.md"}}')"
+
+bypass_out="$(VADE_SKILL_YAML_GUARD_BYPASS=1 run_hook_write /tmp/x/SKILL.md "$BAD_FM_COLON")"
+assert_allow "VADE_SKILL_YAML_GUARD_BYPASS=1 allows invalid frontmatter" \
+  "$bypass_out"
+
+# --- Block reason content sanity check ---
+
+printf '\nBlock-reason content:\n'
+bad_out="$(run_hook_write /tmp/x/SKILL.md "$BAD_FM_COLON")"
+if printf '%s' "$bad_out" | jq -e '.reason | contains("skill-yaml-guard") and contains("mapping values") and contains("VADE_SKILL_YAML_GUARD_BYPASS")' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  reason names hook, parser error, and bypass\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("REASON content")
+  printf '  FAIL  reason content missing expected fragments\n'
+  printf '         reason: %s\n' "$(printf '%s' "$bad_out" | jq -r '.reason')"
+fi
+
+# --- Summary ---
+
+printf '\nTotal: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/hooks/skill-yaml-guard.sh
+++ b/scripts/hooks/skill-yaml-guard.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# PreToolUse Write|Edit hook: refuse a write/edit to any `*/SKILL.md`
+# whose post-write YAML frontmatter (the block between the first pair
+# of `---` markers) fails strict YAML parse. The motivating bug was
+# the 2026-05-30 batch of seven SKILL.md files whose unquoted
+# `description` values contained `: ` (colon-space), which strict
+# YAML treats as a nested-mapping start. Claude Code's permissive
+# loader tolerated them; GitHub's Markdown renderer (and any other
+# strict consumer like read.vade-app.dev) surfaces:
+#   Error in user YAML: mapping values are not allowed in this context
+# Catching this in-session, before the agent commits and pushes, means
+# the deny reason is fed straight back into the conversation and the
+# agent corrects on the next turn — instead of after the PR renders.
+#
+# Why PreToolUse, not PostToolUse: PreToolUse can block the write
+# entirely. PostToolUse would let the bad file land and only warn.
+#
+# Contract: reads PreToolUse JSON on stdin:
+#   { "tool_name": "Write" | "Edit",
+#     "tool_input": { "file_path": "...", "content"|"old_string"|... } }
+# Always exits 0. To block, prints
+#   { "decision": "block", "reason": "..." }
+# on stdout. To allow, prints nothing.
+#
+# Path scope: any path whose last component is `SKILL.md`
+# (case-sensitive). Covers `.claude/skills/<name>/SKILL.md` (live) and
+# `skills/skills/{reference,vendored}/<name>/SKILL.md` (vendored).
+#
+# Pre-existing-invalidity rule (Edit only): if the file's current
+# frontmatter is already invalid, exit 0 — don't punish the agent for
+# a pre-existing bug; the edit may even be the fix. Only block when
+# the edit *introduces* invalidity (current valid → post-edit invalid).
+#
+# Bypass: VADE_SKILL_YAML_GUARD_BYPASS=1 → unconditionally allow.
+#
+# Reference: coo-labs/coo-memory#1088 and coo-labs/skills#26
+# (2026-05-30 batch fix).
+
+set -uo pipefail
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && exit 0
+
+if [ "${VADE_SKILL_YAML_GUARD_BYPASS:-}" = "1" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null || true)"
+case "$tool_name" in
+  Write|Edit) ;;
+  *) exit 0 ;;
+esac
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)"
+case "$file_path" in
+  */SKILL.md) ;;
+  *) exit 0 ;;
+esac
+
+# Delegate the YAML parse + edit-application logic to python3 — same
+# rationale as bash-github-api-guard.sh: bash quoting on multi-line
+# content is fragile, python3 is already in the boot baseline. Pass
+# the envelope JSON as argv (not stdin) because `python3 - ...`
+# already reserves stdin for the heredoc script body.
+result="$(python3 - "$file_path" "$input" <<'PY' 2>/dev/null || true
+import json, sys, os
+
+try:
+    import yaml
+except ImportError:
+    # Fail open if yaml isn't installed — don't block on a hook bug.
+    sys.exit(0)
+
+file_path = sys.argv[1]
+try:
+    env = json.loads(sys.argv[2])
+except (json.JSONDecodeError, IndexError):
+    sys.exit(0)
+tool = env.get('tool_name', '')
+ti = env.get('tool_input', {}) or {}
+
+def extract_fm(text):
+    """Return the frontmatter block between the first pair of ---
+    fences, or None if no frontmatter is present."""
+    if not text.startswith('---'):
+        return None
+    nl = text.find('\n')
+    if nl < 0:
+        return None
+    end = text.find('\n---', nl)
+    if end < 0:
+        return None
+    return text[nl + 1:end]
+
+def parse_or_error(fm):
+    try:
+        yaml.safe_load(fm)
+        return True, ''
+    except yaml.YAMLError as e:
+        return False, str(e)
+
+if tool == 'Write':
+    new_content = ti.get('content', '')
+    new_fm = extract_fm(new_content)
+    if new_fm is None:
+        sys.exit(0)
+    ok, err = parse_or_error(new_fm)
+    if ok:
+        sys.exit(0)
+    print(json.dumps({'error': err}))
+    sys.exit(0)
+
+# Edit branch.
+if not os.path.isfile(file_path):
+    sys.exit(0)
+try:
+    with open(file_path, 'r', encoding='utf-8') as f:
+        current = f.read()
+except (OSError, UnicodeDecodeError):
+    sys.exit(0)
+
+old = ti.get('old_string', '')
+new = ti.get('new_string', '')
+replace_all = bool(ti.get('replace_all', False))
+
+if replace_all:
+    post = current.replace(old, new)
+else:
+    idx = current.find(old)
+    if idx < 0:
+        # old_string doesn't match — Edit itself will error; not ours.
+        sys.exit(0)
+    post = current[:idx] + new + current[idx + len(old):]
+
+post_fm = extract_fm(post)
+if post_fm is None:
+    sys.exit(0)
+post_ok, post_err = parse_or_error(post_fm)
+if post_ok:
+    sys.exit(0)
+
+# Pre-existing-invalidity rule: skip if the current file was already
+# broken — the edit isn't the one introducing the bug.
+current_fm = extract_fm(current)
+if current_fm is not None:
+    cur_ok, _ = parse_or_error(current_fm)
+    if not cur_ok:
+        sys.exit(0)
+
+print(json.dumps({'error': post_err}))
+sys.exit(0)
+PY
+)"
+
+[ -z "$result" ] && exit 0
+
+err="$(printf '%s' "$result" | jq -r '.error // ""' 2>/dev/null)"
+[ -z "$err" ] && exit 0
+
+reason="[skill-yaml-guard] SKILL.md frontmatter would not parse as strict YAML after this write. Error from python3-yaml:
+
+${err}
+
+Usual cause: an unquoted \`description\` or \`argument-hint\` value containing \`: \` (colon-space) — strict YAML treats that as a nested mapping — or starting with \`[\` / \`{\` — parsed as a flow sequence/mapping. Fix: wrap the value in double quotes (escape internal \\\" if any). Example:
+
+  description: \"Author a session-handoff briefing per ... Don't invoke for: single-PR handoffs ...\"
+
+GitHub's Markdown renderer and read.vade-app.dev both error on this even though Claude Code's loader tolerates it — see coo-labs/coo-memory#1088 / coo-labs/skills#26 for the prior batch fix.
+
+Bypass for a deliberate exception: prefix \`VADE_SKILL_YAML_GUARD_BYPASS=1\` in the shell, or set it in env."
+
+jq -n --arg reason "$reason" '{
+  decision: "block",
+  reason: $reason
+}'
+exit 0


### PR DESCRIPTION
## Summary

New PreToolUse hook on `Write|Edit` that refuses any write to a `*/SKILL.md` whose post-write YAML frontmatter would fail strict parse. The deny reason is fed back to the agent in-session, naming the YAML error and the usual root cause (unquoted value containing `: ` or starting with `[`/`{`).

**Motivating bug**: the 2026-05-30 batch of 7 broken SKILL.md frontmatter values (coo-labs/coo-memory#1088, coo-labs/skills#26) that Claude Code's permissive loader tolerated but GitHub's renderer flagged with `Error in user YAML: mapping values are not allowed in this context`. This hook closes the loop so the bug surfaces in the session that introduces it, not after the PR renders.

## Design

- **PreToolUse, not PostToolUse** — blocks the bad write entirely; agent gets the structured deny reason and can correct on the next turn.
- **Path filter in the script** (the `matcher` field is tool-name only): triggers only on paths ending in `/SKILL.md`.
- **Edit branch** reads the current file and applies the `old_string`→`new_string` substitution before validating, so the check runs on the actual post-write state — not just on the fragment.
- **Pre-existing-invalidity rule (Edit only)**: if the current file's frontmatter is already broken, allow the edit. The agent shouldn't be penalized for a bug it isn't introducing (and the edit may be the fix).
- **Bypass**: `VADE_SKILL_YAML_GUARD_BYPASS=1` in shell env for a deliberate exception.
- **Fail-open** if `python3-yaml` isn't importable — never block on a hook bug.

## Files

- `scripts/hooks/skill-yaml-guard.sh` — new hook.
- `.claude/settings.json` — wires the hook under `hooks.PreToolUse` with `matcher: "Write|Edit"`.

## Test plan

Smoke-tested locally against 9 stdin envelopes:

- [x] valid Write — no output, exit 0
- [x] invalid Write (unquoted colon-space) — emits `{decision:"block", reason:...}` with the YAML error inline
- [x] non-SKILL.md path — inert
- [x] Edit introducing invalidity — blocks
- [x] Edit of a pre-existing-invalid file (touching only the body) — does NOT block (pre-existing rule)
- [x] Bash tool (wrong matcher) — inert
- [x] `VADE_SKILL_YAML_GUARD_BYPASS=1` — allows even invalid content
- [x] Real fixture round-trip: post-fix `request-briefing/SKILL.md` passes; pre-fix version blocks

## Pre-merge gating

Hook takes effect on the next fresh container boot (settings.json change). Verifying this PR end-to-end requires:

1. A fresh session after merge.
2. In that session, attempt `Write` of a SKILL.md with `description: foo: bar` (unquoted colon-space) — should be refused with the structured reason.
3. Repeat the same Write with `description: "foo: bar"` (double-quoted) — should succeed.

## Post-merge confirmation

Open a fresh container session, attempt the two writes above, confirm the first is blocked and the second succeeds. Then re-attempt with `VADE_SKILL_YAML_GUARD_BYPASS=1` in env to confirm the bypass works.

Closes: n/a

https://claude.ai/code/session_01BSZWEAMMJv86fdrdiBtBHZ