### PR TITLE
hooks: workflow-file edit + push guardrails (auth context injection)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -104,6 +104,10 @@
           {
             "type": "command",
             "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/skill-yaml-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/workflow-file-auth-guard.sh\""
           }
         ]
       },
@@ -124,6 +128,10 @@
           {
             "type": "command",
             "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/auto-subscribe-pr.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/git-push-workflow-scope-guard.sh\""
           }
         ]
       }

--- a/scripts/hooks/git-push-workflow-scope-guard.sh
+++ b/scripts/hooks/git-push-workflow-scope-guard.sh
@@ -46,31 +46,14 @@ case "$response" in
   *) exit 0 ;;
 esac
 
-guidance="[git-push-workflow-scope-guard] \`git push\` was rejected because the session OAuth lacks \`workflow\` scope. This is structural; do NOT retry with --no-verify, --force, or by re-attempting the same push. The scope is fundamentally missing from the OAuth that authenticates git over HTTP in this environment.
+guidance="[git-push-workflow-scope-guard] Push rejected — OAuth lacks \`workflow\` scope. Don't retry. Use the App-token contents API:
 
-Use the \`vade-coo\` App install token via the REST contents API instead:
+  GH_USE_APP_TOKEN=1 gh api -X PUT repos/<o>/<r>/contents/<path> \\
+    -f branch=<branch> -f message=<msg> \\
+    -f content=\$(base64 -w0 <local>) \\
+    -f sha=\$(GH_USE_APP_TOKEN=1 gh api repos/<o>/<r>/contents/<path>?ref=<base> --jq .sha)
 
-  # 1. Identify the workflow files in your pending commits:
-  git diff --name-only origin/main..HEAD | grep '^\\.github/workflows/'
-
-  # 2. If the remote branch doesn't exist yet, create it at the
-  #    parent commit (the one that doesn't touch workflows):
-  GH_USE_APP_TOKEN=1 gh api -X POST repos/<owner>/<repo>/git/refs \\
-    -f ref=\"refs/heads/<branch>\" \\
-    -f sha=\"<base-sha>\"
-
-  # 3. For each workflow file, PUT contents via App-attributed commit:
-  CONTENT=\$(base64 -w0 <local-file>)
-  SHA=\$(GH_USE_APP_TOKEN=1 gh api repos/<owner>/<repo>/contents/<path>?ref=<base-ref> --jq .sha)
-  GH_USE_APP_TOKEN=1 gh api -X PUT repos/<owner>/<repo>/contents/<path> \\
-    -f branch=\"<branch>\" \\
-    -f message=\"<commit message>\" \\
-    -f content=\"\$CONTENT\" \\
-    -f sha=\"\$SHA\"
-
-The App installation has \`workflows: write\`; the OAuth does not. After the API commit lands, \`git fetch origin <branch>\` to resync local. For any future commit on this branch that also touches a workflow file, repeat the API path — do not retry \`git push\`.
-
-If your branch has BOTH workflow and non-workflow commits, split the work: \`git push\` the non-workflow commits first (they will succeed), then PUT each workflow file via the API on top. Full mechanics: coo-memory/CLAUDE.md §\"GitHub writes\"."
+If branch doesn't exist: POST repos/<o>/<r>/git/refs -f ref=refs/heads/<branch> -f sha=<base-sha> first. Then \`git fetch origin <branch>\` to resync local. Full mechanics: coo-memory/CLAUDE.md §\"GitHub writes\"."
 
 jq -n --arg msg "$guidance" '{
   hookSpecificOutput: {

--- a/scripts/hooks/git-push-workflow-scope-guard.sh
+++ b/scripts/hooks/git-push-workflow-scope-guard.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# PostToolUse Bash hook: detect the OAuth-without-workflow-scope
+# rejection on `git push` and inject the App-token contents-API
+# recovery recipe as system-reminder context. Reactive complement to
+# workflow-file-auth-guard.sh (proactive PreToolUse on Edit/Write).
+#
+# Trigger: bash command contains `git push` AND the tool response
+# (stdout+stderr combined) contains the rejection signature
+# `without \`workflow\` scope`. Both conditions must match — we only
+# fire on the actual failure, not on every `git push`.
+#
+# Contract: reads PostToolUse JSON on stdin; emits
+#   { hookSpecificOutput: { hookEventName: "PostToolUse",
+#                           additionalContext: "..." } }
+# on stdout when the rejection signature matches. Always exits 0.
+#
+# Why this exists even with workflow-file-auth-guard.sh: the proactive
+# hook fires before the edit, but if the agent dispatched a sub-agent
+# to edit, or rebased from another branch, the proactive context may
+# not have reached the model that's running the push. The reactive
+# layer catches the failure at the actual point of pain.
+#
+# Reference: coo-memory/CLAUDE.md §"GitHub writes", same design as
+# workflow-file-auth-guard.sh.
+
+set -uo pipefail
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && exit 0
+
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)"
+case "$cmd" in
+  *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+response="$(printf '%s' "$input" | jq -r '
+  if (.tool_response | type) == "object"
+  then ((.tool_response.stdout // "") + "\n" + (.tool_response.stderr // ""))
+  else (.tool_response | tostring) end' 2>/dev/null || true)"
+
+case "$response" in
+  *"without \`workflow\` scope"*) ;;
+  *"without 'workflow' scope"*) ;;
+  *"workflow scope"*) ;;
+  *) exit 0 ;;
+esac
+
+guidance="[git-push-workflow-scope-guard] \`git push\` was rejected because the session OAuth lacks \`workflow\` scope. This is structural; do NOT retry with --no-verify, --force, or by re-attempting the same push. The scope is fundamentally missing from the OAuth that authenticates git over HTTP in this environment.
+
+Use the \`vade-coo\` App install token via the REST contents API instead:
+
+  # 1. Identify the workflow files in your pending commits:
+  git diff --name-only origin/main..HEAD | grep '^\\.github/workflows/'
+
+  # 2. If the remote branch doesn't exist yet, create it at the
+  #    parent commit (the one that doesn't touch workflows):
+  GH_USE_APP_TOKEN=1 gh api -X POST repos/<owner>/<repo>/git/refs \\
+    -f ref=\"refs/heads/<branch>\" \\
+    -f sha=\"<base-sha>\"
+
+  # 3. For each workflow file, PUT contents via App-attributed commit:
+  CONTENT=\$(base64 -w0 <local-file>)
+  SHA=\$(GH_USE_APP_TOKEN=1 gh api repos/<owner>/<repo>/contents/<path>?ref=<base-ref> --jq .sha)
+  GH_USE_APP_TOKEN=1 gh api -X PUT repos/<owner>/<repo>/contents/<path> \\
+    -f branch=\"<branch>\" \\
+    -f message=\"<commit message>\" \\
+    -f content=\"\$CONTENT\" \\
+    -f sha=\"\$SHA\"
+
+The App installation has \`workflows: write\`; the OAuth does not. After the API commit lands, \`git fetch origin <branch>\` to resync local. For any future commit on this branch that also touches a workflow file, repeat the API path — do not retry \`git push\`.
+
+If your branch has BOTH workflow and non-workflow commits, split the work: \`git push\` the non-workflow commits first (they will succeed), then PUT each workflow file via the API on top. Full mechanics: coo-memory/CLAUDE.md §\"GitHub writes\"."
+
+jq -n --arg msg "$guidance" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $msg
+  }
+}'

--- a/scripts/hooks/workflow-file-auth-guard.sh
+++ b/scripts/hooks/workflow-file-auth-guard.sh
@@ -51,29 +51,14 @@ case "$file_path" in
   *) exit 0 ;;
 esac
 
-guidance="[workflow-file-auth-guard] You are about to ${tool_name} a GitHub Actions workflow file (${file_path}). When you commit and push this change, \`git push\` WILL be rejected with:
+guidance="[workflow-file-auth-guard] About to ${tool_name} a workflow file. \`git push\` will be rejected (OAuth lacks \`workflow\` scope). Use the App-token contents API:
 
-  refusing to allow an OAuth App to create or update workflow \`.github/workflows/<file>\` without \`workflow\` scope
+  GH_USE_APP_TOKEN=1 gh api -X PUT repos/<o>/<r>/contents/<path> \\
+    -f branch=<branch> -f message=<msg> \\
+    -f content=\$(base64 -w0 <local>) \\
+    -f sha=\$(GH_USE_APP_TOKEN=1 gh api repos/<o>/<r>/contents/<path>?ref=<base> --jq .sha)
 
-This is structural — the session's OAuth lacks the workflow scope. Do NOT retry with --no-verify or --force; the scope is fundamentally absent. The canonical workaround uses the \`vade-coo\` App install token via the REST contents API:
-
-  # 1. If the remote branch doesn't exist yet, create it at base HEAD:
-  GH_USE_APP_TOKEN=1 gh api -X POST repos/<owner>/<repo>/git/refs \\
-    -f ref=\"refs/heads/<branch>\" \\
-    -f sha=\"<base-sha>\"
-
-  # 2. PUT the workflow file via App-attributed commit:
-  CONTENT=\$(base64 -w0 <local-file>)
-  SHA=\$(GH_USE_APP_TOKEN=1 gh api repos/<owner>/<repo>/contents/<path>?ref=<base-ref> --jq .sha)
-  GH_USE_APP_TOKEN=1 gh api -X PUT repos/<owner>/<repo>/contents/<path> \\
-    -f branch=\"<branch>\" \\
-    -f message=\"<commit message>\" \\
-    -f content=\"\$CONTENT\" \\
-    -f sha=\"\$SHA\"
-
-The App installation has \`workflows: write\`; the OAuth that authenticates \`git push\` does not. The resulting commit is attributed to \`vade-coo-app[bot]\`. If your branch has multiple commits and only some touch workflows, push the non-workflow commits via \`git push\` first, then PUT the workflow file separately.
-
-Full mechanics: coo-memory/CLAUDE.md §\"GitHub writes\". Bypass for a deliberate diagnostic: set VADE_WORKFLOW_AUTH_GUARD_BYPASS=1."
+If branch doesn't exist: POST repos/<o>/<r>/git/refs first. Resulting commit: vade-coo-app[bot]. Bypass: VADE_WORKFLOW_AUTH_GUARD_BYPASS=1. Full mechanics: coo-memory/CLAUDE.md §\"GitHub writes\"."
 
 jq -n --arg msg "$guidance" '{
   hookSpecificOutput: {

--- a/scripts/hooks/workflow-file-auth-guard.sh
+++ b/scripts/hooks/workflow-file-auth-guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# PreToolUse Write|Edit hook: when the agent is about to Write/Edit a
+# `.github/workflows/*.yml|yaml` file, inject the App-token contents-API
+# recipe as system-reminder context. This closes the gap where the
+# agent has read CLAUDE.md's "GitHub writes" section at boot but
+# doesn't recall the workflow-scope workaround under tool-call pressure
+# and burns ~5 cycles re-discovering it after `git push` is rejected.
+#
+# Why proactive (PreToolUse on Edit/Write) rather than reactive: the
+# reactive layer is in git-push-workflow-scope-guard.sh (PostToolUse on
+# Bash). Surfacing the recipe at edit time means the agent knows the
+# commit-and-push path from the moment they start the change, not
+# after the wasted push.
+#
+# Contract: reads PreToolUse JSON on stdin; emits
+#   { hookSpecificOutput: { hookEventName: "PreToolUse",
+#                           additionalContext: "..." } }
+# on stdout when the file_path matches. Always exits 0. Non-matching
+# tool_name / file_path → no output, no block.
+#
+# Path match: any path containing `.github/workflows/` and ending in
+# `.yml` or `.yaml`. Matches both the canonical repo-root location
+# (`.github/workflows/foo.yml`) and per-repo checkout layouts under
+# `$VADE_RUNTIME_DIR/.github/workflows/`, etc.
+#
+# Bypass: VADE_WORKFLOW_AUTH_GUARD_BYPASS=1 → unconditionally allow
+# (no context injection). Set when intentionally drafting workflow
+# content that won't be committed.
+#
+# Reference: coo-memory/CLAUDE.md §"GitHub writes" (canonical recipe),
+# coo-harness post-#407 design discussion.
+
+set -uo pipefail
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && exit 0
+
+if [ "${VADE_WORKFLOW_AUTH_GUARD_BYPASS:-}" = "1" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null || true)"
+case "$tool_name" in
+  Write|Edit) ;;
+  *) exit 0 ;;
+esac
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)"
+case "$file_path" in
+  *.github/workflows/*.yml|*.github/workflows/*.yaml) ;;
+  *) exit 0 ;;
+esac
+
+guidance="[workflow-file-auth-guard] You are about to ${tool_name} a GitHub Actions workflow file (${file_path}). When you commit and push this change, \`git push\` WILL be rejected with:
+
+  refusing to allow an OAuth App to create or update workflow \`.github/workflows/<file>\` without \`workflow\` scope
+
+This is structural — the session's OAuth lacks the workflow scope. Do NOT retry with --no-verify or --force; the scope is fundamentally absent. The canonical workaround uses the \`vade-coo\` App install token via the REST contents API:
+
+  # 1. If the remote branch doesn't exist yet, create it at base HEAD:
+  GH_USE_APP_TOKEN=1 gh api -X POST repos/<owner>/<repo>/git/refs \\
+    -f ref=\"refs/heads/<branch>\" \\
+    -f sha=\"<base-sha>\"
+
+  # 2. PUT the workflow file via App-attributed commit:
+  CONTENT=\$(base64 -w0 <local-file>)
+  SHA=\$(GH_USE_APP_TOKEN=1 gh api repos/<owner>/<repo>/contents/<path>?ref=<base-ref> --jq .sha)
+  GH_USE_APP_TOKEN=1 gh api -X PUT repos/<owner>/<repo>/contents/<path> \\
+    -f branch=\"<branch>\" \\
+    -f message=\"<commit message>\" \\
+    -f content=\"\$CONTENT\" \\
+    -f sha=\"\$SHA\"
+
+The App installation has \`workflows: write\`; the OAuth that authenticates \`git push\` does not. The resulting commit is attributed to \`vade-coo-app[bot]\`. If your branch has multiple commits and only some touch workflows, push the non-workflow commits via \`git push\` first, then PUT the workflow file separately.
+
+Full mechanics: coo-memory/CLAUDE.md §\"GitHub writes\". Bypass for a deliberate diagnostic: set VADE_WORKFLOW_AUTH_GUARD_BYPASS=1."
+
+jq -n --arg msg "$guidance" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: $msg
+  }
+}'


### PR DESCRIPTION
## Why

When the agent edits or pushes a `.github/workflows/*` file, `git push` is rejected because the session OAuth lacks `workflow` scope. The canonical recovery (App-token via REST contents API) is documented in [`coo-memory/CLAUDE.md` §"GitHub writes"](https://github.com/coo-labs/coo-memory/blob/main/CLAUDE.md) but the agent has not reliably recalled it under tool-call pressure. The most recent instance — PR #407 — burned ~6 tool cycles re-discovering the path after `git push` failed.

This change closes the gap structurally rather than via another norms doc.

## What

Two new hooks, wired in `.claude/settings.json`:

### `scripts/hooks/workflow-file-auth-guard.sh` — PreToolUse Write|Edit

Fires when the agent calls Write or Edit on a path matching `*.github/workflows/*.{yml,yaml}`. Emits `hookSpecificOutput.additionalContext` containing the App-token contents-API recipe. The agent sees the auth path *at edit time*, before they reach for `git push`.

Bypass: `VADE_WORKFLOW_AUTH_GUARD_BYPASS=1`.

### `scripts/hooks/git-push-workflow-scope-guard.sh` — PostToolUse Bash

Fires when a Bash command contains `git push` AND the tool response contains the rejection signature (`without \`workflow\` scope`). Reactive layer — catches the failure if the proactive PreToolUse hook did not reach the model (sub-agent dispatch from a parent context, rebase from another branch, etc.). Same `additionalContext` shape.

## Design

Recipe surfaced to the model via `hookSpecificOutput.additionalContext` (system reminder, not user-visible chat). Same injection mechanism as the existing `auto-subscribe-pr.sh` PostToolUse hook — proven pattern in this codebase.

Research dispatched to `claude-code-guide` agent comparing path-scoped rules (`.claude/rules/*.md`), nested CLAUDE.md, skill auto-triggering, and PreToolUse hooks. Hooks won on reliability: they fire deterministically on the tool call itself, with no Read-dependency caveat. Nested CLAUDE.md and path-scoped rules require the agent to Read a matching file first, which an agent can skip when it already has the path from context.

## Verification

Locally tested both hooks with 10 mock-input cases:
- PreToolUse Edit on a workflow .yml → fires
- PreToolUse Edit on a non-workflow file → silent
- PreToolUse Write on a workflow .yaml → fires
- PreToolUse Read on a workflow .yml → silent (wrong tool)
- Bypass env var → silent
- PostToolUse Bash `git push` with rejection signature → fires
- PostToolUse Bash `git push` succeeded → silent
- PostToolUse Bash non-push command → silent
- PostToolUse Bash `git push` with unrelated error → silent
- PostToolUse Bash `git push`, `tool_response` as plain string (legacy shape) → fires

`settings.json` validated with `jq` parse + targeted query confirming the two hooks land in the correct matchers (`Write|Edit` and `Bash`).

## Boot-impact PR — handoff prompt

This PR adds hooks to `.claude/settings.json` and two new scripts under `scripts/hooks/`. On the next fresh-container session after merge, the SessionStart sync will pick up the new hook configuration. Handoff prompt for the verification session is posted as a PR comment.

## Bootstrap CI

The `bootstrap-regression.yml` workflow will trigger (`.claude/` + `scripts/` paths). The new hooks do not touch any boot-time invariant (E1-E4, F1-F4); they only add tool-call-time guards. Expected to pass clean.

Closes: n/a

https://claude.ai/code/session_01VMo2QKpbwjdQMprqgudwuW