### PR TITLE
scan-transcript v3: tool_result_exact + date prune + direct early-accept

### DIFF
--- a/scripts/lifecycle/session-end-transcript-render.py
+++ b/scripts/lifecycle/session-end-transcript-render.py
@@ -52,6 +52,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 PARSER_VERSION = 1
@@ -1136,19 +1137,32 @@ def main(argv: list[str] | None = None) -> int:
 
     metadata = compute_metadata(session_id, entries)
     meta_bytes = json.dumps(metadata, separators=(",", ":")).encode("utf-8")
-    try:
-        meta_result = _r2_put_bytes(
-            meta_bytes, meta_key,
-            overwrite=args.overwrite,
-            content_type="application/json; charset=utf-8",
-        )
-    except Exception as e:
-        # HTML already landed; sidecar miss is non-fatal — list page tolerates absence.
-        _stderr(f"R2 upload (meta sidecar) failed: {e}")
-        return 0
-    _stderr(f"uploaded → {meta_result['endpoint']}/{meta_result['bucket']}/{meta_result['key']}"
-            + (" (ceded)" if meta_result.get("ceded") else ""))
-    return 0
+    # Retry the sidecar upload — without it the list page's union-find
+    # can't group rotation siblings (it joins on session_url /
+    # first_user_uuid from the sidecar), so the row falls out as an
+    # orphan "(no metadata)" entry. Boto3's max_attempts=3 covers
+    # transient TLS/socket errors at the layer below; the loop here
+    # covers errors that escape that (auth blips, brief endpoint
+    # outages). Surface exit 2 if all three attempts fail rather than
+    # silently absorbing — the Stop-hook caller logs the non-zero rc.
+    last_err: Exception | None = None
+    for attempt in range(3):
+        try:
+            meta_result = _r2_put_bytes(
+                meta_bytes, meta_key,
+                overwrite=args.overwrite,
+                content_type="application/json; charset=utf-8",
+            )
+            _stderr(f"uploaded → {meta_result['endpoint']}/{meta_result['bucket']}/{meta_result['key']}"
+                    + (" (ceded)" if meta_result.get("ceded") else ""))
+            return 0
+        except Exception as e:
+            last_err = e
+            _stderr(f"R2 upload (meta sidecar) attempt {attempt + 1}/3 failed: {e}")
+            if attempt < 2:
+                time.sleep(2 ** attempt)
+    _stderr(f"R2 upload (meta sidecar) gave up after 3 attempts; last error: {last_err}")
+    return 2
 
 
 if __name__ == "__main__":

--- a/scripts/lifecycle/session-end-transcript-render.py
+++ b/scripts/lifecycle/session-end-transcript-render.py
@@ -969,7 +969,7 @@ def render_html(session_id: str, entries: list[dict]) -> str:
 <body>
 {toc}
 <main>
-  <p class="back"><a href="/transcripts/">← All transcripts</a>{(' &nbsp;·&nbsp; <a href="' + _esc(session_url) + '" target="_blank" rel="noopener">Open in Claude Code ↗</a>') if session_url else ''}</p>
+  <p class="back"><a href="/transcripts/">← All transcripts</a>{(' &nbsp;·&nbsp; <a href="' + _esc(session_url) + '" target="_blank" rel="noopener">Open in Claude Code ↗</a> &nbsp;·&nbsp; <a href="/sessions/' + _esc(session_url.rsplit("/session_", 1)[-1]) + '">GitHub artifacts ↗</a>') if session_url else ''}</p>
   <header class="session">
     <h1>{_esc(session_id)}</h1>
     <div class="meta">

--- a/scripts/transcript-url-backfill.py
+++ b/scripts/transcript-url-backfill.py
@@ -228,21 +228,25 @@ def _list_candidate_sidecars(
     return cands
 
 
-def _build_pr_to_url_map(index: dict) -> dict[tuple[str, str], str]:
-    """Map (repo, str(number)) -> session_url for every PR/issue authored
-    by a session in the reverse index. First-write-wins on multi-author
-    collisions (rare)."""
-    out: dict[tuple[str, str], str] = {}
+def _build_pr_to_url_map(index: dict) -> dict[tuple[str, str], tuple[str, str]]:
+    """Map (repo, str(number)) -> (session_url, artifact_type) for every
+    PR/issue authored by a session in the reverse index. artifact_type is
+    'pr' or 'issue' — used to weight votes during scan-transcript resolution
+    (PRs are stronger authorship signals than issues, which sessions
+    frequently reference without having opened). First-write-wins on
+    multi-author collisions (rare)."""
+    out: dict[tuple[str, str], tuple[str, str]] = {}
     for s in index.get("sessions", []):
         url = (s.get("session_url") or "").strip()
         if not url:
             continue
         for a in s.get("artifacts", []):
-            if a.get("type") not in ("pr", "issue"):
+            atype = a.get("type")
+            if atype not in ("pr", "issue"):
                 continue
             key = (a.get("repo"), str(a.get("number")))
             if key not in out:
-                out[key] = url
+                out[key] = (url, atype)
     return out
 
 
@@ -294,20 +298,34 @@ def _normalize_repo(repo: str) -> str:
     return REPO_RENAME.get(repo, repo)
 
 
+SCAN_WEIGHTS = {
+    "pr_link": 10,
+    "pattern_a": 5,
+    "prose_pr": 3,
+    "prose_issue": 1,
+}
+
+
 def _scan_jsonl_for_url(
-    jsonl_path: Path, pr_map: dict[tuple[str, str], str]
+    jsonl_path: Path, pr_map: dict[tuple[str, str], tuple[str, str]]
 ) -> tuple[Optional[str], str]:
     """Scan a decrypted jsonl. Returns (session_url, detail).
 
-    Priority ladder:
-      1. `pr-link` entries (top-level jsonl objects of type='pr-link'
-         emitted by the gh-coo-wrap PostToolUse hook for PRs this
-         session opened). Strong signal — direct authorship.
-      2. Pattern A: literal claude.ai/code/session_<id> URLs (strict
-         01-prefix regex to avoid false positives like 'session_2026').
-      3. Pattern B: coo-labs/* and vade-app/* PR/issue references in
-         prose, reverse-looked-up in pr_map. Requires unanimous OR
-         mode >= 2 * rest.
+    Single weighted vote across four signals, summed per candidate
+    session_url:
+      pr-link entries (top-level jsonl objects of type='pr-link'
+        emitted by gh-coo-wrap's PostToolUse hook for PRs this session
+        opened) — direct authorship, weight 10 each.
+      Pattern A: literal claude.ai/code/session_<id> URLs with strict
+        01-prefix — weight 5 each.
+      Pattern B: prose PR refs (coo-labs/* and vade-app/* normalized)
+        looked up in pr_map; PRs weight 3 each (sessions open few PRs
+        and they strongly indicate authorship), issues weight 1 each
+        (sessions reference many issues they didn't open).
+
+    Accept if the top candidate has >= 2x the second-place votes
+    (unanimous when there's no second place). Reject as conflict
+    otherwise.
     """
     pr_link_prs: set[tuple[str, str]] = set()
     a_votes: Counter = Counter()
@@ -339,42 +357,52 @@ def _scan_jsonl_for_url(
                 for m in TRANSCRIPT_PR_AUTOLINK_RE.findall(txt):
                     prose_prs.add(m)
 
-    if pr_link_prs:
-        pl_votes: Counter = Counter()
-        for repo, num in pr_link_prs:
-            key = (_normalize_repo(repo), str(num))
-            if key in pr_map:
-                pl_votes[pr_map[key]] += 1
-        if pl_votes:
-            url, c = pl_votes.most_common(1)[0]
-            rest = sum(pl_votes.values()) - c
-            if rest == 0:
-                return url, f"pr-link unanimous ({c}/{len(pr_link_prs)} pr-link PRs in index)"
-            if c >= 2 * rest:
-                return url, f"pr-link strong mode ({c} of {sum(pl_votes.values())})"
+    votes: Counter = Counter()
+    breakdown: dict[str, dict[str, int]] = {}
 
-    if a_votes:
-        url, c = a_votes.most_common(1)[0]
-        return url, f"pattern-A literal URL (×{c} of {sum(a_votes.values())})"
+    def _add(url: str, kind: str, n: int = 1):
+        votes[url] += n * SCAN_WEIGHTS[kind]
+        breakdown.setdefault(url, {}).setdefault(kind, 0)
+        breakdown[url][kind] += n
 
-    b_votes: Counter = Counter()
+    for repo, num in pr_link_prs:
+        key = (_normalize_repo(repo), str(num))
+        if key in pr_map:
+            url, _ = pr_map[key]
+            _add(url, "pr_link")
+    for url, c in a_votes.items():
+        _add(url, "pattern_a", c)
     for repo, num in prose_prs:
         key = (_normalize_repo(repo), str(num))
         if key in pr_map:
-            b_votes[pr_map[key]] += 1
+            url, atype = pr_map[key]
+            _add(url, "prose_pr" if atype == "pr" else "prose_issue")
 
-    if not b_votes:
+    if not votes:
         return None, (
             f"no signal (pr-link={len(pr_link_prs)}, "
-            f"prose-PRs={len(prose_prs)}, none in index)"
+            f"prose-PRs={len(prose_prs)}, A-literal={sum(a_votes.values())}, "
+            f"none in index)"
         )
-    url, c = b_votes.most_common(1)[0]
-    rest = sum(b_votes.values()) - c
-    if rest == 0:
-        return url, f"pattern-B unanimous ({c} authored-PR refs)"
-    if c >= 2 * rest:
-        return url, f"pattern-B strong mode ({c} of {sum(b_votes.values())})"
-    return None, f"pattern-B conflict ({b_votes.most_common(3)})"
+    top = votes.most_common(2)
+    top_url, top_score = top[0]
+    runner_score = top[1][1] if len(top) > 1 else 0
+    parts = breakdown.get(top_url, {})
+    parts_str = "+".join(f"{n}{k[0]}" for k, n in parts.items())
+    # Reject weak signal: 1-2pt = single issue reference with no PR/pr-link
+    # backing. Too easy to be a passing reference rather than authorship.
+    if top_score < 3:
+        return None, f"too weak ({top_score}pt: {parts_str})"
+    if runner_score == 0:
+        return top_url, f"unanimous ({top_score}pt: {parts_str})"
+    if top_score >= 2 * runner_score:
+        return top_url, (
+            f"strong mode ({top_score}pt vs {runner_score}pt 2nd; {parts_str})"
+        )
+    return None, (
+        f"conflict (top {top_score}pt vs 2nd {runner_score}pt; "
+        f"top3={votes.most_common(3)})"
+    )
 
 
 def _resolve_via_scan(

--- a/scripts/transcript-url-backfill.py
+++ b/scripts/transcript-url-backfill.py
@@ -70,6 +70,7 @@ and continue — fail-soft.
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import json
 import os
 import re
@@ -102,6 +103,9 @@ TRANSCRIPT_PR_URL_RE = re.compile(
 )
 TRANSCRIPT_PR_AUTOLINK_RE = re.compile(
     r"\b((?:coo-labs|vade-app)/[\w.-]+)#(\d+)\b"
+)
+TOOL_RESULT_EXACT_PR_URL_RE = re.compile(
+    r"^https://github\.com/((?:coo-labs|vade-app)/[\w.-]+)/(?:pull|issues)/(\d+)/?$"
 )
 # vade-app/* repos were renamed under coo-labs/* during the 2026-05 org cutover.
 # Normalize before reverse-lookup in session_artifacts.json (built against
@@ -250,6 +254,25 @@ def _build_pr_to_url_map(index: dict) -> dict[tuple[str, str], tuple[str, str]]:
     return out
 
 
+def _build_session_last_seen(index: dict) -> dict[str, _dt.datetime]:
+    """Map session_url -> last_seen_at datetime (UTC). Used to prune
+    vote candidates whose active window predates the transcript — sessions
+    that boot a fresh container and observe-only still reference PRs from
+    the boot digest, which would otherwise vote for long-completed sessions
+    and skew the mode."""
+    out: dict[str, _dt.datetime] = {}
+    for s in index.get("sessions", []):
+        url = (s.get("session_url") or "").strip()
+        last = (s.get("last_seen_at") or "").strip()
+        if not url or not last:
+            continue
+        try:
+            out[url] = _dt.datetime.fromisoformat(last.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+    return out
+
+
 def _yield_text(entry: dict, root_type: str):
     msg = entry.get("message") or {}
     content = msg.get("content")
@@ -300,14 +323,52 @@ def _normalize_repo(repo: str) -> str:
 
 SCAN_WEIGHTS = {
     "pr_link": 10,
+    "tool_result_exact": 10,
     "pattern_a": 5,
     "prose_pr": 3,
     "prose_issue": 1,
 }
 
 
+def _yield_tool_result_exact_prs(entry: dict):
+    """Yield (repo, number) for tool_result blocks whose content is
+    exactly a single coo-labs/vade-app PR/issue URL — the shape `gh pr
+    create` etc. emits. Direct authorship signal: this session ran the
+    create call. Also checks top-level toolUseResult.stdout for the same
+    shape."""
+    msg = entry.get("message") or {}
+    content = msg.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                continue
+            tc = block.get("content")
+            if isinstance(tc, str):
+                m = TOOL_RESULT_EXACT_PR_URL_RE.match(tc.strip())
+                if m:
+                    yield m.group(1), m.group(2)
+            elif isinstance(tc, list):
+                for sub in tc:
+                    if isinstance(sub, dict) and sub.get("type") == "text":
+                        m = TOOL_RESULT_EXACT_PR_URL_RE.match(
+                            (sub.get("text", "") or "").strip()
+                        )
+                        if m:
+                            yield m.group(1), m.group(2)
+    tur = entry.get("toolUseResult")
+    if isinstance(tur, dict):
+        stdout = tur.get("stdout")
+        if isinstance(stdout, str):
+            m = TOOL_RESULT_EXACT_PR_URL_RE.match(stdout.strip())
+            if m:
+                yield m.group(1), m.group(2)
+
+
 def _scan_jsonl_for_url(
-    jsonl_path: Path, pr_map: dict[tuple[str, str], tuple[str, str]]
+    jsonl_path: Path,
+    pr_map: dict[tuple[str, str], tuple[str, str]],
+    session_last_seen: dict[str, _dt.datetime] | None = None,
+    prune_window_hours: int = 24,
 ) -> tuple[Optional[str], str]:
     """Scan a decrypted jsonl. Returns (session_url, detail).
 
@@ -323,13 +384,22 @@ def _scan_jsonl_for_url(
         and they strongly indicate authorship), issues weight 1 each
         (sessions reference many issues they didn't open).
 
-    Accept if the top candidate has >= 2x the second-place votes
-    (unanimous when there's no second place). Reject as conflict
+    After scoring, prune candidates whose `last_seen_at` predates the
+    transcript's first timestamp by more than `prune_window_hours`. This
+    drops false candidates that arise when an observe-only session
+    references PRs surfaced by the boot digest (those PRs were authored
+    by long-completed sessions). pr_link and pattern_a contributions
+    bypass the prune since they are direct-authorship markers.
+
+    Accept if the top remaining candidate has >= 2x the second-place
+    votes (unanimous when there's no second place). Reject as conflict
     otherwise.
     """
     pr_link_prs: set[tuple[str, str]] = set()
+    tool_result_exact_prs: set[tuple[str, str]] = set()
     a_votes: Counter = Counter()
     prose_prs: set[tuple[str, str]] = set()
+    first_ts: _dt.datetime | None = None
     try:
         f = open(jsonl_path)
     except OSError as e:
@@ -343,12 +413,21 @@ def _scan_jsonl_for_url(
                 entry = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            if first_ts is None:
+                ts = entry.get("timestamp")
+                if isinstance(ts, str):
+                    try:
+                        first_ts = _dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                    except ValueError:
+                        pass
             if entry.get("type") == "pr-link":
                 repo = (entry.get("prRepository") or "").strip()
                 num = entry.get("prNumber")
                 if repo and num is not None:
                     pr_link_prs.add((repo, str(num)))
                 continue
+            for repo, num in _yield_tool_result_exact_prs(entry):
+                tool_result_exact_prs.add((repo, num))
             for txt in _yield_text(entry, entry.get("type", "?")):
                 for m in TRANSCRIPT_SESSION_URL_RE.findall(txt):
                     a_votes[f"{SESSION_URL_PREFIX}{m}"] += 1
@@ -356,6 +435,9 @@ def _scan_jsonl_for_url(
                     prose_prs.add(m)
                 for m in TRANSCRIPT_PR_AUTOLINK_RE.findall(txt):
                     prose_prs.add(m)
+    # Dedupe — tool_result_exact gets the strong weight; prose shouldn't
+    # also score these same PRs.
+    prose_prs -= tool_result_exact_prs
 
     votes: Counter = Counter()
     breakdown: dict[str, dict[str, int]] = {}
@@ -370,6 +452,11 @@ def _scan_jsonl_for_url(
         if key in pr_map:
             url, _ = pr_map[key]
             _add(url, "pr_link")
+    for repo, num in tool_result_exact_prs:
+        key = (_normalize_repo(repo), str(num))
+        if key in pr_map:
+            url, _ = pr_map[key]
+            _add(url, "tool_result_exact")
     for url, c in a_votes.items():
         _add(url, "pattern_a", c)
     for repo, num in prose_prs:
@@ -384,29 +471,94 @@ def _scan_jsonl_for_url(
             f"prose-PRs={len(prose_prs)}, A-literal={sum(a_votes.values())}, "
             f"none in index)"
         )
+
+    pruned_count = 0
+    if first_ts is not None and session_last_seen:
+        cutoff = first_ts - _dt.timedelta(hours=prune_window_hours)
+        kept_votes: Counter = Counter()
+        kept_breakdown: dict[str, dict[str, int]] = {}
+        for url, score in votes.items():
+            url_parts = breakdown.get(url, {})
+            url_has_direct = (
+                url_parts.get("pr_link", 0) > 0
+                or url_parts.get("tool_result_exact", 0) > 0
+                or url_parts.get("pattern_a", 0) > 0
+            )
+            if url_has_direct:
+                kept_votes[url] = score
+                kept_breakdown[url] = url_parts
+                continue
+            last_seen = session_last_seen.get(url)
+            if last_seen is not None and last_seen >= cutoff:
+                kept_votes[url] = score
+                kept_breakdown[url] = url_parts
+            else:
+                pruned_count += 1
+        if not kept_votes:
+            return None, (
+                f"all {pruned_count} candidates predate transcript "
+                f"(first_ts={first_ts.isoformat()}, cutoff={cutoff.isoformat()})"
+            )
+        votes = kept_votes
+        breakdown = kept_breakdown
+
+    prune_note = f" [{pruned_count} pruned by date]" if pruned_count else ""
+
+    def _direct_score(p: dict[str, int]) -> int:
+        return (p.get("pr_link", 0) * SCAN_WEIGHTS["pr_link"]
+                + p.get("tool_result_exact", 0) * SCAN_WEIGHTS["tool_result_exact"]
+                + p.get("pattern_a", 0) * SCAN_WEIGHTS["pattern_a"])
+
+    # Direct-authorship early accept: a candidate with pr_link or
+    # tool_result_exact entries (≥10pt direct signal) is the session that
+    # actually opened those PRs. Accept it regardless of prose-only
+    # competitors, which are necessarily cross-references rather than
+    # authorship.
+    direct_scored = sorted(
+        ((u, _direct_score(breakdown[u]), votes[u]) for u in votes),
+        key=lambda r: (r[1], r[2]),
+        reverse=True,
+    )
+    if direct_scored and direct_scored[0][1] >= 10:
+        url, dscore, tscore = direct_scored[0]
+        runner_d = direct_scored[1][1] if len(direct_scored) > 1 else 0
+        parts = breakdown.get(url, {})
+        parts_str = "+".join(f"{n}{k[0]}" for k, n in parts.items())
+        return url, (
+            f"direct authorship ({dscore}pt direct / {tscore}pt total; "
+            f"{parts_str}; runner-up direct={runner_d}pt){prune_note}"
+        )
+
     top = votes.most_common(2)
     top_url, top_score = top[0]
     runner_score = top[1][1] if len(top) > 1 else 0
     parts = breakdown.get(top_url, {})
     parts_str = "+".join(f"{n}{k[0]}" for k, n in parts.items())
-    # Reject weak signal: 1-2pt = single issue reference with no PR/pr-link
-    # backing. Too easy to be a passing reference rather than authorship.
-    if top_score < 3:
-        return None, f"too weak ({top_score}pt: {parts_str})"
+    # Floor: 5pt for any direct signal (e.g. 1 pattern-a literal URL); 6pt
+    # for prose-only candidates so a single cross-referenced PR (3pt) isn't
+    # enough by itself — a real authoring session typically opens 2+
+    # artifacts. After the date prune, observe-only sessions can otherwise
+    # win unanimously on a single in-window prose reference, which is wrong.
+    has_direct = _direct_score(parts) > 0
+    floor = 5 if has_direct else 6
+    if top_score < floor:
+        return None, f"too weak ({top_score}pt vs floor {floor}; {parts_str}){prune_note}"
     if runner_score == 0:
-        return top_url, f"unanimous ({top_score}pt: {parts_str})"
+        return top_url, f"unanimous ({top_score}pt: {parts_str}){prune_note}"
     if top_score >= 2 * runner_score:
         return top_url, (
-            f"strong mode ({top_score}pt vs {runner_score}pt 2nd; {parts_str})"
+            f"strong mode ({top_score}pt vs {runner_score}pt 2nd; {parts_str}){prune_note}"
         )
     return None, (
         f"conflict (top {top_score}pt vs 2nd {runner_score}pt; "
-        f"top3={votes.most_common(3)})"
+        f"top3={votes.most_common(3)}){prune_note}"
     )
 
 
 def _resolve_via_scan(
-    session_id: str, pr_map: dict[tuple[str, str], str]
+    session_id: str,
+    pr_map: dict[tuple[str, str], tuple[str, str]],
+    session_last_seen: dict[str, _dt.datetime] | None = None,
 ) -> tuple[Optional[str], str]:
     """Decrypt + scan + cleanup. Returns (url, detail)."""
     if not FETCH_SH.is_file():
@@ -424,7 +576,9 @@ def _resolve_via_scan(
     if not jsonl_path or not Path(jsonl_path).is_file():
         return None, f"fetch returned no usable path ({jsonl_path!r})"
     try:
-        url, detail = _scan_jsonl_for_url(Path(jsonl_path), pr_map)
+        url, detail = _scan_jsonl_for_url(
+            Path(jsonl_path), pr_map, session_last_seen=session_last_seen,
+        )
     finally:
         try:
             subprocess.run(
@@ -572,10 +726,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.scan_transcript and misses:
         _stderr(f"scan-transcript: probing {len(misses)} title-miss sids…")
         pr_to_url = _build_pr_to_url_map(index)
-        _stderr(f"  pr/issue reverse-index has {len(pr_to_url)} entries")
+        session_last_seen = _build_session_last_seen(index)
+        _stderr(
+            f"  pr/issue reverse-index has {len(pr_to_url)} entries; "
+            f"session_last_seen has {len(session_last_seen)} entries"
+        )
         for i, (sid, key) in enumerate(misses, 1):
             _stderr(f"[scan {i}/{len(misses)}] {sid}")
-            url, detail = _resolve_via_scan(sid, pr_to_url)
+            url, detail = _resolve_via_scan(sid, pr_to_url, session_last_seen)
             if url:
                 scan_resolved.append((sid, key, url, f"scan:{detail}"))
                 _stderr(f"  scan OK · {detail} -> {url}")


### PR DESCRIPTION
Closes: n/a (follow-up to merged coo-labs/coo-harness#382 + #385 + #386)

## Summary

Three rounds of incremental fixes, all on the same branch:

1. **Renderer template** — add `GitHub artifacts ↗` link to the transcript viewer's page header (when `session_url` is populated, targets `/sessions/<remote_sid>`).
2. **Weighted-vote algorithm** for `scan-transcript` resolution — replaces priority-ladder + sum-of-rest threshold with per-signal weights and `mode >= 2× second-place` criterion. Catches sessions whose vote splits 3-2-2 across cross-referenced PRs.
3. **`tool_result_exact` signal + date prune + direct-authorship early-accept** — three further refinements after Ven's spot-checks revealed:
   - Boot-only sessions referencing PRs surfaced by the SessionStart digest were voting for long-completed sessions. Date prune (drop candidates whose `last_seen_at` predates transcript by >24h) fixes this.
   - Sessions that ran `gh pr create` have the literal PR URL in `tool_result` content — a direct authorship marker stronger than any prose. New `tool_result_exact` signal weights 10pt and triggers an early-accept path.
   - Floor raised so a single in-window prose PR reference doesn't pass unanimously (boot-test sessions could otherwise win on a single notification PR).

## Weight table

| Signal | Weight | Notes |
|---|---|---|
| `pr-link` jsonl entry | 10 | gh-coo-wrap PostToolUse marker |
| `tool_result_exact` PR/issue URL | 10 | `gh pr create` stdout shape |
| Literal `claude.ai/code/session_<id>` URL | 5 | Strict 01-prefix regex |
| Prose PR ref (type=pr in index) | 3 | After dedupe vs tool_result_exact |
| Prose issue ref (type=issue in index) | 1 | Sessions reference many issues they didn't open |

## Acceptance ladder (after vote + prune)

1. **Direct-authorship early-accept** — top candidate with ≥10pt direct signal wins regardless of prose-only competitors.
2. **Floor check** — ≥5pt for direct candidates, ≥6pt for prose-only.
3. **Strong mode** — top ≥ 2× second-place.
4. **Unanimous** — only one candidate after prune.
5. Else: conflict.

## Cumulative empirical state

| Stage | Populated | % |
|---|---|---|
| Session start | 4 | 2% |
| After title-fast-path (#382) | 36 | 18% |
| After scan v1 (#386) | 92 | 45% |
| After scan v2 (weighted + template) | 117 | 57% |
| **After scan v3 (this PR's full algorithm)** | **139** | **68%** |
| Residual | 66 | 32% |

Residual 66 split: 20 real conflicts (transcript references many sessions, no clear authorship), 20 no-signal (transcripts with zero PR/issue refs), 13 below-floor (single in-window reference), 9 fetch-failed (ciphertext missing), 4 all-candidates-predate (boot-only sessions correctly classified as unrecoverable here).

## Live runs

All landed against R2 — the populated sidecars carry both `session_url` and the new template's `GitHub artifacts ↗` link. The 7 orphan HTMLs that lacked sidecars (sessions whose live Stop-hook meta-upload step silently failed — separate root-cause investigation pending) had sidecars regenerated this session: 6 via decrypt+rerender, 1 via synthesis from the rendered HTML (ciphertext missing).