### PR TITLE
feat(boot-brake): event-schema normalization + cause taxonomy

### DIFF
--- a/scripts/ci/test-boot-brake-guard.sh
+++ b/scripts/ci/test-boot-brake-guard.sh
@@ -593,6 +593,57 @@ else
   _fail "Partial read did not FAIL on the unread entry (state=$state_t19c)"
 fi
 
+# ─── Test 20 (NEW): every event carries schema version v (#1168 O1) ─
+echo "Test 20 — every brake event carries schema version v (coo-memory#1168 O1)"
+set -- $(echo "$(_setup_session_dirs "t20")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# Warn-mode FAIL fire → would_have_denied (+ predicate_unmatched).
+_invoke_guard t20 Bash warn "$state_dir" "$home_dir" "ls" > /dev/null
+# Satisfy everything + reads, revalidate → FAIL->OK (all_satisfied transition).
+_make_all_deliverables_present "$state_dir" "$home_dir" "t20"
+sleep 1.1
+_invoke_guard t20 Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+total_ev="$(wc -l < "$state_dir/brake-events.jsonl")"
+with_v="$(jq -c 'select(.v==1)' "$state_dir/brake-events.jsonl" 2>/dev/null | wc -l)"
+if [ "$total_ev" -gt 0 ] && [ "$total_ev" = "$with_v" ]; then
+  _pass "all $total_ev events carry v==1"
+else
+  _fail "not all events carry v==1 ($with_v/$total_ev): $(cat "$state_dir/brake-events.jsonl")"
+fi
+
+# ─── Test 21 (NEW): sentinel records cause on OK and FAIL (#1168 O4) ─
+echo "Test 21 — sentinel records cause on OK and FAIL (coo-memory#1168 O4)"
+set -- $(echo "$(_setup_session_dirs "t21")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_invoke_guard t21 Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+cause_fail="$(jq -r '.cause' "$state_dir/boot-brake.t21.json" 2>/dev/null)"
+_make_all_deliverables_present "$state_dir" "$home_dir" "t21"
+sleep 1.1
+_invoke_guard t21 Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+cause_ok="$(jq -r '.cause' "$state_dir/boot-brake.t21.json" 2>/dev/null)"
+if [ "$cause_fail" = "deliverable_missing" ] && [ "$cause_ok" = "all_satisfied" ]; then
+  _pass "sentinel cause: FAIL->deliverable_missing, OK->all_satisfied"
+else
+  _fail "sentinel cause wrong (fail=$cause_fail, ok=$cause_ok)"
+fi
+
+# ─── Test 22 (NEW): invalid override logs override_invalidated (#1168 O10) ─
+echo "Test 22 — invalid override logs cause=override_invalidated (coo-memory#1168 O10)"
+set -- $(echo "$(_setup_session_dirs "t22")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# Far-future expiry but bogus HMAC → check_override returns hmac_mismatch.
+cat > "$home_dir/.vade/boot-brake-override.t22.json" <<EOF
+{"granted_at":"2026-01-01T00:00:00Z","expires_at":"2099-12-31T23:59:59Z","session_id":"t22","reason":"bogus","hmac":"deadbeef"}
+EOF
+chmod 600 "$home_dir/.vade/boot-brake-override.t22.json"
+_invoke_guard t22 Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+if grep -q '"cause":"override_invalidated"' "$state_dir/brake-events.jsonl" 2>/dev/null \
+   && grep -q '"failure_kind":"hmac_mismatch"' "$state_dir/brake-events.jsonl" 2>/dev/null; then
+  _pass "invalid override (bad HMAC) → cause=override_invalidated, failure_kind=hmac_mismatch"
+else
+  _fail "override_invalidated not logged: $(cat "$state_dir/brake-events.jsonl" 2>/dev/null)"
+fi
+
 # ─── Summary ────────────────────────────────────────────────────
 echo
 echo "===================================="

--- a/scripts/hooks/boot-brake-guard.py
+++ b/scripts/hooks/boot-brake-guard.py
@@ -116,9 +116,18 @@ def atomic_write_json(path, payload):
         return False
 
 
+# brake-events.jsonl schema version. Bump on any breaking change to the
+# event shape so a Phase 1 aggregator can detect format breaks across the
+# accumulated soak data (coo-memory#1168 O1). Every event line carries
+# this as "v"; it is injected centrally in append_event below.
+EVENT_SCHEMA_VERSION = 1
+
+
 def append_event(state_dir, event):
     path = Path(state_dir) / "brake-events.jsonl"
     try:
+        if "v" not in event:
+            event = {"v": EVENT_SCHEMA_VERSION, **event}
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "a") as fh:
             fh.write(json.dumps(event, separators=(",", ":")) + "\n")
@@ -641,23 +650,37 @@ def main():
     # every fire for audit completeness).
     ovr_ok, ovr_info = check_override(home, session_id)
     if ovr_ok:
+        # Non-transition event: an override grant is not a state-machine
+        # transition, so it carries no from/to (coo-memory#1168 O2). The
+        # `cause` field is the universal classifier across all events.
         append_event(state_dir, {
             "ts": now_iso(),
             "session_id": session_id,
             "tool": tool_name,
-            "from": "any",
-            "to": "OK",
             "cause": "manual_override_granted",
             "reason": sanitize(ovr_info.get("reason", "")),
         })
         sys.exit(0)
-    if ovr_info and ovr_info.get("failure") == "expired":
-        append_event(state_dir, {
-            "ts": now_iso(),
-            "session_id": session_id,
-            "cause": "manual_override_expired",
-            "expired_at": ovr_info.get("expired_at"),
-        })
+    if ovr_info and ovr_info.get("failure"):
+        fk = ovr_info.get("failure")
+        if fk == "expired":
+            append_event(state_dir, {
+                "ts": now_iso(),
+                "session_id": session_id,
+                "cause": "manual_override_expired",
+                "expired_at": ovr_info.get("expired_at"),
+            })
+        else:
+            # O10: an override that fails HMAC / session / expires_at
+            # validation is silently ignored by check_override. Surface it
+            # so an operator whose /unbrake didn't take has a signal
+            # (coo-memory#1168 O10).
+            append_event(state_dir, {
+                "ts": now_iso(),
+                "session_id": session_id,
+                "cause": "override_invalidated",
+                "failure_kind": sanitize(fk),
+            })
 
     sentinel_path = Path(state_dir) / f"boot-brake.{session_id}.json"
     sentinel, sentinel_err = read_cached_sentinel(sentinel_path)
@@ -817,6 +840,7 @@ def main():
                     "checked_at_epoch": now_epoch,
                     "manifest_version": manifest.get("manifest_version", 1),
                     "failures": [],
+                    "cause": "race_gate_engaged",
                     "boot_started_at": boot_started_at_str,
                     "content_hashes": (sentinel or {}).get("content_hashes", {}),
                     "race_gate": {
@@ -858,6 +882,9 @@ def main():
                     "checked_at_epoch": now_epoch,
                     "manifest_version": m_version,
                     "failures": failures,
+                    # O4: every sentinel write records a cause so the
+                    # runbook's `jq .cause` triage works uniformly.
+                    "cause": "deliverable_missing" if failures else "all_satisfied",
                     "boot_started_at": boot_started_at_str,
                     "content_hashes": hashes,
                 }
@@ -879,6 +906,7 @@ def main():
                         "tool": tool_name,
                         "from": prev_state,
                         "to": state,
+                        "cause": "all_satisfied",
                     })
 
     state = (sentinel or {}).get("state", "PENDING")
@@ -921,7 +949,7 @@ def main():
             "session_id": session_id,
             "tool": tool_name,
             "state": state,
-            "outcome": "whitelisted",
+            "cause": "whitelisted_in_fail",
         })
         sys.exit(0)
 
@@ -942,7 +970,7 @@ def main():
         "session_id": session_id,
         "tool": tool_name,
         "state": state,
-        "outcome": "denied",
+        "cause": "denied",
         "failures": failures,
     }, state_dir=state_dir)
 


### PR DESCRIPTION
## Summary

Phase 1 of the boot brake, **partial #1168** — the event-schema core (O1/O2/O4/O10) plus the kernel side of the cause taxonomy. This is the stated prerequisite for the soak aggregator and for interpreting the warn→block readiness signal. The doc half (O5 taxonomy table + O3 decision) is the coo-labs/coo-memory PR on the same branch.

Branches off the now-merged #1169 work; only the event-schema changes are in this diff.

## What changes (`scripts/hooks/boot-brake-guard.py`)

- **O1 — schema version.** Every `brake-events.jsonl` line carries `"v": 1`, injected centrally in `append_event`. Bump on any breaking shape change so an aggregator can detect format breaks across accumulated soak data.
- **O2 — event-shape normalization.** `from`/`to` appear only on real state transitions; `cause` is the single universal classifier present on every event. The override-grant event loses its synthetic `from:"any"/to:"OK"`.
- **O4 — sentinel cause.** Every sentinel write records `cause` (`race_gate_engaged`, `deliverable_missing`, `all_satisfied`, `validator_self_fault`) so the Tier-2 `jq .cause` triage recipe works on OK/FAIL/PENDING uniformly, not just the self-fault path.
- **O10 — surface silent override failures.** `check_override` failures (`hmac_mismatch`, `missing_expires_at`, `session_mismatch`) now log `cause=override_invalidated` + `failure_kind` instead of being silently ignored — an operator whose `/unbrake` didn't take now has a signal.

Renames the block-mode event field `outcome` → `cause` (`whitelisted_in_fail`, `denied`) so one classifier covers every event. Safe for the soak corpus: `outcome` only appeared on block-mode events, which don't fire in `warn`.

## Tests (new)

- **20** — every event in `brake-events.jsonl` carries `v==1`.
- **21** — sentinel records `cause` (`deliverable_missing` on FAIL, `all_satisfied` on OK).
- **22** — an override with a bad HMAC logs `cause=override_invalidated` + `failure_kind=hmac_mismatch`.

```
boot-brake CI tests: 39 passed, 0 failed
```

## Design note

O2 suggested a separate `event_type` field for non-transition events; I standardized on `cause` as the single discriminator instead (present on every event; `from`/`to` distinguish transitions). One classifier, not two. Cheap to revisit if you'd prefer `event_type`.

## Scope

Partial #1168: O1, O2, O3 (doc), O4, O5 (doc), O10. Remaining for follow-up PRs: O6–O8 (storage/rotation), O9/O11/O12 (runbook completeness), O13–O15 (CI coverage).

## Closes

Closes: n/a (partial #1168; the issue stays open until O6–O15 land)

Refs: coo-labs/coo-memory#1082, coo-labs/coo-memory#1168

https://claude.ai/code/session_013sVdQsrM1Qgk5yaGeSx4zh