### PR TITLE
fix(boot-brake): warn-mode mirrors block-mode + Read bypasses backpressure on FAIL

### DIFF
--- a/scripts/ci/test-boot-brake-guard.sh
+++ b/scripts/ci/test-boot-brake-guard.sh
@@ -644,6 +644,75 @@ else
   _fail "override_invalidated not logged: $(cat "$state_dir/brake-events.jsonl" 2>/dev/null)"
 fi
 
+# ─── Test 23 (NEW): warn-mode mirrors block-mode for whitelisted tools ─
+echo "Test 23 — warn-mode taxonomy mirrors block-mode (coo-memory#1168 soak-fix)"
+set -- $(echo "$(_setup_session_dirs "t23")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# Deliverables missing → state will land FAIL. Read is whitelisted in
+# block-on-FAIL, so warn-mode must classify it as whitelisted_in_fail,
+# not would_have_denied. Same for Glob / AskUserQuestion / TodoWrite.
+for tool in Read Grep Glob AskUserQuestion TodoWrite; do
+  arg=""
+  [ "$tool" = "Read" ] && arg="/etc/hostname"
+  [ "$tool" = "Grep" ] && arg="pattern"
+  _invoke_guard t23 "$tool" warn "$state_dir" "$home_dir" "$arg" > /dev/null
+  sleep 1.1  # past backpressure cap so each call re-validates cleanly
+done
+# Bash is not whitelisted → must classify as would_have_denied.
+_invoke_guard t23 Bash warn "$state_dir" "$home_dir" "ls" > /dev/null
+wic="$(grep -c '"cause":"whitelisted_in_fail"' "$state_dir/brake-events.jsonl" 2>/dev/null || echo 0)"
+wdc="$(grep -c '"cause":"would_have_denied"' "$state_dir/brake-events.jsonl" 2>/dev/null || echo 0)"
+if [ "$wic" -ge 5 ] && [ "$wdc" -ge 1 ]; then
+  _pass "warn-mode: $wic whitelisted_in_fail (Read/Grep/Glob/AUQ/TodoWrite), $wdc would_have_denied (Bash)"
+else
+  _fail "warn-mode misclassified (whitelisted_in_fail=$wic, would_have_denied=$wdc); events: $(cat "$state_dir/brake-events.jsonl")"
+fi
+
+# ─── Test 24 (NEW): Read bypasses backpressure on FAIL with read_observed ─
+echo "Test 24 — Read against cached FAIL with read_observed bypasses backpressure (coo-memory#1168 soak-fix)"
+set -- $(echo "$(_setup_session_dirs "t24")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+# Stage file deliverables + 1 of 4 identity reads → FAIL on remaining 3.
+_make_all_deliverables_present "$state_dir" "$home_dir"
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '%s\t%s/identity/charter.md\n' "$ts" "$COO_MEMORY_DIR" \
+  >> "$home_dir/.vade/session-reads.t24.log"
+# First fire → sentinel FAIL (charter satisfied, 3 *_consumed unsatisfied)
+_invoke_guard t24 Bash warn "$state_dir" "$home_dir" "ls" > /dev/null
+state_before="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t24.json'))['state'])")"
+if [ "$state_before" != "FAIL" ]; then
+  _fail "Test 24 precondition: expected FAIL after 1-of-4 identity read, got $state_before"
+fi
+# Within 1s (backpressure window), satisfy the other 3 via Reads and
+# fire the guard for each. Without the bypass, the cached FAIL would
+# survive all three Reads. With the bypass, the brake re-validates and
+# transitions FAIL → OK by the last Read.
+for f in governance preferences episodic_memory; do
+  printf '%s\t%s/identity/%s.md\n' "$ts" "$COO_MEMORY_DIR" "$f" \
+    >> "$home_dir/.vade/session-reads.t24.log"
+  _invoke_guard t24 Read warn "$state_dir" "$home_dir" "$COO_MEMORY_DIR/identity/$f.md" > /dev/null
+done
+state_after="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t24.json'))['state'])")"
+if [ "$state_after" = "OK" ]; then
+  _pass "Read in FAIL re-validates within backpressure window → FAIL→OK"
+else
+  _fail "Cached FAIL survived satisfying Reads (state=$state_after); backpressure bypass not effective"
+fi
+# Sanity: a non-Read tool with no satisfying read does NOT bypass — the
+# bypass is targeted to the gate-closing case, not a general escape hatch.
+set -- $(echo "$(_setup_session_dirs "t24b")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+_invoke_guard t24b Bash warn "$state_dir" "$home_dir" "ls" > /dev/null
+checked_at_1="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t24b.json'))['checked_at_epoch'])")"
+_invoke_guard t24b Bash warn "$state_dir" "$home_dir" "ls" > /dev/null
+checked_at_2="$(python3 -c "import json; print(json.load(open('$state_dir/boot-brake.t24b.json'))['checked_at_epoch'])")"
+if [ "$checked_at_1" = "$checked_at_2" ]; then
+  _pass "Non-Read within backpressure window does not re-validate (bypass is targeted)"
+else
+  _fail "Non-Read also bypassed backpressure (over-broad bypass; checked_at changed)"
+fi
+
 # ─── Summary ────────────────────────────────────────────────────
 echo
 echo "===================================="

--- a/scripts/hooks/boot-brake-guard.py
+++ b/scripts/hooks/boot-brake-guard.py
@@ -705,14 +705,29 @@ def main():
         or sentinel.get("state") == "PENDING"
     )
 
-    # Backpressure cap: don't re-validate more than once per second.
+    # Backpressure cap: don't re-validate more than once per second —
+    # EXCEPT when the current tool is a Read against a cached FAIL whose
+    # failures include any read_observed entry. That's the "Read might
+    # have just satisfied a gate" case (coo-memory#1168 soak-fix: parallel
+    # boot Reads that close identity-stack gates would otherwise honor a
+    # cached FAIL through the entire ~2s parallel batch and not transition
+    # to OK until something else fires the guard).
     backpressure_floor = 1.0
     now_epoch = time.time()
     manifest_loaded = None  # cache across cached-check + revalidate branches
     m_err_cached = None
+    read_observed_failure_cached = (
+        tool_name == "Read"
+        and sentinel is not None
+        and sentinel.get("state") == "FAIL"
+        and any(
+            "consumed" in str(f.get("deliverable", ""))
+            for f in sentinel.get("failures", [])
+        )
+    )
     if sentinel and not needs_revalidation:
         last = sentinel.get("checked_at_epoch", 0)
-        if now_epoch - last < backpressure_floor:
+        if now_epoch - last < backpressure_floor and not read_observed_failure_cached:
             pass  # honor the cache
         else:
             # Content-hash drift check
@@ -915,15 +930,21 @@ def main():
     if state == "OK":
         sys.exit(0)
 
-    # FAIL / PENDING in warn mode → allow but log. Tag distinctly so
-    # the Phase 1 aggregator's would-have-denied histogram isn't
-    # polluted by race-gate transients:
-    #   - state=FAIL   → cause=would_have_denied (real denial in block)
-    #   - state=PENDING → cause=race_gate_observed (block-on-FAIL would
-    #     have allowed; block-strict would have denied)
+    # FAIL / PENDING in warn mode → allow but log. Tag each event with
+    # the same outcome that block mode would emit, so warn-mode is a
+    # faithful preview of block-mode (and the soak signal isn't polluted
+    # by tools that block mode would have whitelisted):
+    #   - state=PENDING                            → race_gate_observed
+    #     (block-on-FAIL allows; only block-strict denies)
+    #   - state=FAIL + tool in WHITELIST_TOOLS     → whitelisted_in_fail
+    #     (block-on-FAIL would log this same cause; coo-memory#1168 follow-up)
+    #   - state=FAIL + tool not whitelisted        → would_have_denied
+    #     (the real soak signal: actions block-on-FAIL would refuse)
     if mode == "warn":
         if state == "PENDING":
             cause = "race_gate_observed"
+        elif tool_name in WHITELIST_TOOLS:
+            cause = "whitelisted_in_fail"
         else:
             cause = "would_have_denied"
         append_event(state_dir, {


### PR DESCRIPTION
## Summary

Two soak-signal correctness fixes surfaced by the first post-#1169 fresh-boot test. A reporting session showed 5 `would_have_denied` events during the four identity-stack Reads — but Read is whitelisted in block-on-FAIL, so block-mode would have emitted `whitelisted_in_fail` for the same events. Two modes disagreeing about the same event defeats warn-mode as a faithful preview, and pollutes the warn→block readiness signal.

This PR makes warn-mode mirror block-mode for whitelisted tools, and fixes a separate cached-FAIL issue that kept the sentinel FAIL across a 2-second parallel boot-read batch.

The taxonomy-doc half is the coo-labs/coo-memory companion PR on the same branch.

## What changes (`scripts/hooks/boot-brake-guard.py`)

### Fix 1 — warn-mode whitelist branch

The warn-mode logger had no whitelist check, so any FAIL was logged as `would_have_denied` regardless of tool. Now mirrors block-mode:

```python
if mode == "warn":
    if state == "PENDING":
        cause = "race_gate_observed"
    elif tool_name in WHITELIST_TOOLS:
        cause = "whitelisted_in_fail"   # ← new branch
    else:
        cause = "would_have_denied"
```

After this, `would_have_denied` actually means "block-on-FAIL would refuse this" — which is what the warn→block readiness metric needs to be reading.

### Fix 2 — Read bypasses backpressure on FAIL with read_observed failures

The reporting session showed 5 boot Reads landing within 2 seconds, all honoring the 1s-cached FAIL sentinel because the backpressure cap held. The sentinel stayed FAIL until a non-Read tool fired the guard ~2 minutes later. Targeted bypass — when the current tool is `Read` AND the cached state is `FAIL` AND the failures list contains any `*_consumed` entry, force re-validate regardless of the cap:

```python
read_observed_failure_cached = (
    tool_name == "Read"
    and sentinel is not None
    and sentinel.get("state") == "FAIL"
    and any("consumed" in str(f.get("deliverable","")) for f in sentinel.get("failures", []))
)
if sentinel and not needs_revalidation:
    last = sentinel.get("checked_at_epoch", 0)
    if now_epoch - last < backpressure_floor and not read_observed_failure_cached:
        pass  # honor the cache
    else:
        ...
```

Non-Read tools and OK-state Reads honor the cap unchanged. Test 24's negative leg explicitly asserts the bypass is targeted (Bash within the window does not re-validate).

## What this is NOT

It is *not* a fix for the supposed "chicken-and-egg" pattern named in the reporting session — there is no chicken-and-egg in enforce mode. Read is whitelisted in block-on-FAIL, so the gate-closing boot Reads would always be allowed; the brake never blocks its own remedy. The chicken-and-egg only appeared in the warn-mode log because warn-mode wasn't consulting the whitelist.

## Tests

- **Test 23** — warn-mode with FAIL state: Read/Grep/Glob/AskUserQuestion/TodoWrite each log `whitelisted_in_fail`; Bash logs `would_have_denied`. Mirrors block-mode classification.
- **Test 24** — Read against cached FAIL within backpressure window re-validates and transitions FAIL→OK as the satisfying Reads land. Negative leg: a Bash call within the window does NOT bypass (the bypass stays targeted).

```
boot-brake CI tests: 42 passed, 0 failed
```

## Closes

Closes: n/a (soak-signal correctness; #1168 stays open for O6–O15)

Refs: coo-labs/coo-memory#1082, coo-labs/coo-memory#1168

https://claude.ai/code/session_013sVdQsrM1Qgk5yaGeSx4zh