### PR TITLE
Aggregate output-styles/ subdir so outputStyle:coo loads on boot

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -408,7 +408,7 @@ sync_claude_config() {
     return 0
   fi
   mkdir -p "$dst"
-  for sub in skills agents commands hooks; do
+  for sub in skills agents commands hooks output-styles; do
     [ -d "$src/$sub" ] || continue
     _sync_claude_subdir "$src/$sub" "$dst/$sub"
   done
@@ -527,7 +527,7 @@ aggregate_workspace_claude_config() {
   local dst_root="$1"; shift
   mkdir -p "$dst_root"
   local sub
-  for sub in commands agents skills hooks; do
+  for sub in commands agents skills hooks output-styles; do
     local dst_sub="$dst_root/$sub"
     # If dst is a symlink (legacy single-source layout), materialize it
     # into a real directory so we can union multiple sources into it.


### PR DESCRIPTION
## What this fixes

On a fresh cloud boot the `coo` output style was inert — the system prompt came up as the stock default (git-workflow blocks present, COO override block absent). This was the RED post-merge confirmation of #348.

## Root cause

`outputStyle: coo` resolves `coo.md` from Claude Code's output-style search path (`<…>/.claude/output-styles/`). The boot aggregator unioned only `commands/agents/skills/hooks` into the effective `.claude/` — never `output-styles/`. So `coo-harness/.claude/output-styles/coo.md` was never symlinked in, the setting pointed at a missing file, and Claude Code fell back to the default prompt. Confirmed on this container: `~/.claude/output-styles/` and `/root/.claude/output-styles/` did not exist; `coo.md` existed only in the un-aggregated source.

## The fix

Add `output-styles` to the subdir loop in both projection functions in `scripts/lib/common.sh`:

- `sync_claude_config` (local/mac path)
- `aggregate_workspace_claude_config` (cloud path)

Two-line change. `aggregator.yml` governs the repo list, not subdirs, and is untouched.

## Verification

Called both real functions against a scratch `dst_root`:

- **Cloud path:** `output-styles/coo.md` projects as a symlink → `coo-harness/.claude/output-styles/coo.md`. ✅
- **Local path:** same, as a dir-level symlink. ✅

`integrity-check.sh` does not assert the subdir set, so no invariant is affected; the bootstrap-regression CI exercises the cloud path end-to-end.

## Scope (per handoff)

Aggregator-only. Deliberately **not** touched here:

- The descriptive enumeration comments at `common.sh:383` / `:499` and `coo-memory/operations/BOOT_TOPOLOGY.md` are now slightly stale — follow-up doc sync.
- The `CLAUDE.md` override-paragraph prune **stays blocked** until a fresh post-fix boot proves the `coo` block actually loads in-prompt.

## Boot-impacting

Verification can only happen on a fresh container boot. A self-contained handoff prompt (pre-merge gating + post-merge confirmation) follows as a standalone comment.

Closes: n/a

Follow-up to #348 — resolves the RED post-merge confirmation of that PR; no standalone issue tracks it.

https://claude.ai/code/session_01FQNoUhHfi3Xm9EDS4G2ApA