### PR TITLE
integrity-check(F4): allowlist d3479467 — author-override regression

### DIFF
--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -1039,6 +1039,18 @@ F4_ALLOWLIST_SHA=(
   # F_CUTOFF_GIT comment block above). Cleared in run-2026-05-02T120959
   # full-bootup pass.
   "7cb8a86da4"
+  # d3479467e8 — coo-memory commit "end-session: streamline (pre-fill
+  # title, inline Mem0 shape, scripted PR-open)" on 2026-06-04. Author
+  # leaked as Claude <noreply@anthropic.com>; committer correctly set
+  # to Coo <coo@vade-app.dev>. Root cause: Anthropic shipped a new
+  # silent override on git credentials earlier that day that defeated
+  # the existing COO author-override; the override-on-override was
+  # patched same session, and the prior session re-attributed most of
+  # the affected commits, but this one landed on main before the
+  # remediation and was missed in the sweep. Already pushed to
+  # origin/main — rewriting public history is the wrong tradeoff.
+  # Allowlisted with full causal record above; no policy gap.
+  "d3479467e8"
 )
 if [ -d "$F_REPO/.git" ] && check_cmd git; then
   f4_total=0


### PR DESCRIPTION
Closes #428. Follow-up to [#427](https://github.com/coo-labs/coo-harness/pull/427) (Anthropic CCR git-credentials override patch).

## Context
- `d3479467e8` in coo-labs/coo-memory landed on `main` with `Author: Claude <noreply@anthropic.com>` at 2026-06-04 04:19Z.
- Committer was set correctly to `Coo <coo@vade-app.dev>` — the boot identity ran; only the author-line override was defeated by the Anthropic CCR baseline.
- #427's pin-on-pin remediation landed at 05:03Z and re-attributed most affected commits; this one was already on origin/main upstream of the sweep.

## Disposition
- Commit is published on `origin/main`. Rewriting public history is the wrong tradeoff vs. a documented allowlist carve-out.
- Add to `F4_ALLOWLIST_SHA` with the full causal record, matching the precedent of `7cb8a86da4`.

## Verification
Local `integrity-check.sh` with the (separately) rotated R2 secret: was 28/29 (F4), now 29/29 OK.

No policy gap — #427 is the structural fix; F4 will catch any future leakage.

https://claude.ai/code/session_012doP1NRA9z8iPLiixriZxm