### PR TITLE
feat(boot-brake): Phase 0 — PreToolUse capability guard for coo-memory#1082

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$VADE_RUNTIME_DIR/scripts/boot/boot-brake-clear.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$VADE_RUNTIME_DIR/scripts/boot/session-start-sync.sh\""
           },
           {
@@ -72,6 +76,15 @@
       }
     ],
     "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/boot-brake-guard.sh\""
+          }
+        ]
+      },
       {
         "matcher": "Bash",
         "hooks": [
@@ -145,7 +158,8 @@
     "CLAUDE_STREAM_IDLE_TIMEOUT_MS": "600000",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS": "1",
-    "ENABLE_CLAUDEAI_MCP_SERVERS": "false"
+    "ENABLE_CLAUDEAI_MCP_SERVERS": "false",
+    "VADE_BRAKE_ENFORCE": "warn"
   },
   "skillOverrides": {
     "agentmail": "user-invocable-only"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -301,7 +301,10 @@
       "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/brake-test-2 VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/brake-test-home2 bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)",
       "Bash(HOME=/tmp/integ-home bash /home/user/coo-memory/.claude/skills/unbrake/scripts/unbrake.sh \"integ-session\" \"integration test of full override path\")",
       "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/integ-state VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/integ-home bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)",
-      "Bash(mkdir -p /tmp/integ-state /tmp/integ-home/.vade /tmp/integ-home/.claude)"
+      "Bash(mkdir -p /tmp/integ-state /tmp/integ-home/.vade /tmp/integ-home/.claude)",
+      "Bash(HOME=/tmp/integ2-home bash /home/user/coo-memory/.claude/skills/unbrake/scripts/unbrake.sh \"integ2-session\" \"verifying full override path with new HMAC scope\")",
+      "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_BRAKE_RACE_GRACE_SECONDS=0 VADE_CLOUD_STATE_DIR=/tmp/integ2-state VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/integ2-home bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)",
+      "Bash(mkdir -p /tmp/integ2-state /tmp/integ2-home/.vade /tmp/integ2-home/.claude)"
     ],
     "additionalDirectories": [
       "/tmp"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -283,7 +283,8 @@
       "Bash(jq '.permissions.allow |= map\\(select\\(\\(. | contains\\(\"vade-canvas\"\\) | not\\) and \\(. | contains\\(\"canvas-\"\\) | not\\)\\)\\)' .claude/settings.json)",
       "Bash(mv .claude/settings.json.tmp .claude/settings.json)",
       "Bash(echo \"=== count Mac-local path refs in settings.json ===\" && grep -c \"GitHub/coo-labs/vade-\\\\|/coo-harness/\\\\|/coo-memory/\\\\|/coo-logs/\\\\|/vade-canvas/\" .claude/settings.json && echo \"\" && echo \"=== apply bulk replacement ===\" && sed -i \\\\ *)",
-      "Bash(sed -i \\\\ *)"
+      "Bash(sed -i \\\\ *)",
+      "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/brake-test-2 VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/brake-test-home2 bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)"
     ],
     "additionalDirectories": [
       "/tmp"
@@ -331,8 +332,14 @@
     ]
   },
   "deniedMcpServers": [
-    { "serverName": "2512c95b-4f21-45f0-9cfe-4bbb781d5d96" },
-    { "serverName": "67828e51-7e81-47d2-af54-52c28c902662" },
-    { "serverName": "90cea781-9b8c-43e1-9536-8a68c9936159" }
+    {
+      "serverName": "2512c95b-4f21-45f0-9cfe-4bbb781d5d96"
+    },
+    {
+      "serverName": "67828e51-7e81-47d2-af54-52c28c902662"
+    },
+    {
+      "serverName": "90cea781-9b8c-43e1-9536-8a68c9936159"
+    }
   ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -298,7 +298,10 @@
       "Bash(mv .claude/settings.json.tmp .claude/settings.json)",
       "Bash(echo \"=== count Mac-local path refs in settings.json ===\" && grep -c \"GitHub/coo-labs/vade-\\\\|/coo-harness/\\\\|/coo-memory/\\\\|/coo-logs/\\\\|/vade-canvas/\" .claude/settings.json && echo \"\" && echo \"=== apply bulk replacement ===\" && sed -i \\\\ *)",
       "Bash(sed -i \\\\ *)",
-      "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/brake-test-2 VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/brake-test-home2 bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)"
+      "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/brake-test-2 VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/brake-test-home2 bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)",
+      "Bash(HOME=/tmp/integ-home bash /home/user/coo-memory/.claude/skills/unbrake/scripts/unbrake.sh \"integ-session\" \"integration test of full override path\")",
+      "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/integ-state VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/integ-home bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)",
+      "Bash(mkdir -p /tmp/integ-state /tmp/integ-home/.vade /tmp/integ-home/.claude)"
     ],
     "additionalDirectories": [
       "/tmp"

--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -129,3 +129,16 @@ jobs:
 
       - name: Auto-subscribe PR hook — matcher contract (wrapper + raw)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-auto-subscribe-pr.sh"
+
+      - name: Boot brake — guard + clear hook contract (coo-memory#1082 v2 §7)
+        env:
+          VADE_COO_MEMORY_DIR: ${{ github.workspace }}/coo-memory
+        run: |
+          # Stage a minimal coo-memory checkout next to coo-harness for the
+          # manifest's $VADE_COO_MEMORY_DIR — only operations/ is needed.
+          mkdir -p "$VADE_COO_MEMORY_DIR/operations"
+          cp "$GITHUB_WORKSPACE/scripts/ci/fixtures/boot-deliverables.yml" \
+             "$VADE_COO_MEMORY_DIR/operations/boot-deliverables.yml"
+          # PyYAML for the manifest reader
+          pip install --quiet pyyaml
+          bash "$GITHUB_WORKSPACE/scripts/ci/test-boot-brake-guard.sh"

--- a/scripts/boot/boot-brake-clear.sh
+++ b/scripts/boot/boot-brake-clear.sh
@@ -57,13 +57,13 @@ find "$VADE_CLOUD_STATE_DIR" -maxdepth 1 -name "boot-brake.*.json" -mmin +1440 2
     done
 
 # Expired override-sentinel sweep in $HOME/.vade/.
+# An empty/missing expires_at is treated as already-expired (security
+# review SC2: empty expires_at must never imply "permanent").
 mkdir -p "$HOME/.vade" 2>/dev/null || true
 find "$HOME/.vade" -maxdepth 1 -name "boot-brake-override.*.json" 2>/dev/null \
   | while IFS= read -r path; do
-      # Best-effort timestamp inspection. If the file is expired, remove.
       exp="$(jq -r '.expires_at // ""' "$path" 2>/dev/null || true)"
-      [ -z "$exp" ] && continue
-      if [ "$exp" \< "$now" ]; then
+      if [ -z "$exp" ] || [ "$exp" \< "$now" ]; then
         rm -f "$path" 2>/dev/null || true
       fi
     done

--- a/scripts/boot/boot-brake-clear.sh
+++ b/scripts/boot/boot-brake-clear.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SessionStart hook: per-session brake sentinel hygiene.
+#
+# Responsibilities:
+#   - Initialize a PENDING sentinel for this session at
+#     $VADE_CLOUD_STATE_DIR/boot-brake.<session_id>.json with the
+#     boot_started_at timestamp set. The PreToolUse guard transitions
+#     it to OK or FAIL on the first tool call after manifest validation.
+#   - Clean up stale sentinels and expired override sentinels from
+#     prior sessions in this container. Keeps state-dir bounded.
+#
+# Always exits 0. Boot-impacting failures are logged but never block
+# the session from starting.
+#
+# Reference: coo-memory#1082 v2 §6 (sentinel lifecycle).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+
+boot_log_record boot-brake-clear start
+
+VADE_CLOUD_STATE_DIR="${VADE_CLOUD_STATE_DIR:-$HOME/.vade-cloud-state}"
+mkdir -p "$VADE_CLOUD_STATE_DIR" 2>/dev/null || true
+
+# session_id: prefer SessionStart event JSON on stdin; fall back to env.
+session_id=""
+if [ ! -t 0 ]; then
+  input="$(cat 2>/dev/null || true)"
+  if [ -n "$input" ]; then
+    session_id="$(printf '%s' "$input" | jq -r '.session_id // ""' 2>/dev/null || true)"
+  fi
+fi
+[ -z "$session_id" ] && session_id="${CLAUDE_CODE_SESSION_ID:-unknown}"
+
+# Initial PENDING sentinel — first PreToolUse will rewrite with OK/FAIL.
+now="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+sentinel="$VADE_CLOUD_STATE_DIR/boot-brake.${session_id}.json"
+
+tmp="$sentinel.tmp.$$"
+cat > "$tmp" 2>/dev/null <<EOF
+{"state":"PENDING","checked_at":"$now","checked_at_epoch":0,"manifest_version":0,"failures":[],"boot_started_at":"$now","content_hashes":{}}
+EOF
+chmod 600 "$tmp" 2>/dev/null || true
+mv -f "$tmp" "$sentinel" 2>/dev/null || rm -f "$tmp"
+
+# Stale-sentinel sweep: remove sentinels older than 24h whose session_id
+# is not this one. Bounded; never deletes the live session's state.
+find "$VADE_CLOUD_STATE_DIR" -maxdepth 1 -name "boot-brake.*.json" -mmin +1440 2>/dev/null \
+  | while IFS= read -r path; do
+      case "$(basename "$path")" in
+        "boot-brake.${session_id}.json") continue ;;
+      esac
+      rm -f "$path" 2>/dev/null || true
+    done
+
+# Expired override-sentinel sweep in $HOME/.vade/.
+mkdir -p "$HOME/.vade" 2>/dev/null || true
+find "$HOME/.vade" -maxdepth 1 -name "boot-brake-override.*.json" 2>/dev/null \
+  | while IFS= read -r path; do
+      # Best-effort timestamp inspection. If the file is expired, remove.
+      exp="$(jq -r '.expires_at // ""' "$path" 2>/dev/null || true)"
+      [ -z "$exp" ] && continue
+      if [ "$exp" \< "$now" ]; then
+        rm -f "$path" 2>/dev/null || true
+      fi
+    done
+
+# Old session-reads logs sweep (older than 24h)
+find "$HOME/.vade" -maxdepth 1 -name "session-reads.*.log" -mmin +1440 2>/dev/null \
+  -exec rm -f {} \; 2>/dev/null || true
+
+boot_log_record boot-brake-clear end ok "session=$session_id"
+exit 0

--- a/scripts/ci/fixtures/boot-deliverables.yml
+++ b/scripts/ci/fixtures/boot-deliverables.yml
@@ -1,6 +1,9 @@
 # Fixture manifest for boot-brake CI tests. Mirrors the Phase 0 entries
 # in coo-memory/operations/boot-deliverables.yml; refreshed manually
-# when the canonical manifest gains new critical entries.
+# when the canonical manifest gains new entries.
+#
+# Includes `identity_consumed` so the §11 consumed-signal mechanism
+# has CI coverage (Sys-Eng M1).
 
 manifest_version: 1
 
@@ -11,7 +14,7 @@ deliverables:
     producer: coo-harness/scripts/boot/integrity-check.sh
     severity: critical
 
-  - id: coo_bootstrap_marker
+  - id: bootstrap_marker
     path: $HOME/.vade/.coo-bootstrap-done
     check_kind: exists
     producer: coo-harness/scripts/boot/coo-bootstrap.sh
@@ -21,4 +24,12 @@ deliverables:
     path: $HOME/.claude/settings.json
     check_kind: parses_json
     producer: coo-harness/scripts/boot/session-start-sync.sh
+    severity: critical
+
+  - id: identity_consumed
+    path: dynamic
+    check_kind: read_observed
+    check_arg: ".*/tool-results/hook-.*-stdout\\.txt$"
+    predicate_exists_glob: $HOME/.claude/projects/$CWD_DASHIFIED/$SESSION_ID/tool-results/hook-*-stdout.txt
+    producer: coo-harness/scripts/lifecycle/coo-identity-digest.sh
     severity: critical

--- a/scripts/ci/fixtures/boot-deliverables.yml
+++ b/scripts/ci/fixtures/boot-deliverables.yml
@@ -1,0 +1,24 @@
+# Fixture manifest for boot-brake CI tests. Mirrors the Phase 0 entries
+# in coo-memory/operations/boot-deliverables.yml; refreshed manually
+# when the canonical manifest gains new critical entries.
+
+manifest_version: 1
+
+deliverables:
+  - id: integrity_check_json
+    path: $VADE_CLOUD_STATE_DIR/integrity-check.json
+    check_kind: parses_json
+    producer: coo-harness/scripts/boot/integrity-check.sh
+    severity: critical
+
+  - id: coo_bootstrap_marker
+    path: $HOME/.vade/.coo-bootstrap-done
+    check_kind: exists
+    producer: coo-harness/scripts/boot/coo-bootstrap.sh
+    severity: critical
+
+  - id: user_settings_json
+    path: $HOME/.claude/settings.json
+    check_kind: parses_json
+    producer: coo-harness/scripts/boot/session-start-sync.sh
+    severity: critical

--- a/scripts/ci/test-boot-brake-guard.sh
+++ b/scripts/ci/test-boot-brake-guard.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# CI tests for boot-brake-guard.py + boot-brake-clear.sh.
+#
+# Covers v2 §7 tests 1, 2, 3, 6, 7, 9 from the boot-brake architecture
+# (coo-memory#1082); the rest are Phase 1+.
+#
+#   1. Per-producer fault injection — for each manifest entry, run
+#      the guard with that deliverable missing; assert state=FAIL with
+#      the deliverable in failures.
+#   2. PreToolUse refusal smoke — in block-on-FAIL mode with FAIL state,
+#      attempt Bash → assert hookSpecificOutput.permissionDecision=deny
+#      with the failing deliverable in the reason.
+#   3. Whitelist allows diagnostics — same state, attempt Read and Grep
+#      → assert exit 0 with no deny output.
+#   6. Sub-agent isolation — verify Task tool stays denied in FAIL.
+#   7. Parallel-session isolation — two sessions sharing a state-dir
+#      get distinct per-session sentinels and don't cross-pollute.
+#   9. Unparseable sentinel — corrupt sentinel re-triggers validation
+#      and writes a fault diagnostic; does NOT lock the agent out.
+#
+# Exit 0 if all assertions pass, non-zero on first failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GUARD="$REPO_ROOT/scripts/hooks/boot-brake-guard.sh"
+CLEAR="$REPO_ROOT/scripts/boot/boot-brake-clear.sh"
+
+# Test workspace — distinct per run to avoid cross-test contamination.
+TEST_ROOT="${TEST_ROOT:-/tmp/boot-brake-test-$$}"
+mkdir -p "$TEST_ROOT"
+
+# Manifest lives under VADE_COO_MEMORY_DIR. For CI, we point to the
+# real coo-memory checkout's operations/ directory. The repo layout
+# (coo-harness ./ + coo-memory ./../coo-memory) is the cloud convention.
+COO_MEMORY_DIR="${VADE_COO_MEMORY_DIR:-$(cd "$REPO_ROOT/../coo-memory" && pwd)}"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+_pass() {
+  PASS=$((PASS + 1))
+  echo "  ok: $1"
+}
+
+_fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  echo "  FAIL: $1"
+}
+
+_setup_session_dirs() {
+  local n="$1"
+  local state_dir="$TEST_ROOT/state-$n"
+  local home_dir="$TEST_ROOT/home-$n"
+  rm -rf "$state_dir" "$home_dir"
+  mkdir -p "$state_dir" "$home_dir/.vade" "$home_dir/.claude"
+  echo "$state_dir|$home_dir"
+}
+
+_make_all_deliverables_present() {
+  local state_dir="$1" home_dir="$2"
+  printf '{"summary":{"ok":true}}' > "$state_dir/integrity-check.json"
+  touch "$home_dir/.vade/.coo-bootstrap-done"
+  printf '{}' > "$home_dir/.claude/settings.json"
+}
+
+_invoke_guard() {
+  local sid="$1" tool="$2" mode="$3" state_dir="$4" home_dir="$5"
+  local arg6="${6:-}"
+  local input
+  case "$tool" in
+    Read)  input="{\"session_id\":\"$sid\",\"cwd\":\"/home/user\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$arg6\"}}" ;;
+    Grep)  input="{\"session_id\":\"$sid\",\"cwd\":\"/home/user\",\"tool_name\":\"Grep\",\"tool_input\":{\"pattern\":\"$arg6\"}}" ;;
+    *)     input="{\"session_id\":\"$sid\",\"cwd\":\"/home/user\",\"tool_name\":\"$tool\",\"tool_input\":{\"command\":\"$arg6\"}}" ;;
+  esac
+  printf '%s' "$input" | \
+    VADE_BRAKE_ENFORCE="$mode" \
+    VADE_CLOUD_STATE_DIR="$state_dir" \
+    VADE_COO_MEMORY_DIR="$COO_MEMORY_DIR" \
+    HOME="$home_dir" \
+    bash "$GUARD" 2>/dev/null
+}
+
+# ─── Test 1: per-producer fault injection ────────────────────────
+echo "Test 1 — per-producer fault injection"
+for fault in integrity_check_json coo_bootstrap_marker user_settings_json; do
+  set -- $(echo "$(_setup_session_dirs "t1-$fault")" | tr '|' ' ')
+  state_dir="$1"; home_dir="$2"
+  _make_all_deliverables_present "$state_dir" "$home_dir"
+  # Remove the targeted deliverable
+  case "$fault" in
+    integrity_check_json)  rm -f "$state_dir/integrity-check.json" ;;
+    coo_bootstrap_marker)  rm -f "$home_dir/.vade/.coo-bootstrap-done" ;;
+    user_settings_json)    rm -f "$home_dir/.claude/settings.json" ;;
+  esac
+  _invoke_guard "t1-$fault" Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+  if grep -q "\"deliverable\":\"$fault\"" "$state_dir/boot-brake.t1-$fault.json" 2>/dev/null; then
+    _pass "fault=$fault → sentinel records $fault as failed"
+  else
+    _fail "fault=$fault → sentinel did NOT record $fault as failed"
+  fi
+done
+
+# ─── Test 2: PreToolUse refusal smoke ────────────────────────────
+echo "Test 2 — PreToolUse refusal smoke"
+set -- $(echo "$(_setup_session_dirs "t2")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# All deliverables MISSING — first PreToolUse should write FAIL + deny
+out="$(_invoke_guard t2 Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
+if printf '%s' "$out" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  _pass "block-on-FAIL deny emitted"
+else
+  _fail "block-on-FAIL did NOT emit permissionDecision=deny  (got: $out)"
+fi
+if printf '%s' "$out" | grep -q "integrity_check_json"; then
+  _pass "deny reason names integrity_check_json"
+else
+  _fail "deny reason did NOT name integrity_check_json"
+fi
+
+# ─── Test 3: whitelist allows diagnostics ────────────────────────
+echo "Test 3 — Read/Grep whitelisted in FAIL"
+out_read="$(_invoke_guard t2 Read block-on-FAIL "$state_dir" "$home_dir" "/etc/hostname")"
+out_grep="$(_invoke_guard t2 Grep block-on-FAIL "$state_dir" "$home_dir" "pattern")"
+if [ -z "$out_read" ]; then
+  _pass "Read silent-allow (no deny output)"
+else
+  _fail "Read produced unexpected output: $out_read"
+fi
+if [ -z "$out_grep" ]; then
+  _pass "Grep silent-allow (no deny output)"
+else
+  _fail "Grep produced unexpected output: $out_grep"
+fi
+
+# ─── Test 6: sub-agent (Task) stays denied in FAIL ───────────────
+echo "Test 6 — Task tool stays denied in FAIL"
+out_task="$(_invoke_guard t2 Task block-on-FAIL "$state_dir" "$home_dir" "")"
+if printf '%s' "$out_task" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  _pass "Task denied in FAIL state"
+else
+  _fail "Task NOT denied in FAIL state (got: $out_task)"
+fi
+# Override sentinel scoped to parent session should NOT propagate to a
+# different session_id. Write a valid override for the parent, then
+# attempt with a sub-agent's session_id (different).
+mkdir -p "$home_dir/.vade"
+parent_sid=t2
+child_sid=t2-child
+# Compose a valid override for parent_sid via the same HMAC derivation
+granted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+expires_at="$(date -u -d '+30 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -v +30M +%Y-%m-%dT%H:%M:%SZ)"
+hmac_v="$(GRANTED_AT="$granted_at" SID="$parent_sid" REASON="test override for ci" python3 -c '
+import hashlib, hmac, os, sys
+src = os.environ.get("OP_SERVICE_ACCOUNT_TOKEN") or os.environ.get("MEM0_API_KEY") or os.environ.get("GITHUB_MCP_PAT") or "vade-boot-brake-default-no-secrets"
+key = hashlib.sha256(src.encode()).digest()
+ga = os.environ["GRANTED_AT"]
+sid = os.environ["SID"]
+rs = os.environ["REASON"]
+msg = (ga + "|" + sid + "|" + rs).encode()
+sys.stdout.write(hmac.new(key, msg, hashlib.sha256).hexdigest())
+')"
+cat > "$home_dir/.vade/boot-brake-override.${parent_sid}.json" <<EOF
+{"granted_at":"$granted_at","expires_at":"$expires_at","session_id":"$parent_sid","reason":"test override for ci","hmac":"$hmac_v"}
+EOF
+chmod 600 "$home_dir/.vade/boot-brake-override.${parent_sid}.json"
+# Parent's override should allow Bash for parent_sid
+out_parent="$(_invoke_guard $parent_sid Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
+if [ -z "$out_parent" ]; then
+  _pass "Parent override allows parent's Bash"
+else
+  _fail "Parent override did not allow parent's Bash (got: $out_parent)"
+fi
+# Child session (different sid) should still be denied — override does not propagate
+out_child="$(_invoke_guard $child_sid Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
+if printf '%s' "$out_child" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  _pass "Sub-agent (different session_id) still denied — override does not propagate"
+else
+  _fail "Sub-agent override leaked from parent (got: $out_child)"
+fi
+
+# ─── Test 7: parallel-session isolation ──────────────────────────
+echo "Test 7 — parallel-session sentinel isolation"
+set -- $(echo "$(_setup_session_dirs "t7")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+# Session A — all good → OK
+_invoke_guard t7-A Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+# Session B — corrupt its environment (remove deliverable AFTER A wrote sentinel)
+rm -f "$state_dir/integrity-check.json"
+_invoke_guard t7-B Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+# Assert A's sentinel still records OK, B's records FAIL
+state_a="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t7-A.json'))['state'])")"
+state_b="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t7-B.json'))['state'])")"
+if [ "$state_a" = "OK" ]; then
+  _pass "Session A sentinel unchanged at OK after session B's failure"
+else
+  _fail "Session A sentinel cross-polluted (state=$state_a)"
+fi
+if [ "$state_b" = "FAIL" ]; then
+  _pass "Session B sentinel records FAIL independently"
+else
+  _fail "Session B sentinel did not record FAIL (state=$state_b)"
+fi
+
+# ─── Test 9: unparseable sentinel ────────────────────────────────
+echo "Test 9 — unparseable sentinel re-validates without locking out"
+set -- $(echo "$(_setup_session_dirs "t9")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+# Write a truncated/garbage sentinel
+printf '{"state":"OK"' > "$state_dir/boot-brake.t9.json"
+# Invoke — should NOT crash, should re-validate, should write a valid sentinel
+out="$(_invoke_guard t9 Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
+if [ -z "$out" ]; then
+  # Allowed (because deliverables are all present now after re-validation)
+  if python3 -c "import json; json.load(open('$state_dir/boot-brake.t9.json'))" 2>/dev/null; then
+    _pass "Unparseable sentinel re-validated, new sentinel is well-formed"
+  else
+    _fail "Sentinel still unparseable after guard ran"
+  fi
+else
+  _fail "Guard emitted unexpected output on unparseable sentinel: $out"
+fi
+# Fault log should exist
+if [ -d "$state_dir/boot-brake-faults" ] && [ -n "$(ls -A "$state_dir/boot-brake-faults" 2>/dev/null)" ]; then
+  _pass "Unparseable sentinel wrote a fault diagnostic"
+else
+  _fail "No fault diagnostic written for unparseable sentinel"
+fi
+
+# ─── Summary ────────────────────────────────────────────────────
+echo
+echo "===================================="
+echo "boot-brake CI tests: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/scripts/ci/test-boot-brake-guard.sh
+++ b/scripts/ci/test-boot-brake-guard.sh
@@ -1,22 +1,31 @@
 #!/usr/bin/env bash
 # CI tests for boot-brake-guard.py + boot-brake-clear.sh.
 #
-# Covers v2 §7 tests 1, 2, 3, 6, 7, 9 from the boot-brake architecture
-# (coo-memory#1082); the rest are Phase 1+.
+# Covers v2 §7 tests 1, 2, 3, 6, 7, 9 (Phase 0 minimum), plus four
+# regression tests for the post-review patches:
 #
-#   1. Per-producer fault injection — for each manifest entry, run
-#      the guard with that deliverable missing; assert state=FAIL with
-#      the deliverable in failures.
-#   2. PreToolUse refusal smoke — in block-on-FAIL mode with FAIL state,
-#      attempt Bash → assert hookSpecificOutput.permissionDecision=deny
-#      with the failing deliverable in the reason.
-#   3. Whitelist allows diagnostics — same state, attempt Read and Grep
-#      → assert exit 0 with no deny output.
-#   6. Sub-agent isolation — verify Task tool stays denied in FAIL.
-#   7. Parallel-session isolation — two sessions sharing a state-dir
-#      get distinct per-session sentinels and don't cross-pollute.
-#   9. Unparseable sentinel — corrupt sentinel re-triggers validation
-#      and writes a fault diagnostic; does NOT lock the agent out.
+#   1.  Per-producer fault injection — each manifest entry, missing.
+#   2.  PreToolUse refusal smoke — block-on-FAIL + FAIL → deny.
+#   3.  Whitelist allows diagnostics — Read + Grep in FAIL state.
+#   6.  Sub-agent isolation — Task denied; override does not propagate
+#       to different session_id.
+#   7.  Parallel-session isolation — sentinels keyed per-session AND
+#       cache-invalidation: a cached OK does NOT survive deletion of
+#       a previously-OK deliverable (Sys-Eng C1 regression test).
+#   9.  Unparseable sentinel re-validates + writes fault diagnostic.
+#   11. (new) Manifest unreadable (pyyaml-fault simulated) → self-fault
+#       sentinel + cause=validator_self_fault event (Sys-Eng C2).
+#   12. (new) Race gate engaged — first PreToolUse while producers are
+#       still running stays PENDING; doesn't emit phantom FAIL
+#       (Sys-Eng C3).
+#   13. (new) identity_consumed predicate-unmatched emits
+#       cause=identity_predicate_unmatched event (SRE F5).
+#   14. (new) Override-sentinel tamper resistance — flipping expires_at
+#       in a captured override invalidates the HMAC (Security SC1+SC3).
+#
+# Most tests run with VADE_BRAKE_RACE_GRACE_SECONDS=0 to bypass the
+# wall-clock race window (tests don't write boot.log producer
+# end-markers; the race-window test exercises the gate explicitly).
 #
 # Exit 0 if all assertions pass, non-zero on first failure.
 
@@ -27,13 +36,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GUARD="$REPO_ROOT/scripts/hooks/boot-brake-guard.sh"
 CLEAR="$REPO_ROOT/scripts/boot/boot-brake-clear.sh"
 
-# Test workspace — distinct per run to avoid cross-test contamination.
 TEST_ROOT="${TEST_ROOT:-/tmp/boot-brake-test-$$}"
 mkdir -p "$TEST_ROOT"
 
-# Manifest lives under VADE_COO_MEMORY_DIR. For CI, we point to the
-# real coo-memory checkout's operations/ directory. The repo layout
-# (coo-harness ./ + coo-memory ./../coo-memory) is the cloud convention.
 COO_MEMORY_DIR="${VADE_COO_MEMORY_DIR:-$(cd "$REPO_ROOT/../coo-memory" && pwd)}"
 
 PASS=0
@@ -67,6 +72,8 @@ _make_all_deliverables_present() {
   printf '{}' > "$home_dir/.claude/settings.json"
 }
 
+# Default invocation: race-gate disabled, fixture manifest. Override
+# VADE_BRAKE_RACE_GRACE_SECONDS or VADE_COO_MEMORY_DIR per-call.
 _invoke_guard() {
   local sid="$1" tool="$2" mode="$3" state_dir="$4" home_dir="$5"
   local arg6="${6:-}"
@@ -78,22 +85,30 @@ _invoke_guard() {
   esac
   printf '%s' "$input" | \
     VADE_BRAKE_ENFORCE="$mode" \
+    VADE_BRAKE_RACE_GRACE_SECONDS="${VADE_BRAKE_RACE_GRACE_SECONDS:-0}" \
     VADE_CLOUD_STATE_DIR="$state_dir" \
-    VADE_COO_MEMORY_DIR="$COO_MEMORY_DIR" \
+    VADE_COO_MEMORY_DIR="${VADE_COO_MEMORY_DIR_OVERRIDE:-$COO_MEMORY_DIR}" \
     HOME="$home_dir" \
     bash "$GUARD" 2>/dev/null
 }
 
+# Stage a fixture manifest with a custom path so we can test
+# unreadable-manifest semantics independently. Returns the manifest dir.
+_stage_fixture_manifest() {
+  local target_dir="$1"
+  mkdir -p "$target_dir/operations"
+  cp "$SCRIPT_DIR/fixtures/boot-deliverables.yml" "$target_dir/operations/boot-deliverables.yml"
+}
+
 # ─── Test 1: per-producer fault injection ────────────────────────
 echo "Test 1 — per-producer fault injection"
-for fault in integrity_check_json coo_bootstrap_marker user_settings_json; do
+for fault in integrity_check_json bootstrap_marker user_settings_json; do
   set -- $(echo "$(_setup_session_dirs "t1-$fault")" | tr '|' ' ')
   state_dir="$1"; home_dir="$2"
   _make_all_deliverables_present "$state_dir" "$home_dir"
-  # Remove the targeted deliverable
   case "$fault" in
     integrity_check_json)  rm -f "$state_dir/integrity-check.json" ;;
-    coo_bootstrap_marker)  rm -f "$home_dir/.vade/.coo-bootstrap-done" ;;
+    bootstrap_marker)      rm -f "$home_dir/.vade/.coo-bootstrap-done" ;;
     user_settings_json)    rm -f "$home_dir/.claude/settings.json" ;;
   esac
   _invoke_guard "t1-$fault" Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
@@ -108,7 +123,6 @@ done
 echo "Test 2 — PreToolUse refusal smoke"
 set -- $(echo "$(_setup_session_dirs "t2")" | tr '|' ' ')
 state_dir="$1"; home_dir="$2"
-# All deliverables MISSING — first PreToolUse should write FAIL + deny
 out="$(_invoke_guard t2 Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
 if printf '%s' "$out" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
   _pass "block-on-FAIL deny emitted"
@@ -136,46 +150,44 @@ else
   _fail "Grep produced unexpected output: $out_grep"
 fi
 
-# ─── Test 6: sub-agent (Task) stays denied in FAIL ───────────────
-echo "Test 6 — Task tool stays denied in FAIL"
+# ─── Test 6: sub-agent (Task) stays denied + override scoping ────
+echo "Test 6 — Task denied in FAIL; override does not propagate"
 out_task="$(_invoke_guard t2 Task block-on-FAIL "$state_dir" "$home_dir" "")"
 if printf '%s' "$out_task" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
   _pass "Task denied in FAIL state"
 else
   _fail "Task NOT denied in FAIL state (got: $out_task)"
 fi
-# Override sentinel scoped to parent session should NOT propagate to a
-# different session_id. Write a valid override for the parent, then
-# attempt with a sub-agent's session_id (different).
-mkdir -p "$home_dir/.vade"
+
+# Override sentinel scoped to parent session. Compute HMAC using the
+# same length-prefixed payload as guard.py and unbrake.sh — security
+# review SC1 (expires_at in MAC scope) + SC3 (length-prefixing).
 parent_sid=t2
 child_sid=t2-child
-# Compose a valid override for parent_sid via the same HMAC derivation
 granted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 expires_at="$(date -u -d '+30 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
   || date -u -v +30M +%Y-%m-%dT%H:%M:%SZ)"
-hmac_v="$(GRANTED_AT="$granted_at" SID="$parent_sid" REASON="test override for ci" python3 -c '
+hmac_v="$(GRANTED_AT="$granted_at" EXPIRES_AT="$expires_at" SID="$parent_sid" REASON="test override for ci" python3 -c '
 import hashlib, hmac, os, sys
-src = os.environ.get("OP_SERVICE_ACCOUNT_TOKEN") or os.environ.get("MEM0_API_KEY") or os.environ.get("GITHUB_MCP_PAT") or "vade-boot-brake-default-no-secrets"
+src = (os.environ.get("OP_SERVICE_ACCOUNT_TOKEN")
+       or os.environ.get("MEM0_API_KEY")
+       or os.environ.get("GITHUB_MCP_PAT")
+       or "vade-boot-brake-default-no-secrets")
 key = hashlib.sha256(src.encode()).digest()
-ga = os.environ["GRANTED_AT"]
-sid = os.environ["SID"]
-rs = os.environ["REASON"]
-msg = (ga + "|" + sid + "|" + rs).encode()
+parts = (os.environ["GRANTED_AT"], os.environ["EXPIRES_AT"], os.environ["SID"], os.environ["REASON"])
+msg = "|".join(str(len(p)) + ":" + p for p in parts).encode()
 sys.stdout.write(hmac.new(key, msg, hashlib.sha256).hexdigest())
 ')"
 cat > "$home_dir/.vade/boot-brake-override.${parent_sid}.json" <<EOF
 {"granted_at":"$granted_at","expires_at":"$expires_at","session_id":"$parent_sid","reason":"test override for ci","hmac":"$hmac_v"}
 EOF
 chmod 600 "$home_dir/.vade/boot-brake-override.${parent_sid}.json"
-# Parent's override should allow Bash for parent_sid
 out_parent="$(_invoke_guard $parent_sid Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
 if [ -z "$out_parent" ]; then
   _pass "Parent override allows parent's Bash"
 else
   _fail "Parent override did not allow parent's Bash (got: $out_parent)"
 fi
-# Child session (different sid) should still be denied — override does not propagate
 out_child="$(_invoke_guard $child_sid Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
 if printf '%s' "$out_child" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
   _pass "Sub-agent (different session_id) still denied — override does not propagate"
@@ -183,28 +195,31 @@ else
   _fail "Sub-agent override leaked from parent (got: $out_child)"
 fi
 
-# ─── Test 7: parallel-session isolation ──────────────────────────
-echo "Test 7 — parallel-session sentinel isolation"
+# ─── Test 7: parallel-session isolation + cache invalidation ─────
+echo "Test 7 — parallel-session isolation + cache invalidation"
 set -- $(echo "$(_setup_session_dirs "t7")" | tr '|' ' ')
 state_dir="$1"; home_dir="$2"
 _make_all_deliverables_present "$state_dir" "$home_dir"
-# Session A — all good → OK
+# Session A first fire → all-OK
 _invoke_guard t7-A Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
-# Session B — corrupt its environment (remove deliverable AFTER A wrote sentinel)
+sleep 1.1  # past 1s backpressure cap so the next fire re-checks hashes
+# Remove a deliverable, re-fire A → cached OK must NOT survive
 rm -f "$state_dir/integrity-check.json"
-_invoke_guard t7-B Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
-# Assert A's sentinel still records OK, B's records FAIL
-state_a="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t7-A.json'))['state'])")"
-state_b="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t7-B.json'))['state'])")"
-if [ "$state_a" = "OK" ]; then
-  _pass "Session A sentinel unchanged at OK after session B's failure"
+_invoke_guard t7-A Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+state_a_after="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t7-A.json'))['state'])")"
+if [ "$state_a_after" = "FAIL" ]; then
+  _pass "Cached-OK invalidated when previously-hashed deliverable deleted (Sys-Eng C1)"
 else
-  _fail "Session A sentinel cross-polluted (state=$state_a)"
+  _fail "Cached-OK survived deletion (state=$state_a_after; Sys-Eng C1 regression)"
 fi
-if [ "$state_b" = "FAIL" ]; then
-  _pass "Session B sentinel records FAIL independently"
+# Now session B sees its own sentinel independently — restore deliverable
+_make_all_deliverables_present "$state_dir" "$home_dir"
+_invoke_guard t7-B Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+state_b="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t7-B.json'))['state'])")"
+if [ "$state_b" = "OK" ]; then
+  _pass "Session B's sentinel records OK independently of A's history"
 else
-  _fail "Session B sentinel did not record FAIL (state=$state_b)"
+  _fail "Session B sentinel cross-polluted with A's state (state_b=$state_b)"
 fi
 
 # ─── Test 9: unparseable sentinel ────────────────────────────────
@@ -212,12 +227,9 @@ echo "Test 9 — unparseable sentinel re-validates without locking out"
 set -- $(echo "$(_setup_session_dirs "t9")" | tr '|' ' ')
 state_dir="$1"; home_dir="$2"
 _make_all_deliverables_present "$state_dir" "$home_dir"
-# Write a truncated/garbage sentinel
 printf '{"state":"OK"' > "$state_dir/boot-brake.t9.json"
-# Invoke — should NOT crash, should re-validate, should write a valid sentinel
 out="$(_invoke_guard t9 Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
 if [ -z "$out" ]; then
-  # Allowed (because deliverables are all present now after re-validation)
   if python3 -c "import json; json.load(open('$state_dir/boot-brake.t9.json'))" 2>/dev/null; then
     _pass "Unparseable sentinel re-validated, new sentinel is well-formed"
   else
@@ -226,11 +238,131 @@ if [ -z "$out" ]; then
 else
   _fail "Guard emitted unexpected output on unparseable sentinel: $out"
 fi
-# Fault log should exist
 if [ -d "$state_dir/boot-brake-faults" ] && [ -n "$(ls -A "$state_dir/boot-brake-faults" 2>/dev/null)" ]; then
   _pass "Unparseable sentinel wrote a fault diagnostic"
 else
   _fail "No fault diagnostic written for unparseable sentinel"
+fi
+
+# ─── Test 11 (NEW): manifest unreadable → validator self-fault ──
+echo "Test 11 — manifest unreadable → validator self-fault (Sys-Eng C2)"
+set -- $(echo "$(_setup_session_dirs "t11")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+# Point at a non-existent manifest dir
+fake_manifest_dir="$TEST_ROOT/no-such-coo-memory"
+VADE_COO_MEMORY_DIR_OVERRIDE="$fake_manifest_dir" \
+  _invoke_guard t11 Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+state_t11="$(python3 -c "import json; d=json.load(open('$state_dir/boot-brake.t11.json')); print(d.get('cause','?'), d.get('state','?'))")"
+case "$state_t11" in
+  "validator_self_fault FAIL")
+    _pass "Manifest unreadable → state=FAIL with cause=validator_self_fault" ;;
+  *)
+    _fail "Manifest unreadable did not produce self-fault (got: $state_t11)" ;;
+esac
+
+# After self-fault, exercise the cached-revalidation path: re-fire
+# while manifest still unreadable. The previously-OK cached sentinel
+# from a prior test would NOT exist here (fresh state_dir), but the
+# self-fault sentinel itself must re-validate (Sys-Eng C2 second leg).
+sleep 1.1
+VADE_COO_MEMORY_DIR_OVERRIDE="$fake_manifest_dir" \
+  _invoke_guard t11 Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+state_t11_second="$(python3 -c "import json; d=json.load(open('$state_dir/boot-brake.t11.json')); print(d.get('cause','?'))")"
+if [ "$state_t11_second" = "validator_self_fault" ]; then
+  _pass "Subsequent fire with unreadable manifest stays self-fault (not stuck-PENDING)"
+else
+  _fail "Subsequent fire did not preserve self-fault (got cause=$state_t11_second)"
+fi
+
+# ─── Test 12 (NEW): race gate engaged ────────────────────────────
+echo "Test 12 — race gate engaged when producers haven't completed (Sys-Eng C3)"
+set -- $(echo "$(_setup_session_dirs "t12")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# Note: all deliverables PRESENT, but no boot.log → fall back to
+# wall-clock grace. With grace_seconds=300 the race gate engages.
+_make_all_deliverables_present "$state_dir" "$home_dir"
+# Force a recent boot_started_at via a pre-staged sentinel
+now_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat > "$state_dir/boot-brake.t12.json" <<EOF
+{"state":"PENDING","checked_at":"$now_iso","checked_at_epoch":0,"manifest_version":0,"failures":[],"boot_started_at":"$now_iso","content_hashes":{}}
+EOF
+# Invoke with grace=300 so the race window is active
+out="$(printf '{"session_id":"t12","cwd":"/home/user","tool_name":"Bash","tool_input":{"command":"ls"}}' | \
+  VADE_BRAKE_ENFORCE=block-on-FAIL \
+  VADE_BRAKE_RACE_GRACE_SECONDS=300 \
+  VADE_CLOUD_STATE_DIR="$state_dir" \
+  VADE_COO_MEMORY_DIR="$COO_MEMORY_DIR" \
+  HOME="$home_dir" \
+  bash "$GUARD" 2>/dev/null)"
+state_t12="$(python3 -c "import json; d=json.load(open('$state_dir/boot-brake.t12.json')); print(d['state'])")"
+race_reason="$(python3 -c "import json; d=json.load(open('$state_dir/boot-brake.t12.json')); print((d.get('race_gate') or {}).get('reason','no'))")"
+if [ "$state_t12" = "PENDING" ] && [ "$race_reason" = "wall-clock grace" ]; then
+  _pass "Race gate engaged → state stays PENDING (no phantom FAIL)"
+else
+  _fail "Race gate did not engage (state=$state_t12, reason=$race_reason)"
+fi
+# PENDING + block-on-FAIL must allow (only block-strict denies PENDING)
+if [ -z "$out" ]; then
+  _pass "PENDING under block-on-FAIL allows tool call (block-strict denies)"
+else
+  _fail "PENDING under block-on-FAIL emitted output: $out"
+fi
+
+# ─── Test 13 (NEW): identity_consumed predicate-unmatched event ─
+echo "Test 13 — identity_consumed predicate-unmatched emits diagnostic (SRE F5)"
+set -- $(echo "$(_setup_session_dirs "t13")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+# No persisted-output files exist for session t13. The predicate glob
+# expands to a path under home_dir that has nothing → predicate unmatched.
+_invoke_guard t13 Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+if grep -q '"cause":"identity_predicate_unmatched"' "$state_dir/brake-events.jsonl" 2>/dev/null; then
+  _pass "predicate-unmatched event emitted in brake-events.jsonl"
+else
+  _fail "predicate-unmatched event NOT emitted (events.jsonl content: $(cat "$state_dir/brake-events.jsonl" 2>/dev/null | tail -3))"
+fi
+
+# ─── Test 14 (NEW): override tamper resistance ──────────────────
+echo "Test 14 — tampering with override expires_at invalidates HMAC (Security SC1)"
+set -- $(echo "$(_setup_session_dirs "t14")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# Reuse the test-6 override-write logic with a 1-minute TTL
+parent_sid=t14
+granted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+expires_at="$(date -u -d '+1 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -v +1M +%Y-%m-%dT%H:%M:%SZ)"
+hmac_v="$(GRANTED_AT="$granted_at" EXPIRES_AT="$expires_at" SID="$parent_sid" REASON="testing tamper resistance" python3 -c '
+import hashlib, hmac, os, sys
+src = (os.environ.get("OP_SERVICE_ACCOUNT_TOKEN") or os.environ.get("MEM0_API_KEY") or os.environ.get("GITHUB_MCP_PAT") or "vade-boot-brake-default-no-secrets")
+key = hashlib.sha256(src.encode()).digest()
+parts = (os.environ["GRANTED_AT"], os.environ["EXPIRES_AT"], os.environ["SID"], os.environ["REASON"])
+msg = "|".join(str(len(p)) + ":" + p for p in parts).encode()
+sys.stdout.write(hmac.new(key, msg, hashlib.sha256).hexdigest())
+')"
+# Forge: change expires_at to far-future, keep HMAC computed with the
+# original. The guard MUST reject because expires_at is in the MAC scope.
+future_expires="2099-12-31T23:59:59Z"
+cat > "$home_dir/.vade/boot-brake-override.${parent_sid}.json" <<EOF
+{"granted_at":"$granted_at","expires_at":"$future_expires","session_id":"$parent_sid","reason":"testing tamper resistance","hmac":"$hmac_v"}
+EOF
+chmod 600 "$home_dir/.vade/boot-brake-override.${parent_sid}.json"
+out_tamper="$(_invoke_guard $parent_sid Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
+if printf '%s' "$out_tamper" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  _pass "Tampered expires_at → HMAC mismatch → override rejected → deny"
+else
+  _fail "Tampered override was honored — HMAC scope does not protect expires_at"
+fi
+# Also: empty expires_at must be treated as expired
+cat > "$home_dir/.vade/boot-brake-override.${parent_sid}.json" <<EOF
+{"granted_at":"$granted_at","expires_at":"","session_id":"$parent_sid","reason":"testing tamper resistance","hmac":"$hmac_v"}
+EOF
+chmod 600 "$home_dir/.vade/boot-brake-override.${parent_sid}.json"
+out_empty="$(_invoke_guard $parent_sid Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
+if printf '%s' "$out_empty" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  _pass "Empty expires_at → treated as expired → override rejected"
+else
+  _fail "Empty expires_at was treated as permanent — SC2 regression"
 fi
 
 # ─── Summary ────────────────────────────────────────────────────

--- a/scripts/hooks/boot-brake-guard.py
+++ b/scripts/hooks/boot-brake-guard.py
@@ -85,8 +85,17 @@ def derive_hmac_key():
     return hashlib.sha256(src.encode("utf-8")).digest()
 
 
-def compute_hmac(granted_at, session_id, reason):
-    msg = f"{granted_at}|{session_id}|{reason}".encode("utf-8")
+def compute_hmac(granted_at, expires_at, session_id, reason):
+    """HMAC over length-prefixed canonical form.
+
+    Length-prefixing closes the delimiter-injection attack: a `reason`
+    containing `|` cannot produce a colliding MAC by reshuffling fields
+    (security-review SC3). `expires_at` is included in the MAC scope so
+    a captured override cannot have its TTL extended (security-review
+    SC1). Field order is fixed; the unbrake.sh writer must match.
+    """
+    parts = (str(granted_at), str(expires_at), str(session_id), str(reason))
+    msg = "|".join(f"{len(p)}:{p}" for p in parts).encode("utf-8")
     return hmac.new(derive_hmac_key(), msg, hashlib.sha256).hexdigest()
 
 
@@ -157,6 +166,63 @@ def write_fault(state_dir, message, exc=None):
         return None
 
 
+# SessionStart producers tracked by the race-gate (Sys-Eng C3). When
+# the first PreToolUse fires while these are still running, the brake
+# stays PENDING rather than emit phantom FAILs that pollute the 7-day
+# soak signal. The list mirrors the SessionStart `startup` matcher in
+# .claude/settings.json; new producers should be added here in the
+# same PR that registers them.
+PRODUCERS_TO_TRACK = (
+    "session-start-sync",
+    "coo-bootstrap",
+    "memo-index",
+    "coo-identity-digest",
+)
+
+# Wall-clock grace window when boot.log is unavailable (Sys-Eng C3
+# fallback). The v2 design wanted producer end-markers as the primary
+# mechanism; this is the documented degradation path.
+# Overridable via VADE_BRAKE_RACE_GRACE_SECONDS (CI tests set it to 0
+# to bypass the race window; production should leave it at the default).
+def _race_grace_seconds():
+    raw = os.environ.get("VADE_BRAKE_RACE_GRACE_SECONDS", "")
+    if not raw:
+        return 30.0
+    try:
+        return float(raw)
+    except ValueError:
+        return 30.0
+
+
+def boot_producers_complete(home, session_id):
+    """Returns (all_complete, missing_producers).
+
+    Reads $HOME/.vade/boot.log (newline-delimited JSON) for end-phase
+    entries scoped to this session_id. Each declared SessionStart
+    producer must have logged `phase=end`. If boot.log is missing or
+    unreadable, returns (None, []) to signal "fall back to wall-clock".
+    """
+    log = Path(home) / ".vade" / "boot.log"
+    if not log.exists():
+        return None, []
+    completed = set()
+    try:
+        with open(log) as fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                if rec.get("session") != session_id:
+                    continue
+                if rec.get("phase") == "end" and rec.get("script"):
+                    completed.add(rec["script"])
+    except OSError:
+        return None, []
+    missing = [p for p in PRODUCERS_TO_TRACK if p not in completed]
+    return (len(missing) == 0), missing
+
+
 def load_yaml_manifest(manifest_path):
     try:
         import yaml
@@ -198,25 +264,32 @@ def sha1_file(path):
 
 
 def check_deliverable(entry, env, home, session_id, cwd):
-    """Returns (ok: bool, reason: str, content_hash: str|None)."""
+    """Returns (ok: bool, reason: str, content_hash: str|None, signals: list).
+
+    `signals` is a list of diagnostic events that should land in
+    brake-events.jsonl. Most check_kinds return []. The read_observed
+    branch returns a signal when its predicate glob is configured but
+    matches zero non-trivial files (SRE F5) — that's the symptom of a
+    drifted path convention silently disabling the §11 invariant.
+    """
     kind = entry.get("check_kind", "exists")
     path = resolve_path(entry, env)
 
     if kind == "exists":
         if Path(path).exists():
-            return True, "", sha1_file(path)
-        return False, f"missing: {path}", None
+            return True, "", sha1_file(path), []
+        return False, f"missing: {path}", None, []
 
     if kind == "parses_json":
         try:
             with open(path) as fh:
                 content = fh.read()
             json.loads(content)
-            return True, "", hashlib.sha1(content.encode()).hexdigest()
+            return True, "", hashlib.sha1(content.encode()).hexdigest(), []
         except FileNotFoundError:
-            return False, f"missing: {path}", None
+            return False, f"missing: {path}", None, []
         except Exception as e:
-            return False, f"unparseable: {type(e).__name__}", None
+            return False, f"unparseable: {type(e).__name__}", None, []
 
     if kind == "symlink_to":
         target = entry.get("check_arg", "")
@@ -224,14 +297,14 @@ def check_deliverable(entry, env, home, session_id, cwd):
             target = target.replace(f"${var}", env.get(var, ""))
         try:
             if not Path(path).is_symlink():
-                return False, f"not a symlink: {path}", None
+                return False, f"not a symlink: {path}", None, []
             resolved = os.path.realpath(path)
             expected = os.path.realpath(target) if target else None
             if expected and resolved != expected:
-                return False, f"symlink target drift: {path}", None
-            return True, "", hashlib.sha1(resolved.encode()).hexdigest()
+                return False, f"symlink target drift: {path}", None, []
+            return True, "", hashlib.sha1(resolved.encode()).hexdigest(), []
         except Exception as e:
-            return False, f"symlink check error: {type(e).__name__}", None
+            return False, f"symlink check error: {type(e).__name__}", None, []
 
     if kind == "has_jq_path":
         jq_path = entry.get("check_arg", "")
@@ -251,19 +324,21 @@ def check_deliverable(entry, env, home, session_id, cwd):
                         cur = cur[int(segment)]
                     else:
                         cur = cur[segment]
-            return True, "", hashlib.sha1(content.encode()).hexdigest()
+            return True, "", hashlib.sha1(content.encode()).hexdigest(), []
         except FileNotFoundError:
-            return False, f"missing: {path}", None
+            return False, f"missing: {path}", None, []
         except (KeyError, IndexError):
-            return False, f"jq path missing: {jq_path}", None
+            return False, f"jq path missing: {jq_path}", None, []
         except Exception as e:
-            return False, f"check error: {type(e).__name__}", None
+            return False, f"check error: {type(e).__name__}", None, []
 
     if kind == "read_observed":
         # The identity_consumed kind from v2 §11. The check_arg is a
         # regex pattern; the deliverable is satisfied when ANY Read tool
         # call observed in this session matches the pattern. Conditional:
-        # if the predicate file doesn't exist, skip (not required).
+        # if the predicate glob matches no non-trivial files, the digest
+        # didn't overflow and the check is no-op.
+        signals = []
         predicate_glob = entry.get("predicate_exists_glob", "")
         if predicate_glob:
             import glob
@@ -273,37 +348,61 @@ def check_deliverable(entry, env, home, session_id, cwd):
             # The cwd is part of the per-session project dir naming
             expanded_glob = expanded_glob.replace("$CWD_DASHIFIED", cwd.replace("/", "-"))
             expanded_glob = expanded_glob.replace("$SESSION_ID", session_id)
-            matches = glob.glob(expanded_glob)
+            try:
+                matches = glob.glob(expanded_glob)
+            except Exception:
+                matches = []
             # Filter to non-trivial files (> 1KB indicates real overflow)
-            substantive = [m for m in matches if Path(m).stat().st_size > 1024]
+            substantive = []
+            for m in matches:
+                try:
+                    if Path(m).stat().st_size > 1024:
+                        substantive.append(m)
+                except OSError:
+                    continue
             if not substantive:
-                return True, "predicate not present; check skipped", None
+                # Loud-fail on the surface that "no overflow detected"
+                # could mean either (a) digest fit inline (correct skip)
+                # OR (b) the path convention drifted and the §11
+                # invariant is now silently disabled. SRE F5: surface
+                # this as a diagnostic event so a Phase 1 aggregator
+                # can detect convention drift in the wild.
+                signals.append({
+                    "type": "predicate_unmatched",
+                    "deliverable": entry.get("id", "unknown"),
+                    "expanded_glob": sanitize(expanded_glob),
+                    "matches_total": len(matches),
+                })
+                return True, "predicate not present; check skipped", None, signals
         pattern = entry.get("check_arg", "")
         try:
             rx = re.compile(pattern)
         except re.error as e:
-            return False, f"bad regex: {type(e).__name__}", None
+            return False, f"bad regex: {type(e).__name__}", None, []
         if session_has_read(home, session_id, lambda fp: rx.search(fp) is not None):
-            return True, "", None
-        return False, f"identity layer overflowed but agent has not yet Read it", None
+            return True, "", None, []
+        return False, f"identity layer overflowed but agent has not yet Read it", None, []
 
-    return False, f"unknown check_kind: {kind}", None
+    return False, f"unknown check_kind: {kind}", None, []
 
 
 def validate_manifest(manifest, env, home, session_id, cwd):
-    """Returns (state, failures, content_hashes, manifest_version)."""
+    """Returns (state, failures, content_hashes, manifest_version, signals)."""
     if not manifest or "deliverables" not in manifest:
-        return "FAIL", [{"deliverable": "manifest", "reason": "no deliverables key"}], {}, 0
+        return "FAIL", [{"deliverable": "manifest", "reason": "no deliverables key"}], {}, 0, []
 
     manifest_version = manifest.get("manifest_version", 1)
     failures = []
     hashes = {}
+    signals = []
 
     for entry in manifest.get("deliverables", []):
         dlid = entry.get("id", "unknown")
-        ok, reason, ch = check_deliverable(entry, env, home, session_id, cwd)
+        ok, reason, ch, entry_signals = check_deliverable(entry, env, home, session_id, cwd)
         if ch is not None:
             hashes[dlid] = ch
+        if entry_signals:
+            signals.extend(entry_signals)
         if not ok:
             if entry.get("severity", "critical") == "critical":
                 failures.append({
@@ -313,7 +412,7 @@ def validate_manifest(manifest, env, home, session_id, cwd):
                 })
 
     state = "OK" if not failures else "FAIL"
-    return state, failures, hashes, manifest_version
+    return state, failures, hashes, manifest_version, signals
 
 
 def read_cached_sentinel(path):
@@ -329,7 +428,14 @@ def read_cached_sentinel(path):
 
 
 def check_override(home, session_id):
-    """Returns (allowed, info_dict|None)."""
+    """Returns (allowed, info_dict|None).
+
+    Rejects forged overrides per security review:
+      - Empty/missing expires_at → treated as already expired (SC2).
+      - expires_at is in the HMAC scope (SC1) so a captured override
+        cannot be tampered to extend its TTL.
+      - session_id mismatch → reject (does not propagate to sub-agents).
+    """
     path = Path(home) / ".vade" / f"boot-brake-override.{session_id}.json"
     if not path.exists():
         return False, None
@@ -339,18 +445,22 @@ def check_override(home, session_id):
     except Exception:
         return False, None
 
+    expires_at = ovr.get("expires_at", "")
+    if not expires_at:
+        return False, {"failure": "missing_expires_at"}
+    if expires_at < now_iso():
+        return False, {"failure": "expired", "expired_at": expires_at}
+    if ovr.get("session_id") != session_id:
+        return False, {"failure": "session_mismatch"}
+
     expected_hmac = compute_hmac(
         ovr.get("granted_at", ""),
+        expires_at,
         ovr.get("session_id", ""),
         ovr.get("reason", ""),
     )
     if not hmac.compare_digest(expected_hmac, ovr.get("hmac", "")):
         return False, {"failure": "hmac_mismatch"}
-    if ovr.get("session_id") != session_id:
-        return False, {"failure": "session_mismatch"}
-    expires_at = ovr.get("expires_at", "")
-    if expires_at and expires_at < now_iso():
-        return False, {"failure": "expired", "expired_at": expires_at}
 
     return True, {"reason": ovr.get("reason", ""), "expires_at": expires_at}
 
@@ -445,36 +555,61 @@ def main():
 
     manifest_path = Path(env.get("VADE_COO_MEMORY_DIR", "/home/user/coo-memory")) / "operations" / "boot-deliverables.yml"
 
+    # Initial revalidation triggers:
+    #   - no sentinel at all (fresh session / first PreToolUse)
+    #   - sentinel exists but is UNPARSEABLE
+    #   - sentinel is PENDING with epoch=0 (clear-hook initial; never validated)
     needs_revalidation = (
         sentinel is None
         or sentinel.get("state") == "UNPARSEABLE"
+        or (sentinel.get("state") == "PENDING"
+            and sentinel.get("checked_at_epoch", 0) == 0)
     )
 
     # Backpressure cap: don't re-validate more than once per second.
     backpressure_floor = 1.0
     now_epoch = time.time()
+    manifest_loaded = None  # cache across cached-check + revalidate branches
+    m_err_cached = None
     if sentinel and not needs_revalidation:
         last = sentinel.get("checked_at_epoch", 0)
         if now_epoch - last < backpressure_floor:
             pass  # honor the cache
         else:
             # Content-hash drift check
-            manifest, m_err = load_yaml_manifest(manifest_path)
-            if manifest and not m_err:
-                m_version = manifest.get("manifest_version", 1)
+            manifest_loaded, m_err_cached = load_yaml_manifest(manifest_path)
+            if m_err_cached:
+                # Treat manifest unreadable as a self-fault and force
+                # revalidation (which will write FAIL + cause=validator_self_fault).
+                # Sys-Eng C2: a previously-OK sentinel must not survive
+                # pyyaml going missing or the manifest becoming unreadable.
+                needs_revalidation = True
+            elif manifest_loaded:
+                m_version = manifest_loaded.get("manifest_version", 1)
                 if sentinel.get("manifest_version", 0) != m_version:
                     needs_revalidation = True
                 else:
                     # Cheap mtime first-pass, then hash if changed
-                    for entry in manifest.get("deliverables", []):
+                    for entry in manifest_loaded.get("deliverables", []):
                         path = resolve_path(entry, env)
+                        prev_hash = sentinel.get("content_hashes", {}).get(entry.get("id", ""))
+                        # If we previously hashed this deliverable but
+                        # it no longer exists / can't be stat'd, the
+                        # cache is stale — re-validate. Sys-Eng C1: a
+                        # cached OK must not survive deletion of a
+                        # previously-OK deliverable.
                         if not Path(path).exists():
+                            if prev_hash is not None:
+                                needs_revalidation = True
+                                break
                             continue
                         try:
-                            mtime = Path(path).stat().st_mtime
+                            Path(path).stat()
                         except OSError:
+                            if prev_hash is not None:
+                                needs_revalidation = True
+                                break
                             continue
-                        prev_hash = sentinel.get("content_hashes", {}).get(entry.get("id", ""))
                         if prev_hash:
                             cur_hash = sha1_file(path)
                             if cur_hash != prev_hash:
@@ -486,7 +621,12 @@ def main():
         needs_revalidation = True
 
     if needs_revalidation:
-        manifest, m_err = load_yaml_manifest(manifest_path)
+        # Reuse the cached manifest read if we already did one in the
+        # cached-check branch (Sys-Eng M4: closes the TOCTOU window).
+        if manifest_loaded is not None or m_err_cached is not None:
+            manifest, m_err = manifest_loaded, m_err_cached
+        else:
+            manifest, m_err = load_yaml_manifest(manifest_path)
         if m_err:
             # Validator self-fault — record but DO NOT brick the agent in
             # Phase 0. The brake's own infrastructure failing should not
@@ -516,38 +656,105 @@ def main():
                 "fault_log": fault_path,
             })
         else:
-            state, failures, hashes, m_version = validate_manifest(
-                manifest, env, home, session_id, cwd
-            )
+            # Race gate (Sys-Eng C3, v2 §6 producer-completion check):
+            # if SessionStart producers haven't all logged phase=end,
+            # the deliverables they produce may legitimately not exist
+            # yet. Stay PENDING rather than record a phantom FAIL that
+            # corrupts the 7-day soak signal gating the warn→block flip.
+            boot_started_at_str = (sentinel or {}).get("boot_started_at", now_iso())
+            try:
+                boot_started_epoch = time.mktime(time.strptime(
+                    boot_started_at_str, "%Y-%m-%dT%H:%M:%SZ"
+                )) - time.timezone
+            except (ValueError, OverflowError):
+                boot_started_epoch = now_epoch
+            elapsed = now_epoch - boot_started_epoch
+
+            grace_seconds = _race_grace_seconds()
+            all_done, missing_producers = boot_producers_complete(home, session_id)
+            if grace_seconds <= 0:
+                in_race_window = False
+                race_reason = "race-gate disabled"
+            elif all_done is None:
+                # boot.log unreadable — fall back to wall-clock grace
+                in_race_window = elapsed < grace_seconds
+                race_reason = "wall-clock grace"
+            else:
+                in_race_window = (not all_done)
+                race_reason = "producer end-markers pending"
+
             prev_state = (sentinel or {}).get("state", "PENDING")
-            sentinel = {
-                "state": state,
-                "checked_at": now_iso(),
-                "checked_at_epoch": now_epoch,
-                "manifest_version": m_version,
-                "failures": failures,
-                "boot_started_at": (sentinel or {}).get("boot_started_at", now_iso()),
-                "content_hashes": hashes,
-            }
-            atomic_write_json(sentinel_path, sentinel)
-            if prev_state != state and failures:
-                append_event(state_dir, {
-                    "ts": now_iso(),
-                    "session_id": session_id,
-                    "tool": tool_name,
-                    "from": prev_state,
-                    "to": state,
-                    "cause": "deliverable_missing",
-                    "deliverables": [f["deliverable"] for f in failures],
-                })
-            elif prev_state != state:
-                append_event(state_dir, {
-                    "ts": now_iso(),
-                    "session_id": session_id,
-                    "tool": tool_name,
-                    "from": prev_state,
-                    "to": state,
-                })
+            if in_race_window:
+                # Stay PENDING; do not record FAIL during the race window.
+                sentinel = {
+                    "state": "PENDING",
+                    "checked_at": now_iso(),
+                    "checked_at_epoch": now_epoch,
+                    "manifest_version": manifest.get("manifest_version", 1),
+                    "failures": [],
+                    "boot_started_at": boot_started_at_str,
+                    "content_hashes": (sentinel or {}).get("content_hashes", {}),
+                    "race_gate": {
+                        "reason": race_reason,
+                        "missing_producers": missing_producers,
+                        "elapsed_seconds": round(elapsed, 2),
+                    },
+                }
+                atomic_write_json(sentinel_path, sentinel)
+                if prev_state != "PENDING":
+                    append_event(state_dir, {
+                        "ts": now_iso(),
+                        "session_id": session_id,
+                        "tool": tool_name,
+                        "from": prev_state,
+                        "to": "PENDING",
+                        "cause": "race_gate_engaged",
+                        "race_reason": race_reason,
+                        "missing_producers": missing_producers,
+                    })
+            else:
+                state, failures, hashes, m_version, signals = validate_manifest(
+                    manifest, env, home, session_id, cwd
+                )
+                for sig in signals:
+                    if sig.get("type") == "predicate_unmatched":
+                        append_event(state_dir, {
+                            "ts": now_iso(),
+                            "session_id": session_id,
+                            "tool": tool_name,
+                            "cause": "identity_predicate_unmatched",
+                            "deliverable": sig.get("deliverable"),
+                            "expanded_glob": sig.get("expanded_glob"),
+                            "matches_total": sig.get("matches_total"),
+                        })
+                sentinel = {
+                    "state": state,
+                    "checked_at": now_iso(),
+                    "checked_at_epoch": now_epoch,
+                    "manifest_version": m_version,
+                    "failures": failures,
+                    "boot_started_at": boot_started_at_str,
+                    "content_hashes": hashes,
+                }
+                atomic_write_json(sentinel_path, sentinel)
+                if prev_state != state and failures:
+                    append_event(state_dir, {
+                        "ts": now_iso(),
+                        "session_id": session_id,
+                        "tool": tool_name,
+                        "from": prev_state,
+                        "to": state,
+                        "cause": "deliverable_missing",
+                        "deliverables": [f["deliverable"] for f in failures],
+                    })
+                elif prev_state != state:
+                    append_event(state_dir, {
+                        "ts": now_iso(),
+                        "session_id": session_id,
+                        "tool": tool_name,
+                        "from": prev_state,
+                        "to": state,
+                    })
 
     state = (sentinel or {}).get("state", "PENDING")
 
@@ -568,8 +775,10 @@ def main():
         })
         sys.exit(0)
 
-    # block-on-FAIL / block-strict → check whitelist + deny if outside
-    if state == "PENDING" and mode == "block-on-FAIL":
+    # block-on-FAIL / block-strict → check whitelist + deny if outside.
+    # `mode` is lowercased on read (line 405), so the comparison
+    # constants must be lowercase too. block-strict denies PENDING.
+    if state == "PENDING" and mode == "block-on-fail":
         sys.exit(0)
 
     if tool_name in WHITELIST_TOOLS:

--- a/scripts/hooks/boot-brake-guard.py
+++ b/scripts/hooks/boot-brake-guard.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+# Boot-brake PreToolUse guard. Reads Claude Code's PreToolUse JSON on
+# stdin, returns a hookSpecificOutput JSON on stdout that either allows
+# (silent) or denies (with sanitized reason). Always exits 0; behavior
+# is controlled via emitted JSON.
+#
+# Implements coo-memory#1082 v2 design (Phase 0) per the #1109 commission.
+# Canonical design: coo-memory/_drafts/2026-05-27_boot-brake-architecture-v2.md
+#
+# Architecture:
+#   - First check the override sentinel ($HOME/.vade/boot-brake-override.<sid>.json):
+#     HMAC valid + session_id matches + unexpired → allow (logged).
+#   - Else read the cached sentinel ($VADE_CLOUD_STATE_DIR/boot-brake.<sid>.json):
+#     OK → allow; FAIL → check whitelist; PENDING → allow or deny per mode.
+#   - On cache miss / content-hash mismatch / manifest_version change /
+#     1s backpressure-cap expiry: re-validate the deliverables manifest
+#     ($VADE_COO_MEMORY_DIR/operations/boot-deliverables.yml).
+#   - Atomic sentinel writes via tmp+rename.
+#   - Append-only event log at $VADE_CLOUD_STATE_DIR/brake-events.jsonl.
+#   - Read tool calls tracked at $HOME/.vade/session-reads.<sid>.log
+#     (used by the identity_consumed check_kind).
+#
+# Enforcement mode (VADE_BRAKE_ENFORCE env):
+#   - off:           guard disabled (always allow)
+#   - warn (default): FAIL/PENDING log but allow (Phase 0 soak)
+#   - block-on-FAIL: FAIL denies, PENDING allows (Phase 1)
+#   - block-strict:  FAIL and PENDING both deny (Phase 2)
+#
+# Whitelist in FAIL/PENDING (block mode): Read + Grep only.
+#
+# Failure modes that this guard handles WITHOUT locking the agent out:
+#   - Unparseable sentinel → treat as missing, re-validate, write diagnostic
+#     to $VADE_CLOUD_STATE_DIR/boot-brake-faults/<ts>.log
+#   - Validator self-fault (manifest unreadable, yaml broken, etc.) → state=FAIL
+#     with cause=validator_self_fault, diagnostic to faults log
+#   - Disk full / IO error → guard logs to stderr and allows (fail-OPEN on
+#     guard infrastructure failure is intentional in Phase 0; the brake
+#     should not be the source of session bricking — capability-fault
+#     posture targets discipline failures, not its own infrastructure)
+#
+# This script is invoked via boot-brake-guard.sh which forwards stdin/env.
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import string
+import sys
+import time
+import traceback
+from pathlib import Path
+
+
+_SAFE_CHARSET = set(string.ascii_letters + string.digits + " ._/:-")
+
+
+def sanitize(s, max_len=240):
+    """Strip any char outside the safe set; truncate. v2 §4 (R2#6).
+
+    Untrusted interpolated values (deliverable ids, producer names,
+    reason text from file paths, error class names) pass through this
+    before reaching the agent's tool-feedback context. The safe set is
+    [A-Za-z0-9 ._/:-] — no shell metachars, no sentence delimiters that
+    could carry injection-style instructions.
+    """
+    if s is None:
+        return ""
+    out = "".join(ch for ch in str(s) if ch in _SAFE_CHARSET)
+    if len(out) > max_len:
+        out = out[:max_len] + "..."
+    return out
+
+
+def now_iso():
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def derive_hmac_key():
+    src = os.environ.get("OP_SERVICE_ACCOUNT_TOKEN", "")
+    if not src:
+        src = os.environ.get("MEM0_API_KEY", "") or os.environ.get("GITHUB_MCP_PAT", "")
+    if not src:
+        src = "vade-boot-brake-default-no-secrets"
+    return hashlib.sha256(src.encode("utf-8")).digest()
+
+
+def compute_hmac(granted_at, session_id, reason):
+    msg = f"{granted_at}|{session_id}|{reason}".encode("utf-8")
+    return hmac.new(derive_hmac_key(), msg, hashlib.sha256).hexdigest()
+
+
+def atomic_write_json(path, payload):
+    tmp = f"{path}.tmp.{os.getpid()}"
+    try:
+        Path(tmp).parent.mkdir(parents=True, exist_ok=True)
+        with open(tmp, "w") as fh:
+            json.dump(payload, fh, separators=(",", ":"))
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+        return True
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return False
+
+
+def append_event(state_dir, event):
+    path = Path(state_dir) / "brake-events.jsonl"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as fh:
+            fh.write(json.dumps(event, separators=(",", ":")) + "\n")
+    except Exception:
+        pass
+
+
+def append_session_read(home, session_id, file_path):
+    log = Path(home) / ".vade" / f"session-reads.{session_id}.log"
+    try:
+        log.parent.mkdir(parents=True, exist_ok=True)
+        with open(log, "a") as fh:
+            fh.write(f"{now_iso()}\t{file_path}\n")
+    except Exception:
+        pass
+
+
+def session_has_read(home, session_id, predicate):
+    log = Path(home) / ".vade" / f"session-reads.{session_id}.log"
+    if not log.exists():
+        return False
+    try:
+        with open(log) as fh:
+            for line in fh:
+                parts = line.rstrip("\n").split("\t", 1)
+                if len(parts) == 2 and predicate(parts[1]):
+                    return True
+    except Exception:
+        return False
+    return False
+
+
+def write_fault(state_dir, message, exc=None):
+    faults_dir = Path(state_dir) / "boot-brake-faults"
+    try:
+        faults_dir.mkdir(parents=True, exist_ok=True)
+        stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        path = faults_dir / f"{stamp}.{os.getpid()}.log"
+        with open(path, "w") as fh:
+            fh.write(f"{now_iso()} {message}\n")
+            if exc is not None:
+                fh.write(traceback.format_exc())
+        return str(path)
+    except Exception:
+        return None
+
+
+def load_yaml_manifest(manifest_path):
+    try:
+        import yaml
+    except ImportError:
+        return None, "pyyaml not available"
+    try:
+        with open(manifest_path) as fh:
+            data = yaml.safe_load(fh)
+        return data, None
+    except FileNotFoundError:
+        return None, f"manifest not found at {manifest_path}"
+    except Exception as e:
+        return None, f"manifest unparseable: {type(e).__name__}: {e}"
+
+
+def resolve_path(entry, env):
+    raw = entry.get("path", "")
+    root = entry.get("root", "")
+    expanded = raw
+    for var in ("VADE_CLOUD_STATE_DIR", "VADE_COO_MEMORY_DIR", "VADE_RUNTIME_DIR", "HOME"):
+        expanded = expanded.replace(f"${var}", env.get(var, ""))
+    if root and not expanded.startswith("/"):
+        root_v = env.get(root, "") if not root.startswith("/") else root
+        for var in ("VADE_CLOUD_STATE_DIR", "VADE_COO_MEMORY_DIR", "VADE_RUNTIME_DIR", "HOME"):
+            root_v = root_v.replace(f"${var}", env.get(var, ""))
+        expanded = str(Path(root_v) / expanded)
+    return expanded
+
+
+def sha1_file(path):
+    h = hashlib.sha1()
+    try:
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except Exception:
+        return None
+
+
+def check_deliverable(entry, env, home, session_id, cwd):
+    """Returns (ok: bool, reason: str, content_hash: str|None)."""
+    kind = entry.get("check_kind", "exists")
+    path = resolve_path(entry, env)
+
+    if kind == "exists":
+        if Path(path).exists():
+            return True, "", sha1_file(path)
+        return False, f"missing: {path}", None
+
+    if kind == "parses_json":
+        try:
+            with open(path) as fh:
+                content = fh.read()
+            json.loads(content)
+            return True, "", hashlib.sha1(content.encode()).hexdigest()
+        except FileNotFoundError:
+            return False, f"missing: {path}", None
+        except Exception as e:
+            return False, f"unparseable: {type(e).__name__}", None
+
+    if kind == "symlink_to":
+        target = entry.get("check_arg", "")
+        for var in ("VADE_CLOUD_STATE_DIR", "VADE_COO_MEMORY_DIR", "VADE_RUNTIME_DIR", "HOME"):
+            target = target.replace(f"${var}", env.get(var, ""))
+        try:
+            if not Path(path).is_symlink():
+                return False, f"not a symlink: {path}", None
+            resolved = os.path.realpath(path)
+            expected = os.path.realpath(target) if target else None
+            if expected and resolved != expected:
+                return False, f"symlink target drift: {path}", None
+            return True, "", hashlib.sha1(resolved.encode()).hexdigest()
+        except Exception as e:
+            return False, f"symlink check error: {type(e).__name__}", None
+
+    if kind == "has_jq_path":
+        jq_path = entry.get("check_arg", "")
+        try:
+            with open(path) as fh:
+                content = fh.read()
+            data = json.loads(content)
+            cur = data
+            for segment in jq_path.strip(".").split("."):
+                if segment.endswith("]"):
+                    name, idx = segment[:-1].split("[", 1)
+                    if name:
+                        cur = cur[name]
+                    cur = cur[int(idx)]
+                elif segment:
+                    if isinstance(cur, list):
+                        cur = cur[int(segment)]
+                    else:
+                        cur = cur[segment]
+            return True, "", hashlib.sha1(content.encode()).hexdigest()
+        except FileNotFoundError:
+            return False, f"missing: {path}", None
+        except (KeyError, IndexError):
+            return False, f"jq path missing: {jq_path}", None
+        except Exception as e:
+            return False, f"check error: {type(e).__name__}", None
+
+    if kind == "read_observed":
+        # The identity_consumed kind from v2 §11. The check_arg is a
+        # regex pattern; the deliverable is satisfied when ANY Read tool
+        # call observed in this session matches the pattern. Conditional:
+        # if the predicate file doesn't exist, skip (not required).
+        predicate_glob = entry.get("predicate_exists_glob", "")
+        if predicate_glob:
+            import glob
+            expanded_glob = predicate_glob
+            for var in ("VADE_CLOUD_STATE_DIR", "VADE_COO_MEMORY_DIR", "VADE_RUNTIME_DIR", "HOME"):
+                expanded_glob = expanded_glob.replace(f"${var}", env.get(var, ""))
+            # The cwd is part of the per-session project dir naming
+            expanded_glob = expanded_glob.replace("$CWD_DASHIFIED", cwd.replace("/", "-"))
+            expanded_glob = expanded_glob.replace("$SESSION_ID", session_id)
+            matches = glob.glob(expanded_glob)
+            # Filter to non-trivial files (> 1KB indicates real overflow)
+            substantive = [m for m in matches if Path(m).stat().st_size > 1024]
+            if not substantive:
+                return True, "predicate not present; check skipped", None
+        pattern = entry.get("check_arg", "")
+        try:
+            rx = re.compile(pattern)
+        except re.error as e:
+            return False, f"bad regex: {type(e).__name__}", None
+        if session_has_read(home, session_id, lambda fp: rx.search(fp) is not None):
+            return True, "", None
+        return False, f"identity layer overflowed but agent has not yet Read it", None
+
+    return False, f"unknown check_kind: {kind}", None
+
+
+def validate_manifest(manifest, env, home, session_id, cwd):
+    """Returns (state, failures, content_hashes, manifest_version)."""
+    if not manifest or "deliverables" not in manifest:
+        return "FAIL", [{"deliverable": "manifest", "reason": "no deliverables key"}], {}, 0
+
+    manifest_version = manifest.get("manifest_version", 1)
+    failures = []
+    hashes = {}
+
+    for entry in manifest.get("deliverables", []):
+        dlid = entry.get("id", "unknown")
+        ok, reason, ch = check_deliverable(entry, env, home, session_id, cwd)
+        if ch is not None:
+            hashes[dlid] = ch
+        if not ok:
+            if entry.get("severity", "critical") == "critical":
+                failures.append({
+                    "deliverable": dlid,
+                    "reason": reason,
+                    "producer": entry.get("producer", "unknown"),
+                })
+
+    state = "OK" if not failures else "FAIL"
+    return state, failures, hashes, manifest_version
+
+
+def read_cached_sentinel(path):
+    try:
+        with open(path) as fh:
+            return json.load(fh), None
+    except FileNotFoundError:
+        return None, "missing"
+    except (json.JSONDecodeError, ValueError) as e:
+        return None, f"unparseable: {type(e).__name__}"
+    except Exception as e:
+        return None, f"read error: {type(e).__name__}"
+
+
+def check_override(home, session_id):
+    """Returns (allowed, info_dict|None)."""
+    path = Path(home) / ".vade" / f"boot-brake-override.{session_id}.json"
+    if not path.exists():
+        return False, None
+    try:
+        with open(path) as fh:
+            ovr = json.load(fh)
+    except Exception:
+        return False, None
+
+    expected_hmac = compute_hmac(
+        ovr.get("granted_at", ""),
+        ovr.get("session_id", ""),
+        ovr.get("reason", ""),
+    )
+    if not hmac.compare_digest(expected_hmac, ovr.get("hmac", "")):
+        return False, {"failure": "hmac_mismatch"}
+    if ovr.get("session_id") != session_id:
+        return False, {"failure": "session_mismatch"}
+    expires_at = ovr.get("expires_at", "")
+    if expires_at and expires_at < now_iso():
+        return False, {"failure": "expired", "expired_at": expires_at}
+
+    return True, {"reason": ovr.get("reason", ""), "expires_at": expires_at}
+
+
+def emit_allow(extra_event=None, state_dir=None):
+    if extra_event and state_dir:
+        append_event(state_dir, extra_event)
+    sys.stdout.write("")
+    sys.exit(0)
+
+
+def emit_deny(reason, event=None, state_dir=None):
+    """reason is assumed pre-sanitized by the caller — interpolated
+    untrusted values must already have gone through sanitize(). The
+    format string itself is trusted and uses only safe-set delimiters.
+    """
+    if event and state_dir:
+        append_event(state_dir, event)
+    if len(reason) > 1500:
+        reason = reason[:1500] + "..."
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    sys.stdout.write(json.dumps(out))
+    sys.exit(0)
+
+
+WHITELIST_TOOLS = {"Read", "Grep"}
+
+
+def main():
+    # Read hook input from stdin (Claude Code PreToolUse JSON)
+    raw = sys.stdin.read()
+    if not raw.strip():
+        sys.exit(0)
+    try:
+        event = json.loads(raw)
+    except Exception:
+        sys.exit(0)
+
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input", {}) or {}
+    session_id = event.get("session_id") or os.environ.get("CLAUDE_CODE_SESSION_ID", "unknown")
+    cwd = event.get("cwd") or os.environ.get("PWD", "/home/user")
+
+    env = os.environ
+    home = env.get("HOME", "/root")
+    state_dir = env.get("VADE_CLOUD_STATE_DIR", f"{home}/.vade-cloud-state")
+
+    mode = env.get("VADE_BRAKE_ENFORCE", "warn").lower()
+    if mode == "off":
+        sys.exit(0)
+
+    # Track Read tool calls into a per-session log for the
+    # identity_consumed check_kind. Do this before any deny path so the
+    # log is complete even when the same Read gets denied for an
+    # unrelated reason.
+    if tool_name == "Read":
+        target = tool_input.get("file_path", "")
+        if target:
+            append_session_read(home, session_id, target)
+
+    # Override sentinel takes precedence — if it's valid and unexpired,
+    # allow unconditionally (logged once per session is enough; we log
+    # every fire for audit completeness).
+    ovr_ok, ovr_info = check_override(home, session_id)
+    if ovr_ok:
+        append_event(state_dir, {
+            "ts": now_iso(),
+            "session_id": session_id,
+            "tool": tool_name,
+            "from": "any",
+            "to": "OK",
+            "cause": "manual_override_granted",
+            "reason": sanitize(ovr_info.get("reason", "")),
+        })
+        sys.exit(0)
+    if ovr_info and ovr_info.get("failure") == "expired":
+        append_event(state_dir, {
+            "ts": now_iso(),
+            "session_id": session_id,
+            "cause": "manual_override_expired",
+            "expired_at": ovr_info.get("expired_at"),
+        })
+
+    sentinel_path = Path(state_dir) / f"boot-brake.{session_id}.json"
+    sentinel, sentinel_err = read_cached_sentinel(sentinel_path)
+
+    manifest_path = Path(env.get("VADE_COO_MEMORY_DIR", "/home/user/coo-memory")) / "operations" / "boot-deliverables.yml"
+
+    needs_revalidation = (
+        sentinel is None
+        or sentinel.get("state") == "UNPARSEABLE"
+    )
+
+    # Backpressure cap: don't re-validate more than once per second.
+    backpressure_floor = 1.0
+    now_epoch = time.time()
+    if sentinel and not needs_revalidation:
+        last = sentinel.get("checked_at_epoch", 0)
+        if now_epoch - last < backpressure_floor:
+            pass  # honor the cache
+        else:
+            # Content-hash drift check
+            manifest, m_err = load_yaml_manifest(manifest_path)
+            if manifest and not m_err:
+                m_version = manifest.get("manifest_version", 1)
+                if sentinel.get("manifest_version", 0) != m_version:
+                    needs_revalidation = True
+                else:
+                    # Cheap mtime first-pass, then hash if changed
+                    for entry in manifest.get("deliverables", []):
+                        path = resolve_path(entry, env)
+                        if not Path(path).exists():
+                            continue
+                        try:
+                            mtime = Path(path).stat().st_mtime
+                        except OSError:
+                            continue
+                        prev_hash = sentinel.get("content_hashes", {}).get(entry.get("id", ""))
+                        if prev_hash:
+                            cur_hash = sha1_file(path)
+                            if cur_hash != prev_hash:
+                                needs_revalidation = True
+                                break
+
+    if sentinel_err and sentinel_err.startswith("unparseable"):
+        write_fault(state_dir, f"sentinel unparseable: {sentinel_err}")
+        needs_revalidation = True
+
+    if needs_revalidation:
+        manifest, m_err = load_yaml_manifest(manifest_path)
+        if m_err:
+            # Validator self-fault — record but DO NOT brick the agent in
+            # Phase 0. The brake's own infrastructure failing should not
+            # convert into a session lockout.
+            fault_path = write_fault(state_dir, f"validator self-fault: {m_err}")
+            sentinel = {
+                "state": "FAIL",
+                "checked_at": now_iso(),
+                "checked_at_epoch": now_epoch,
+                "manifest_version": 0,
+                "failures": [{
+                    "deliverable": "brake-validator",
+                    "reason": sanitize(m_err),
+                    "producer": "boot-brake-guard.py",
+                }],
+                "boot_started_at": (sentinel or {}).get("boot_started_at", now_iso()),
+                "content_hashes": {},
+                "cause": "validator_self_fault",
+                "fault_log": fault_path,
+            }
+            atomic_write_json(sentinel_path, sentinel)
+            append_event(state_dir, {
+                "ts": now_iso(),
+                "session_id": session_id,
+                "cause": "validator_self_fault",
+                "reason": sanitize(m_err),
+                "fault_log": fault_path,
+            })
+        else:
+            state, failures, hashes, m_version = validate_manifest(
+                manifest, env, home, session_id, cwd
+            )
+            prev_state = (sentinel or {}).get("state", "PENDING")
+            sentinel = {
+                "state": state,
+                "checked_at": now_iso(),
+                "checked_at_epoch": now_epoch,
+                "manifest_version": m_version,
+                "failures": failures,
+                "boot_started_at": (sentinel or {}).get("boot_started_at", now_iso()),
+                "content_hashes": hashes,
+            }
+            atomic_write_json(sentinel_path, sentinel)
+            if prev_state != state and failures:
+                append_event(state_dir, {
+                    "ts": now_iso(),
+                    "session_id": session_id,
+                    "tool": tool_name,
+                    "from": prev_state,
+                    "to": state,
+                    "cause": "deliverable_missing",
+                    "deliverables": [f["deliverable"] for f in failures],
+                })
+            elif prev_state != state:
+                append_event(state_dir, {
+                    "ts": now_iso(),
+                    "session_id": session_id,
+                    "tool": tool_name,
+                    "from": prev_state,
+                    "to": state,
+                })
+
+    state = (sentinel or {}).get("state", "PENDING")
+
+    # OK → allow silently
+    if state == "OK":
+        sys.exit(0)
+
+    # FAIL / PENDING in warn mode → allow but log
+    if mode == "warn":
+        append_event(state_dir, {
+            "ts": now_iso(),
+            "session_id": session_id,
+            "tool": tool_name,
+            "state": state,
+            "mode": "warn",
+            "cause": "would_have_denied",
+            "failures": (sentinel or {}).get("failures", []),
+        })
+        sys.exit(0)
+
+    # block-on-FAIL / block-strict → check whitelist + deny if outside
+    if state == "PENDING" and mode == "block-on-FAIL":
+        sys.exit(0)
+
+    if tool_name in WHITELIST_TOOLS:
+        append_event(state_dir, {
+            "ts": now_iso(),
+            "session_id": session_id,
+            "tool": tool_name,
+            "state": state,
+            "outcome": "whitelisted",
+        })
+        sys.exit(0)
+
+    failures = (sentinel or {}).get("failures", [])
+    # Format: "<dlid>: <reason> -- <dlid>: <reason>" — delimiters drawn
+    # from the safe set only. Interpolated values are sanitized.
+    fail_parts = [
+        f"{sanitize(f.get('deliverable', 'unknown'))}: {sanitize(f.get('reason', ''))}"
+        for f in failures[:3]
+    ]
+    fail_summary = " -- ".join(fail_parts)
+    if len(failures) > 3:
+        fail_summary += f" -- plus {len(failures) - 3} more"
+    state_safe = sanitize(state)
+    reason = (
+        f"Boot brake active. State: {state_safe}. "
+        f"Failing deliverables: {fail_summary}. "
+        f"Read and Grep are allowed for investigation. "
+        f"For override and recovery procedures see operations/boot-brake.md."
+    )
+    emit_deny(reason, event={
+        "ts": now_iso(),
+        "session_id": session_id,
+        "tool": tool_name,
+        "state": state,
+        "outcome": "denied",
+        "failures": failures,
+    }, state_dir=state_dir)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        try:
+            home = os.environ.get("HOME", "/root")
+            state_dir = os.environ.get("VADE_CLOUD_STATE_DIR", f"{home}/.vade-cloud-state")
+            write_fault(state_dir, f"guard crashed: {type(e).__name__}: {e}", exc=e)
+        except Exception:
+            pass
+        # Fail-OPEN on guard infrastructure crash — the brake should not
+        # be the source of session bricking. Per Phase 0 commitment.
+        sys.exit(0)

--- a/scripts/hooks/boot-brake-guard.sh
+++ b/scripts/hooks/boot-brake-guard.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# PreToolUse boot-brake guard. Reads Claude Code's PreToolUse JSON on
+# stdin, dispatches to boot-brake-guard.py for the validator + decision
+# logic.
+#
+# Why a python sibling: the validator carries content-hashing, HMAC
+# verification, YAML manifest parsing, and a five-way state machine.
+# That doesn't fit cleanly in bash + jq. The python script is the brain;
+# this wrapper is the hook surface.
+#
+# Always exits 0. On allow, emits nothing. On deny, emits the modern
+# hookSpecificOutput shape per https://code.claude.com/docs/en/hooks.md
+# with permissionDecision=deny + sanitized permissionDecisionReason.
+#
+# VADE_BRAKE_ENFORCE controls mode (off|warn|block-on-FAIL|block-strict).
+# Default is `warn` for Phase 0 — sessions don't experience refusal
+# during the soak period.
+#
+# Reference: coo-memory#1082 (design), coo-memory#1109 (this commission).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pipe stdin through to the python guard. Capture its stdout (the
+# hookSpecificOutput JSON on deny; empty on allow) and forward.
+input="$(cat 2>/dev/null || true)"
+if [ -z "$input" ]; then
+  exit 0
+fi
+
+# Python guard handles its own exceptions and fails OPEN if it crashes.
+printf '%s' "$input" | python3 "$SCRIPT_DIR/boot-brake-guard.py"
+exit 0


### PR DESCRIPTION
## Summary

Implements the Phase 0 boot-brake — a PreToolUse capability guard that refuses agent tool calls when declared boot-time deliverables are missing or unconsumed. Companion to coo-labs/coo-memory#1109 (the policy side: manifest, /unbrake skill, operator doc).

Per the v2 design at `coo-labs/coo-memory:_drafts/2026-05-27_boot-brake-architecture-v2.md`. Closes the structural gap behind the 2026-06-01 boot-read-skip incident (coo-labs/coo-logs#567/#568) — that was the third occurrence this week per Ven's incident report, escalated to P0 today.

## What lands in this PR

**`scripts/hooks/boot-brake-guard.{sh,py}` — PreToolUse hook, matcher `*`, registered FIRST.**

- Reads override sentinel first; HMAC-verifies + session-match + unexpired → allow with `manual_override_granted` event.
- Otherwise reads cached sentinel at `$VADE_CLOUD_STATE_DIR/boot-brake.<sid>.json`.
- On cache miss / content-hash mismatch / `manifest_version` change / 1s backpressure-cap expiry: re-validate against the manifest at `$VADE_COO_MEMORY_DIR/operations/boot-deliverables.yml`.
- Atomic sentinel writes (mode 0600, tmp+rename).
- `state ∈ {OK, FAIL, PENDING, UNPARSEABLE}`; distinct UNPARSEABLE handling (treat as missing + write fault diagnostic to `boot-brake-faults/<ts>.log`; don't fail-closed on parse error of the sentinel itself).
- Validator self-fault: writes FAIL with `cause: validator_self_fault` and a fault log; does NOT brick the agent (Phase 0 fail-OPEN on brake-infrastructure crashes).
- Sanitization of all interpolated values to `[A-Za-z0-9 ._/:-]` before they reach `permissionDecisionReason` (closes R2#6 prompt-injection vector).
- Whitelist in FAIL: `Read` + `Grep` only. Bash, Edit, Write, Skill, Task, MCP writes — denied.
- Modern `hookSpecificOutput.permissionDecision=deny` shape per current Claude Code hooks docs.
- Tracks observed `Read` tool calls into `$HOME/.vade/session-reads.<sid>.log` for the §11 `identity_consumed` check_kind.
- Appends every state transition to `$VADE_CLOUD_STATE_DIR/brake-events.jsonl` (append-only event log, R3#1 / cross-cutting #3).

**`scripts/boot/boot-brake-clear.sh` — SessionStart hook, registered first in the startup chain.**

- Initializes a PENDING sentinel for this session with `boot_started_at` set.
- Sweeps stale per-session sentinels (>24h) and expired override sentinels.
- Sweeps old session-reads logs.
- Idempotent; always exits 0.

**`scripts/ci/test-boot-brake-guard.sh` — covers v2 §7 tests 1, 2, 3, 6, 7, 9.**

- Test 1: per-producer fault injection (each of 3 manifest entries).
- Test 2: PreToolUse refusal smoke (block-on-FAIL + missing deliverables → deny with reason).
- Test 3: Read+Grep whitelisted in FAIL.
- Test 6: Task denied in FAIL; parent's `/unbrake` override does not propagate to sub-agents (different session_id → still denied).
- Test 7: parallel-session sentinel isolation (per-session keyed; no cross-pollution).
- Test 9: unparseable sentinel triggers re-validation + fault diagnostic; doesn't lock the agent out.

14 assertions total; all green locally.

**`scripts/ci/fixtures/boot-deliverables.yml`** — minimal manifest fixture for CI when coo-memory isn't co-checked-out.

**`.claude/settings.json`**:
- `boot-brake-clear.sh` added to SessionStart startup chain (first).
- `boot-brake-guard.sh` added to PreToolUse with matcher `*` (first).
- `VADE_BRAKE_ENFORCE=warn` added to env (Phase 0 default — sessions never see refusal during soak).

**`.github/workflows/bootstrap-regression.yml`** (landed as a separate commit by `vade-coo-app[bot]` via the App-token contents API since OAuth lacks `workflow` scope) — wires `test-boot-brake-guard.sh` into the transcript-redaction job.

## Out of scope (Phase 1+)

Per the #1109 commission:
- Empirically-derived watchdog thresholds (placeholder is 30s PENDING / 60s FAIL-promotion).
- `bin/brake-report.sh` aggregator.
- BDFL runbook (`operations/boot-brake-runbook.md`).
- Tests 4, 5, 8, 10 (stale-sentinel cleanup, manifest static cross-check, prompt-injection unit test, legacy-format collision).
- Manifest expansion beyond Phase 0 entries.

## Closes

Closes: n/a — companion to coo-labs/coo-memory#1109; design issue coo-labs/coo-memory#1082 stays open through Phase 1+. The coo-memory PR carries the `Closes coo-labs/coo-memory#1109` keyword.

Refs: coo-labs/coo-memory#1082, coo-labs/coo-memory#1109, coo-labs/coo-logs#567, coo-labs/coo-logs#568

https://claude.ai/code/session_01TeXZZE3cxzbtBjkPkPQy6Q