### PR TITLE
gh-pr-create: auto-skip closing-keyword lint on session: prefix

### DIFF
--- a/scripts/gh-pr-create.sh
+++ b/scripts/gh-pr-create.sh
@@ -120,6 +120,15 @@ if [ "$skip_check" -eq 1 ]; then
   exec gh pr create "${pass_args[@]}"
 fi
 
+# Mirror the workflow's exempt-class registry for session-log PRs: title
+# prefix `session:` is the contract used by the /end-session skill and the
+# auto-subscribe-pr hook. The coo-logs auto-merge workflow doesn't gate on
+# closing keywords for these, so the local lint shouldn't either — saves
+# the agent from remembering --skip-closing-keyword-check.
+if [[ "$title" == session:* ]]; then
+  exec gh pr create "${pass_args[@]}"
+fi
+
 # Resolve body content for the lint. Title + body together, mirroring
 # the workflow's title-OR-body check.
 content="$title"


### PR DESCRIPTION
Mirror the coo-logs auto-merge workflow's exempt-class registry for session-log PRs: title prefix `session:` is already the canonical contract used by /end-session and the auto-subscribe-pr hook. The workflow doesn't gate closing keywords for these; the local lint shouldn't either.

Surfaced as friction on a real /end-session run on 2026-06-04 — PR coo-labs/coo-logs#576 needed `--skip-closing-keyword-check` even though it would have auto-merged regardless.

After this change, the wrapper script `session-log-pr-open.sh` (paired in coo-labs/coo-memory PR) builds a clean `session: <slug>` PR title with no closing-keyword incantation and no bypass flag.

Same behavior for the explicit `--skip-closing-keyword-check` flag is preserved; the new branch is purely additive.

Closes: n/a

https://claude.ai/code/session_013nbjabYiLkVYRtVBFk9V7B