### PR TITLE
Add --rerender mode to transcript-url-backfill (HTML body link gap)

### DIFF
--- a/scripts/transcript-url-backfill.py
+++ b/scripts/transcript-url-backfill.py
@@ -20,6 +20,13 @@ Algorithm (per the 2026-05-30 comment on coo-console#23):
   3. List R2 `<key-prefix>/*.meta.json` sidecars; for each missing
      `session_url`, look the sid up in the map; on hit, fetch,
      patch in place, PUT back.
+  4. Optional (`--rerender`): also re-run the renderer for each hit
+     with `CLAUDE_CODE_SESSION_ID` + `CLAUDE_CODE_REMOTE_SESSION_ID`
+     env injected so the renderer's path-1 env-recovery fires. This
+     uploads a fresh HTML body whose template includes the
+     `Open in Claude Code` link. Best-effort: sids whose ciphertext
+     is no longer in the R2 archive log a FAIL and the sidecar
+     patch still stands.
 
 Coverage caveat: only sids landed by per-session auto-meta-PRs are
 in scope. Sids landed by bulk PRs, or never auto-PR'd at all
@@ -32,7 +39,7 @@ in-scope slice (see #23 comment thread for the cohort breakdown).
 
 Usage:
   transcript-url-backfill.py [--limit N] [--dry-run] [--include-populated]
-                             [--key-prefix rendered]
+                             [--rerender] [--key-prefix rendered]
 
 Env:
   R2_TRANSCRIPTS_ACCESS_KEY_ID      — R2 access key
@@ -57,6 +64,12 @@ import re
 import shutil
 import subprocess
 import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+FETCH_SH = SCRIPT_DIR / "lib" / "transcript-fetch.sh"
+RENDER_PY = SCRIPT_DIR / "lifecycle" / "session-end-transcript-render.py"
+SESSION_URL_PREFIX = "https://claude.ai/code/session_"
 
 SESSION_ID_RE = re.compile(
     r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
@@ -178,6 +191,62 @@ def _list_candidate_sidecars(
     return cands
 
 
+def _rerender_one(session_id: str, key_prefix: str, session_url: str) -> tuple[bool, str]:
+    """Decrypt ciphertext via transcript-fetch.sh and re-run the renderer
+    with env-injected CLAUDE_CODE_SESSION_ID/REMOTE_SESSION_ID so the
+    renderer's path-1 env recovery fires. Uploads fresh HTML + sidecar
+    to R2 via the renderer's own put pipeline."""
+    if not FETCH_SH.is_file():
+        return False, f"fetch wrapper missing: {FETCH_SH}"
+    if not RENDER_PY.is_file():
+        return False, f"render script missing: {RENDER_PY}"
+    remote = session_url.removeprefix(SESSION_URL_PREFIX).strip()
+    if not remote:
+        return False, f"could not parse remote sid from {session_url!r}"
+
+    try:
+        fetch = subprocess.run(
+            ["bash", str(FETCH_SH), session_id],
+            check=True, capture_output=True, text=True, timeout=120,
+        )
+    except subprocess.CalledProcessError as e:
+        return False, f"fetch failed: rc={e.returncode} stderr={e.stderr.strip()[:200]}"
+    except subprocess.TimeoutExpired:
+        return False, "fetch timed out after 120s"
+    jsonl_path = fetch.stdout.strip()
+    if not jsonl_path or not Path(jsonl_path).is_file():
+        return False, f"fetch returned no usable path ({jsonl_path!r})"
+
+    env = os.environ.copy()
+    env["CLAUDE_CODE_SESSION_ID"] = session_id
+    env["CLAUDE_CODE_REMOTE_SESSION_ID"] = remote
+
+    try:
+        render = subprocess.run(
+            [str(RENDER_PY),
+             "--session-id", session_id,
+             "--input", jsonl_path,
+             "--key-prefix", key_prefix,
+             "--overwrite"],
+            check=True, capture_output=True, text=True, timeout=120, env=env,
+        )
+    except subprocess.CalledProcessError as e:
+        return False, f"render failed: rc={e.returncode} stderr={e.stderr.strip()[:200]}"
+    except subprocess.TimeoutExpired:
+        return False, "render timed out after 120s"
+    finally:
+        try:
+            subprocess.run(
+                ["bash", str(FETCH_SH), "--cleanup", jsonl_path],
+                check=False, capture_output=True, timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            pass
+
+    last = render.stderr.strip().splitlines()[-1] if render.stderr.strip() else ""
+    return True, f"re-rendered ({last})"
+
+
 def _patch_one(s3, bucket: str, key: str, session_url: str) -> tuple[bool, str]:
     try:
         body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
@@ -209,6 +278,10 @@ def main(argv: list[str] | None = None) -> int:
                    help="print sid<TAB>session_url assignments without patching")
     p.add_argument("--include-populated", action="store_true",
                    help="also consider sidecars whose session_url is already set")
+    p.add_argument("--rerender", action="store_true",
+                   help="after patching the sidecar, also re-run the renderer "
+                        "with env-injected CLAUDE_CODE_SESSION_ID/REMOTE_SESSION_ID "
+                        "so the HTML body includes the 'Open in Claude Code' link")
     p.add_argument("--key-prefix", default="rendered",
                    help="R2 key prefix for rendered HTML/meta (default: rendered)")
     args = p.parse_args(argv)
@@ -253,18 +326,36 @@ def main(argv: list[str] | None = None) -> int:
 
     ok = 0
     failed = 0
+    rerender_ok = 0
+    rerender_fail = 0
     for i, (sid, key, url) in enumerate(hits, 1):
         _stderr(f"[{i}/{len(hits)}] {sid}")
         success, detail = _patch_one(s3, bucket, key, url)
         if success:
             ok += 1
-            _stderr(f"  OK · {detail}")
+            _stderr(f"  patch OK · {detail}")
         else:
             failed += 1
-            _stderr(f"  FAIL · {detail}")
+            _stderr(f"  patch FAIL · {detail}")
+            continue
+        if args.rerender:
+            r_success, r_detail = _rerender_one(sid, key_prefix, url)
+            if r_success:
+                rerender_ok += 1
+                _stderr(f"  rerender OK · {r_detail}")
+            else:
+                rerender_fail += 1
+                _stderr(f"  rerender FAIL · {r_detail}")
 
-    _stderr(f"done: ok={ok} fail={failed} total={len(hits)}")
-    return 0 if failed == 0 else 2
+    summary = f"done: patch ok={ok} fail={failed} total={len(hits)}"
+    if args.rerender:
+        summary += f" | rerender ok={rerender_ok} fail={rerender_fail}"
+    _stderr(summary)
+    if failed:
+        return 2
+    if args.rerender and rerender_fail:
+        return 2
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes: n/a (follow-up to merged coo-labs/coo-harness#382; coo-labs/coo-console#23 already closed)

## Why

The shipped v1 of `transcript-url-backfill.py` patched the R2 `rendered/<sid>.meta.json` sidecar so the `/transcripts/` list-page columns reflect the recovered `session_url`. But the rendered HTML body itself was unchanged — the `Open in Claude Code` link is a render-time conditional on `session_url` in the template, so an HTML rendered with `session_url=""` doesn't carry the link element at all, regardless of any later sidecar patch.

Result before this PR: 34 sidecars patched in #382, but opening any of those transcript views in the browser shows no "Open in Claude Code" link in the page header. Sidebar list is correct; viewer page is incomplete.

## What this PR adds

A `--rerender` flag to `transcript-url-backfill.py` that runs after the sidecar patch:

1. Decrypts the sid's ciphertext via the existing `scripts/lib/transcript-fetch.sh`.
2. Parses the remote-sid portion out of the recovered URL.
3. Sets `CLAUDE_CODE_SESSION_ID=<sid>` and `CLAUDE_CODE_REMOTE_SESSION_ID=<remote>` in the child env.
4. Invokes `scripts/lifecycle/session-end-transcript-render.py --session-id <sid> --input <jsonl> --key-prefix <prefix> --overwrite`. The renderer's existing path-1 env recovery in `_compute_session_url` (added by coo-labs/coo-harness#375 for the forward-recovery case) trips on the matching env, returns the URL via `_format_session_url`, and emits HTML carrying the link.
5. Cleans up the decrypted jsonl from the local cache.

Per-sid failure (e.g. ciphertext missing from R2 archive) logs FAIL and continues; the sidecar patch still stands. Both summary counts surface in the final line.

## Verification (run today)

```
[transcript-url-backfill] done: patch ok=34 fail=0 total=34 | rerender ok=34 fail=0
```

R2 audit after run:

- 36/36 sidecars with `session_url` populated.
- 36/36 corresponding HTML bodies contain the `Open in Claude Code` link.

## Why this is its own PR

The original close-out on coo-labs/coo-console#23 was scoped to "sidecar patched", which I treated as complete. The viewer-page completeness gap surfaced when Ven opened a viewer on iPad and saw no link in the page header. Worth landing separately so the git history shows the v1 (cheap sidecar patch) and v2 (rerender) as distinct, debuggable steps — useful if anyone hits a similar template-vs-sidecar gap in another viewer in the future.

No new dependencies. No renderer-side change (uses the existing env recovery path). Idempotent re-runs.

https://claude.ai/code/session_01MxJUwPAXHVqfN1UtQeFPkc