### PR TITLE
fix(boot): force-disable git instructions via env var on cloud

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -118,7 +118,8 @@
   },
   "env": {
     "CLAUDE_STREAM_IDLE_TIMEOUT_MS": "600000",
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS": "1"
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## What this does

Adds `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` to the static `env` block in `.claude/settings.json`.

## Why

On the Claude Code **web/cloud** surface, `includeGitInstructions: false` is **not honored** — the `## Git Operations` block (commit/PR workflow + git-status snapshot) survives in the system prompt despite the setting. Verified first-hand on a 2026-05-30 fresh boot — the same boot that ran the post-merge confirmation of #351 (output-style aggregation).

Per the [settings docs](https://code.claude.com/docs/en/settings.md), `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` *"takes precedence over this setting when set."* It's the lever that bites on cloud where the settings.json key doesn't.

## Scope — what this does and does NOT remove

This env var (and `includeGitInstructions`) govern **only** the `## Git Operations` block. The other two git-shaped blocks in the cloud system prompt are **separate web-platform injections** this lever does not reach:

- `## Git Development Branch Requirements` — actually *correct* for cloud (the gitproxy gates push to the session branch); we would not want to suppress it.
- `## GitHub Integration` ("no `gh` CLI, use MCP") — the load-bearing contradiction with our canonical `gh` write path. No documented lever; the output-style override (`coo.md` standing-override #1) stays load-bearing for this regardless.

So this is a partial cleanup, not a fix for the `gh`-vs-MCP contradiction — and the CLAUDE.md override-paragraph prune **stays blocked**.

## Governance

Static committed env var — same class as `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, **not** a runtime-injected secret threaded through `_write_claude_settings_env`'s positional args. So this is *not* the "coordinated change / explicit approval" surface named in `CLAUDE.md`. Propagation verified against `_sync_claude_settings` (`scripts/lib/common.sh:588` — `merged.env = {...src.env, ...dstEnv}`: source keys land, existing secrets overlay, nothing deleted).

## Verification

Boot-impacting — effect is only observable on a fresh container boot. A handoff prompt (pre-merge gating + post-merge confirmation) follows as a standalone comment.

Follow-up to #351; resolves the `## Git Operations` half of that PR's open question.

Closes: n/a

https://claude.ai/code/session_0163ZbtN5Bsm77vHC6RRbUdY