### PR TITLE
renderer: url_source tagging — env-recovery / export-meta-fallback

### DIFF
--- a/scripts/lifecycle/session-end-transcript-render.py
+++ b/scripts/lifecycle/session-end-transcript-render.py
@@ -788,22 +788,32 @@ def _fetch_remote_sid_from_export_meta(session_id: str) -> str:
         return ""
 
 
-def _compute_session_url(session_id: str) -> str:
+def _compute_session_url(session_id: str) -> tuple[str, str]:
     """Derive the claude.ai/code session URL for `session_id`.
 
     Lookup order:
       1. Env (CLAUDE_CODE_SESSION_ID matches target → use
          CLAUDE_CODE_REMOTE_SESSION_ID). Stop-hook path is here.
+         Source tag: "env-recovery".
       2. Export meta.json sidecar in R2 (schema v3+ carries the
-         remote-session-id). Backfill path is here.
-    Returns "" when neither source has it."""
+         remote-session-id). Backfill `_rerender_one` path is here.
+         Source tag: "export-meta-fallback".
+
+    Returns ``(url, source)``. ``("", "")`` when neither source has it.
+    Both source tags name authoritative provenance — sidecars carrying
+    them are immutable from any future reconcile pass; only ``scan-*``
+    sources are reconcile-eligible. See the briefing-039 url_source
+    enum for the full source taxonomy."""
     env_sid = os.environ.get("CLAUDE_CODE_SESSION_ID", "").strip()
     if env_sid and env_sid == session_id:
         remote = os.environ.get("CLAUDE_CODE_REMOTE_SESSION_ID", "").strip()
         url = _format_session_url(remote)
         if url:
-            return url
-    return _format_session_url(_fetch_remote_sid_from_export_meta(session_id))
+            return url, "env-recovery"
+    url = _format_session_url(_fetch_remote_sid_from_export_meta(session_id))
+    if url:
+        return url, "export-meta-fallback"
+    return "", ""
 
 
 def compute_metadata(session_id: str, entries: list[dict]) -> dict:
@@ -902,7 +912,8 @@ def compute_metadata(session_id: str, entries: list[dict]) -> dict:
     if first_ts is not None and last_ts is not None:
         duration_seconds = max(0, int((last_ts - first_ts).total_seconds()))
 
-    return {
+    session_url, url_source = _compute_session_url(session_id)
+    metadata = {
         "session_id": session_id,
         "started_at": first_ts.isoformat() if first_ts else None,
         "ended_at": last_ts.isoformat() if last_ts else None,
@@ -917,13 +928,16 @@ def compute_metadata(session_id: str, entries: list[dict]) -> dict:
         "models": models,
         "cwds": cwds,
         "cc_version": cc_version,
-        "session_url": _compute_session_url(session_id),
+        "session_url": session_url,
         "renderer_version": PARSER_VERSION,
     }
+    if url_source:
+        metadata["url_source"] = url_source
+    return metadata
 
 
 def render_html(session_id: str, entries: list[dict]) -> str:
-    session_url = _compute_session_url(session_id)
+    session_url, _ = _compute_session_url(session_id)
     rendered: list[str] = []
     toc_entries: list[tuple[int, str, str]] = []
     prev_ts: datetime.datetime | None = None


### PR DESCRIPTION
Closes: n/a (briefing-039 Phase 2 — url_source tagging on renderer; briefing 039 is the work tracker, no per-phase issue)

## Summary

Phase 2 of [briefing 039](https://github.com/coo-labs/coo-memory/blob/main/briefings/039-transcript-pipeline-robustness.md). Adds `url_source` tagging to the renderer side. Phase 3 will land the backfill side + the reconcile invariant.

## Change

`_compute_session_url` now returns `(url, source)` instead of just the URL.

| path | source tag | when |
|---|---|---|
| 1 | `"env-recovery"` | `CLAUDE_CODE_SESSION_ID` env matches target → use `CLAUDE_CODE_REMOTE_SESSION_ID`. Stop-hook live-render path. |
| 2 | `"export-meta-fallback"` | R2 `transcripts/meta/<sid>.meta.json` schema-v3 sidecar carries the remote-sid. Backfill `_rerender_one` path with env-injected sid. |
| miss | `""` | Neither path matched. |

Both populated sources are authoritative — immutable from any future reconcile pass. Only `scan-*` sources (Phase 3) will be reconcile-eligible.

`compute_metadata` writes `url_source` only when `session_url` is non-empty — the field is **absent** from sidecars without a URL rather than being explicitly `null`. This is per briefing 039: "omits the field when `session_url` is empty."

`render_html` discards the source (only the URL is needed for the HTML link block).

## Design decision (split vs collapse)

The briefing body said "tag both `env-recovery`" but the *Known bounds* section flagged path-2 as a different authority class — "downstream of an explicit schema-v3 sidecar that might itself be stale." Contradictory.

Resolved in session-handoff with the BDFL: **split into `env-recovery` + `export-meta-fallback`**. Costs nothing in storage or code (~6 lines). Both stay authoritative under the same reconcile invariant; the split gives audit-grain. From any sidecar we can tell which path produced the URL without re-running anything.

Reconcile-eligible set stays exactly `scan-*`.

## Verification

Local smoke (out of band; no R2):

```
path1 hit:   url='https://claude.ai/code/session_01XYZ' src='env-recovery'
env-mismatch:url='' src=''
no env:      url='' src=''

compute_metadata(0 entries):  session_url=''       'url_source' in meta? False
compute_metadata path-1:      session_url='...01PATHONE' url_source='env-recovery'

ALL SMOKES PASS
```

Path 2 (R2 export-meta lookup) not directly exercised in the smoke (no R2 creds in scope), but the code path is structurally identical to path 1 — the URL-vs-empty branch decides the tag.

Bootstrap-regression CI will exercise the boot path (the renderer module isn't invoked during bootstrap, so CI doesn't cover the path-1/path-2 split; the prose change is low risk).

## Not in scope here

- Backfill side (`transcript-url-backfill.py`) — Phase 3.
- Reconcile invariant declaration in the backfill — Phase 3.
- v3 rerender to re-populate sidecars with `url_source` — Phase 4.

## Briefing 039 known-bounds checked

- *"Author hasn't verified that renderer-side `url_source` writing composes cleanly with `_compute_session_url`'s two-path lookup."* — verified by smoke; both paths produce well-formed (url, source) tuples, the conditional-write in `compute_metadata` honors the "omit when empty" rule.
- *"Author did not consider whether changing `compute_metadata` to write `url_source` affects the renderer's existing retry-and-surface failure mode (PR #387)."* — `compute_metadata` is called once inside `main()`; the retry loop wraps `main()` externally and re-invokes on transient failure. Adding an optional field to the returned dict doesn't change `main()`'s success/failure surface. The retry path remains correctly governed by the existing exception flow.