### PR TITLE
boot: pin git author/committer env to COO (CCR hook race fix)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -163,7 +163,11 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS": "1",
     "ENABLE_CLAUDEAI_MCP_SERVERS": "false",
-    "VADE_BRAKE_ENFORCE": "block-on-FAIL"
+    "VADE_BRAKE_ENFORCE": "block-on-FAIL",
+    "GIT_AUTHOR_NAME": "COO",
+    "GIT_AUTHOR_EMAIL": "coo@vade-app.dev",
+    "GIT_COMMITTER_NAME": "COO",
+    "GIT_COMMITTER_EMAIL": "coo@vade-app.dev"
   },
   "skillOverrides": {
     "agentmail": "user-invocable-only"


### PR DESCRIPTION
## Summary

Anthropic shipped a new Claude Code Remote (CCR) baseline today (2026-06-04) that adds a SessionStart hook calling `~/.claude/session-start-git-identity.sh`. It unconditionally writes `user.email=noreply@anthropic.com` + `user.name=Claude` to the global gitconfig so commits signed by CCR's SSH key verify on GitHub.

Hook order between CCR's `launcher-settings.json` and our `settings.json` is not deterministic. In sessions where CCR's hook ran last, our `coo-bootstrap.sh` override lost and commits attributed to `Claude <noreply@anthropic.com>`:

- [d3479467](https://github.com/coo-labs/coo-memory/commit/d3479467e829c960de7d10da3c341cbe764e4780) on `coo-memory` main (committer=Coo, author=Claude — amend after the gitconfig flip preserved bad author)
- All 5 commits on [coo-labs/coo-memory#1178](https://github.com/coo-labs/coo-memory/pull/1178) (both fields Claude — flip was active at commit time)
- Source commit of [coo-labs/coo-memory#1172](https://github.com/coo-labs/coo-memory/pull/1172) (c9e4391, same shape)

## Fix

Pin `GIT_AUTHOR_NAME`/`EMAIL` and `GIT_COMMITTER_NAME`/`EMAIL` in `.claude/settings.json` env block. Claude Code injects these into every Bash subprocess, and env vars beat gitconfig in git's precedence, so attribution lands as `COO`/`coo@vade-app.dev` regardless of which session-start hook won the race.

## Verification

Live probe in this session (`/tmp/attr-test`) confirms `GIT_AUTHOR_EMAIL=x git commit ...` overrides the `user.email=coo@vade-app.dev` gitconfig — author becomes `x`, not the gitconfig value. After this merges and a fresh container boots, every `git commit` Bash call will see the four pinned env vars before reaching gitconfig.

## Non-effects

No change to signing posture: `commit.gpgsign=false` set by `coo-bootstrap.sh`, so the GitHub "Verified" badge wasn't in play. A future "sign commits with the vade-coo key for verified attribution" change is orthogonal.

## Followup

PR [coo-labs/coo-memory#1178](https://github.com/coo-labs/coo-memory/pull/1178)'s existing bad commits need an interactive rebase with `--reset-author` before merge — being handled in the session that opened that PR.

Restores F4 integrity invariant pass on origin/main HEAD once #1178 is rebased.

Closes: n/a (defect fix; tracked as F4 boot-integrity invariant)

https://claude.ai/code/session_7152166e-dc28-403a-9fe6-e216e89e8388