### PR TITLE
settings: deny 4 claude.ai connectors via deniedMcpServers (corrects #397)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -305,5 +305,11 @@
       "mcp__github__enable_pr_auto_merge",
       "mcp__github__disable_pr_auto_merge"
     ]
-  }
+  },
+  "deniedMcpServers": [
+    { "serverName": "2512c95b-4f21-45f0-9cfe-4bbb781d5d96" },
+    { "serverName": "67828e51-7e81-47d2-af54-52c28c902662" },
+    { "serverName": "90cea781-9b8c-43e1-9536-8a68c9936159" },
+    { "serverName": "caac47f1-f6fd-4492-9383-132f4ad16a8f" }
+  ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -309,7 +309,6 @@
   "deniedMcpServers": [
     { "serverName": "2512c95b-4f21-45f0-9cfe-4bbb781d5d96" },
     { "serverName": "67828e51-7e81-47d2-af54-52c28c902662" },
-    { "serverName": "90cea781-9b8c-43e1-9536-8a68c9936159" },
-    { "serverName": "caac47f1-f6fd-4492-9383-132f4ad16a8f" }
+    { "serverName": "90cea781-9b8c-43e1-9536-8a68c9936159" }
   ]
 }


### PR DESCRIPTION
Closes: n/a (corrective follow-up to #397)

## What

Adds top-level `deniedMcpServers` to `.claude/settings.json` matching 3 claude.ai connectors by their per-account `toolbox_mcp_server_id` UUIDs:

| UUID | Connector |
|---|---|
| `2512c95b-4f21-45f0-9cfe-4bbb781d5d96` | Composio |
| `67828e51-7e81-47d2-af54-52c28c902662` | Heptabase |
| `90cea781-9b8c-43e1-9536-8a68c9936159` | Google Calendar |

vade-app OAuth (`caac47f1-...`) retained as load-bearing.

Per [code.claude.com/docs/en/managed-mcp.md](https://code.claude.com/docs/en/managed-mcp.md), denylisted servers "silently disappear from `/mcp` and `claude mcp list`" — never load, no tools, no deferred-tool-listing tokens.

## Why

The previous change (#397) set `ENABLE_CLAUDEAI_MCP_SERVERS=false`, but that env var is documented as **local-CLI-only**. In Claude Code on the web sessions, the cloud orchestrator writes `/tmp/mcp-config-cse_*.json` with explicit connector entries *before* Claude Code reads the env var — so the env var is inert in cloud, which is where the entire ~22k-token cost lives. The original mechanism check was a docs lookup, not a runtime verification; a fresh session showed all 4 connectors still loaded.

`deniedMcpServers` is the correct mechanism. It lives in any settings file, filters at server-load time, and survives the cloud orchestrator's injection path because filtering is process-side.

`ENABLE_CLAUDEAI_MCP_SERVERS=false` is kept as defense-in-depth for any future local-CLI invocations.

## Known brittleness

The match is by `serverName` (UUID exact). UUIDs are likely stable per claude.ai connector installation but will change if a connector is disconnected → reconnected in the claude.ai UI. If that happens the denylist silently goes stale and the connector reappears. Address later if needed (belt-and-suspenders with `serverUrl` wildcards is the obvious next step).

## Test plan

In a fresh session: confirm `mcp__2512c95b...`, `mcp__67828e51...`, and `mcp__90cea781...` tool prefixes do NOT appear in the deferred tool list at SessionStart. `mcp__caac47f1...` (vade-app), `gh`, `mem0`, `agentmail`, `1password` should remain.

## Follow-up

Memo revision (supersede `MEMO-2026-05-31-jhp5` with corrected mechanism + scope) in coo-labs/coo-memory#1141.

https://claude.ai/code/session_0117593LJEuDATdGhYTwjKyy