### PR TITLE
feat(hooks): block Read on boot-digest-inlined files (#399)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -106,6 +106,15 @@
             "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/skill-yaml-guard.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/read-boot-inlined-guard.sh\""
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/scripts/ci/test-read-boot-inlined-guard.sh
+++ b/scripts/ci/test-read-boot-inlined-guard.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# test-read-boot-inlined-guard: smoke-test scripts/hooks/read-boot-inlined-guard.sh.
+#
+# Mirrors test-skill-yaml-guard.sh / test-bash-github-api-guard.sh:
+# pipe PreToolUse JSON envelopes into the hook, assert block / allow
+# per case.
+#
+# Run: bash scripts/ci/test-read-boot-inlined-guard.sh
+# Exit: 0 on all pass, 1 otherwise.
+#
+# Reference: coo-harness#399.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/read-boot-inlined-guard.sh"
+
+[ -x "$HOOK" ] || { echo "FAIL: hook not executable at $HOOK"; exit 1; }
+command -v jq >/dev/null || { echo "FAIL: jq required"; exit 1; }
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+# run_hook_read <file_path>
+run_hook_read() {
+  jq -n --arg fp "$1" \
+    '{tool_name: "Read", tool_input: {file_path: $fp}}' \
+    | "$HOOK" 2>/dev/null
+}
+
+# run_hook_raw <stdin-json>
+run_hook_raw() {
+  printf '%s' "$1" | "$HOOK" 2>/dev/null
+}
+
+assert_block() {
+  local name="$1" out="$2"
+  if printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  BLOCK: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("BLOCK: $name")
+    printf '  FAIL  BLOCK: %s\n' "$name"
+    printf '         hook output: %s\n' "${out:-<empty>}"
+  fi
+}
+
+assert_allow() {
+  local name="$1" out="$2"
+  if [ -z "$out" ] || ! printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  ALLOW: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("ALLOW: $name")
+    printf '  FAIL  ALLOW: %s\n' "$name"
+    printf '         hook output: %s\n' "$out"
+  fi
+}
+
+# --- Block cases: Read on the boot-inlined files ---
+
+printf 'Block cases (Read on boot-inlined paths):\n'
+
+assert_block "Read memo_index.json (absolute canonical path)" \
+  "$(run_hook_read /home/user/coo-memory/memos/memo_index.json)"
+
+assert_block "Read memo_index.json (relative path)" \
+  "$(run_hook_read coo-memory/memos/memo_index.json)"
+
+assert_block "Read memo_index.json (sibling-checkout path)" \
+  "$(run_hook_read /workspace/vade-coo-memory/memos/memo_index.json)"
+
+assert_block "Read identity_layer.md (absolute canonical path)" \
+  "$(run_hook_read /home/user/coo-memory/identity/identity_layer.md)"
+
+assert_block "Read identity_layer.md (relative path)" \
+  "$(run_hook_read coo-memory/identity/identity_layer.md)"
+
+# --- Allow cases: Read on unrelated paths, or non-Read tools ---
+
+printf '\nAllow cases (Read on unrelated paths, or non-Read tools):\n'
+
+assert_allow "Read CLAUDE.md (not on the block list)" \
+  "$(run_hook_read /home/user/coo-memory/CLAUDE.md)"
+
+assert_allow "Read a specific memo file (not the index)" \
+  "$(run_hook_read /home/user/coo-memory/memos/2026-05-31-jhp5.md)"
+
+assert_allow "Read an identity file other than identity_layer.md" \
+  "$(run_hook_read /home/user/coo-memory/identity/governance.md)"
+
+assert_allow "Read an unrelated JSON file with similar name" \
+  "$(run_hook_read /home/user/coo-memory/briefings/briefing_index.json)"
+
+assert_allow "Read a file whose path contains the substring but not the tail" \
+  "$(run_hook_read /home/user/coo-memory/memos/memo_index.json.bak)"
+
+# Tool-name discrimination: Edit / Write / Bash on the same paths must pass.
+assert_allow "Edit on memo_index.json (committee revisions allowed)" \
+  "$(run_hook_raw '{"tool_name":"Edit","tool_input":{"file_path":"/home/user/coo-memory/memos/memo_index.json","old_string":"x","new_string":"y"}}')"
+
+assert_allow "Write on identity_layer.md (committee revisions allowed)" \
+  "$(run_hook_raw '{"tool_name":"Write","tool_input":{"file_path":"/home/user/coo-memory/identity/identity_layer.md","content":"..."}}')"
+
+assert_allow "Bash on a command that touches memo_index.json (jq/cat escape hatch)" \
+  "$(run_hook_raw '{"tool_name":"Bash","tool_input":{"command":"jq . /home/user/coo-memory/memos/memo_index.json"}}')"
+
+# --- Malformed / empty envelope safety ---
+
+printf '\nSafety cases:\n'
+
+assert_allow "empty stdin" \
+  "$(run_hook_raw '')"
+
+assert_allow "malformed JSON stdin" \
+  "$(run_hook_raw 'not json')"
+
+assert_allow "Read envelope with no file_path" \
+  "$(run_hook_raw '{"tool_name":"Read","tool_input":{}}')"
+
+assert_allow "unknown tool envelope" \
+  "$(run_hook_raw '{"tool_name":"Glob","tool_input":{"pattern":"**/memo_index.json"}}')"
+
+# --- Bypass env var ---
+
+printf '\nBypass cases:\n'
+
+bypass_out="$(VADE_BOOT_INLINED_READ_GUARD_BYPASS=1 run_hook_read /home/user/coo-memory/memos/memo_index.json)"
+assert_allow "VADE_BOOT_INLINED_READ_GUARD_BYPASS=1 allows blocked Read (memo_index)" \
+  "$bypass_out"
+
+bypass_out="$(VADE_BOOT_INLINED_READ_GUARD_BYPASS=1 run_hook_read /home/user/coo-memory/identity/identity_layer.md)"
+assert_allow "VADE_BOOT_INLINED_READ_GUARD_BYPASS=1 allows blocked Read (identity_layer)" \
+  "$bypass_out"
+
+# --- Block-reason content sanity check ---
+
+printf '\nBlock-reason content:\n'
+
+memo_out="$(run_hook_read /home/user/coo-memory/memos/memo_index.json)"
+if printf '%s' "$memo_out" | jq -e '.reason | contains("read-boot-inlined-guard") and contains("jq") and contains("/memo-query") and contains("VADE_BOOT_INLINED_READ_GUARD_BYPASS")' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  memo_index reason names hook, jq escape, /memo-query, and bypass\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("REASON memo_index content")
+  printf '  FAIL  memo_index reason content missing expected fragments\n'
+  printf '         reason: %s\n' "$(printf '%s' "$memo_out" | jq -r '.reason')"
+fi
+
+ident_out="$(run_hook_read /home/user/coo-memory/identity/identity_layer.md)"
+if printf '%s' "$ident_out" | jq -e '.reason | contains("read-boot-inlined-guard") and contains("CB-") and contains("cat") and contains("VADE_BOOT_INLINED_READ_GUARD_BYPASS")' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  identity_layer reason names hook, CB-* surface, cat escape, and bypass\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("REASON identity_layer content")
+  printf '  FAIL  identity_layer reason content missing expected fragments\n'
+  printf '         reason: %s\n' "$(printf '%s' "$ident_out" | jq -r '.reason')"
+fi
+
+# --- Summary ---
+
+printf '\nTotal: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/hooks/read-boot-inlined-guard.sh
+++ b/scripts/hooks/read-boot-inlined-guard.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# PreToolUse Read hook: refuse Read on files already inlined by the
+# SessionStart `coo-identity-digest`. Reading them duplicates context
+# the boot banner already surfaced.
+#
+# Why: When CLAUDE.md documented "don't Read this" / "only Read if
+# truncated" in prose, models reasoned about whether-to-read on each
+# call and sometimes got it wrong — wasted-cycles tax that compounds
+# across the session. Per the coo-memory#1133 trim review:
+#
+#   > "this is now in the digest and models have to reason to skip it,
+#     ending up skipping other files. remove" (identity_layer.md)
+#   > "don't tell what not to read. block reading via hook such that
+#     models don't even try" (memo_index.json)
+#
+# The hook route is structural: Read just refuses, the message names
+# the escape hatch, the agent's next move is the right one.
+#
+# Contract: reads Claude Code's PreToolUse JSON on stdin,
+#   { "tool_name": "Read", "tool_input": { "file_path": "..." } }
+# Always exits 0. To block, emits
+#   { "decision": "block", "reason": "..." }
+# on stdout. To allow, emits nothing.
+#
+# Path matching: tail-suffix match on `file_path` against known
+# boot-surfaced files. We don't canonicalize — the canonical paths
+# live under `*/coo-memory/{memos,identity}/...` and a suffix match
+# catches direct paths from any sibling-checkout location without
+# stat-ing the filesystem.
+#
+# Blocked paths:
+#   - */memos/memo_index.json
+#     Flat JSON, ≳25K tokens, regenerated each container epoch from
+#     memos/*.md by the `memo-index` SessionStart hook. 10-most-recent
+#     in digest; deeper slices via `jq` per operations/memo-access.md.
+#   - */identity/identity_layer.md
+#     Fully inlined in the digest's "Identity layer (CB-*/OG-*)" block.
+#     If genuinely truncated, force-read via `cat` from Bash.
+#
+# Scope: Read only. Edit / Write / Bash all pass through — committee
+# revisions, /memo-sync regenerations, and `jq`/`cat` queries against
+# the same files remain unblocked.
+#
+# Bypass: VADE_BOOT_INLINED_READ_GUARD_BYPASS=1 → unconditionally allow.
+#
+# Reference: coo-harness#399; coo-memory#1133.
+
+set -uo pipefail
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && exit 0
+
+if [ "${VADE_BOOT_INLINED_READ_GUARD_BYPASS:-}" = "1" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null || true)"
+[ "$tool_name" = "Read" ] || exit 0
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)"
+[ -z "$file_path" ] && exit 0
+
+reason=""
+case "$file_path" in
+  */memos/memo_index.json)
+    reason="[read-boot-inlined-guard] memos/memo_index.json is regenerated each container epoch from memos/*.md and the 10-most-recent slice is already in the boot digest's \"Latest memos\" block. The full file is ≳25K tokens — Read would dump it into context unnecessarily.
+
+Use one of:
+  - \`jq '...' memos/memo_index.json\` from a Bash call for deeper slices (schema: operations/memo-access.md).
+  - \`/memo-query <term>\` for literal keyword lookup.
+  - \`/memo-query --semantic \"<query>\"\` for concept search.
+
+Edit/Write are unblocked — /memo-sync regenerations and manual fixes still work.
+
+Bypass for a deliberate diagnostic: prefix \`VADE_BOOT_INLINED_READ_GUARD_BYPASS=1\`. See coo-harness#399."
+    ;;
+  */identity/identity_layer.md)
+    reason="[read-boot-inlined-guard] identity/identity_layer.md is fully inlined in the SessionStart digest's \"Identity layer (CB-*/OG-*)\" block — every CB-* belief and OG-* goal is already in your context. Read would duplicate it.
+
+If the digest was genuinely truncated this session, force-read via:
+  cat /home/user/coo-memory/identity/identity_layer.md
+
+Edit/Write are unblocked — committee revisions and citation updates still work normally.
+
+Bypass for a deliberate diagnostic: prefix \`VADE_BOOT_INLINED_READ_GUARD_BYPASS=1\`. See coo-harness#399."
+    ;;
+esac
+
+[ -z "$reason" ] && exit 0
+
+jq -n --arg reason "$reason" '{
+  decision: "block",
+  reason: $reason
+}'
+exit 0


### PR DESCRIPTION
Closes #399.

## What

Adds a PreToolUse Read hook (`scripts/hooks/read-boot-inlined-guard.sh`) that refuses to load the two files already fully inlined by the SessionStart `coo-identity-digest`:

| File | Why blocked |
|---|---|
| `memos/memo_index.json` | ≳25K tokens, flat JSON, regenerated each container epoch by the `memo-index` SessionStart hook. The 10-most-recent slice is in the digest's "Latest memos" block; deeper slices go through `jq` per `operations/memo-access.md`. |
| `identity/identity_layer.md` | Fully inlined in the digest's "Identity layer (CB-*/OG-*)" block. Every CB-* belief and OG-* goal already lands in the agent's context at boot. |

## Why structural, not documentation

The prior route was CLAUDE.md prose ("only Read if truncated", "don't Read this — ≳25K tokens"). Per the coo-memory#1133 trim review by Ven:

> "this is now in the digest and models have to reason to skip it, ending up skipping other files. remove" — on `identity/identity_layer.md`

> "don't tell what not to read. block reading via hook such that models doesn't even try" — on `memos/memo_index.json`

The documentation route makes models reason about whether-to-read on every call and sometimes get it wrong; the wasted-cycles tax compounds. The hook route is structural — Read refuses, the message names the escape hatch (`jq … memos/memo_index.json`, `cat /home/user/coo-memory/identity/identity_layer.md`, `/memo-query`), and the agent's next move is the right one. Pattern parity with `agent-model-guard.sh` (refuses silent-Haiku) and `bash-github-api-guard.sh` (refuses raw curl to api.github.com).

## Scope

- **Read only.** Edit / Write / Bash all pass through. Committee revisions of `identity_layer.md`, `/memo-sync` regenerations of `memo_index.json`, and `jq` / `cat` queries against either file remain unblocked.
- **Sub-agents inherit.** PreToolUse hooks apply to sub-agent tool calls too — the parallel-instance protocol's "forbid re-Reading enumerated files" rule becomes structurally enforced for these two.
- **Tail-match on `file_path`.** `*/memos/memo_index.json` and `*/identity/identity_layer.md`. Catches any sibling-checkout layout without stat-ing the filesystem.

## Bypass

`VADE_BOOT_INLINED_READ_GUARD_BYPASS=1` → unconditionally allow. Matches the convention of the other PreToolUse hooks. For deliberate diagnostics only.

## Deliberate non-decisions (issue's "other candidates" question)

The issue asks: what else could get the same treatment?

- **`CLAUDE.md`** — already loaded by harness memory and symlinked from `/home/user/CLAUDE.md`. Accidental re-reads are rare (most agents don't try to load it directly), and blocking would interfere with the edit-then-verify flow on the file itself. **Deferred — re-evaluate if we observe an actual re-read pattern.**
- **`briefings/briefing_index.json`** — 32K, borderline by size. But the digest surfaces only *open* briefings; agents may legitimately want to query closed or full-set briefings without going through per-file Reads. **Deferred — the cost-of-block exceeds the cost-of-occasional-duplicate-load for now.**
- **Lineage `README.md` files** — issue notes these are probably not block candidates (legitimate reads when working in a specific lineage event). **Not in scope.**

If a future trim review shows another file that fits the "fully inlined in digest, agents wastefully re-read it" pattern, the hook is a one-line array addition in the `case` statement.

## Testing

`scripts/ci/test-read-boot-inlined-guard.sh` — 21 cases, all pass locally:

```
Block cases (Read on boot-inlined paths):                      5/5 pass
Allow cases (Read on unrelated paths / non-Read tools):        8/8 pass
Safety cases (empty / malformed / unknown):                    4/4 pass
Bypass cases (VADE_BOOT_INLINED_READ_GUARD_BYPASS=1):          2/2 pass
Block-reason content (hook name, escape hatch, bypass named):  2/2 pass
```

Matches the local-invocation pattern of `test-skill-yaml-guard.sh`, `test-bash-token-guard.sh`, `test-bash-github-api-guard.sh` (none of which are wired into the bootstrap-regression workflow either — that's a separate question, deferred to keep this PR scoped).

## Verification

In-session verification isn't possible — this session was started with the old `.claude/settings.json`. The hook becomes live on the next container boot when `session-start-sync.sh` copies the updated `settings.json` into `/home/user/.claude/settings.json`. Smoke test from a fresh session:

```sh
# Should block with the named escape-hatch message
Read('/home/user/coo-memory/memos/memo_index.json')

# Should still work (different file, same parent dir)
Read('/home/user/coo-memory/memos/2026-05-31-jhp5.md')

# Should still work (Edit, not Read)
Edit('/home/user/coo-memory/identity/identity_layer.md', ...)
```

CI: `bootstrap-regression.yml` will run on this PR (touches `scripts/` and `.claude/`). It verifies `settings.json` parses, the integrity-check still passes, and the boot pipeline stays green.

## Files

- `scripts/hooks/read-boot-inlined-guard.sh` — the hook (new, +101 lines).
- `scripts/ci/test-read-boot-inlined-guard.sh` — local-invocation test suite (new, +169 lines).
- `.claude/settings.json` — registers the hook under `PreToolUse` with matcher `Read` (+9 lines).

https://claude.ai/code/session_01XM4NGFGBQ3rpEfe3juZQQD