### PR TITLE
lifecycle: forward-recover session URL via export sidecar v3 (#375)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 *.log
 # Docker build cruft
 .buildx-cache/
-settings.local.json
+settings.local.json__pycache__/

--- a/scripts/ci/test-transcript-export.py
+++ b/scripts/ci/test-transcript-export.py
@@ -176,6 +176,7 @@ def main() -> int:
         # Shape assertions.
         for key in (
             "schema_version", "parser_version", "session_id",
+            "claude_code_remote_session_id",
             "exported_at", "events_processed",
             "bytes_pre_redaction", "bytes_post_redaction",
             "bytes_post_gzip", "bytes_ciphertext", "ciphertext_sha256",
@@ -191,8 +192,15 @@ def main() -> int:
 
         if meta["session_id"] != sid:
             fail(f"session_id mismatch: {meta['session_id']!r} != {sid!r}")
-        if meta["schema_version"] != 2:
-            fail(f"schema_version != 2: {meta['schema_version']}")
+        if meta["schema_version"] != 3:
+            fail(f"schema_version != 3: {meta['schema_version']}")
+        # Schema v3 adds claude_code_remote_session_id; the CI env doesn't
+        # set CLAUDE_CODE_REMOTE_SESSION_ID, so the field should be present
+        # but empty. (Stop-hook context populates it; absence in CI is
+        # expected.)
+        if not isinstance(meta["claude_code_remote_session_id"], str):
+            fail(f"claude_code_remote_session_id not a string: "
+                 f"{meta['claude_code_remote_session_id']!r}")
         if meta["events_processed"] != 4:
             fail(f"events_processed != 4: {meta['events_processed']}")
         if meta["r2"].get("uploaded") is not False:
@@ -221,7 +229,8 @@ def main() -> int:
     print(textwrap.dedent("""\
         OK: transcript-export-hook smoke
           - sidecar shape: 12+ keys
-          - schema_version: 2
+          - schema_version: 3
+          - claude_code_remote_session_id present (empty in CI env)
           - r2.meta_key set (flat-by-id; #207 fix shape (b))
           - events_processed: 4
           - thinking-block redacted

--- a/scripts/lifecycle/session-end-transcript-export.py
+++ b/scripts/lifecycle/session-end-transcript-export.py
@@ -756,9 +756,11 @@ def main() -> int:
                 }
 
             sidecar = {
-                "schema_version": 2,
+                "schema_version": 3,
                 "parser_version": PARSER_VERSION,
                 "session_id": session_id,
+                "claude_code_remote_session_id":
+                    os.environ.get("CLAUDE_CODE_REMOTE_SESSION_ID", "").strip(),
                 "exported_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
                 "source_jsonl": str(jsonl_path),
                 "events_processed": redaction_summary.get("events_processed", 0),

--- a/scripts/lifecycle/session-end-transcript-render.py
+++ b/scripts/lifecycle/session-end-transcript-render.py
@@ -705,21 +705,67 @@ def _build_toc(rendered_entries: list[tuple[int, str, str]]) -> str:
     return f'<nav class="toc"><h2>User turns</h2><ol>{"".join(items)}</ol></nav>'
 
 
-def _compute_session_url(session_id: str) -> str:
-    """Derive the claude.ai/code session URL from env. Only safe when
-    CLAUDE_CODE_SESSION_ID matches the session being rendered — the
-    SessionEnd-hook path satisfies this by construction; manual
-    renders satisfy it iff the operator targets the current session;
-    backfill never satisfies it (returns "")."""
-    env_sid = os.environ.get("CLAUDE_CODE_SESSION_ID", "").strip()
-    if not env_sid or env_sid != session_id:
-        return ""
-    remote_sid = os.environ.get("CLAUDE_CODE_REMOTE_SESSION_ID", "").strip()
+def _format_session_url(remote_sid: str) -> str:
+    remote_sid = remote_sid.strip()
     if not remote_sid:
         return ""
     if remote_sid.startswith("cse_"):
         remote_sid = remote_sid[4:]
     return f"https://claude.ai/code/session_{remote_sid}"
+
+
+def _fetch_remote_sid_from_export_meta(session_id: str) -> str:
+    """Best-effort lookup of CLAUDE_CODE_REMOTE_SESSION_ID from the
+    export pipeline's meta.json at transcripts/meta/<sid>.meta.json.
+    Returns "" on any failure or absence. Schema version 3 added the
+    field; older sidecars return "" silently."""
+    access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
+    secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
+    if not access_key or not secret_key:
+        return ""
+    try:
+        endpoint, bucket = _r2_endpoint_bucket()
+    except RuntimeError:
+        return ""
+    try:
+        import boto3
+        from botocore.config import Config
+        from botocore.exceptions import ClientError
+    except ImportError:
+        return ""
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="auto",
+        config=Config(signature_version="s3v4", retries={"max_attempts": 2, "mode": "standard"}),
+    )
+    try:
+        resp = s3.get_object(Bucket=bucket, Key=f"transcripts/meta/{session_id}.meta.json")
+        body = resp["Body"].read()
+        meta = json.loads(body)
+        return str(meta.get("claude_code_remote_session_id") or "")
+    except (ClientError, KeyError, ValueError):
+        return ""
+
+
+def _compute_session_url(session_id: str) -> str:
+    """Derive the claude.ai/code session URL for `session_id`.
+
+    Lookup order:
+      1. Env (CLAUDE_CODE_SESSION_ID matches target → use
+         CLAUDE_CODE_REMOTE_SESSION_ID). Stop-hook path is here.
+      2. Export meta.json sidecar in R2 (schema v3+ carries the
+         remote-session-id). Backfill path is here.
+    Returns "" when neither source has it."""
+    env_sid = os.environ.get("CLAUDE_CODE_SESSION_ID", "").strip()
+    if env_sid and env_sid == session_id:
+        remote = os.environ.get("CLAUDE_CODE_REMOTE_SESSION_ID", "").strip()
+        url = _format_session_url(remote)
+        if url:
+            return url
+    return _format_session_url(_fetch_remote_sid_from_export_meta(session_id))
 
 
 def compute_metadata(session_id: str, entries: list[dict]) -> dict:


### PR DESCRIPTION
Closes coo-labs/coo-harness#375. Follow-up issue coo-labs/coo-console#23 carries the historical-session recovery heuristic for sessions exported under the older schema v2.

Two coordinated changes so the renderer can backfill the **Open in Claude Code** URL for any session exported after this lands:

- `session-end-transcript-export.py`: capture `CLAUDE_CODE_REMOTE_SESSION_ID` from env into the sidecar JSON. Schema 2 → 3 (additive — v2 readers tolerate the new field).
- `session-end-transcript-render.py`: `_compute_session_url(session_id)` now layers two sources:
  1. **Env** (existing): `CLAUDE_CODE_SESSION_ID == target` → derive from `CLAUDE_CODE_REMOTE_SESSION_ID`. SessionEnd-hook path stays in here.
  2. **R2 fallback** (new): fetch `transcripts/meta/<sid>.meta.json` and read `claude_code_remote_session_id` from it. Backfill path now recovers the URL exactly for any session exported under schema v3.

Pre-schema-v3 exports return `""` silently — surfaced as the "(no URL)" state on the list page. coo-labs/coo-console#23 is the heuristic recovery for those.

**Drive-bys:**
- Add `__pycache__/` to `.gitignore` (a `.pyc` slipped into my last commit; cleaned up here).

**Verified locally**: env path for current session returns the URL; historical session `04cdb655` (schema v2) returns `""` (no field present in old sidecar) — both via direct invocation of `_compute_session_url`.

https://claude.ai/code/session_01Xn9FqL7KEuB3Yfo1BqMiEV