### PR TITLE
feat(coo-harness): gh-coo-wrap CI-read routing + bootstrap-regression fail-only comment

### DIFF
--- a/scripts/ci/post-or-update-pr-comment.sh
+++ b/scripts/ci/post-or-update-pr-comment.sh
@@ -1,28 +1,46 @@
 #!/usr/bin/env bash
-# Post or update the bootstrap-regression PR comment.
+# Post the bootstrap-regression PR comment ONLY when the suite fails;
+# delete any prior failure-comment when the suite passes.
 #
-# Identifies the prior comment by a magic header marker
-# ("<!-- bootstrap-regression-comment -->") emitted by render-integrity-summary.sh
-# so re-runs replace the previous comment instead of stacking duplicates.
+# Behavior matrix:
+#   pass + no prior comment   → silent, no PR write (no context bloat for
+#                                downstream agent sessions reading the PR).
+#   pass + prior fail-comment → delete the stale comment (auto-cleanup
+#                                after a fix lands).
+#   fail + no prior comment   → post new fail-comment.
+#   fail + prior comment      → update existing comment in place.
+#
+# Identifies prior comments by a magic header marker
+# ("<!-- bootstrap-regression-comment -->") emitted by
+# render-integrity-summary.sh so re-runs don't stack duplicates.
 #
 # Required env (set by the workflow step):
-#   GH_TOKEN         — token with issues:write
-#   PR               — pull request number
-#   REPO             — owner/name
+#   GH_TOKEN  — token with issues:write
+#   PR        — pull request number
+#   REPO      — owner/name
 # Optional env:
-#   VADE_CI_SUMMARY_OUT — path to the rendered markdown summary
+#   VADE_CI_SUMMARY_OUT  — path to the rendered markdown summary
+#                          (default /tmp/bootstrap-regression-summary.md)
+#   VADE_CI_RESULT_OUT   — path to the structured result.json
+#                          (default /tmp/bootstrap-regression-result.json,
+#                          mirrors run-bootstrap-regression.sh's default)
 set -euo pipefail
 
 SUMMARY="${VADE_CI_SUMMARY_OUT:-/tmp/bootstrap-regression-summary.md}"
+RESULT="${VADE_CI_RESULT_OUT:-/tmp/bootstrap-regression-result.json}"
 HEADER='<!-- bootstrap-regression-comment -->'
 
-if [ ! -f "$SUMMARY" ]; then
-  echo "[ci-bootstrap-regression] summary file missing at $SUMMARY; nothing to post" >&2
-  exit 0
-fi
 if [ -z "${PR:-}" ] || [ -z "${REPO:-}" ]; then
   echo "[ci-bootstrap-regression] PR or REPO unset; skipping comment" >&2
   exit 0
+fi
+
+# Determine pass/fail from result.json. If result.json is missing
+# (unexpected — would mean the suite aborted before the result step),
+# default to "fail" so the operator gets a comment instead of silence.
+OK="false"
+if [ -f "$RESULT" ]; then
+  OK="$(jq -r '.ok // false' "$RESULT")"
 fi
 
 EXISTING_ID="$(
@@ -31,16 +49,32 @@ EXISTING_ID="$(
     2>/dev/null | head -1 || true
 )"
 
+if [ "$OK" = "true" ]; then
+  if [ -n "$EXISTING_ID" ]; then
+    echo "[ci-bootstrap-regression] pass: deleting stale fail-comment $EXISTING_ID"
+    gh api --method DELETE "/repos/$REPO/issues/comments/$EXISTING_ID" >/dev/null
+  else
+    echo "[ci-bootstrap-regression] pass: no prior comment, nothing to post"
+  fi
+  exit 0
+fi
+
+# Fail path — post or update the sticky comment.
+if [ ! -f "$SUMMARY" ]; then
+  echo "[ci-bootstrap-regression] FAIL but summary file missing at $SUMMARY; cannot post" >&2
+  exit 0
+fi
+
 PAYLOAD="$(mktemp)"
 trap 'rm -f "$PAYLOAD"' EXIT
 jq -n --rawfile body "$SUMMARY" '{body: $body}' > "$PAYLOAD"
 
 if [ -n "$EXISTING_ID" ]; then
-  echo "[ci-bootstrap-regression] updating existing comment $EXISTING_ID"
+  echo "[ci-bootstrap-regression] fail: updating existing fail-comment $EXISTING_ID"
   gh api --method PATCH "/repos/$REPO/issues/comments/$EXISTING_ID" \
     --input "$PAYLOAD" >/dev/null
 else
-  echo "[ci-bootstrap-regression] posting new comment on PR #$PR"
+  echo "[ci-bootstrap-regression] fail: posting new fail-comment on PR #$PR"
   gh api --method POST "/repos/$REPO/issues/$PR/comments" \
     --input "$PAYLOAD" >/dev/null
 fi

--- a/scripts/ci/test-gh-coo-wrap.sh
+++ b/scripts/ci/test-gh-coo-wrap.sh
@@ -410,6 +410,100 @@ out="$(VADE_RUNTIME_DIR="/nonexistent-vade-runtime" \
 assert_contains "minter missing: warns" "$out" "minter not found"
 assert_contains "minter missing: falls back to MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
 
+# ============================================================
+# App-only-read auto-routes (coo-memory#1157).
+# ============================================================
+# CI / check-state / Actions read endpoints route to App. PAT can't be
+# granted Checks: Read (community#129512); App holds both Checks and
+# Commit statuses. GET-shape only — writes against the same surfaces
+# stay on the user PAT.
+
+printf '\nApp-only-read routing tests:\n'
+
+# --- check-runs / check-suites read ---
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/commits/abc123/check-runs)"
+assert_contains "check-runs (combined): App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api /repos/coo-labs/coo-memory/commits/abc123/check-runs)"
+assert_contains "check-runs leading slash: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/commits/abc123/check-suites)"
+assert_contains "check-suites: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/check-runs/12345)"
+assert_contains "check-runs by id: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/check-suites/678)"
+assert_contains "check-suites by id: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+# --- commit status read (combined + list) ---
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/commits/abc123/status)"
+assert_contains "commit status (combined): App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/commits/abc123/statuses)"
+assert_contains "commit statuses (list): App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+# --- Actions read ---
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/actions/runs)"
+assert_contains "actions/runs list: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/actions/runs/12345)"
+assert_contains "actions/runs by id: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/actions/runs/12345/logs)"
+assert_contains "actions/runs logs: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/actions/jobs/567)"
+assert_contains "actions/jobs by id: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/actions/jobs/567/logs)"
+assert_contains "actions/jobs logs: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/actions/workflows/9999/runs)"
+assert_contains "actions/workflows runs: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+# --- explicit GET method still auto-routes ---
+
+out="$("$WRAPPER" api -X GET repos/coo-labs/coo-memory/commits/abc/check-runs)"
+assert_contains "explicit -X GET check-runs: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+# --- writes against the same surfaces stay on user PAT ---
+
+out="$("$WRAPPER" api -X POST repos/coo-labs/coo-memory/check-runs/12345)"
+assert_contains "POST against check-runs: stays on MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+out="$("$WRAPPER" api -X PATCH repos/coo-labs/coo-memory/check-runs/12345)"
+assert_contains "PATCH against check-runs: stays on MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/commits/abc/statuses -f state=success)"
+assert_contains "POST status via -f: stays on MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/actions/runs/123/rerun -X POST)"
+assert_contains "POST actions/runs rerun: stays on MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# --- non-matching read paths stay on MCP_PAT (regression coverage) ---
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/issues/1)"
+assert_contains "non-matching read path: stays on MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+out="$("$WRAPPER" api repos/coo-labs/coo-memory/contents/README.md)"
+assert_contains "contents/ read: stays on MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
+# --- gh pr checks subcommand ---
+
+out="$("$WRAPPER" pr checks 1154)"
+assert_contains "gh pr checks: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+out="$("$WRAPPER" -R coo-labs/coo-memory pr checks 1154)"
+assert_contains "gh -R ... pr checks: App token" "$out" "GH_TOKEN=APP_TOKEN_TESTING"
+
+# Sanity: other pr subcommands don't accidentally trigger
+out="$("$WRAPPER" pr view 1154)"
+assert_contains "gh pr view: stays on MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
+
 printf '\n'
 printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"
 if [ "$FAIL" -gt 0 ]; then

--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -294,11 +294,122 @@ is_org_admin_api() {
   return 1
 }
 
+# is_app_only_read: returns 0 iff argv parses as `gh api <path>` where
+# <path> targets a Check-API, commit-status, or Actions surface AND the
+# request is GET-shaped (no -X POST/PATCH/PUT/DELETE, no -f/--field,
+# no --input). The fine-grained PAT cannot grant `Checks: Read` at all
+# (a permanent GitHub limitation — see coo-labs/coo-memory#1157 and
+# community#129512), and the substrate prefers to keep CI/check-state
+# reads on a single token route. Writes against these surfaces stay on
+# the user PAT to preserve the identity invariant — only reads auto-
+# route to the App.
+#
+# Matched patterns (read-only):
+#   repos/<o>/<r>/commits/<ref>/check-runs[/...]
+#   repos/<o>/<r>/commits/<ref>/check-suites[/...]
+#   repos/<o>/<r>/check-runs/<id>[/...]
+#   repos/<o>/<r>/check-suites/<id>[/...]
+#   repos/<o>/<r>/commits/<ref>/status
+#   repos/<o>/<r>/commits/<ref>/statuses
+#   repos/<o>/<r>/actions/runs[/...]
+#   repos/<o>/<r>/actions/jobs/<id>[/...]
+#   repos/<o>/<r>/actions/workflows/<id>/runs[/...]
+is_app_only_read() {
+  local sub=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --) shift ;;
+      --*=*) shift ;;
+      -R|--repo|--hostname) shift; [ $# -gt 0 ] && shift ;;
+      -*) shift ;;
+      *)
+        sub="$1"; shift; break ;;
+    esac
+  done
+  [ "$sub" = "api" ] || return 1
+
+  local method="GET" path=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -X|--method)
+        shift; [ $# -gt 0 ] && { method="$1"; shift; }
+        ;;
+      -X=*|--method=*)
+        method="${1#*=}"; shift
+        ;;
+      --input|-f|--field|-F|--raw-field)
+        # Non-GET shape: writes a body. Refuse auto-route.
+        return 1
+        ;;
+      --input=*|-f=*|--field=*|-F=*|--raw-field=*)
+        return 1
+        ;;
+      --*=*) shift ;;
+      --*|-*)
+        if __gh_valued_flag "$1"; then
+          shift; [ $# -gt 0 ] && shift
+        else
+          shift
+        fi
+        ;;
+      *)
+        path="${1#/}"
+        shift
+        ;;
+    esac
+  done
+
+  [ "$method" = "GET" ] || return 1
+  [ -n "$path" ] || return 1
+
+  case "$path" in
+    repos/*/*/commits/*/check-runs|repos/*/*/commits/*/check-runs/*) return 0 ;;
+    repos/*/*/commits/*/check-suites|repos/*/*/commits/*/check-suites/*) return 0 ;;
+    repos/*/*/check-runs/*) return 0 ;;
+    repos/*/*/check-suites/*) return 0 ;;
+    repos/*/*/commits/*/status|repos/*/*/commits/*/statuses) return 0 ;;
+    repos/*/*/actions/runs|repos/*/*/actions/runs/*) return 0 ;;
+    repos/*/*/actions/jobs/*) return 0 ;;
+    repos/*/*/actions/workflows/*/runs|repos/*/*/actions/workflows/*/runs/*) return 0 ;;
+  esac
+  return 1
+}
+
+# is_pr_checks: returns 0 iff argv parses as `gh pr checks ...`. The
+# subcommand calls the GraphQL `statusCheckRollup` field, which aggregates
+# both check-runs (App-only) and commit-statuses. Routing to the App
+# unblocks the rollup end-to-end; the App holds both `Checks: Read` and
+# `Commit statuses: Read`.
+is_pr_checks() {
+  local sub="" act=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --) shift ;;
+      --*=*) shift ;;
+      -R|--repo|--hostname) shift; [ $# -gt 0 ] && shift ;;
+      -*) shift ;;
+      *)
+        if [ -z "$sub" ]; then
+          sub="$1"; shift
+        else
+          act="$1"; break
+        fi
+        ;;
+    esac
+  done
+  [ "$sub" = "pr" ] && [ "$act" = "checks" ]
+}
+
 # Routing precedence:
 #   1. GH_USE_APP_TOKEN=1 → mint App token (explicit opt-in; for GraphQL).
-#   2. `gh api <org-admin-path>` → mint App token (auto).
-#   3. owner != coo-labs + GITHUB_PUBLIC_PAT → public PAT (cross-org).
-#   4. default → $GITHUB_MCP_PAT via gh's auth context (no override here).
+#   2. `gh api <org-admin-path>` → mint App token (auto, write).
+#   3. `gh api <check/status/actions read path>` → mint App token (auto,
+#      read-only; GET-shape only, see is_app_only_read). Closes the
+#      PAT-lacks-Checks-permission gap (coo-memory#1157).
+#   4. `gh pr checks ...` → mint App token (the GraphQL statusCheckRollup
+#      field aggregates both check-runs (App-only) and statuses).
+#   5. owner != coo-labs + GITHUB_PUBLIC_PAT → public PAT (cross-org).
+#   6. default → $GITHUB_MCP_PAT via gh's auth context (no override here).
 #
 # App-token routing is attempted only when GITHUB_APP_ID is set in env
 # (the boot-time signal that Phase 1 of coo-memory#837 has been
@@ -306,7 +417,7 @@ is_org_admin_api() {
 # to the cross-org branch and the org-admin call lands on the PAT — which
 # 403s with the same error class the App fixes. Failure mode is symmetric
 # with the pre-App state, not silently wrong.
-if [ -n "${GITHUB_APP_ID:-}" ] && { [ "${GH_USE_APP_TOKEN:-0}" = "1" ] || is_org_admin_api "$@"; }; then
+if [ -n "${GITHUB_APP_ID:-}" ] && { [ "${GH_USE_APP_TOKEN:-0}" = "1" ] || is_org_admin_api "$@" || is_app_only_read "$@" || is_pr_checks "$@"; }; then
   # The minter lives in coo-harness/scripts/, not next to this wrapper.
   # ensure_gh_coo_wrap (lib/common.sh) installs *only* gh-coo-wrap.sh to
   # ~/.local/bin/gh — the minter stays canonical at its repo path. Locate


### PR DESCRIPTION
## Why

This PR bundles two coo-harness changes that emerged from the same 2026-06-01 session investigating CI noise and routing gaps.

---

## Change 1 — gh-coo-wrap: auto-route CI/check-state reads to App token

The fine-grained PAT (`vade-coo-self-2026-04`) cannot be granted `Checks: Read` — it's a permanent GitHub limitation, documented in [community#129512](https://github.com/orgs/community/discussions/129512). Until today, that meant `gh pr checks`, `gh api .../check-runs`, and the Actions logs endpoints either silently 403'd or required the operator to remember the `GH_USE_APP_TOKEN=1` opt-in by hand.

This PR teaches the shim to auto-route those reads to the `vade-coo-app` installation token (same mechanism as the existing org-admin auto-route), so the agent never has to think about it. Identity invariant preserved: only reads route to the App; writes against the same surfaces stay on the user PAT.

Closes coo-labs/coo-memory#1157.

### What changed

Two helpers and one routing-precedence update in `scripts/gh-coo-wrap.sh`:

```
is_app_only_read  — gh api <path> for check-runs, check-suites,
                    commit status, Actions runs/jobs/workflows reads.
                    GET-shape only: -X POST/PATCH/PUT/DELETE or
                    -f/-F/--field/--input falls through to PAT.

is_pr_checks      — gh pr checks. The GraphQL statusCheckRollup
                    field aggregates check-runs (App-only) + statuses.
```

Updated routing precedence (was 4 layers, now 6):

1. `GH_USE_APP_TOKEN=1` → App (explicit opt-in)
2. `is_org_admin_api` → App (auto, write surface)
3. **`is_app_only_read` (NEW)** → App (auto, read surface)
4. **`is_pr_checks` (NEW)** → App (auto, GraphQL rollup)
5. owner ≠ `coo-labs` + public PAT set → public PAT
6. default → `coo-labs` PAT

### Surfaces matched (read-only)

- `repos/<o>/<r>/commits/<ref>/check-runs[/...]`
- `repos/<o>/<r>/commits/<ref>/check-suites[/...]`
- `repos/<o>/<r>/check-runs/<id>[/...]`
- `repos/<o>/<r>/check-suites/<id>[/...]`
- `repos/<o>/<r>/commits/<ref>/status`
- `repos/<o>/<r>/commits/<ref>/statuses`
- `repos/<o>/<r>/actions/runs[/...]` (includes `/logs`, `/jobs`)
- `repos/<o>/<r>/actions/jobs/<id>[/...]` (includes `/logs`)
- `repos/<o>/<r>/actions/workflows/<id>/runs[/...]`

### Tests

23 new cases in `scripts/ci/test-gh-coo-wrap.sh`. All 88 tests pass (23 new + 65 existing). Live smoke test against `coo-labs/coo-memory@acccd65` confirmed the auto-routes hit the App without `GH_USE_APP_TOKEN=1`.

### Prerequisites (already done, recorded on #1157)

The App `vade-coo-app` must have `Checks: Read`, `Commit statuses: Read`, and `Actions: Read` granted **and the installation must have accepted** the new permissions. All three confirmed live this session.

---

## Change 2 — bootstrap-regression: post comment only on fail, clean up on pass

Sibling improvement landed in the same PR per request.

The bootstrap-regression workflow currently posts a verbose pass-summary sticky comment on every PR run. The pass-comment is large (full invariant table) and bloats context for any agent session that reads the PR thread afterwards — the green path is the expected outcome and doesn't need restating in prose.

`scripts/ci/post-or-update-pr-comment.sh` now reads `result.json`'s `.ok` field and branches:

| State | Action |
|---|---|
| pass + no prior comment | silent — no PR write |
| pass + prior fail-comment | delete the stale comment (auto-cleanup once a fix lands) |
| fail + no prior comment | post new fail-comment |
| fail + prior comment | update existing comment in place |

If `result.json` is missing (the suite aborted before the result step), defaults to the fail path so operators get visibility rather than silence on unexpected pipeline breakage.

No workflow YAML change — the decision lives entirely in the helper script. `if: always()` on the workflow step stays so the script always gets a chance to clean up.

---

## Files touched

- `scripts/gh-coo-wrap.sh` — Change 1
- `scripts/ci/test-gh-coo-wrap.sh` — Change 1 tests
- `scripts/ci/post-or-update-pr-comment.sh` — Change 2

## Boot-impact note

Change 1 is boot-impact (shim runs at every `gh` invocation, installed by `ensure_gh_coo_wrap`). Change 2 only affects CI workflow runs, not boot. Handoff prompt addresses Change 1.

Closes: coo-labs/coo-memory#1157

https://claude.ai/code/session_01FLrQGDFd2CvqhvgADce7wy