### PR TITLE
ci(bootstrap-regression): wire test-auto-subscribe-pr.sh

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -126,3 +126,6 @@ jobs:
 
       - name: Identity digest — gap-warning contract (coo-memory#1069)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-digest-gap-warnings.sh"
+
+      - name: Auto-subscribe PR hook — matcher contract (wrapper + raw)
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/test-auto-subscribe-pr.sh"


### PR DESCRIPTION
## Summary

Follow-up to [#401](https://github.com/coo-labs/coo-harness/pull/401), which fixed the auto-subscribe-pr hook's matcher but couldn't include the workflow wiring because the OAuth that opened that PR lacks `workflow` scope. This PR is source-only and lands via the vade-coo App install token (committed through the Contents API).

Wires `scripts/ci/test-auto-subscribe-pr.sh` (added in #401) into `.github/workflows/bootstrap-regression.yml` alongside the other hook smoke tests (`test-skill-yaml-guard`, `test-digest-gap-warnings`, `test-session-idle-watchdog`).

## Why this matters

The hook in #401 was invisible-when-broken (always exits 0) for six days because nothing in CI exercised its matcher. The test exists and passes locally; this PR is the discipline pass that makes the regression actually unrepeatable.

## Diff

One step added to the `transcript-redaction` job:

```yaml
      - name: Auto-subscribe PR hook — matcher contract (wrapper + raw)
        run: bash "$GITHUB_WORKSPACE/scripts/ci/test-auto-subscribe-pr.sh"
```

Closes: n/a — discipline follow-up to #401 / #400.

https://claude.ai/code/session_014FwF1RGng8NxSdDxnc89Ry