### PR TITLE
Cleanup coo-labs/coo-memory#1120 stale coo/X/ refs (coo-harness)

### DIFF
--- a/.claude/skills/tagging-taxonomy/SKILL.md
+++ b/.claude/skills/tagging-taxonomy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tagging-taxonomy
-description: "Apply or look up VADE issue metadata. Use when filing, triaging, or searching issues across coo-labs repos by dimension (issue type, area, Readiness field, Priority field, needs/blocked). Native types + Issue fields are the primary metadata layer; operational reference: `coo/operations/issue-fields-and-types.md` (field list, pinning matrix, API surface). `area:*` and qualifier labels are what remains label-encoded."
+description: "Apply or look up VADE issue metadata. Use when filing, triaging, or searching issues across coo-labs repos by dimension (issue type, area, Readiness field, Priority field, needs/blocked). Native types + Issue fields are the primary metadata layer; operational reference: `operations/issue-fields-and-types.md` (field list, pinning matrix, API surface). `area:*` and qualifier labels are what remains label-encoded."
 metadata:
   type: procedural
   vendoring: custom
@@ -20,7 +20,7 @@ The coo-labs repos share metadata across two layers:
    `external-code`, `publish`, `permanently-open`), and
    discussion-specific labels.
 
-Canonical reference: `coo-labs/coo-memory/coo/operations/issue-fields-and-types.md` —
+Canonical reference: `coo-labs/coo-memory/operations/issue-fields-and-types.md` —
 field list, pinning matrix, API surface, label vocabulary.
 
 Read the canonical when the digest below looks stale.
@@ -37,7 +37,7 @@ Invoke when you need to:
 
 Don't invoke for: PR-level review labels (none defined), project-board
 `Status` / `Owner` fields (those live on the project, not on labels —
-see `coo/operations/project-board.md`), or commit-message conventions
+see `operations/project-board.md`), or commit-message conventions
 (handled elsewhere).
 
 ## The dimensions
@@ -157,7 +157,7 @@ When asked to tag a new issue, run this in order:
 
 ## Search recipes — "what should I work on?"
 
-**Layer rule** (canonical: [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md) §"API surface"): issue fields live on a dedicated API surface — REST `/repos/<o>/<r>/issues/<n>/issue-field-values` per-issue, or GraphQL `issueFieldValues` connection on the `Issue` type. GitHub issue-search qualifiers (`gh issue list --search`) honor `type:<Type>` but **do not** honor `readiness:*` / `priority:*` / `effort:*` — those silently fall back to text matching and return wrong results. The VADE project board does not expose issue fields on `gh project item-list` JSON either (Status / Owner / Milestone are project-item fields, a different layer). Filter on issue-field values via GraphQL or per-issue REST, not via `--search` or `gh project`.
+**Layer rule** (canonical: [`operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/issue-fields-and-types.md) §"API surface"): issue fields live on a dedicated API surface — REST `/repos/<o>/<r>/issues/<n>/issue-field-values` per-issue, or GraphQL `issueFieldValues` connection on the `Issue` type. GitHub issue-search qualifiers (`gh issue list --search`) honor `type:<Type>` but **do not** honor `readiness:*` / `priority:*` / `effort:*` — those silently fall back to text matching and return wrong results. The VADE project board does not expose issue fields on `gh project item-list` JSON either (Status / Owner / Milestone are project-item fields, a different layer). Filter on issue-field values via GraphQL or per-issue REST, not via `--search` or `gh project`.
 
 What works on `--search`:
 - `type:<Type>` — native issue type (works since 2026-03)
@@ -209,7 +209,7 @@ for n in $(gh issue list --repo $REPO --state open --limit 500 --json number --j
 done
 ```
 
-Field IDs (from canonical ops doc): Priority `41357630`, Effort `41357633`, Readiness `42387399`. See [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md) §"API surface" for the full table + REST shape gotchas.
+Field IDs (from canonical ops doc): Priority `41357630`, Effort `41357633`, Readiness `42387399`. See [`operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/issue-fields-and-types.md) §"API surface" for the full table + REST shape gotchas.
 
 ### Find the research queue (Readiness="Needs research")
 
@@ -278,8 +278,8 @@ cross-repo invariant.
 ## Canonical sources
 
 ```text
-coo-labs/coo-memory/coo/operations/issue-fields-and-types.md
-coo-labs/coo-memory/coo/memos/2026-05-21-xfqh.md
+coo-labs/coo-memory/operations/issue-fields-and-types.md
+coo-labs/coo-memory/memos/2026-05-21-xfqh.md
 ```
 
 When this digest and the canonical docs disagree, the canonical

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -13,7 +13,7 @@ body:
         each child issue (or use the GraphQL `addSubIssue` mutation).
 
         Native sub-issue linkage is **required** for Epic-type issues per
-        [`coo/operations/issue-pr-hygiene.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-pr-hygiene.md) —
+        [`operations/issue-pr-hygiene.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/issue-pr-hygiene.md) —
         markdown checklists of `#N` references in the epic body are insufficient
         because they're invisible to GraphQL queries and the project board's
         tracker UI.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -14,7 +14,7 @@ body:
 
         Native-field widgets at the bottom (Priority, Readiness) are
         bridged to the issue's native fields by a workflow on creation.
-        See [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md).
+        See [`operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/issue-fields-and-types.md).
 
   - type: textarea
     id: summary

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-  Issue / PR hygiene checklist (Patterns A–D from coo/operations/issue-pr-hygiene.md).
+  Issue / PR hygiene checklist (Patterns A–D from operations/issue-pr-hygiene.md).
   The hygiene workflow validates this body on PR open/sync. Pattern B (closing
   keywords) is advisory in this repo (BLOCKING in coo-memory only,
   pending betterment-cadence promotion per briefing-014); A/C/D are advisory.
@@ -19,7 +19,7 @@
        Closes: n/a                         (no issue resolved)
 
      NEVER use `Closes coo-memory#N` (no `coo-labs/` prefix) — it
-     autolinks but does NOT auto-close. See coo/operations/issue-pr-hygiene.md.
+     autolinks but does NOT auto-close. See operations/issue-pr-hygiene.md.
 
      For multiple issues, ONE `Closes` LINE PER ISSUE — comma-lists
      silently fail (only the first ref auto-closes):

--- a/scripts/boot/cloud-setup.sh
+++ b/scripts/boot/cloud-setup.sh
@@ -201,7 +201,7 @@ fi
 # COO identity bootstrap runs only when OP_SERVICE_ACCOUNT_TOKEN is set
 # in the cloud environment config. Non-fatal on failure — the base VADE
 # env should still come up even if 1Password is unreachable.
-# See coo-memory/coo/cloud-env-bootstrap.md for the contract.
+# See coo-memory/operations/BOOT_TOPOLOGY.md for the contract.
 # Anthropic cloud envs may scope custom env vars to the session process
 # only; the SessionStart hook in .claude/settings.json picks up the
 # slack in that case.

--- a/scripts/hooks/agent-model-guard.sh
+++ b/scripts/hooks/agent-model-guard.sh
@@ -35,7 +35,7 @@
 # in the call site.
 #
 # Reference: MEMO-2026-05-25-<suffix>; coo-memory#781;
-# coo/parallel_instance_protocol.md §8.6.
+# operations/parallel_instance_protocol.md §8.6.
 
 set -uo pipefail
 
@@ -55,7 +55,7 @@ if [ -n "$model" ]; then
   exit 0
 fi
 
-reason="[agent-model-guard] Built-in subagent '${subagent_type}' defaults to Haiku per code.claude.com/docs/en/sub-agents.md. Pass an explicit \`model:\` argument so the choice is calibrated: \`\"sonnet\"\` (or higher) for any result the parent will act on; \`\"haiku\"\` only when the result will be independently verified by the caller (e.g. a narrow file-existence check, a one-line lookup). Silent omission is refused because the failure profile of Haiku on load-bearing work — high-confidence shallow heuristics, uncalibrated assertions, plausible hallucinations — propagates errors that the parent then has to disambiguate. See coo/parallel_instance_protocol.md §8.6 and MEMO references in coo-memory#781."
+reason="[agent-model-guard] Built-in subagent '${subagent_type}' defaults to Haiku per code.claude.com/docs/en/sub-agents.md. Pass an explicit \`model:\` argument so the choice is calibrated: \`\"sonnet\"\` (or higher) for any result the parent will act on; \`\"haiku\"\` only when the result will be independently verified by the caller (e.g. a narrow file-existence check, a one-line lookup). Silent omission is refused because the failure profile of Haiku on load-bearing work — high-confidence shallow heuristics, uncalibrated assertions, plausible hallucinations — propagates errors that the parent then has to disambiguate. See operations/parallel_instance_protocol.md §8.6 and MEMO references in coo-memory#781."
 
 jq -n --arg reason "$reason" '{
   decision: "block",

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1262,7 +1262,7 @@ ensure_mem0_mcp_server() {
 # the snapshot-persistent tree so the bundle survives resume.
 #
 # Rationale: introduced for the 2026-shiffrin-conference deck
-# (coo-memory/coo/_drafts/2026-shiffrin-conference/), kept as a
+# (coo-memory/_drafts/2026-shiffrin-conference/), kept as a
 # standing tool for future markdown-to-{revealjs,pptx,pdf} workflows.
 # Best-effort at build time; cloud-setup logs a warning on failure and
 # the first session that needs Quarto fetches on demand.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -675,7 +675,7 @@ print_versions() {
 # Used by scripts/coo-bootstrap.sh when OP_SERVICE_ACCOUNT_TOKEN is set.
 # Fetch COO identity material from a 1Password vault named "COO" via the
 # op CLI. Vault/item contract and the cloud-env boot flow are documented
-# in coo-memory/coo/cloud-env-bootstrap.md.
+# in coo-memory/operations/BOOT_TOPOLOGY.md.
 
 OP_VERSION_DEFAULT="2.31.0"
 GH_VERSION_DEFAULT="2.91.0"

--- a/scripts/lifecycle/discussions-digest.sh
+++ b/scripts/lifecycle/discussions-digest.sh
@@ -96,7 +96,7 @@ if (recent.length === 0) {
                 " (" + humanAgo(Date.parse(n.updatedAt)) + ", @" + author +
                 ", " + n.comments.totalCount + "c)");
   }
-  console.log("URLs: github.com/orgs/coo-labs/discussions/<num>; norms: coo/agent-boot-discussions-check.md");
+  console.log("URLs: github.com/orgs/coo-labs/discussions/<num>; norms: operations/agent-boot-discussions-check.md");
 }
 ' "$RESPONSE" "$CURSOR" && PARSE_OK=1
 


### PR DESCRIPTION
## Summary

Per-repo sweep of stale `coo/X/` path references for the cross-repo
wrapper-drop cleanup. Applies coo-labs/coo-memory#1120's manifest
([`bin/manifests/coo-wrapper.yaml`](https://github.com/coo-labs/coo-memory/blob/main/bin/manifests/coo-wrapper.yaml))
via the migration-sweep tool: mechanical prefix rewrites of
`coo/X/` → `X/` (directory promotions) and `coo/X.md` →
`identity/` or `operations/` (boot-promoted single-file moves).

* canonical `.github/ISSUE_TEMPLATE/{epic,task}.yml` source — propagates to all consumer repos via sync-issue-templates workflow on merge.

## Scope-discipline

* `.github/workflows/*.yml` intentionally NOT modified — the COO PAT
  lacks workflow scope; the same residual class as F9, tracked under
  coo-labs/coo-memory#1114.
* `.github/ISSUE_TEMPLATE/*.yml` not edited here — those are synced
  from coo-labs/coo-harness via `sync-issue-templates.yml`; updating
  the canonical (coo-harness) propagates on its PR's merge.

Part of the 9-PR arc closing coo-labs/coo-memory#1120; the
issue-closing PR is coo-labs/coo-memory#1124 (where the manifest
lives).

Closes: n/a

https://claude.ai/code/session_01Msos7DB8mpqiGjgWAymzC4