### PR TITLE
lifecycle/project-board-digest: temporarily disable boot fetch (GH project quota incident)

### DIFF
--- a/scripts/lifecycle/project-board-digest.sh
+++ b/scripts/lifecycle/project-board-digest.sh
@@ -20,6 +20,11 @@ trap '_rc=$?; boot_log_record project-board-digest end $([ $_rc -eq 0 ] && echo 
 
 wait_for_coo_bootstrap 60
 
+# TEMPORARILY DISABLED — GitHub project / API quota investigation in flight.
+# Remove this guard to restore the digest fetch.
+echo "Boot: VADE project digest — TEMPORARILY DISABLED (GitHub project fetch / API quota investigation in flight). Do not query the project board this session unless explicitly asked."
+exit 0
+
 TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-${GITHUB_MCP_PAT:-}}}"
 if [ -z "$TOKEN" ]; then
   log "GH_TOKEN unset; skipping project-board digest."


### PR DESCRIPTION
Closes: n/a

GitHub project / API quota incident under investigation (Ven request, 2026-05-30). The boot-time `project-board-digest` hook now short-circuits with a one-line notice instead of running `gh project item-list`. Original fetch code preserved below the guard for a clean one-line revert.

Paired with the coo-memory side (CLAUDE.md §9 + episodic_memory.md 'Active work surface') on the same branch — that side tells the agent not to query the board even if the hook is restored.

Scope is the boot fetch only. Not touched: `gh project` permission entries in settings.json, the `manage-project` skill, charter / public-authority pointers, the discussions hook. No investigation of the quota cause performed (per request).

Restore: remove lines 23–26 of `scripts/lifecycle/project-board-digest.sh`.

https://claude.ai/code/session_019mKHV84GSMJJWv8XB1C12w