### PR TITLE
feat(boot-brake): identity-stack read gates + FAIL re-validate

### DIFF
--- a/scripts/ci/fixtures/boot-deliverables.yml
+++ b/scripts/ci/fixtures/boot-deliverables.yml
@@ -1,11 +1,12 @@
-# Fixture manifest for boot-brake CI tests. Mirrors the Phase 0 entries
-# in coo-memory/operations/boot-deliverables.yml; refreshed manually
-# when the canonical manifest gains new entries.
+# Fixture manifest for boot-brake CI tests. Mirrors the canonical
+# entries in coo-memory/operations/boot-deliverables.yml; refreshed
+# manually when the canonical manifest gains new entries.
 #
 # Includes `identity_consumed` so the §11 consumed-signal mechanism
-# has CI coverage (Sys-Eng M1).
+# has CI coverage (Sys-Eng M1), plus the four Phase 1 always-on
+# identity-stack read gates (coo-memory#1169) exercised by Test 19.
 
-manifest_version: 1
+manifest_version: 2
 
 deliverables:
   - id: integrity_check_json
@@ -32,4 +33,35 @@ deliverables:
     check_arg: ".*/tool-results/hook-.*-stdout\\.txt$"
     predicate_exists_glob: $HOME/.claude/projects/$CWD_DASHIFIED/$SESSION_ID/tool-results/hook-*-stdout.txt
     producer: coo-harness/scripts/lifecycle/coo-identity-digest.sh
+    severity: critical
+
+  # Phase 1 (coo-memory#1169): always-on identity-stack reads, mirroring
+  # the canonical manifest. No predicate_exists_glob — required every
+  # boot. Exercised by Test 19.
+  - id: charter_consumed
+    path: dynamic
+    check_kind: read_observed
+    check_arg: "/identity/charter\\.md$"
+    producer: coo-memory/identity/charter.md
+    severity: critical
+
+  - id: governance_consumed
+    path: dynamic
+    check_kind: read_observed
+    check_arg: "/identity/governance\\.md$"
+    producer: coo-memory/identity/governance.md
+    severity: critical
+
+  - id: preferences_consumed
+    path: dynamic
+    check_kind: read_observed
+    check_arg: "/identity/preferences\\.md$"
+    producer: coo-memory/identity/preferences.md
+    severity: critical
+
+  - id: episodic_memory_consumed
+    path: dynamic
+    check_kind: read_observed
+    check_arg: "/identity/episodic_memory\\.md$"
+    producer: coo-memory/identity/episodic_memory.md
     severity: critical

--- a/scripts/ci/test-boot-brake-guard.sh
+++ b/scripts/ci/test-boot-brake-guard.sh
@@ -66,10 +66,24 @@ _setup_session_dirs() {
 }
 
 _make_all_deliverables_present() {
-  local state_dir="$1" home_dir="$2"
+  local state_dir="$1" home_dir="$2" sid="${3:-}"
   printf '{"summary":{"ok":true}}' > "$state_dir/integrity-check.json"
   touch "$home_dir/.vade/.coo-bootstrap-done"
   printf '{}' > "$home_dir/.claude/settings.json"
+  # When a session id is supplied, also satisfy the Phase 1 always-on
+  # identity-stack read_observed entries (coo-memory#1169) by seeding the
+  # per-session Read log with the four identity files. Without this,
+  # "all deliverables present" would still FAIL the read-gated entries
+  # and any OK-expecting assertion would break.
+  if [ -n "$sid" ]; then
+    mkdir -p "$home_dir/.vade"
+    local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    local f
+    for f in charter governance preferences episodic_memory; do
+      printf '%s\t%s/identity/%s.md\n' "$ts" "$COO_MEMORY_DIR" "$f" \
+        >> "$home_dir/.vade/session-reads.$sid.log"
+    done
+  fi
 }
 
 # Default invocation: race-gate disabled, fixture manifest. Override
@@ -199,7 +213,7 @@ fi
 echo "Test 7 — parallel-session isolation + cache invalidation"
 set -- $(echo "$(_setup_session_dirs "t7")" | tr '|' ' ')
 state_dir="$1"; home_dir="$2"
-_make_all_deliverables_present "$state_dir" "$home_dir"
+_make_all_deliverables_present "$state_dir" "$home_dir" "t7-A"
 # Session A first fire → all-OK
 _invoke_guard t7-A Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
 sleep 1.1  # past 1s backpressure cap so the next fire re-checks hashes
@@ -213,7 +227,7 @@ else
   _fail "Cached-OK survived deletion (state=$state_a_after; Sys-Eng C1 regression)"
 fi
 # Now session B sees its own sentinel independently — restore deliverable
-_make_all_deliverables_present "$state_dir" "$home_dir"
+_make_all_deliverables_present "$state_dir" "$home_dir" "t7-B"
 _invoke_guard t7-B Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
 state_b="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t7-B.json'))['state'])")"
 if [ "$state_b" = "OK" ]; then
@@ -226,7 +240,7 @@ fi
 echo "Test 9 — unparseable sentinel re-validates without locking out"
 set -- $(echo "$(_setup_session_dirs "t9")" | tr '|' ' ')
 state_dir="$1"; home_dir="$2"
-_make_all_deliverables_present "$state_dir" "$home_dir"
+_make_all_deliverables_present "$state_dir" "$home_dir" "t9"
 printf '{"state":"OK"' > "$state_dir/boot-brake.t9.json"
 out="$(_invoke_guard t9 Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
 if [ -z "$out" ]; then
@@ -369,7 +383,7 @@ fi
 echo "Test 15 — boot_producers_complete treats start+elapsed as done (soak-fix #A)"
 set -- $(echo "$(_setup_session_dirs "t15")" | tr '|' ' ')
 state_dir="$1"; home_dir="$2"
-_make_all_deliverables_present "$state_dir" "$home_dir"
+_make_all_deliverables_present "$state_dir" "$home_dir" "t15"
 # Stage a boot.log with phase=start for each tracked producer and
 # NO phase=end (simulating coo-bootstrap's marker-present-skip path).
 # Backdate the start timestamps so elapsed > PRODUCER_DONE_THRESHOLD.
@@ -522,6 +536,61 @@ if printf '%s' "$out" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
   _pass "Write still denied in FAIL (whitelist hasn't widened to writes)"
 else
   _fail "Write was not denied — whitelist may have over-widened"
+fi
+
+# ─── Test 19 (NEW): identity-stack always-on read gate (coo-memory#1169) ─
+echo "Test 19 — identity-stack read_observed entries gate until Read (coo-memory#1169)"
+set -- $(echo "$(_setup_session_dirs "t19")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# File deliverables present, but NO identity reads yet → the 4 always-on
+# *_consumed entries must FAIL.
+_make_all_deliverables_present "$state_dir" "$home_dir"
+_invoke_guard t19 Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+unread_all=1
+for d in charter_consumed governance_consumed preferences_consumed episodic_memory_consumed; do
+  grep -q "\"deliverable\":\"$d\"" "$state_dir/boot-brake.t19.json" 2>/dev/null || unread_all=0
+done
+if [ "$unread_all" = "1" ]; then
+  _pass "Identity stack unread → all 4 *_consumed entries recorded as failed"
+else
+  _fail "Not all 4 *_consumed entries failed (sentinel: $(cat "$state_dir/boot-brake.t19.json" 2>/dev/null))"
+fi
+# Deny reason collapses the 4 into a single aggregate directive (ergonomics)
+out19="$(_invoke_guard t19 Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
+if printf '%s' "$out19" | grep -q "identity stack not consumed"; then
+  _pass "Deny reason aggregates *_consumed entries into one directive"
+else
+  _fail "Deny reason did not aggregate *_consumed entries (got: $out19)"
+fi
+# Read all 4 identity files → state transitions to OK, Bash allowed.
+ts19="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+for f in charter governance preferences episodic_memory; do
+  printf '%s\t%s/identity/%s.md\n' "$ts19" "$COO_MEMORY_DIR" "$f" \
+    >> "$home_dir/.vade/session-reads.t19.log"
+done
+sleep 1.1  # past 1s backpressure cap so the next fire re-validates
+out19b="$(_invoke_guard t19 Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
+state_t19="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t19.json'))['state'])")"
+if [ "$state_t19" = "OK" ] && [ -z "$out19b" ]; then
+  _pass "All 4 identity files Read → state=OK, Bash allowed"
+else
+  _fail "Identity stack Read but not OK (state=$state_t19, out=$out19b)"
+fi
+# Partial read: only 3 of 4 → FAIL naming the unread entry (acceptance).
+set -- $(echo "$(_setup_session_dirs "t19c")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+ts19c="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+for f in charter governance preferences; do
+  printf '%s\t%s/identity/%s.md\n' "$ts19c" "$COO_MEMORY_DIR" "$f" \
+    >> "$home_dir/.vade/session-reads.t19c.log"
+done
+_invoke_guard t19c Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+state_t19c="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t19c.json'))['state'])")"
+if [ "$state_t19c" = "FAIL" ] && grep -q '"deliverable":"episodic_memory_consumed"' "$state_dir/boot-brake.t19c.json"; then
+  _pass "Read 3 of 4 → FAIL naming the unread episodic_memory_consumed"
+else
+  _fail "Partial read did not FAIL on the unread entry (state=$state_t19c)"
 fi
 
 # ─── Summary ────────────────────────────────────────────────────

--- a/scripts/hooks/boot-brake-guard.py
+++ b/scripts/hooks/boot-brake-guard.py
@@ -541,6 +541,55 @@ def emit_deny(reason, event=None, state_dir=None):
     sys.exit(0)
 
 
+def _strip_consumed_suffix(dlid):
+    """`charter_consumed` -> `charter`; leaves non-suffixed ids intact."""
+    suffix = "_consumed"
+    s = str(dlid)
+    return s[: -len(suffix)] if s.endswith(suffix) else s
+
+
+def format_failures(failures):
+    """Render the failing-deliverables summary for a deny reason.
+
+    Identity-stack `read_observed` entries (id ending `_consumed`)
+    collapse into a single directive when 2+ are failing — the typical
+    first-boot pattern, where listing each at ~80 chars blows past
+    readable density (coo-memory#1169 deny-reason ergonomics). Other
+    failures render individually, capped at 3 with a "plus N more" tail.
+    All interpolated values are sanitized; separators are safe-set only.
+    """
+    consumed = [f for f in failures if str(f.get("deliverable", "")).endswith("_consumed")]
+    other = [f for f in failures if not str(f.get("deliverable", "")).endswith("_consumed")]
+
+    segments = []
+    if len(consumed) >= 2:
+        names = " ".join(
+            sanitize(_strip_consumed_suffix(f.get("deliverable", "unknown")))
+            for f in consumed
+        )
+        segments.append(
+            "identity stack not consumed: " + names
+            + " -- Read the corresponding identity .md files and any "
+            "persisted boot digest before proceeding"
+        )
+    else:
+        for f in consumed:
+            segments.append(
+                f"{sanitize(f.get('deliverable', 'unknown'))}: {sanitize(f.get('reason', ''))}"
+            )
+
+    shown_other = other[:3]
+    for f in shown_other:
+        segments.append(
+            f"{sanitize(f.get('deliverable', 'unknown'))}: {sanitize(f.get('reason', ''))}"
+        )
+    overflow = len(other) - len(shown_other)
+    if overflow > 0:
+        segments.append(f"plus {overflow} more")
+
+    return " -- ".join(segments) if segments else "none"
+
+
 # Tools that may run even when the brake is FAIL/PENDING under block-mode.
 # Restricted to non-substrate-affecting reads and in-session-memory updates:
 #   - Read, Grep, Glob  : filesystem inspection (no writes, no network)
@@ -622,6 +671,10 @@ def main():
     #     re-evaluating to detect "producers now done → transition to
     #     OK/FAIL" without waiting for content-hash drift, which the
     #     race-gate path may not have recorded yet)
+    # FAIL is handled in the backpressure branch below (not here) so it
+    # re-checks at most once per second: a FAIL caused by an unsatisfied
+    # read_observed entry must clear when the agent Reads the file, which
+    # the content-hash drift check cannot see (coo-memory#1169).
     # Backpressure cap below bounds the cost.
     needs_revalidation = (
         sentinel is None
@@ -648,6 +701,15 @@ def main():
                 # pyyaml going missing or the manifest becoming unreadable.
                 needs_revalidation = True
             elif manifest_loaded:
+                # FAIL is not steady-state: re-validate past the
+                # backpressure cap so it clears as soon as the underlying
+                # condition is fixed. This is the only trigger that catches
+                # a now-satisfied read_observed entry (charter/governance/
+                # etc.), whose satisfaction changes via session Reads, not
+                # file content, and is therefore invisible to the
+                # content-hash drift check below (coo-memory#1169).
+                if sentinel.get("state") == "FAIL":
+                    needs_revalidation = True
                 m_version = manifest_loaded.get("manifest_version", 1)
                 if sentinel.get("manifest_version", 0) != m_version:
                     needs_revalidation = True
@@ -864,15 +926,10 @@ def main():
         sys.exit(0)
 
     failures = (sentinel or {}).get("failures", [])
-    # Format: "<dlid>: <reason> -- <dlid>: <reason>" — delimiters drawn
-    # from the safe set only. Interpolated values are sanitized.
-    fail_parts = [
-        f"{sanitize(f.get('deliverable', 'unknown'))}: {sanitize(f.get('reason', ''))}"
-        for f in failures[:3]
-    ]
-    fail_summary = " -- ".join(fail_parts)
-    if len(failures) > 3:
-        fail_summary += f" -- plus {len(failures) - 3} more"
+    # format_failures collapses the identity-stack *_consumed entries into
+    # one directive when 2+ are failing (coo-memory#1169 ergonomics);
+    # separators are safe-set only and interpolated values are sanitized.
+    fail_summary = format_failures(failures)
     state_safe = sanitize(state)
     reason = (
         f"Boot brake active. State: {state_safe}. "


### PR DESCRIPTION
## Summary

Phase 1 of the boot brake (coo-labs/coo-memory#1169): extend §11's `read_observed` mechanism from the digest-overflow file to the rest of the CLAUDE.md mandatory reading order. This is the **kernel half**; the manifest + recovery-doc half is the coo-labs/coo-memory PR on the same branch (`claude/relaxed-newton-VNtRi`).

## What changes

**`scripts/ci/fixtures/boot-deliverables.yml`** — add `charter`/`governance`/`preferences`/`episodic_memory` as always-on `read_observed` entries (no `predicate_exists_glob` → required every boot), mirroring the canonical manifest. Bump `manifest_version` 1 → 2.

**`scripts/hooks/boot-brake-guard.py`**

- `format_failures()` — collapse the four `*_consumed` entries into a single deny directive when 2+ are failing (the first-boot pattern), so the deny reason stays readable instead of four ~80-char lines: `identity stack not consumed: charter governance preferences episodic_memory -- Read the corresponding identity .md files ...`.
- **FAIL now re-validates past the backpressure cap.** A FAIL caused by an unsatisfied `read_observed` entry was invisible to the content-hash drift check — read satisfaction changes via session Reads, not file content — so the sentinel never cleared after the agent complied. It now re-checks at most once/second and clears on the next call after the Read. This is the "Read the file, brake re-validates and clears" transition the v2 §11 design promised but no test exercised. The latent gap was harmless under Phase 0's single `identity_consumed` entry (satisfied during the first-call / PENDING window); the always-on entries make FAIL→OK-via-Read the common path.

## Test 19 (new)

- Stack unread → all 4 `*_consumed` recorded FAIL + deny reason aggregates them into one directive.
- All 4 Read → state OK, Bash allowed (exercises FAIL re-validate).
- 3 of 4 Read → FAIL naming the unread `episodic_memory_consumed`.

```
boot-brake CI tests: 36 passed, 0 failed
```

Whitelist threat model unchanged (still `{Read, Grep, Glob, AskUserQuestion, TodoWrite}` from #421).

## Soak-signal interaction (heads-up)

Always-on gates mean every boot starts with the identity stack unread, so there is a FAIL/PENDING window until the agent Reads the four files. The race gate (PENDING during early boot) absorbs most of it — if the reads land inside the ~30s grace window the brake goes straight PENDING→OK with no `would_have_denied`. Reads lagging past producer-completion will log `would_have_denied` that then clears. That is true-positive logging, but it shifts the warn→block readiness metric; distinguishing cleared-within-session from never-cleared is the coo-labs/coo-memory#1168 event-taxonomy work. Worth weighing before the flip.

## Merge order

Recommend merging this (kernel) **before** the coo-memory sibling: the canonical manifest is read live by warn-mode sessions the moment it lands, and the FAIL-revalidate fix here is what lets the new gates clear cleanly. The coo-memory PR carries `Closes #1169`.

## Closes

Closes: n/a (kernel half; the issue is closed by the coo-memory sibling PR)

Refs: coo-labs/coo-memory#1082, coo-labs/coo-memory#1169, coo-labs/coo-memory#1168, coo-labs/coo-logs#567

https://claude.ai/code/session_013sVdQsrM1Qgk5yaGeSx4zh