### PR TITLE
digest: surface open briefings at SessionStart (reads briefing_index.json)

### DIFF
--- a/scripts/lifecycle/coo-identity-digest.sh
+++ b/scripts/lifecycle/coo-identity-digest.sh
@@ -280,6 +280,31 @@ fi
 
 echo "───────────────────────────────────────────────────────────────"
 
+# Open briefings — strictly "needs pickup" subset (status=open AND
+# claimed_by_session=null). Claimed briefings are already in flight and
+# don't need recall on every boot. Silent (no header) when zero open or
+# index missing — keeps the digest lean on a clean board and survives a
+# partial-deploy boot where coo-memory has the index but coo-harness
+# hasn't been updated to read it yet. Schema + claim lifecycle in
+# .claude/skills/briefing/reference.md. (coo-memory#1092 / #1097.)
+BRIEFING_INDEX="$MEM_REPO/briefings/briefing_index.json"
+if [ -f "$BRIEFING_INDEX" ] && check_cmd jq; then
+  open_briefings=$(jq -r '
+    map(select(.status == "open" and (.claimed_by_session == null))) |
+    sort_by(.nnn) | .[0:10] | .[] |
+    "  " + (.nnn | tostring | ("000"[0:3-length]) + .) + " " + .slug
+  ' "$BRIEFING_INDEX" 2>/dev/null)
+  if [ -n "$open_briefings" ]; then
+    echo ""
+    echo "───────────────────────────────────────────────────────────────"
+    echo "Open briefings (awaiting pickup; full list: briefings/)"
+    echo "───────────────────────────────────────────────────────────────"
+    printf '%s\n' "$open_briefings"
+    echo ""
+    echo "Pick up via: /briefing pickup"
+  fi
+fi
+
 # Bootstrap posture — loud surface of whether this session boots with
 # a full identity. Three signals:
 #   (a) last coo-bootstrap outcome (from the log)


### PR DESCRIPTION
Closes #371.

## Summary

Sister PR to [coo-labs/coo-memory#1097](https://github.com/coo-labs/coo-memory/pull/1097). Adds a 25-line block to `scripts/lifecycle/coo-identity-digest.sh` that surfaces briefings awaiting pickup at SessionStart, modeled on the existing 'Latest memos' block.

**Filter:** strictly `status == "open" AND claimed_by_session == null`. Claimed briefings are already in flight and don't need recall.
**Sort:** ascending NNN — oldest unclaimed sits at the top (longest-waiting = most at risk of being lost, per the user's framing).
**Cap:** 10.
**Silent when empty:** no header on a clean board.
**Silent when index missing:** survives partial-deploy boot where coo-memory hasn't been updated to provide the JSON.

## Sample output (live data, 36 open briefings post-migration)

```
───────────────────────────────────────────────────────────────
Open briefings (awaiting pickup; full list: briefings/)
───────────────────────────────────────────────────────────────
  001 session-token-plan
  003 claude-code-cross-session-state
  004 cloud-binary-vendor
  005 concurrent-pr-coordination-experiment
  006 transcript-context-bloat-audit
  007 boot-discipline-regression
  008 shared-canvas-and-fast-comms
  009 letter-to-anthropic-v2-multi-instance
  010 tool-creator-design
  011 tool-creator-prototype-run-313

Pick up via: /briefing pickup
```

The 10 surfaced here are pre-#1097 backlog (briefings that were worked but never had Status flipped to delivered). Ven can sweep them via `/briefing done NNN` over time; the list will narrow to truly-open briefings.

## No settings.json change

The block is in the existing `coo-identity-digest.sh` script that already runs in the SessionStart chain. No new hook entry. No new wrapper script — `briefing_index.json` is maintained by slash commands + CI in coo-memory; this script just reads it.

## Sequencing

This PR can land before or after [coo-memory#1097](https://github.com/coo-labs/coo-memory/pull/1097). When the JSON isn't yet present (pre-#1097-merge state), the block is silent. When #1097 lands, the next fresh boot picks up the JSON and renders.

https://claude.ai/code/session_01HnwJEnnpNdLXVxqem6v43x