### PR TITLE
transcript-export: recover first-writer meta on R2 PUT cede

### DIFF
--- a/scripts/lifecycle/session-end-transcript-export.py
+++ b/scripts/lifecycle/session-end-transcript-export.py
@@ -380,6 +380,50 @@ def _r2_upload(
         raise
 
 
+def _r2_head_object_metadata(
+    key: str,
+    *,
+    endpoint: str,
+    bucket: str,
+) -> dict[str, str] | None:
+    """Fetch R2 user-metadata for an existing key via head_object.
+
+    Used by the cede branch (coo-harness#416): on first-write-wins cede,
+    the canonical writer's sidecar JSON is embedded in
+    `x-amz-meta-vade-meta-json` on the ciphertext key. Reading it back
+    lets the second writer reconstruct the local sidecar from the first
+    writer's dict (not its own stale dict whose ciphertext_sha256 no
+    longer matches what's in R2).
+
+    Returns the lowercased Metadata dict on success, None on any failure
+    (caller falls back to breadcrumb-only behavior).
+    """
+    access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
+    secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
+    if not access_key or not secret_key:
+        return None
+
+    try:
+        import boto3
+        from botocore.config import Config
+
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name="auto",
+            config=Config(
+                signature_version="s3v4",
+                retries={"max_attempts": 3, "mode": "standard"},
+            ),
+        )
+        resp = s3.head_object(Bucket=bucket, Key=key)
+        return resp.get("Metadata") or {}
+    except BaseException:
+        return None
+
+
 def _encode_meta_for_object_metadata(sidecar: dict) -> dict[str, str] | None:
     """Encode the meta sidecar dict for embedding as R2 object metadata.
 
@@ -802,18 +846,42 @@ def main() -> int:
                 # First-write-wins cede (coo-harness#204): another writer
                 # already holds this R2 key. Our ciphertext_sha256 does NOT
                 # match what's in R2 — writing meta.json with our SHA would
-                # re-create the mismatch this fix prevents. Drop a
-                # breadcrumb so operators can trace which session ceded,
-                # then exit cleanly without writing the sidecar or
-                # opening the auto-PR. The canonical writer's meta
-                # (in their object-metadata + flat-key) wins.
+                # re-create the mismatch the cede prevents. Instead, fetch
+                # the first writer's sidecar back from object metadata via
+                # head_object and continue the normal flat-key + sidecar +
+                # auto-PR flow with their dict. Keeps the transcript
+                # discoverable through every navigation path (coo-harness#416).
                 if upload.get("ceded"):
-                    _emit_meta_pr_error(
-                        sidecar_dir,
-                        session_id,
-                        f"R2 PUT ceded to first writer (key={r2_key}); skipped meta.json write",
+                    md = _r2_head_object_metadata(
+                        r2_key, endpoint=r2_endpoint, bucket=r2_bucket,
                     )
-                    return 0
+                    embed = (md or {}).get("vade-meta-json", "")
+                    recovered: dict | None = None
+                    if embed:
+                        try:
+                            recovered = json.loads(embed)
+                        except json.JSONDecodeError:
+                            recovered = None
+
+                    if recovered is None:
+                        # Outlier: first writer was too large to embed
+                        # (None return from _encode_meta_for_object_metadata)
+                        # or head_object itself failed. Fall through to the
+                        # prior breadcrumb-only behavior.
+                        _emit_meta_pr_error(
+                            sidecar_dir,
+                            session_id,
+                            f"R2 PUT ceded to first writer (key={r2_key}); "
+                            "vade-meta-json embed not recoverable; "
+                            "skipped meta.json write",
+                        )
+                        return 0
+
+                    _stderr(
+                        f"R2 PUT ceded; recovered first writer's meta via "
+                        f"head_object (key={r2_key})"
+                    )
+                    sidecar = recovered
 
             # Best-effort secondary: flat-key meta PUT (fast-resolve index
             # for transcript-fetch.py — avoids list+head_object on the


### PR DESCRIPTION
## Symptom

When two writers race the ciphertext PUT, the loser cedes correctly (412 PreconditionFailed under `IfNoneMatch=*`) but then exits 0 without writing the local sidecar, the flat-key meta, or opening the auto-PR. Net: ciphertext durable on R2, no sidecar in coo-logs, transcript unfindable through any normal navigation path. Two sessions orphaned on 2026-06-01 (recovered manually via [coo-labs/coo-logs#566](https://github.com/coo-labs/coo-logs/pull/566)).

## Root cause

The cede branch treated the race-loss as terminal. The first writer's sidecar dict IS in R2 — embedded as `x-amz-meta-vade-meta-json` on the ciphertext key per the atomic-PUT layer (#215 follow-up) — but the second writer never fetched it back. Writing our own (stale) dict was the wrong fix because our `ciphertext_sha256` no longer matches what's in R2; dropping a breadcrumb and exiting was the wrong fix because it orphans the sidecar.

## Fix

On cede:

1. `head_object` the existing R2 key.
2. Decode `vade-meta-json` from the returned user-metadata.
3. Rebind the local `sidecar` variable to the first writer's dict.
4. Fall through to the existing flat-key meta PUT, local sidecar write, and `_open_meta_pr` steps. The flat-key PUT cedes (first writer wrote it); the local sidecar and auto-PR carry the first writer's SHA so every meta tier agrees.

New helper `_r2_head_object_metadata` mirrors `_r2_upload`'s auth/setup.

## Outlier path preserved

If the first writer's encode returned None (meta too large to embed even after dropping `redaction_hits`), or `head_object` itself fails, we fall through to the prior breadcrumb-only behavior. The outlier-of-outlier case behaves exactly as before, so no regression for sessions that already worked.

## Test plan

- [x] AST parse clean.
- [x] Bootstrap-regression CI exercises the boot/integrity path; the transcript-export cede branch isn't reached under fake-env (no R2 in CI).
- [ ] Real-world verification arrives when the next parallel-end-session race fires; until then, the breadcrumb is replaced with a recovery action and the orphaning failure mode is closed.

## Related

- coo-harness#204 / [MEMO-2026-05-03-bgk3](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-05-03-bgk3.md) — first-write-wins IfNoneMatch contract.
- coo-harness#207 — meta-vs-R2 asymmetry instrumentation.
- coo-harness#215 — atomic-PUT meta embed.

Closes #416

https://claude.ai/code/session_017f4ptAnXMxxUxG9i63LRzC