### PR TITLE
Sync aggregator comments for the output-styles subdir

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -380,7 +380,7 @@ install_deps() {
 }
 
 # Mirror the committed .claude/ directory into Claude Code's user-scope
-# config dir. Subdirs (skills/, agents/, commands/, hooks/) are
+# config dir. Subdirs (skills/, agents/, commands/, hooks/, output-styles/) are
 # symlinked so edits in the repo are live next SessionStart.
 # settings.json is copied so coo-bootstrap can mutate the env block
 # without dirtying the git working tree. Plans/, projects/, todos/,
@@ -496,7 +496,7 @@ load_aggregator_repos() {
   printf '%s\n' "$repos"
 }
 
-# Aggregate per-repo .claude/{commands,agents,skills,hooks} into the
+# Aggregate per-repo .claude/{commands,agents,skills,hooks,output-styles} into the
 # workspace .claude/ via per-file symlinks.
 #
 # Why: under the data-ownership rule (MEMO 2026-04-25-02), slash


### PR DESCRIPTION
Doc-only follow-up to #351, which added `output-styles` to the aggregator subdir loops. The two function-header comments in `scripts/lib/common.sh` still enumerated the pre-output-styles subdir set (`sync_claude_config` and `aggregate_workspace_claude_config`); this brings them in line with the code. No behavior change.

Closes: n/a

https://claude.ai/code/session_01FQNoUhHfi3Xm9EDS4G2ApA