### PR TITLE
backfill: rerender preserves authoritative url_source; v3-backfill driver

### DIFF
--- a/scripts/transcript-rerender-v3-backfill.py
+++ b/scripts/transcript-rerender-v3-backfill.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["boto3>=1.34,<2"]
+# ///
+"""
+transcript-rerender-v3-backfill.py — briefing 039 Phase 4 driver.
+
+Walks `r2://<bucket>/<key-prefix>/*.meta.json` sidecars with
+`session_url` populated and re-runs the renderer on each. Idempotent —
+re-renders existing populated sidecars to capture v3 schema fields
+(`first_user_uuid`, `models`, `cwds`, `cc_version`) and ensure the
+sidecar carries a canonical `url_source` tag.
+
+The actual rerender call is `transcript_url_backfill._rerender_one`,
+which:
+  - Captures the pre-existing `url_source` if it's AUTHORITATIVE and
+    not already `env-recovery` (preservation rule from briefing 039
+    *Critical* — must-preserve).
+  - Decrypts the ciphertext, spawns the renderer with env-injected
+    `CLAUDE_CODE_SESSION_ID` / `CLAUDE_CODE_REMOTE_SESSION_ID`.
+  - Restores the preserved `url_source` after the renderer writes its
+    own `env-recovery` tag.
+
+Defaults to `--dry-run`. Use `--apply` for the actual rerender pass.
+
+Env: R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY.
+op-reads endpoint + bucket from op://COO/r2-transcripts/{endpoint,bucket}.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+BACKFILL_PY = SCRIPT_DIR / "transcript-url-backfill.py"
+
+
+def _stderr(msg: str) -> None:
+    sys.stderr.write(f"[transcript-rerender-v3-backfill] {msg}\n")
+
+
+def _load_backfill_module():
+    spec = importlib.util.spec_from_file_location("transcript_url_backfill", BACKFILL_PY)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {BACKFILL_PY}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[1] if __doc__ else "")
+    p.add_argument("--apply", action="store_true",
+                   help="actually re-render (default is --dry-run summary only)")
+    p.add_argument("--key-prefix", default="rendered",
+                   help="R2 key prefix for rendered HTML/meta (default: rendered)")
+    p.add_argument("--limit", type=int, default=None,
+                   help="rerender at most N sidecars (default: all populated)")
+    p.add_argument("--filter-renderer-version", type=int, default=None,
+                   help="only rerender sidecars whose existing renderer_version "
+                        "is less than this (default: rerender every populated sidecar)")
+    args = p.parse_args(argv)
+
+    bf = _load_backfill_module()
+    try:
+        s3, bucket = bf._r2_client()
+    except RuntimeError as e:
+        _stderr(str(e))
+        return 1
+
+    key_prefix = args.key_prefix.rstrip("/")
+    _stderr(f"scanning r2://{bucket}/{key_prefix}/ for populated sidecars…")
+
+    eligible: list[tuple[str, str, str]] = []  # (sid, key, session_url)
+    skipped_no_url = 0
+    skipped_filtered = 0
+
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=f"{key_prefix}/"):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if not key.endswith(".meta.json"):
+                continue
+            sid = key[len(f"{key_prefix}/"):-len(".meta.json")]
+            try:
+                body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+                meta = json.loads(body)
+            except Exception as e:
+                _stderr(f"  skip {sid}: read failed ({e})")
+                continue
+            session_url = (meta.get("session_url") or "").strip()
+            if not session_url:
+                skipped_no_url += 1
+                continue
+            if args.filter_renderer_version is not None:
+                rv = meta.get("renderer_version")
+                if isinstance(rv, int) and rv >= args.filter_renderer_version:
+                    skipped_filtered += 1
+                    continue
+            eligible.append((sid, key, session_url))
+
+    _stderr(
+        f"  eligible={len(eligible)} skipped_no_url={skipped_no_url} "
+        f"skipped_filtered={skipped_filtered}"
+    )
+
+    if args.limit is not None:
+        eligible = eligible[: args.limit]
+        _stderr(f"  limited to {len(eligible)}")
+
+    if not args.apply:
+        _stderr("DRY-RUN — would rerender:")
+        for sid, _key, url in eligible:
+            sys.stdout.write(f"{sid}\t{url}\n")
+        _stderr(f"DRY-RUN summary: would rerender {len(eligible)} sidecar(s).")
+        _stderr("Re-run with --apply to actually re-render.")
+        return 0
+
+    ok = 0
+    failed = 0
+    for i, (sid, _key, url) in enumerate(eligible, 1):
+        _stderr(f"[{i}/{len(eligible)}] {sid}")
+        success, detail = bf._rerender_one(s3, bucket, sid, key_prefix, url)
+        if success:
+            ok += 1
+            _stderr(f"  OK · {detail}")
+        else:
+            failed += 1
+            _stderr(f"  FAIL · {detail}")
+
+    _stderr(f"done: ok={ok} fail={failed} total={len(eligible)}")
+    return 2 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/transcript-url-backfill.py
+++ b/scripts/transcript-url-backfill.py
@@ -654,11 +654,20 @@ def _resolve_via_scan(
     return url, detail, source
 
 
-def _rerender_one(session_id: str, key_prefix: str, session_url: str) -> tuple[bool, str]:
+def _rerender_one(
+    s3, bucket: str, session_id: str, key_prefix: str, session_url: str,
+) -> tuple[bool, str]:
     """Decrypt ciphertext via transcript-fetch.sh and re-run the renderer
     with env-injected CLAUDE_CODE_SESSION_ID/REMOTE_SESSION_ID so the
     renderer's path-1 env recovery fires. Uploads fresh HTML + sidecar
-    to R2 via the renderer's own put pipeline."""
+    to R2 via the renderer's own put pipeline.
+
+    Preserves the pre-existing `url_source` on the sidecar when it was
+    AUTHORITATIVE and not already ``env-recovery``. The renderer's
+    env-injection tags every URL ``env-recovery`` by construction, which
+    is correct for first-time renders but erases historical provenance
+    (e.g. ``html-extract``, ``title-fast-path``, ``export-meta-fallback``)
+    on subsequent rerenders. Briefing 039 *Critical* — must-preserve."""
     if not FETCH_SH.is_file():
         return False, f"fetch wrapper missing: {FETCH_SH}"
     if not RENDER_PY.is_file():
@@ -666,6 +675,25 @@ def _rerender_one(session_id: str, key_prefix: str, session_url: str) -> tuple[b
     remote = session_url.removeprefix(SESSION_URL_PREFIX).strip()
     if not remote:
         return False, f"could not parse remote sid from {session_url!r}"
+
+    # Capture pre-existing authoritative url_source so we can restore it
+    # after the renderer overwrites the sidecar with env-recovery.
+    meta_key = f"{key_prefix}/{session_id}.meta.json"
+    preserved_url_source: str | None = None
+    try:
+        body = s3.get_object(Bucket=bucket, Key=meta_key)["Body"].read()
+        existing = json.loads(body)
+        existing_src = existing.get("url_source")
+        if (
+            existing_src in AUTHORITATIVE_URL_SOURCES
+            and existing_src != "env-recovery"
+        ):
+            preserved_url_source = existing_src
+    except Exception:
+        # No pre-existing sidecar or unreadable — fail-soft; the renderer
+        # will write a fresh env-recovery tag, which is correct first-run
+        # behavior.
+        pass
 
     try:
         fetch = subprocess.run(
@@ -707,7 +735,31 @@ def _rerender_one(session_id: str, key_prefix: str, session_url: str) -> tuple[b
             pass
 
     last = render.stderr.strip().splitlines()[-1] if render.stderr.strip() else ""
-    return True, f"re-rendered ({last})"
+
+    if preserved_url_source is None:
+        return True, f"re-rendered ({last})"
+
+    # Restore the pre-existing authoritative url_source. Unconditional
+    # write here — the rerender-restore is a known-correct override of
+    # the env-recovery tag the renderer just wrote. _patch_one's
+    # preservation check would refuse this write because env-recovery
+    # is itself authoritative; the restore is the one place that
+    # legitimately replaces one authoritative tag with another.
+    try:
+        body = s3.get_object(Bucket=bucket, Key=meta_key)["Body"].read()
+        meta = json.loads(body)
+        meta["url_source"] = preserved_url_source
+        new_body = json.dumps(meta, separators=(",", ":")).encode("utf-8")
+        s3.put_object(
+            Bucket=bucket, Key=meta_key, Body=new_body,
+            ContentType="application/json; charset=utf-8",
+        )
+        return True, f"re-rendered ({last}) · url_source restored: {preserved_url_source}"
+    except Exception as e:
+        return True, (
+            f"re-rendered ({last}) · WARN: url_source restore failed: {e} "
+            f"(was {preserved_url_source}, now env-recovery)"
+        )
 
 
 def _patch_one(
@@ -854,7 +906,7 @@ def main(argv: list[str] | None = None) -> int:
             _stderr(f"  patch FAIL · {detail}")
             continue
         if args.rerender:
-            r_success, r_detail = _rerender_one(sid, key_prefix, url)
+            r_success, r_detail = _rerender_one(s3, bucket, sid, key_prefix, url)
             if r_success:
                 rerender_ok += 1
                 _stderr(f"  rerender OK · {r_detail}")


### PR DESCRIPTION
Closes: n/a (briefing-039 Phase 4 — rerender preservation + v3-backfill driver; briefing 039 is the work tracker)

## Summary

Phase 4 of [briefing 039](https://github.com/coo-labs/coo-memory/blob/main/briefings/039-transcript-pipeline-robustness.md). Two changes that land together because the second uses the first:

1. **`_rerender_one` preserves AUTHORITATIVE `url_source`** across the rerender. The renderer's env-injection makes path-1 fire by construction, tagging every URL `env-recovery`. Without preservation, every rerender erases historical provenance (`html-extract`, `title-fast-path`, `export-meta-fallback`). Briefing 039 flagged this as *Critical*.

2. **New driver script** `scripts/transcript-rerender-v3-backfill.py` walks all populated-`session_url` sidecars under the `rendered/` prefix and calls `_rerender_one` for each. Defaults to `--dry-run` per briefing *Constraints*; `--apply` for the actual mutation pass.

## How preservation works

`_rerender_one(s3, bucket, sid, key_prefix, session_url)`:

1. **Before rerender** — GET sidecar; if existing `url_source` is in `AUTHORITATIVE_URL_SOURCES` and `!= "env-recovery"`, capture it.
2. **Renderer runs** — env-injects `CLAUDE_CODE_SESSION_ID` / `CLAUDE_CODE_REMOTE_SESSION_ID`; spawns the renderer subprocess; renderer's `compute_metadata` writes `url_source: env-recovery`.
3. **After rerender** — if captured, GET the freshly-written sidecar, set `url_source` back to the captured value, PUT. This is an **unconditional** write — `_patch_one`'s preservation check would refuse because env-recovery is itself authoritative; the rerender-restore is the one legitimate place that replaces one authoritative tag with another.

The decision boundary:

| existing `url_source` | rerender behavior |
|---|---|
| absent | renderer tags `env-recovery`; no restore |
| `env-recovery` | renderer tags `env-recovery` again; no restore (no-op) |
| `html-extract`, `title-fast-path`, `export-meta-fallback` | preserved across rerender |
| `scan-*` (RECONCILE_ELIGIBLE) | upgraded to `env-recovery` by the rerender (env-injection proves we have an authoritative URL) |

## Driver script

```
transcript-rerender-v3-backfill.py [--apply] [--key-prefix rendered]
                                   [--limit N]
                                   [--filter-renderer-version N]
```

Default behavior (no `--apply`): prints `sid<TAB>url` for every eligible sidecar and a summary line, exits 0. Operator reviews the diff, re-runs with `--apply` to actually re-render.

`--filter-renderer-version N` skips sidecars whose existing `renderer_version >= N`. Useful for partial reruns; default rerenders everything populated to also ensure the `url_source` tag lands on already-v3 sidecars (which lack it today because the renderer didn't write the field pre-Phase-2).

## Live dry-run summary (preview of what `--apply` will do)

Run against the production bucket just before this PR:

```
eligible=132   skipped_no_url=82   skipped_filtered=0
DRY-RUN summary: would rerender 132 sidecar(s).
```

(Of those 132: 28 are already at renderer_version=3 but lack `url_source`; 104 are pre-v3 and will pick up both the v3 schema fields and a `url_source` tag.)

Canary preservation behavior on the live data: **1 of 7 canary sids carries an existing `html-extract` tag** (`8d1808da-…`) — it will be captured, then restored after rerender. The other 6 canary sids have no existing `url_source`; they'll be tagged `env-recovery` by the rerender (correct first-time tag).

## Not in scope here

- The actual `--apply` run — gated on BDFL sign-off after this PR merges. Will run from main and report counts.
- Cohort-residual report on the 2× threshold (Phase 5).

## Briefing 039 known-bounds checked

- *"Critical after the url_source tagging change: the rerender must preserve any existing `url_source` field on the sidecar."* — addressed at the call site that knows the context. No renderer changes needed.
- *"Author hasn't verified that renderer-side `url_source` writing composes cleanly with `_compute_session_url`'s two-path lookup."* — verified earlier in Phase 2 PR; confirmed again here by reasoning: `_rerender_one` env-injects `CLAUDE_CODE_SESSION_ID` matching the target sid, so path-1 always fires and tags `env-recovery`. Path-2 never runs in the rerender context.

#1122

https://claude.ai/code/session_0146dWU8wPHNwLyNLLJLuTYL