### PR TITLE
fix(boot-brake): expand FAIL-state whitelist for non-substrate tools

### DIFF
--- a/scripts/ci/test-boot-brake-guard.sh
+++ b/scripts/ci/test-boot-brake-guard.sh
@@ -489,6 +489,41 @@ else
   _fail "Clear-hook re-run corrupted sentinel (state=$state_t17)"
 fi
 
+# ─── Test 18 (NEW): expanded whitelist for non-substrate tools ──
+echo "Test 18 — AskUserQuestion / TodoWrite / Glob whitelisted in FAIL"
+set -- $(echo "$(_setup_session_dirs "t18")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# Leave deliverables missing → state will be FAIL
+for tool in AskUserQuestion TodoWrite Glob; do
+  input="{\"session_id\":\"t18\",\"cwd\":\"/home/user\",\"tool_name\":\"$tool\",\"tool_input\":{}}"
+  out="$(printf '%s' "$input" | \
+    VADE_BRAKE_ENFORCE=block-on-FAIL \
+    VADE_BRAKE_RACE_GRACE_SECONDS=0 \
+    VADE_CLOUD_STATE_DIR="$state_dir" \
+    VADE_COO_MEMORY_DIR="$COO_MEMORY_DIR" \
+    HOME="$home_dir" \
+    bash "$GUARD" 2>/dev/null)"
+  if [ -z "$out" ]; then
+    _pass "$tool silent-allow in FAIL (substrate-non-affecting)"
+  else
+    _fail "$tool produced unexpected output: $out"
+  fi
+done
+# Confirm a substrate-affecting tool is still denied for contrast
+input='{"session_id":"t18","cwd":"/home/user","tool_name":"Write","tool_input":{}}'
+out="$(printf '%s' "$input" | \
+  VADE_BRAKE_ENFORCE=block-on-FAIL \
+  VADE_BRAKE_RACE_GRACE_SECONDS=0 \
+  VADE_CLOUD_STATE_DIR="$state_dir" \
+  VADE_COO_MEMORY_DIR="$COO_MEMORY_DIR" \
+  HOME="$home_dir" \
+  bash "$GUARD" 2>/dev/null)"
+if printf '%s' "$out" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  _pass "Write still denied in FAIL (whitelist hasn't widened to writes)"
+else
+  _fail "Write was not denied — whitelist may have over-widened"
+fi
+
 # ─── Summary ────────────────────────────────────────────────────
 echo
 echo "===================================="

--- a/scripts/hooks/boot-brake-guard.py
+++ b/scripts/hooks/boot-brake-guard.py
@@ -541,7 +541,18 @@ def emit_deny(reason, event=None, state_dir=None):
     sys.exit(0)
 
 
-WHITELIST_TOOLS = {"Read", "Grep"}
+# Tools that may run even when the brake is FAIL/PENDING under block-mode.
+# Restricted to non-substrate-affecting reads and in-session-memory updates:
+#   - Read, Grep, Glob  : filesystem inspection (no writes, no network)
+#   - AskUserQuestion   : agent → user clarification (no substrate effect)
+#   - TodoWrite         : in-session memory only (doesn't escape)
+# Surfaced by the 2026-06-03 soak verification: AskUserQuestion was the
+# most-impactful ergonomics gap — a brake-blocked instance trying to ask
+# Ven "what should I do?" was being denied as if it were a write tool.
+# Every other tool (Bash, Edit, Write, Skill, Task, MCP writes, WebFetch,
+# WebSearch, Monitor, NotebookEdit) stays denied — the threat model is
+# unchanged.
+WHITELIST_TOOLS = {"Read", "Grep", "Glob", "AskUserQuestion", "TodoWrite"}
 
 
 def main():


### PR DESCRIPTION
## Summary

Expands the boot-brake's FAIL-state whitelist from `{Read, Grep}` to `{Read, Grep, Glob, AskUserQuestion, TodoWrite}`. Surfaced by the 2026-06-03 soak verification: when the math-proof+commit smoke test ran on a fresh session, the resulting `brake-events.jsonl` showed 8 `would_have_denied` events spanning Bash, AskUserQuestion, and Write. The AskUserQuestion entry is the load-bearing observation — that's the model trying to ask Ven a clarifying question, and denying it in block mode would mean a brake-blocked agent can't even ask for help.

## What changes

`scripts/hooks/boot-brake-guard.py`:

```python
WHITELIST_TOOLS = {"Read", "Grep", "Glob", "AskUserQuestion", "TodoWrite"}
```

Bash, Edit, Write, Skill, Task, MCP write tools, WebFetch, WebSearch, Monitor, NotebookEdit, PushNotification — all still denied. The threat model is unchanged.

Rationale per addition:

| Tool | Why safe to whitelist |
|---|---|
| `Glob` | Filesystem pattern search; no writes; identical posture to Grep. |
| `AskUserQuestion` | Agent → user clarification dialog; structurally cannot affect substrate. Denying it makes the brake hostile to legitimate recovery patterns. |
| `TodoWrite` | In-session memory only; doesn't escape the conversation surface; functionally similar to Read for FAIL-whitelist purposes. |

## Test 18 (new)

Asserts each new whitelist member is silent-allow in FAIL state, AND that a representative substrate-affecting tool (`Write`) is still denied. The negative assertion closes the regression vector where a future whitelist expansion silently widens too far.

```
boot-brake CI tests: 32 passed, 0 failed
```

## Why now

The brake is in `warn` mode default. The eventual warn → block-on-FAIL flip is gated by soak-signal quality (clean `brake-events.jsonl`) and by the Phase 1 follow-ups in [coo-memory#1167](https://github.com/coo-labs/coo-memory/issues/1167) / [#1168](https://github.com/coo-labs/coo-memory/issues/1168) / [#1169](https://github.com/coo-labs/coo-memory/issues/1169). This patch removes one ergonomics blocker for that flip: a model that needs to clarify intent before acting should be able to ask, even when ungrounded. The flip becomes harder to justify if every brake-blocked session also can't reach the user.

## Closes

Closes: n/a (small ergonomics patch; threads back to coo-labs/coo-memory#1082 Phase 0 + the #420 soak fixes).

Refs: coo-labs/coo-memory#1082, coo-labs/coo-memory#1168, coo-labs/coo-logs#567

https://claude.ai/code/session_01TeXZZE3cxzbtBjkPkPQy6Q