### PR TITLE
fix(boot-brake): soak-signal fixes — race-gate, event taxonomy, compaction

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$VADE_RUNTIME_DIR/scripts/boot/boot-brake-clear.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$VADE_RUNTIME_DIR/scripts/lifecycle/session-lifecycle.sh\""
           }
         ]

--- a/scripts/ci/test-boot-brake-guard.sh
+++ b/scripts/ci/test-boot-brake-guard.sh
@@ -365,6 +365,130 @@ else
   _fail "Empty expires_at was treated as permanent — SC2 regression"
 fi
 
+# ─── Test 15 (NEW): producer-complete tolerates skip-paths ─────
+echo "Test 15 — boot_producers_complete treats start+elapsed as done (soak-fix #A)"
+set -- $(echo "$(_setup_session_dirs "t15")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+# Stage a boot.log with phase=start for each tracked producer and
+# NO phase=end (simulating coo-bootstrap's marker-present-skip path).
+# Backdate the start timestamps so elapsed > PRODUCER_DONE_THRESHOLD.
+mkdir -p "$home_dir/.vade"
+old_iso="$(date -u -d '-60 seconds' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null \
+  || date -u -v -60S +%Y-%m-%dT%H:%M:%S.000Z)"
+cat > "$home_dir/.vade/boot.log" <<EOF
+{"ts":"$old_iso","session":"t15","script":"session-start-sync","phase":"start"}
+{"ts":"$old_iso","session":"t15","script":"coo-bootstrap","phase":"start"}
+{"ts":"$old_iso","session":"t15","script":"coo-identity-digest","phase":"start"}
+EOF
+# Invoke with race-gate ENABLED (grace=300). With the fix, the start+elapsed
+# path treats producers as done; race-gate clears; state transitions to OK.
+out="$(printf '{"session_id":"t15","cwd":"/home/user","tool_name":"Bash","tool_input":{"command":"ls"}}' | \
+  VADE_BRAKE_ENFORCE=block-on-FAIL \
+  VADE_BRAKE_RACE_GRACE_SECONDS=300 \
+  VADE_CLOUD_STATE_DIR="$state_dir" \
+  VADE_COO_MEMORY_DIR="$COO_MEMORY_DIR" \
+  HOME="$home_dir" \
+  bash "$GUARD" 2>/dev/null)"
+state_t15="$(python3 -c "import json; d=json.load(open('$state_dir/boot-brake.t15.json')); print(d['state'])")"
+if [ "$state_t15" = "OK" ]; then
+  _pass "Producers with start+elapsed > threshold treated as done; race-gate cleared"
+else
+  _fail "Race-gate stayed engaged despite producer-start being 60s old (state=$state_t15)"
+fi
+
+# Negative case: a producer that JUST started (no elapsed) keeps the race-gate engaged.
+set -- $(echo "$(_setup_session_dirs "t15b")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+mkdir -p "$home_dir/.vade"
+now_iso="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+cat > "$home_dir/.vade/boot.log" <<EOF
+{"ts":"$now_iso","session":"t15b","script":"session-start-sync","phase":"start"}
+EOF
+printf '{"session_id":"t15b","cwd":"/home/user","tool_name":"Bash","tool_input":{"command":"ls"}}' | \
+  VADE_BRAKE_ENFORCE=block-on-FAIL \
+  VADE_BRAKE_RACE_GRACE_SECONDS=300 \
+  VADE_CLOUD_STATE_DIR="$state_dir" \
+  VADE_COO_MEMORY_DIR="$COO_MEMORY_DIR" \
+  HOME="$home_dir" \
+  bash "$GUARD" 2>/dev/null > /dev/null
+state_t15b="$(python3 -c "import json; d=json.load(open('$state_dir/boot-brake.t15b.json')); print(d['state'])")"
+missing_t15b="$(python3 -c "import json; d=json.load(open('$state_dir/boot-brake.t15b.json')); print(','.join((d.get('race_gate') or {}).get('missing_producers', [])))")"
+if [ "$state_t15b" = "PENDING" ] && [[ "$missing_t15b" == *"coo-bootstrap"* ]]; then
+  _pass "Producers with recent start still missing → race-gate stays engaged (negative case)"
+else
+  _fail "Negative race-gate check failed (state=$state_t15b, missing=$missing_t15b)"
+fi
+
+# ─── Test 16 (NEW): warn-mode event taxonomy split ──────────────
+echo "Test 16 — warn-mode tags PENDING as race_gate_observed (not would_have_denied) (soak-fix #C)"
+# Use t15b's PENDING sentinel from above; fire under VADE_BRAKE_ENFORCE=warn
+set -- $(echo "$(_setup_session_dirs "t16")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+mkdir -p "$home_dir/.vade"
+now_iso="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+cat > "$home_dir/.vade/boot.log" <<EOF
+{"ts":"$now_iso","session":"t16","script":"session-start-sync","phase":"start"}
+EOF
+printf '{"session_id":"t16","cwd":"/home/user","tool_name":"Bash","tool_input":{"command":"ls"}}' | \
+  VADE_BRAKE_ENFORCE=warn \
+  VADE_BRAKE_RACE_GRACE_SECONDS=300 \
+  VADE_CLOUD_STATE_DIR="$state_dir" \
+  VADE_COO_MEMORY_DIR="$COO_MEMORY_DIR" \
+  HOME="$home_dir" \
+  bash "$GUARD" 2>/dev/null > /dev/null
+if grep -q '"cause":"race_gate_observed"' "$state_dir/brake-events.jsonl"; then
+  _pass "PENDING in warn mode → cause=race_gate_observed"
+else
+  _fail "PENDING in warn mode did not emit race_gate_observed (events: $(cat "$state_dir/brake-events.jsonl"))"
+fi
+if grep -q '"cause":"would_have_denied"' "$state_dir/brake-events.jsonl"; then
+  _fail "PENDING in warn mode incorrectly emitted would_have_denied (soak-signal pollution)"
+else
+  _pass "PENDING in warn mode does NOT emit would_have_denied (clean soak signal)"
+fi
+# FAIL in warn mode still emits would_have_denied
+rm -f "$state_dir/integrity-check.json"
+sleep 1.1  # past backpressure cap
+printf '{"session_id":"t16","cwd":"/home/user","tool_name":"Bash","tool_input":{"command":"ls"}}' | \
+  VADE_BRAKE_ENFORCE=warn \
+  VADE_BRAKE_RACE_GRACE_SECONDS=0 \
+  VADE_CLOUD_STATE_DIR="$state_dir" \
+  VADE_COO_MEMORY_DIR="$COO_MEMORY_DIR" \
+  HOME="$home_dir" \
+  bash "$GUARD" 2>/dev/null > /dev/null
+if grep -q '"cause":"would_have_denied"' "$state_dir/brake-events.jsonl"; then
+  _pass "FAIL in warn mode → cause=would_have_denied (real denial signal preserved)"
+else
+  _fail "FAIL in warn mode did not emit would_have_denied (events: $(cat "$state_dir/brake-events.jsonl"))"
+fi
+
+# ─── Test 17 (NEW): clear-hook is idempotent on resume/compaction ─
+echo "Test 17 — boot-brake-clear is idempotent (re-run after sentinel exists; soak-fix #B)"
+set -- $(echo "$(_setup_session_dirs "t17")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# First run: clear-hook installs initial PENDING sentinel.
+VADE_CLOUD_STATE_DIR="$state_dir" HOME="$home_dir" \
+  CLAUDE_CODE_SESSION_ID="t17" \
+  bash "$CLEAR" 2>/dev/null </dev/null
+if [ -f "$state_dir/boot-brake.t17.json" ]; then
+  _pass "Clear-hook installs initial sentinel"
+else
+  _fail "Clear-hook did not install initial sentinel"
+fi
+# Second run: should be safe (same sentinel rewritten with current ts)
+VADE_CLOUD_STATE_DIR="$state_dir" HOME="$home_dir" \
+  CLAUDE_CODE_SESSION_ID="t17" \
+  bash "$CLEAR" 2>/dev/null </dev/null
+state_t17="$(python3 -c "import json; d=json.load(open('$state_dir/boot-brake.t17.json')); print(d['state'])")"
+if [ "$state_t17" = "PENDING" ]; then
+  _pass "Clear-hook re-run on existing sentinel is idempotent (PENDING preserved)"
+else
+  _fail "Clear-hook re-run corrupted sentinel (state=$state_t17)"
+fi
+
 # ─── Summary ────────────────────────────────────────────────────
 echo
 echo "===================================="

--- a/scripts/hooks/boot-brake-guard.py
+++ b/scripts/hooks/boot-brake-guard.py
@@ -169,15 +169,29 @@ def write_fault(state_dir, message, exc=None):
 # SessionStart producers tracked by the race-gate (Sys-Eng C3). When
 # the first PreToolUse fires while these are still running, the brake
 # stays PENDING rather than emit phantom FAILs that pollute the 7-day
-# soak signal. The list mirrors the SessionStart `startup` matcher in
-# .claude/settings.json; new producers should be added here in the
-# same PR that registers them.
+# soak signal. Only producers of the manifest's critical deliverables
+# go here:
+#   - session-start-sync produces user_settings_json AND drives
+#     integrity-check.sh (integrity_check_json)
+#   - coo-bootstrap produces bootstrap_marker
+#   - coo-identity-digest produces the persisted-output file that
+#     triggers the identity_consumed predicate when the digest overflows
+# memo-index, discussions-digest, project-board-digest, and the
+# idle-watchdog are intentionally NOT tracked — they don't produce
+# manifest entries, so we don't wait on them.
 PRODUCERS_TO_TRACK = (
     "session-start-sync",
     "coo-bootstrap",
-    "memo-index",
     "coo-identity-digest",
 )
+
+# A producer is treated as "done" if either:
+#   - phase=end has been logged for this session, OR
+#   - phase=start has been logged AND elapsed > this threshold
+# The start-based fallback tolerates early-exit skip paths (e.g.
+# coo-bootstrap.sh's "marker present this container" branch which
+# does `trap - EXIT; exit 0` and never writes phase=end).
+PRODUCER_DONE_THRESHOLD_SECONDS = 15.0
 
 # Wall-clock grace window when boot.log is unavailable (Sys-Eng C3
 # fallback). The v2 design wanted producer end-markers as the primary
@@ -197,15 +211,25 @@ def _race_grace_seconds():
 def boot_producers_complete(home, session_id):
     """Returns (all_complete, missing_producers).
 
-    Reads $HOME/.vade/boot.log (newline-delimited JSON) for end-phase
-    entries scoped to this session_id. Each declared SessionStart
-    producer must have logged `phase=end`. If boot.log is missing or
-    unreadable, returns (None, []) to signal "fall back to wall-clock".
+    Reads $HOME/.vade/boot.log (newline-delimited JSON) for entries
+    scoped to this session_id. A producer is treated as complete if
+    either:
+      - phase=end has been logged (the canonical signal), OR
+      - phase=start has been logged AND elapsed since that start
+        exceeds PRODUCER_DONE_THRESHOLD_SECONDS (tolerates early-exit
+        skip paths that don't write phase=end — e.g. coo-bootstrap.sh's
+        "marker present this container" branch does `trap - EXIT; exit
+        0` without firing the _on_exit trap that would have logged the
+        end marker).
+
+    Returns (None, []) when boot.log is missing or unreadable so the
+    caller can fall back to the wall-clock grace heuristic.
     """
     log = Path(home) / ".vade" / "boot.log"
     if not log.exists():
         return None, []
     completed = set()
+    started = {}  # producer name → earliest start epoch
     try:
         with open(log) as fh:
             for line in fh:
@@ -215,11 +239,36 @@ def boot_producers_complete(home, session_id):
                     continue
                 if rec.get("session") != session_id:
                     continue
-                if rec.get("phase") == "end" and rec.get("script"):
-                    completed.add(rec["script"])
+                script = rec.get("script")
+                phase = rec.get("phase")
+                if not script or not phase:
+                    continue
+                if phase == "end":
+                    completed.add(script)
+                elif phase == "start":
+                    ts = rec.get("ts", "")
+                    try:
+                        # ts is e.g. "2026-06-03T11:22:53.123Z" — slice
+                        # the fractional seconds before strptime.
+                        ts_clean = ts.split(".")[0].rstrip("Z")
+                        start_epoch = time.mktime(time.strptime(
+                            ts_clean, "%Y-%m-%dT%H:%M:%S"
+                        )) - time.timezone
+                    except (ValueError, OverflowError):
+                        continue
+                    if script not in started or start_epoch < started[script]:
+                        started[script] = start_epoch
     except OSError:
         return None, []
-    missing = [p for p in PRODUCERS_TO_TRACK if p not in completed]
+
+    now = time.time()
+    missing = []
+    for p in PRODUCERS_TO_TRACK:
+        if p in completed:
+            continue
+        if p in started and (now - started[p]) > PRODUCER_DONE_THRESHOLD_SECONDS:
+            continue
+        missing.append(p)
     return (len(missing) == 0), missing
 
 
@@ -558,12 +607,15 @@ def main():
     # Initial revalidation triggers:
     #   - no sentinel at all (fresh session / first PreToolUse)
     #   - sentinel exists but is UNPARSEABLE
-    #   - sentinel is PENDING with epoch=0 (clear-hook initial; never validated)
+    #   - sentinel is PENDING (race-gate engaged previously; must keep
+    #     re-evaluating to detect "producers now done → transition to
+    #     OK/FAIL" without waiting for content-hash drift, which the
+    #     race-gate path may not have recorded yet)
+    # Backpressure cap below bounds the cost.
     needs_revalidation = (
         sentinel is None
         or sentinel.get("state") == "UNPARSEABLE"
-        or (sentinel.get("state") == "PENDING"
-            and sentinel.get("checked_at_epoch", 0) == 0)
+        or sentinel.get("state") == "PENDING"
     )
 
     # Backpressure cap: don't re-validate more than once per second.
@@ -762,15 +814,24 @@ def main():
     if state == "OK":
         sys.exit(0)
 
-    # FAIL / PENDING in warn mode → allow but log
+    # FAIL / PENDING in warn mode → allow but log. Tag distinctly so
+    # the Phase 1 aggregator's would-have-denied histogram isn't
+    # polluted by race-gate transients:
+    #   - state=FAIL   → cause=would_have_denied (real denial in block)
+    #   - state=PENDING → cause=race_gate_observed (block-on-FAIL would
+    #     have allowed; block-strict would have denied)
     if mode == "warn":
+        if state == "PENDING":
+            cause = "race_gate_observed"
+        else:
+            cause = "would_have_denied"
         append_event(state_dir, {
             "ts": now_iso(),
             "session_id": session_id,
             "tool": tool_name,
             "state": state,
             "mode": "warn",
-            "cause": "would_have_denied",
+            "cause": cause,
             "failures": (sentinel or {}).get("failures", []),
         })
         sys.exit(0)


### PR DESCRIPTION
## Summary

Fixes three coupled bugs in the Phase 0 boot-brake (merged in [#417](https://github.com/coo-labs/coo-harness/pull/417)) that the adversarial review missed but the first production-soak verification surfaced. Brake itself worked; warn-mode signal was poisoned by them. Urgent because every minute of warn-mode usage accumulates more poisoned data in `brake-events.jsonl` and the warn→block flip depends on a clean soak signal.

## Findings (from the first verification report)

1. **Race-gate permanence.** `boot_producers_complete()` required `phase=end` in `boot.log` for each tracked producer. But `coo-bootstrap.sh` has multiple early-exit skip paths (marker-present-this-container, op-token-unset, non-cloud) that all do `trap - EXIT; exit 0` — clearing the trap that would have logged `phase=end`. Every resumed session permanently saw coo-bootstrap as "not done", race-gate engaged forever, sentinel stayed PENDING. `memo-index.sh` never writes to `boot.log` at all (different logging convention).
2. **Compaction creates uncleared sentinel.** Mid-conversation compaction creates a fresh `session_id` but the SessionStart `matcher: "startup"` chain (where `boot-brake-clear.sh` lives) doesn't fire on resume/compaction events. First PreToolUse in the new session fires with no sentinel and immediately race-gates with empty failures.
3. **Warn-mode tagged race-gate PENDING as `would_have_denied`.** But `PENDING + block-on-FAIL` ALLOWS the tool call (only `block-strict` denies PENDING) — so tagging PENDING as `would_have_denied` was factually wrong AND polluted the soak signal that gates the warn→block flip.

Bonus: cached PENDING sentinels with non-zero epoch weren't triggering revalidation, so a PENDING-with-race-gate session couldn't naturally transition to OK or FAIL on subsequent fires.

## What lands in this PR

- **`scripts/hooks/boot-brake-guard.py`:**
  - `PRODUCERS_TO_TRACK` reduced to `session-start-sync`, `coo-bootstrap`, `coo-identity-digest` (the three that produce manifest deliverables). `memo-index` removed.
  - `boot_producers_complete()` now treats a producer as done if `phase=end` logged OR `phase=start` logged + `elapsed > PRODUCER_DONE_THRESHOLD_SECONDS` (15s). Tolerates early-exit skip paths without requiring edits to producer scripts.
  - Warn-mode event taxonomy split: `cause=would_have_denied` only when `state=FAIL`; `cause=race_gate_observed` when `state=PENDING`.
  - PENDING sentinels always revalidate on the next fire (backpressure cap still bounds cost). Closes the cached-PENDING-stuck case.

- **`.claude/settings.json`:** `boot-brake-clear.sh` added to the no-matcher SessionStart entry alongside `session-lifecycle.sh`. Fires on resume/compaction events; idempotent.

- **`scripts/ci/test-boot-brake-guard.sh`:** 21 → 28 assertions. Three new tests:
  - **Test 15**: `boot_producers_complete()` treats start+elapsed > threshold as done (positive case) + stays engaged on recent start (negative case).
  - **Test 16**: warn-mode taxonomy split — PENDING → `race_gate_observed`, FAIL → `would_have_denied`; PENDING does NOT emit `would_have_denied`.
  - **Test 17**: `boot-brake-clear.sh` idempotent on re-run with existing sentinel (the compaction case).

## Why now

Phase 0 is in `warn` mode by default, so these bugs aren't actively bricking sessions — but they ARE actively poisoning the events log. Every PreToolUse fires in a stuck-race-gate session writes another `would_have_denied` event. The 7-day soak signal that gates the eventual warn → block-on-FAIL flip is being corrupted right now. Sooner the fix lands, sooner the data starts being meaningful.

## Verification

`bash scripts/ci/test-boot-brake-guard.sh` → `28 passed, 0 failed`. CI on this branch should match.

End-to-end:
- Race-gate clears in a normal already-bootstrapped resume (15s after coo-bootstrap's phase=start lands).
- Compaction-equivalent (clear-hook running on a session with no startup-matcher fired) installs a fresh PENDING sentinel without corrupting prior state.
- Warn-mode events now distinguish "would have denied for a real reason" from "race-gate transient."

## Closes

Closes: n/a (no specific issue; surfaced by the soak verification on top of [#417](https://github.com/coo-labs/coo-harness/pull/417)). The fixes belong to the [coo-memory#1082](https://github.com/coo-labs/coo-memory/issues/1082) work surface; should-fix tier tracked at [coo-memory#1167](https://github.com/coo-labs/coo-memory/issues/1167) / [#1168](https://github.com/coo-labs/coo-memory/issues/1168). This PR doesn't satisfy either — it patches Phase 0 itself.

Refs: coo-labs/coo-memory#1082, coo-labs/coo-memory#1167, coo-labs/coo-memory#1168, coo-labs/coo-logs#567

https://claude.ai/code/session_01TeXZZE3cxzbtBjkPkPQy6Q