### PR TITLE
Cleanup post-coo-labs/coo-memory#1120 residual: CLAUDE.md handoff-prompts ref

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ export, end-session helpers), the boot-time skill aggregator.
 - Update boot scripts under `scripts/`.
 - Revise `.mcp.json` / `.claude/settings.json` for new MCP servers
   or hook chains (boot-impact PR convention: handoff prompt
-  required, see `coo/operations/handoff-prompts.md` in coo-memory).
+  required, see `operations/handoff-prompts.md` in coo-memory).
 - Update pinned tool versions in `versions.lock` with rationale.
 - Open PRs for review.
 


### PR DESCRIPTION
## Summary

Follow-on cleanup of one stale ref in `CLAUDE.md` that
coo-harness#391 didn't sweep (the manifest covered `.claude/`,
`scripts/`, and GitHub-template files):

* `CLAUDE.md` L29: `` `coo/operations/handoff-prompts.md` `` →
  `` `operations/handoff-prompts.md` `` (the wrapper was dropped
  in coo-labs/coo-memory PR8; the `operations/` folder now lives at
  the repo root).

Part of the post-coo-labs/coo-memory#1120 residual cleanup
(coo-labs/coo-memory PR alongside).

Closes: n/a

https://claude.ai/code/session_01Msos7DB8mpqiGjgWAymzC4