### PR TITLE
lib/transcripts: claudeai-events-uuid in AUTHORITATIVE + events-dump snippet

### DIFF
--- a/lib/transcripts/provenance.py
+++ b/lib/transcripts/provenance.py
@@ -20,6 +20,7 @@ AUTHORITATIVE_URL_SOURCES: frozenset[str] = frozenset(
         "html-extract",
         "env-recovery",
         "export-meta-fallback",
+        "claudeai-events-uuid",
     }
 )
 

--- a/lib/transcripts/schema.py
+++ b/lib/transcripts/schema.py
@@ -36,6 +36,7 @@ class UrlSource(str, Enum):
     HTML_EXTRACT = "html-extract"
     ENV_RECOVERY = "env-recovery"
     EXPORT_META_FALLBACK = "export-meta-fallback"
+    CLAUDEAI_EVENTS_UUID = "claudeai-events-uuid"
     SCAN_PR_LINK = "scan-pr-link"
     SCAN_TOOL_RESULT = "scan-tool-result"
     SCAN_PATTERN_A = "scan-pattern-a"

--- a/lib/transcripts/tests/test_provenance.py
+++ b/lib/transcripts/tests/test_provenance.py
@@ -30,8 +30,11 @@ class TestAuthoritativeSet:
     def test_contains_export_meta_fallback(self) -> None:
         assert "export-meta-fallback" in AUTHORITATIVE_URL_SOURCES
 
+    def test_contains_claudeai_events_uuid(self) -> None:
+        assert "claudeai-events-uuid" in AUTHORITATIVE_URL_SOURCES
+
     def test_exact_size(self) -> None:
-        assert len(AUTHORITATIVE_URL_SOURCES) == 4
+        assert len(AUTHORITATIVE_URL_SOURCES) == 5
 
     def test_disjoint_from_reconcile_eligible(self) -> None:
         assert AUTHORITATIVE_URL_SOURCES.isdisjoint(RECONCILE_ELIGIBLE_URL_SOURCES)

--- a/scripts/transcript-url-backfill.py
+++ b/scripts/transcript-url-backfill.py
@@ -159,6 +159,7 @@ AUTHORITATIVE_URL_SOURCES = frozenset({
     "html-extract",
     "env-recovery",
     "export-meta-fallback",
+    "claudeai-events-uuid",
 })
 RECONCILE_ELIGIBLE_URL_SOURCES = frozenset({
     "scan-pr-link",

--- a/snippets/events-dump.js
+++ b/snippets/events-dump.js
@@ -1,0 +1,91 @@
+// events-dump.js — operator-mediated dump tool for claude.ai/v1/sessions/<id>/events.
+//
+// Origin: coo-labs/coo-console#28 (events-API discovery during briefing-039 Phase 5).
+//
+// Usage:
+//   1. Open claude.ai in a logged-in browser tab.
+//   2. Open DevTools (F12) → Console.
+//   3. Paste this entire file's contents.
+//   4. Call dumpEvents(['session_01abc...', 'session_01def...']) with the session IDs.
+//   5. Save the returned blob:
+//        const data = await dumpEvents([...]);
+//        const blob = new Blob([JSON.stringify(data)], {type:'application/json'});
+//        const url = URL.createObjectURL(blob);
+//        const a = document.createElement('a'); a.href = url; a.download = 'events.json'; a.click();
+//   6. scp the file to the container for ingestion (per Decision 5 in the substrate handoff:
+//      no pre-signed PUT — leaked URL is a corpus-poisoning attack surface).
+//
+// Batch sizing: ~80 sessions per browser invocation, cookie-expiry bounded. For the
+// ~294-session dark-mass backfill, plan on ~4 batches.
+//
+// Throttle: 250ms between page requests. claude.ai has no documented rate limit on
+// this endpoint; the throttle is operator-courtesy, not a hard requirement.
+
+async function dumpEvents(sessionIds, options = {}) {
+  const {pageSize = 500, throttleMs = 250, onProgress = null} = options;
+  const out = {
+    parser_version: 1,         // shared constant with lib/transcripts (see _PARSER_VERSION)
+    dumped_at: new Date().toISOString(),
+    sessions: {},
+    errors: [],
+  };
+
+  for (let i = 0; i < sessionIds.length; i++) {
+    const sid = sessionIds[i];
+    if (onProgress) onProgress({sid, index: i, total: sessionIds.length});
+
+    const sessionEvents = [];
+    let afterId = 0;
+    let pageNum = 0;
+
+    while (true) {
+      const url = `/v1/sessions/${sid}/events?after_id=${afterId}&limit=${pageSize}`;
+      let response;
+      try {
+        response = await fetch(url, {credentials: 'include'});
+      } catch (e) {
+        out.errors.push({sid, page: pageNum, error: `fetch failed: ${e.message}`});
+        break;
+      }
+      if (!response.ok) {
+        out.errors.push({sid, page: pageNum, error: `HTTP ${response.status} ${response.statusText}`});
+        break;
+      }
+      let body;
+      try {
+        body = await response.json();
+      } catch (e) {
+        out.errors.push({sid, page: pageNum, error: `JSON parse failed: ${e.message}`});
+        break;
+      }
+      const events = body.events || [];
+      if (events.length === 0) break;
+      sessionEvents.push(...events);
+      afterId = events[events.length - 1].id;
+      pageNum += 1;
+      if (events.length < pageSize) break;
+      if (throttleMs > 0) await new Promise(r => setTimeout(r, throttleMs));
+    }
+
+    out.sessions[sid] = sessionEvents;
+  }
+
+  return out;
+}
+
+// Convenience: dump-and-download in one call. For interactive use.
+async function dumpEventsToFile(sessionIds, filename = 'events.json', options = {}) {
+  const data = await dumpEvents(sessionIds, {
+    ...options,
+    onProgress: ({sid, index, total}) => console.log(`[${index + 1}/${total}] ${sid}`),
+  });
+  const blob = new Blob([JSON.stringify(data, null, 2)], {type: 'application/json'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+  console.log(`Dumped ${Object.keys(data.sessions).length} sessions, ${data.errors.length} errors → ${filename}`);
+  return data;
+}


### PR DESCRIPTION
## What

Phase 2 events-API tag binding per MEMO-2026-06-01-903b (sibling PR: coo-labs/coo-memory#1161). Plus the operator-side browser snippet for `claude.ai/v1/sessions/<sid>/events`.

## Diff summary

| File | Change |
|---|---|
| `lib/transcripts/provenance.py` | `AUTHORITATIVE_URL_SOURCES`: 4 → 5 (adds `claudeai-events-uuid`) |
| `lib/transcripts/schema.py` | `UrlSource` enum gains `CLAUDEAI_EVENTS_UUID` |
| `lib/transcripts/tests/test_provenance.py` | Adds membership test + bumps size assertion 4 → 5 |
| `scripts/transcript-url-backfill.py` | Inlined `AUTHORITATIVE_URL_SOURCES` gets the same tag — **load-bearing** |
| `snippets/events-dump.js` | Operator browser snippet for events-API dumps |

## Why update the script too

`transcript-url-backfill.py:688` is the canonical reconcile-preservation site:

```python
existing_src = existing.get("url_source")
if existing_src in AUTHORITATIVE_URL_SOURCES:
    # short-circuit; do not overwrite
```

If the lib gets the tag but the script doesn't, the script's reconcile would silently overwrite sidecars tagged by the future events-API driver — defeating the AUTHORITATIVE preservation invariant the package exists to defend. The parity check at `scripts/ci/test-lib-transcripts-parity.py` catches the drift if anyone forgets one side.

## Local verification

| Tool | Result |
|---|---|
| `ruff check lib/transcripts` | All checks passed |
| `mypy lib/transcripts` (strict) | Success: no issues found |
| `pytest` | 58/58 passed, 96% coverage |
| `scripts/ci/test-lib-transcripts-parity.py` | OK — 5 auth, 4 reconcile, PARSER_VERSION=3 |

## What stays out

The events-API driver itself (translator events → synthetic jsonl, probe for schema-drift, R2 sidecar writer) lands in a follow-up PR gated on the operator producing a real events-stream fixture from `claude.ai/v1/sessions/<sid>/events` for one validated session. This PR ships the snippet so the operator has the tool.

Closes: n/a — partial progress on Phase 2 sub-issue coo-labs/coo-memory#1148 (driver PR closes it).
Refs: coo-labs/coo-memory#1148, coo-labs/coo-console#28, coo-labs/coo-memory#1161 (memo).

https://claude.ai/code/session_01NB9h2MgCzVjCtJFZooRGdf