### PR TITLE
renderer: schema v3 — add models / cwds / cc_version / first_user_uuid

### DIFF
--- a/scripts/lifecycle/session-end-transcript-render.py
+++ b/scripts/lifecycle/session-end-transcript-render.py
@@ -55,7 +55,7 @@ import sys
 import time
 from pathlib import Path
 
-PARSER_VERSION = 1
+PARSER_VERSION = 3
 SCRIPT_DIR = Path(__file__).resolve().parent
 
 
@@ -809,11 +809,14 @@ def _compute_session_url(session_id: str) -> str:
 def compute_metadata(session_id: str, entries: list[dict]) -> dict:
     """Walk entries once; return the metadata blob for the list-page sidecar.
 
-    Schema (renderer_version=1):
+    Schema (renderer_version=3):
       session_id, started_at, ended_at, duration_seconds,
       entry_count, user_turn_count, assistant_turn_count,
       tool_call_count, error_count, first_user_preview,
-      renderer_version.
+      first_user_uuid, session_url, renderer_version,
+      models (list of distinct model strings from assistant messages),
+      cwds (list of distinct cwd strings),
+      cc_version (last seen Claude Code client version).
     """
     first_ts: datetime.datetime | None = None
     last_ts: datetime.datetime | None = None
@@ -822,6 +825,14 @@ def compute_metadata(session_id: str, entries: list[dict]) -> dict:
     tool_call_count = 0
     error_count = 0
     first_user_preview = ""
+    first_user_uuid = ""
+    models: list[str] = []
+    cwds: list[str] = []
+    cc_version = ""
+
+    def _add_unique(lst: list[str], val: str) -> None:
+        if val and val not in lst:
+            lst.append(val)
 
     for entry in entries:
         kind = _classify(entry)
@@ -830,6 +841,12 @@ def compute_metadata(session_id: str, entries: list[dict]) -> dict:
             if first_ts is None:
                 first_ts = ts
             last_ts = ts
+        v = entry.get("version")
+        if isinstance(v, str) and v:
+            cc_version = v
+        cwd = entry.get("cwd")
+        if isinstance(cwd, str):
+            _add_unique(cwds, cwd)
 
         if kind == "user":
             if _is_auto_notification_user_entry(entry):
@@ -838,6 +855,10 @@ def compute_metadata(session_id: str, entries: list[dict]) -> dict:
                 pass
             else:
                 user_count += 1
+                if not first_user_uuid:
+                    uuid = entry.get("uuid")
+                    if isinstance(uuid, str) and uuid:
+                        first_user_uuid = uuid
                 if not first_user_preview:
                     msg = entry.get("message", {}) or {}
                     content = msg.get("content")
@@ -855,6 +876,9 @@ def compute_metadata(session_id: str, entries: list[dict]) -> dict:
         elif kind in ("assistant", "tool_use", "thinking"):
             assistant_count += 1
             msg = entry.get("message", {}) or {}
+            model = msg.get("model")
+            if isinstance(model, str):
+                _add_unique(models, model)
             content = msg.get("content")
             if isinstance(content, list):
                 for block in content:
@@ -889,6 +913,10 @@ def compute_metadata(session_id: str, entries: list[dict]) -> dict:
         "tool_call_count": tool_call_count,
         "error_count": error_count,
         "first_user_preview": first_user_preview,
+        "first_user_uuid": first_user_uuid,
+        "models": models,
+        "cwds": cwds,
+        "cc_version": cc_version,
         "session_url": _compute_session_url(session_id),
         "renderer_version": PARSER_VERSION,
     }


### PR DESCRIPTION
Closes: n/a (paired with coo-labs/coo-console#26 — the consumer)

## What

Renderer sidecar schema bump v1 → v3 adding four fields:

| Field | Type | Source |
|---|---|---|
| `models` | `list[str]` | distinct `entry.message.model` strings from assistant turns (e.g. `["claude-opus-4-7", "claude-opus-4-8"]`) |
| `cwds` | `list[str]` | distinct `entry.cwd` strings observed |
| `cc_version` | `str` | last seen `entry.version` (Claude Code client version) |
| `first_user_uuid` | `str` | uuid of first non-auto user message; the perfect invariant the list page's union-find already uses for rotation-sibling grouping |

## Why now

The coo-console transcripts list gained a column-driven filter UI (PR #26 over there). The new columns it surfaces (`Tool calls` already in v1, `Models` + `Client` new) need the renderer to emit the data. `first_user_uuid` was implicitly expected at v2 but only sometimes populated — making it part of v3 closes that gap.

## Version numbering

PARSER_VERSION jumps 1 → 3 (not 2) because some sidecars in R2 already carry `renderer_version: 2` from a previous out-of-tree code path that wrote `first_user_uuid` alone. Going straight to 3 lets us distinguish the full new schema from that partial v2 surface.

## Perf

All four fields are populated in the existing single-pass walk of entries inside `compute_metadata` — no extra iteration, negligible overhead.

## Backfill

Existing R2 sidecars stay at v1 / partial-v2 until they are re-rendered. The new `/transcripts/` list page columns degrade gracefully to `—` for those rows. A backfill rerender of all populated sidecars is running locally now; future Stop-hook renders will emit v3 automatically.

https://claude.ai/code/session_01MxJUwPAXHVqfN1UtQeFPkc