### PR TITLE
renderer enrichment + ci footer fix (#367 #369 #370)

### DIFF
--- a/scripts/ci/render-integrity-summary.sh
+++ b/scripts/ci/render-integrity-summary.sh
@@ -72,8 +72,8 @@ node -e '
 
   lines.push("---");
   lines.push("");
-  lines.push("Workflow: `.github/workflows/bootstrap-regression.yml`. " +
-             "Re-run by pushing to this PR or using the workflow_dispatch trigger. " +
+  lines.push("CI definition: `bootstrap-regression`. " +
+             "Re-run by pushing to this PR or via the GitHub Actions UI. " +
              "Tracked at coo-labs/coo-harness#86.");
 
   fs.writeFileSync(outPath, lines.join("\n") + "\n");

--- a/scripts/lifecycle/session-end-transcript-render.py
+++ b/scripts/lifecycle/session-end-transcript-render.py
@@ -705,6 +705,88 @@ def _build_toc(rendered_entries: list[tuple[int, str, str]]) -> str:
     return f'<nav class="toc"><h2>User turns</h2><ol>{"".join(items)}</ol></nav>'
 
 
+def compute_metadata(session_id: str, entries: list[dict]) -> dict:
+    """Walk entries once; return the metadata blob for the list-page sidecar.
+
+    Schema (renderer_version=1):
+      session_id, started_at, ended_at, duration_seconds,
+      entry_count, user_turn_count, assistant_turn_count,
+      tool_call_count, error_count, first_user_preview,
+      renderer_version.
+    """
+    first_ts: datetime.datetime | None = None
+    last_ts: datetime.datetime | None = None
+    user_count = 0
+    assistant_count = 0
+    tool_call_count = 0
+    error_count = 0
+    first_user_preview = ""
+
+    for entry in entries:
+        kind = _classify(entry)
+        ts = _ts_to_dt(entry.get("timestamp"))
+        if ts is not None:
+            if first_ts is None:
+                first_ts = ts
+            last_ts = ts
+
+        if kind == "user":
+            user_count += 1
+            if not first_user_preview:
+                msg = entry.get("message", {}) or {}
+                content = msg.get("content")
+                text = ""
+                if isinstance(content, str):
+                    text = content
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "")
+                            break
+                text = SYSTEM_REMINDER_RE.sub("", text).strip()
+                if text:
+                    first_user_preview = _first_line(text, 140)
+        elif kind in ("assistant", "tool_use", "thinking"):
+            assistant_count += 1
+            msg = entry.get("message", {}) or {}
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        tool_call_count += 1
+        elif kind == "tool_result":
+            msg = entry.get("message", {}) or {}
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        if block.get("is_error"):
+                            error_count += 1
+        elif kind == "attachment":
+            att = entry.get("attachment", {}) or {}
+            exit_code = att.get("exitCode")
+            if isinstance(exit_code, int) and exit_code != 0:
+                error_count += 1
+
+    duration_seconds = 0
+    if first_ts is not None and last_ts is not None:
+        duration_seconds = max(0, int((last_ts - first_ts).total_seconds()))
+
+    return {
+        "session_id": session_id,
+        "started_at": first_ts.isoformat() if first_ts else None,
+        "ended_at": last_ts.isoformat() if last_ts else None,
+        "duration_seconds": duration_seconds,
+        "entry_count": len(entries),
+        "user_turn_count": user_count,
+        "assistant_turn_count": assistant_count,
+        "tool_call_count": tool_call_count,
+        "error_count": error_count,
+        "first_user_preview": first_user_preview,
+        "renderer_version": PARSER_VERSION,
+    }
+
+
 def render_html(session_id: str, entries: list[dict]) -> str:
     rendered: list[str] = []
     toc_entries: list[tuple[int, str, str]] = []
@@ -836,7 +918,14 @@ def _r2_endpoint_bucket() -> tuple[str, str]:
     return endpoint, bucket
 
 
-def _r2_put_html(html_bytes: bytes, key: str, *, overwrite: bool) -> dict:
+def _r2_put_bytes(
+    body: bytes,
+    key: str,
+    *,
+    overwrite: bool,
+    content_type: str,
+    cache_control: str = "private, max-age=0, must-revalidate",
+) -> dict:
     access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
     secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
     if not access_key or not secret_key:
@@ -861,9 +950,9 @@ def _r2_put_html(html_bytes: bytes, key: str, *, overwrite: bool) -> dict:
     put_kwargs = {
         "Bucket": bucket,
         "Key": key,
-        "Body": html_bytes,
-        "ContentType": "text/html; charset=utf-8",
-        "CacheControl": "private, max-age=0, must-revalidate",
+        "Body": body,
+        "ContentType": content_type,
+        "CacheControl": cache_control,
     }
     if not overwrite:
         put_kwargs["IfNoneMatch"] = "*"
@@ -920,14 +1009,35 @@ def main(argv: list[str] | None = None) -> int:
             sys.stdout.write(html_doc)
         return 0
 
-    key = f"{args.key_prefix.rstrip('/')}/{session_id}.html"
+    key_prefix = args.key_prefix.rstrip("/")
+    html_key = f"{key_prefix}/{session_id}.html"
+    meta_key = f"{key_prefix}/{session_id}.meta.json"
     try:
-        result = _r2_put_html(html_bytes, key, overwrite=args.overwrite)
+        html_result = _r2_put_bytes(
+            html_bytes, html_key,
+            overwrite=args.overwrite,
+            content_type="text/html; charset=utf-8",
+        )
     except Exception as e:
-        _stderr(f"R2 upload failed: {e}")
+        _stderr(f"R2 upload (html) failed: {e}")
         return 2
-    _stderr(f"uploaded → {result['endpoint']}/{result['bucket']}/{result['key']}"
-            + (" (ceded)" if result.get("ceded") else ""))
+    _stderr(f"uploaded → {html_result['endpoint']}/{html_result['bucket']}/{html_result['key']}"
+            + (" (ceded)" if html_result.get("ceded") else ""))
+
+    metadata = compute_metadata(session_id, entries)
+    meta_bytes = json.dumps(metadata, separators=(",", ":")).encode("utf-8")
+    try:
+        meta_result = _r2_put_bytes(
+            meta_bytes, meta_key,
+            overwrite=args.overwrite,
+            content_type="application/json; charset=utf-8",
+        )
+    except Exception as e:
+        # HTML already landed; sidecar miss is non-fatal — list page tolerates absence.
+        _stderr(f"R2 upload (meta sidecar) failed: {e}")
+        return 0
+    _stderr(f"uploaded → {meta_result['endpoint']}/{meta_result['bucket']}/{meta_result['key']}"
+            + (" (ceded)" if meta_result.get("ceded") else ""))
     return 0
 
 

--- a/scripts/lifecycle/session-end-transcript-render.py
+++ b/scripts/lifecycle/session-end-transcript-render.py
@@ -528,6 +528,9 @@ nav.toc a { color: var(--fg); text-decoration: none; display: block;
   padding: 4px 6px; border-radius: 4px; }
 nav.toc a:hover { background: var(--bg); }
 main { padding: 16px 24px; min-width: 0; max-width: 100%; }
+p.back { margin: 0 0 8px 0; font-size: 12px; }
+p.back a { color: var(--muted); text-decoration: none; }
+p.back a:hover { color: var(--accent); }
 header.session { padding-bottom: 16px; border-bottom: 1px solid var(--border);
   margin-bottom: 16px; }
 header.session h1 { margin: 0 0 4px 0; font-size: 18px; font-family: ui-monospace,
@@ -774,6 +777,7 @@ def render_html(session_id: str, entries: list[dict]) -> str:
 <body>
 {toc}
 <main>
+  <p class="back"><a href="/transcripts/">← All transcripts</a></p>
   <header class="session">
     <h1>{_esc(session_id)}</h1>
     <div class="meta">

--- a/scripts/transcript-render-backfill.py
+++ b/scripts/transcript-render-backfill.py
@@ -117,7 +117,7 @@ def _list_sessions(s3, bucket: str, prefix: str, key_re: re.Pattern[str]) -> set
     return sids
 
 
-def _render_one(session_id: str, key_prefix: str) -> tuple[bool, str]:
+def _render_one(session_id: str, key_prefix: str, overwrite: bool) -> tuple[bool, str]:
     """Returns (ok, detail). detail is a one-line message for stderr."""
     # 1. Fetch (decrypt) → path on stdout, lives under ~/.vade/transcript-cache/
     try:
@@ -139,15 +139,18 @@ def _render_one(session_id: str, key_prefix: str) -> tuple[bool, str]:
     if not jsonl.is_file():
         return False, f"fetch claimed {jsonl_path} but file missing"
 
-    # 2. Render → uploads to R2 under <key-prefix>/<sid>.html (first-write-wins).
+    # 2. Render → uploads to R2 under <key-prefix>/<sid>.html.
+    render_cmd = [
+        str(RENDER_PY),
+        "--session-id", session_id,
+        "--input", str(jsonl),
+        "--key-prefix", key_prefix,
+    ]
+    if overwrite:
+        render_cmd.append("--overwrite")
     try:
         render = subprocess.run(
-            [
-                str(RENDER_PY),
-                "--session-id", session_id,
-                "--input", str(jsonl),
-                "--key-prefix", key_prefix,
-            ],
+            render_cmd,
             check=True,
             capture_output=True,
             text=True,
@@ -182,6 +185,8 @@ def main(argv: list[str] | None = None) -> int:
                    help="list what would be rendered without doing it")
     p.add_argument("--include-existing", action="store_true",
                    help="re-render sessions that already have an HTML in R2")
+    p.add_argument("--overwrite", action="store_true",
+                   help="pass --overwrite to the renderer (default: first-write-wins)")
     p.add_argument("--key-prefix", default="rendered",
                    help="R2 key prefix for rendered HTML (default: rendered)")
     args = p.parse_args(argv)
@@ -226,7 +231,7 @@ def main(argv: list[str] | None = None) -> int:
     failed = 0
     for i, sid in enumerate(targets, 1):
         _stderr(f"[{i}/{len(targets)}] {sid}")
-        success, detail = _render_one(sid, args.key_prefix)
+        success, detail = _render_one(sid, args.key_prefix, args.overwrite)
         if success:
             ok += 1
             _stderr(f"  OK · {detail}")


### PR DESCRIPTION
Closes #367.
Closes #369.
Closes #370.

Renderer-side enrichment + an ambient CI fix, both feeding the deployed transcript viewer (coo-labs/coo-console#12).

- **Renderer:** `<p class="back"><a href="/transcripts/">← All transcripts</a></p>` above the session header. First tappable element on both desktop and mobile single-column layouts.
- **Renderer:** new `compute_metadata()` walks parsed entries once and returns the schema the list page needs (`session_id`, `started_at`, `ended_at`, `duration_seconds`, `entry_count`, `user_turn_count`, `assistant_turn_count`, `tool_call_count`, `error_count`, `first_user_preview`, `renderer_version`). `main()` uploads two objects per session — `rendered/<sid>.html` + `rendered/<sid>.meta.json`. Meta failure is non-fatal (list page tolerates absence).
- **Backfill:** `--overwrite` flag passes through to the renderer. Required to re-render existing R2 objects when the template/schema changes.
- **CI:** rephrase the bootstrap-regression sticky-comment footer to drop the literal "Workflow:" / "workflow_dispatch trigger" prose. Was triggering the Claude Code harness's "Workflow tool" auto-skill-matcher on every bot post (the matcher scans the full prompt envelope, including bot comment bodies inside webhook tags).

Companion: coo-labs/coo-console#16 ships the rich list page (sort + filter + parallel sidecar fetch).

After both PRs land I'll fire `transcript-render-backfill.py --include-existing --overwrite` to populate sidecars on the early-backfilled batch.

https://claude.ai/code/session_01Xn9FqL7KEuB3Yfo1BqMiEV