### PR TITLE
secrets(track-1b): integrity-check group S invariants (S1-S5, S7, S8)

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -153,15 +153,11 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
 
       - name: Integrity group S — secrets-schema invariants (coo-memory#871)
-        env:
-          VADE_COO_MEMORY_DIR: ${{ github.workspace }}/coo-memory-clone
         run: |
           # jsonschema for the S1 validator path. PyYAML already
-          # installed in the prior step's chain.
+          # installed in the prior step's chain. Validator + JSON
+          # Schema live under scripts/ci/fixtures/ (synced from
+          # coo-memory's Track 1a; sync convention noted in the
+          # test runner's _stage_memory fallback).
           pip install --quiet jsonschema pyyaml
-          # Clone coo-memory at HEAD so the test runner can stage the
-          # live Track 1a validator + JSON Schema into per-test dirs.
-          # Shallow clone — only the working tree is needed.
-          git clone --depth=1 https://github.com/coo-labs/coo-memory \
-            "$VADE_COO_MEMORY_DIR"
           bash "$GITHUB_WORKSPACE/scripts/ci/test-integrity-group-s.sh"

--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -142,3 +142,19 @@ jobs:
           # PyYAML for the manifest reader
           pip install --quiet pyyaml
           bash "$GITHUB_WORKSPACE/scripts/ci/test-boot-brake-guard.sh"
+
+      - name: Install yq (Go) for Group S tests
+        # Group S helpers parse schema.yaml via yq. The Python yq
+        # (apt's `yq`) has different syntax; install the Go binary
+        # the production container ships.
+        run: |
+          sudo wget -q -O /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Integrity group S — secrets-schema invariants (coo-memory#871)
+        run: |
+          # jsonschema for the S1 validator path. PyYAML already
+          # installed in the prior step's chain.
+          pip install --quiet jsonschema pyyaml
+          bash "$GITHUB_WORKSPACE/scripts/ci/test-integrity-group-s.sh"

--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -153,8 +153,15 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
 
       - name: Integrity group S — secrets-schema invariants (coo-memory#871)
+        env:
+          VADE_COO_MEMORY_DIR: ${{ github.workspace }}/coo-memory-clone
         run: |
           # jsonschema for the S1 validator path. PyYAML already
           # installed in the prior step's chain.
           pip install --quiet jsonschema pyyaml
+          # Clone coo-memory at HEAD so the test runner can stage the
+          # live Track 1a validator + JSON Schema into per-test dirs.
+          # Shallow clone — only the working tree is needed.
+          git clone --depth=1 https://github.com/coo-labs/coo-memory \
+            "$VADE_COO_MEMORY_DIR"
           bash "$GITHUB_WORKSPACE/scripts/ci/test-integrity-group-s.sh"

--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -1292,6 +1292,37 @@ else
   _add F8 skip "requires $F_REPO/bin/framed-as-caution.py + retrospectives + memos + python3"
 fi
 
+# ── Group S: Secrets-schema invariants ───────────────────────
+# Implements S1, S2, S3, S4, S5, S7, S8 from
+# coo-memory/operations/secrets/README.md §3.4. S6 demoted to warning
+# per SOP rationalization R-3 and intentionally NOT emitted here.
+#
+# Track 1b of the secrets-management implementation epic
+# (coo-memory#871). Probe-not-repair: every failure surfaces in the
+# JSON output, but the script keeps exit 0. Boot-blocking integration
+# is a follow-up PR after this soaks clean.
+#
+# Skip semantics (per S-invariant):
+#   - S1: skip if validator or PyYAML/jsonschema missing.
+#   - S2: skip if yq missing.
+#   - S3: works in CI for filesystem mirrors; sha8 check + org/repo
+#         secret checks skip when op CLI or gh CLI is unavailable.
+#   - S4: skip if op CLI not live (CI fake-env or missing
+#         OP_SERVICE_ACCOUNT_TOKEN).
+#   - S5: works in CI for filesystem path inspection; degraded reports
+#         do not impede other invariants.
+#   - S7: skip if op CLI not live.
+#   - S8: works everywhere — classifies current process env against
+#         schema + writes today's keynames snapshot.
+S_LIB="$SCRIPT_DIR/../lib/integrity-group-s.sh"
+if [ -r "$S_LIB" ]; then
+  # shellcheck source=../lib/integrity-group-s.sh
+  source "$S_LIB"
+  s_check_all
+else
+  _add S1 skip "integrity-group-s.sh helper missing at $S_LIB"
+fi
+
 # ── Serialize ────────────────────────────────────────────────
 mkdir -p "$VADE_CLOUD_STATE_DIR" 2>/dev/null || true
 

--- a/scripts/ci/fixtures/secrets-schema-check.py
+++ b/scripts/ci/fixtures/secrets-schema-check.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "PyYAML>=6.0",
+#   "jsonschema>=4.0",
+# ]
+# ///
+"""secrets-schema-check — validate operations/secrets/schema.yaml against
+operations/secrets/schema.schema.json.
+
+Track 1a of the secrets-management implementation epic (coo-memory#871).
+Enforces the S1 invariant from SOP §3.4 (schema.yaml parses + is
+shape-valid). Catches typos (env_alias misspellings, mirror surface enum
+violations, malformed credential ids) while tolerating `TBD:`-marker
+strings on fields not yet backfilled.
+
+Usage:
+  python3 bin/secrets-schema-check.py [<schema.yaml>] [--schema <schema.json>]
+
+  Default <schema.yaml>:  operations/secrets/schema.yaml
+  Default <schema.json>:  operations/secrets/schema.schema.json
+                         (alongside the yaml unless overridden)
+
+Exit codes:
+  0  clean — no schema violations.
+  1  schema violations — report printed.
+  2  invocation error (missing file, bad YAML, bad JSON Schema).
+
+Output shape (on violations):
+  <file>: <json-pointer-path>: <message>
+
+The json-pointer is the path to the offending node inside the YAML
+document; useful for grepping straight to the entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError as exc:
+    print(
+        f"secrets-schema-check: PyYAML required but not importable: {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+try:
+    from jsonschema import Draft202012Validator
+    from jsonschema.exceptions import SchemaError
+except ImportError as exc:
+    print(
+        f"secrets-schema-check: jsonschema required but not importable: {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def load_yaml(path: Path):
+    try:
+        with path.open() as fh:
+            return yaml.safe_load(fh)
+    except FileNotFoundError:
+        print(f"secrets-schema-check: file not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    except yaml.YAMLError as exc:
+        print(f"secrets-schema-check: YAML parse error in {path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def load_json(path: Path):
+    try:
+        with path.open() as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        print(f"secrets-schema-check: file not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    except json.JSONDecodeError as exc:
+        print(f"secrets-schema-check: JSON parse error in {path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def pointer_for(path_parts) -> str:
+    """Render a json-pointer (RFC 6901) for a deque of path parts."""
+    if not path_parts:
+        return ""
+    out = []
+    for part in path_parts:
+        s = str(part)
+        s = s.replace("~", "~0").replace("/", "~1")
+        out.append(s)
+    return "/" + "/".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        prog="secrets-schema-check",
+        description="Validate operations/secrets/schema.yaml against its JSON Schema.",
+    )
+    ap.add_argument(
+        "yaml_path",
+        nargs="?",
+        default="operations/secrets/schema.yaml",
+        help="Path to schema.yaml (default: operations/secrets/schema.yaml)",
+    )
+    ap.add_argument(
+        "--schema",
+        default=None,
+        help="Path to schema.schema.json (default: alongside the yaml)",
+    )
+    args = ap.parse_args()
+
+    yaml_path = Path(args.yaml_path)
+    if args.schema is None:
+        schema_path = yaml_path.with_name("schema.schema.json")
+    else:
+        schema_path = Path(args.schema)
+
+    instance = load_yaml(yaml_path)
+    schema = load_json(schema_path)
+
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError as exc:
+        print(
+            f"secrets-schema-check: invalid JSON Schema at {schema_path}: {exc.message}",
+            file=sys.stderr,
+        )
+        return 2
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.absolute_path))
+
+    if not errors:
+        print(f"{yaml_path}: ok ({schema_path.name} clean)")
+        return 0
+
+    for err in errors:
+        pointer = pointer_for(err.absolute_path) or "/"
+        msg = err.message.replace("\n", " ")
+        print(f"{yaml_path}: {pointer}: {msg}")
+    print(
+        f"\nsecrets-schema-check: {len(errors)} violation(s) against {schema_path.name}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/fixtures/secrets-schema-clean.yaml
+++ b/scripts/ci/fixtures/secrets-schema-clean.yaml
@@ -1,0 +1,123 @@
+# Minimal synthetic schema.yaml fixture for the integrity-group-s test
+# suite. Matches the shape of operations/secrets/schema.yaml but holds
+# only the entries needed to exercise the S invariants in isolation.
+#
+# Each test in test-integrity-group-s.sh derives mutated copies of this
+# file to inject specific failure modes. The CI-mode skips (S4, S7
+# requiring live op CLI; S3 sha8) prevent live `op read` from being
+# invoked here.
+
+schema_version: 1
+implementation_status: design-stage
+vault: COO
+
+service_account_root:
+  op_item: "Service Account Auth Token: test"
+  rotation_class: III
+  break_glass: "see test stub"
+  notes: "fixture for integrity-group-s tests"
+
+non_secret_env_allowlist:
+  - PATH
+  - HOME
+  - LANG
+  - LC_ALL
+  - VADE_TEST_KNOWN
+
+non_secret_env_prefixes:
+  - VADE_TEST_PFX_
+  - CLAUDE_CODE_
+
+env_drift_detection:
+  snapshot_path: "operations/secrets/env-snapshots/<YYYY-MM-DD>.txt"
+  snapshot_format: keynames-only
+  classification_order:
+    - declared_secret
+    - declared_allowlist
+    - prefix_allowlist
+    - unknown_secret_shape
+    - unknown_other
+  baseline_anthropic_docs: "https://docs.claude.com/en/docs/claude-code/iam"
+  policy_on_unknown: warn-do-not-block
+
+secret_shapes:
+  - name: github-classic-pat
+    pattern: 'ghp_[A-Za-z0-9]{36}'
+    class: github
+  - name: mem0-api-key
+    pattern: 'm0-[A-Za-z0-9]{32}'
+    class: mem0
+
+mirror_surfaces:
+  - container_env
+  - org_secret
+  - repo_secret
+  - workflow_op_inline
+  - file
+
+failure_classes:
+  - class: A
+    name: "Mirror drift"
+    detector: "/verify-secrets"
+
+credentials:
+  - id: test-github-pat
+    op_item: test-github-pat
+    op_field: token
+    purpose: "Synthetic GitHub PAT for the integrity-group-s test fixture."
+    owner: vade-coo
+    status: active
+    rotation_class: III
+    expires_at: "2026-12-31"
+    rotation_policy_days: 365
+    last_rotated: "2026-06-04"
+    env_aliases:
+      - VADE_TEST_GHPAT
+    mirrors:
+      - surface: container_env
+        path_or_name: "__FIXTURE_DIR__/settings.json::env::VADE_TEST_GHPAT"
+        format: json-key-replace
+    consumers:
+      - type: script
+        location: "tests/synthetic"
+
+  - id: test-multi-field
+    op_item: test-multi-field
+    op_field: token
+    op_alt_fields:
+      - secondary
+    purpose: "Synthetic multi-field item — exercises S4 (no stale empty 'credential')."
+    owner: vade-coo
+    status: active
+    rotation_class: III
+    expires_at: "never"
+    rotation_policy_days: 365
+    last_rotated: "2026-06-04"
+    env_aliases:
+      - VADE_TEST_MULTI
+    mirrors:
+      - surface: container_env
+        path_or_name: "__FIXTURE_DIR__/settings.json::env::VADE_TEST_MULTI"
+        format: json-key-replace
+    consumers:
+      - type: script
+        location: "tests/synthetic"
+
+  - id: test-dormant
+    op_item: test-dormant
+    op_field: credential
+    purpose: "Synthetic dormant item — S2 should NOT report its missing env alias."
+    owner: vade-coo
+    status: dormant
+    rotation_class: IV
+    expires_at: "never"
+    rotation_policy_days: 0
+    last_rotated: "2026-06-04"
+    env_aliases:
+      - VADE_TEST_DORMANT_UNSET
+    mirrors: []
+    consumers: []
+
+out_of_schema: []
+
+deferrals: []

--- a/scripts/ci/fixtures/secrets-schema.schema.json
+++ b/scripts/ci/fixtures/secrets-schema.schema.json
@@ -1,0 +1,326 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/coo-labs/coo-memory/operations/secrets/schema.schema.json",
+  "title": "VADE secrets schema (schema.yaml validator)",
+  "description": "Strict-but-TBD-tolerant JSON Schema for operations/secrets/schema.yaml. Catches typos (env_alias misspellings, mirror surface enum violations); permits TBD: strings on fields not yet backfilled. CI shape-check entry point.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "implementation_status",
+    "vault",
+    "service_account_root",
+    "non_secret_env_allowlist",
+    "non_secret_env_prefixes",
+    "env_drift_detection",
+    "secret_shapes",
+    "mirror_surfaces",
+    "failure_classes",
+    "credentials",
+    "out_of_schema",
+    "deferrals"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "implementation_status": {
+      "type": "string",
+      "enum": ["design-stage", "in-progress", "operational"]
+    },
+    "vault": {
+      "type": "string",
+      "minLength": 1
+    },
+    "service_account_root": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op_item", "rotation_class", "break_glass", "notes"],
+      "properties": {
+        "op_item": {"type": "string"},
+        "rotation_class": {"$ref": "#/$defs/rotation_class"},
+        "break_glass": {"type": "string"},
+        "notes": {"type": "string"}
+      }
+    },
+    "non_secret_env_allowlist": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]*$"},
+      "uniqueItems": true
+    },
+    "non_secret_env_prefixes": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]*$"},
+      "uniqueItems": true
+    },
+    "env_drift_detection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "snapshot_path",
+        "snapshot_format",
+        "classification_order",
+        "baseline_anthropic_docs",
+        "policy_on_unknown"
+      ],
+      "properties": {
+        "snapshot_path": {"type": "string"},
+        "snapshot_format": {
+          "type": "string",
+          "enum": ["keynames-only"]
+        },
+        "classification_order": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "declared_secret",
+              "declared_allowlist",
+              "prefix_allowlist",
+              "unknown_secret_shape",
+              "unknown_other"
+            ]
+          },
+          "uniqueItems": true,
+          "minItems": 1
+        },
+        "baseline_anthropic_docs": {"type": "string"},
+        "policy_on_unknown": {
+          "type": "string",
+          "enum": ["warn-do-not-block", "block", "ignore"]
+        }
+      }
+    },
+    "secret_shapes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "pattern", "class"],
+        "properties": {
+          "name": {"type": "string", "pattern": "^[a-z][a-z0-9-]*$"},
+          "pattern": {"type": "string", "minLength": 1},
+          "class": {"type": "string", "minLength": 1},
+          "false_positive_risk": {
+            "type": "string",
+            "enum": ["low", "medium", "high"]
+          },
+          "notes": {"type": "string"}
+        }
+      },
+      "uniqueItems": false,
+      "minItems": 1
+    },
+    "mirror_surfaces": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/mirror_surface"},
+      "uniqueItems": true,
+      "minItems": 1
+    },
+    "failure_classes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["class", "name", "detector"],
+        "properties": {
+          "class": {"type": "string", "minLength": 1},
+          "name": {"type": "string", "minLength": 1},
+          "detector": {"type": "string", "minLength": 1},
+          "detector_notes": {"type": "string"}
+        }
+      },
+      "minItems": 1
+    },
+    "credentials": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/credential"},
+      "minItems": 1
+    },
+    "out_of_schema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["op_item", "reason"],
+        "properties": {
+          "op_item": {"type": "string"},
+          "reason": {"type": "string"}
+        }
+      }
+    },
+    "deferrals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["topic", "reason"],
+        "properties": {
+          "topic": {"type": "string"},
+          "reason": {"type": "string"}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "rotation_class": {
+      "type": "string",
+      "enum": ["I", "II", "III", "IV"]
+    },
+    "mirror_surface": {
+      "type": "string",
+      "enum": [
+        "container_env",
+        "org_secret",
+        "repo_secret",
+        "codespaces_secret",
+        "dependabot_secret",
+        "workflow_op_inline",
+        "file"
+      ]
+    },
+    "tbd_marker": {
+      "type": "string",
+      "pattern": "^TBD(\\b|:|$)"
+    },
+    "date_iso": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "credential": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "op_item",
+        "op_field",
+        "purpose",
+        "owner",
+        "status",
+        "rotation_class",
+        "expires_at",
+        "rotation_policy_days",
+        "last_rotated",
+        "env_aliases",
+        "mirrors",
+        "consumers"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "op_item": {"type": "string", "minLength": 1},
+        "op_field": {"type": "string", "minLength": 1},
+        "op_alt_fields": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "op_field_notes": {"type": "string"},
+        "purpose": {"type": "string", "minLength": 1},
+        "owner": {
+          "oneOf": [
+            {"type": "string", "enum": ["vade-coo", "ven", "service-account", "vade-coo-app", "n/a"]},
+            {"$ref": "#/$defs/tbd_marker"}
+          ]
+        },
+        "status": {
+          "oneOf": [
+            {"type": "string", "enum": ["active", "dormant", "pending_decommission", "pending_decategorization", "n/a"]},
+            {"$ref": "#/$defs/tbd_marker"}
+          ]
+        },
+        "rotation_class": {"$ref": "#/$defs/rotation_class"},
+        "expires_at": {
+          "oneOf": [
+            {"$ref": "#/$defs/date_iso"},
+            {"type": "string", "enum": ["never", "1h-rolling", "n/a"]},
+            {"$ref": "#/$defs/tbd_marker"}
+          ]
+        },
+        "rotation_policy_days": {
+          "oneOf": [
+            {"type": "integer", "minimum": 0},
+            {"$ref": "#/$defs/tbd_marker"}
+          ]
+        },
+        "last_rotated": {
+          "oneOf": [
+            {"$ref": "#/$defs/date_iso"},
+            {"type": "string", "enum": ["auto", "n/a"]},
+            {"$ref": "#/$defs/tbd_marker"}
+          ]
+        },
+        "expected_fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "env_aliases": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Z0-9_]*$"
+          },
+          "uniqueItems": true
+        },
+        "mirrors": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/mirror"}
+        },
+        "consumers": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/consumer"}
+        },
+        "permission_scopes": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "notes": {"type": "string"}
+      }
+    },
+    "mirror": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["surface", "path_or_name"],
+      "properties": {
+        "surface": {"$ref": "#/$defs/mirror_surface"},
+        "path_or_name": {"type": "string", "minLength": 1},
+        "format": {
+          "oneOf": [
+            {"type": "string", "enum": ["json-key-replace", "sh-export-replace", "gh-secret-set", "file-replace"]},
+            {"$ref": "#/$defs/tbd_marker"}
+          ]
+        },
+        "visibility": {
+          "type": "string",
+          "enum": ["all", "selected"]
+        },
+        "pre_grant_path": {"type": "string"},
+        "post_grant_path": {"type": "string"},
+        "notes": {"type": "string"}
+      }
+    },
+    "consumer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["shim", "script", "workflow", "mcp_child", "manual"]
+        },
+        "location": {"type": "string"},
+        "repo": {"type": "string"},
+        "workflow": {"type": "string"},
+        "secret_name": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]*$"
+        },
+        "name": {"type": "string"},
+        "notes": {"type": "string"}
+      }
+    }
+  }
+}

--- a/scripts/ci/test-integrity-group-s.sh
+++ b/scripts/ci/test-integrity-group-s.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# Test suite for the Group S secrets-schema invariants in
+# scripts/lib/integrity-group-s.sh.
+#
+# Each test materializes a synthetic schema.yaml (and optional
+# settings.json / coo-env file) under $TEST_ROOT, sources the helper
+# with a stubbed $VADE_COO_MEMORY_DIR + override variables that route
+# the invariant to the synthetic fixtures, and asserts the invariant's
+# (key, ok, detail) triple.
+#
+# Coverage:
+#   - S1: clean → ok; injected malformed schema → fail.
+#   - S2: every alias set → ok; one alias unset (non-dormant) → fail.
+#         Dormant credential's unset alias does NOT fail.
+#   - S3: declared container_env mirror present in synthetic
+#         settings.json → ok; mirror file absent → fail.
+#   - S4: skip in CI fake-env (documents the skip path).
+#   - S5: synthetic sanctioned path with secret-shape match → ok;
+#         empty/no-match sanctioned path → fail.
+#   - S7: skip in CI fake-env (documents the skip path).
+#   - S8: env classification — known alias goes to declared_secret;
+#         unknown allowlisted prefix → prefix_allowlist; injected
+#         token-shape value on an unknown name → unknown_secret_shape.
+#
+# Skips:
+#   - S4 + S7 live `op` integration is exercised in the cloud session
+#     (Track 1b soak), not here — CI fake-env can't validate op-read.
+#     The test asserts the skip detail wording is sensible.
+#
+# Exit 0 if all assertions pass, 1 on any failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/lib/integrity-group-s.sh"
+FIXTURE="$REPO_ROOT/scripts/ci/fixtures/secrets-schema-clean.yaml"
+
+[ -r "$HELPER" ]   || { echo "FAIL: helper not readable at $HELPER"; exit 1; }
+[ -r "$FIXTURE" ]  || { echo "FAIL: fixture not readable at $FIXTURE"; exit 1; }
+command -v yq      >/dev/null 2>&1 || { echo "FAIL: yq required"; exit 1; }
+command -v jq      >/dev/null 2>&1 || { echo "FAIL: jq required"; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "FAIL: python3 required"; exit 1; }
+python3 -c 'import yaml' 2>/dev/null || { echo "FAIL: PyYAML required"; exit 1; }
+
+TEST_ROOT="${TEST_ROOT:-/tmp/integrity-group-s-test-$$}"
+mkdir -p "$TEST_ROOT"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+_pass() {
+  PASS=$((PASS + 1))
+  printf '  ok: %s\n' "$1"
+}
+
+_fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  printf '  FAIL: %s\n' "$1"
+}
+
+# Render a fresh fixture into $1 with __FIXTURE_DIR__ replaced by $2.
+_render_fixture() {
+  local dst="$1" fixdir="$2"
+  sed "s#__FIXTURE_DIR__#$fixdir#g" "$FIXTURE" > "$dst"
+}
+
+# Stage a synthetic VADE_COO_MEMORY_DIR-shaped tree under a per-test
+# directory. Returns the path on stdout.
+_stage_memory() {
+  local dir="$1"
+  mkdir -p "$dir/operations/secrets/env-snapshots" "$dir/bin"
+  # Stage a copy of secrets-schema-check.py + schema.schema.json from
+  # the live coo-memory checkout if available. If not, S1 will skip
+  # cleanly (caller decides whether to assert).
+  local src_validator="${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}/bin/secrets-schema-check.py"
+  local src_schema="${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}/operations/secrets/schema.schema.json"
+  if [ -f "$src_validator" ]; then
+    cp "$src_validator" "$dir/bin/secrets-schema-check.py"
+    chmod +x "$dir/bin/secrets-schema-check.py"
+  fi
+  if [ -f "$src_schema" ]; then
+    cp "$src_schema" "$dir/operations/secrets/schema.schema.json"
+  fi
+  _render_fixture "$dir/operations/secrets/schema.yaml" "$dir"
+  printf '%s' "$dir"
+}
+
+# Source the helper + run a single S<N> check inside a subshell with
+# RESULTS captured. Sets `_LAST_KEY`, `_LAST_OK`, `_LAST_DETAIL` from
+# the FIRST matching `<key>|<ok>|<detail>` line emitted.
+_run_invariant() {
+  local key="$1" mem_dir="$2"
+  shift 2
+  local out
+  out="$(
+    VADE_COO_MEMORY_DIR="$mem_dir" \
+    VADE_SECRETS_SNAPSHOT_DIR="$mem_dir/operations/secrets/env-snapshots" \
+    VADE_SECRETS_SNAPSHOT_SKIP="${VADE_SECRETS_SNAPSHOT_SKIP:-1}" \
+    "$@" bash -c '
+      set -uo pipefail
+      RESULTS=()
+      _add() { RESULTS+=("$1|$2|$3"); }
+      source "'"$HELPER"'"
+      s_check_'"$key"'
+      printf "%s\n" "${RESULTS[@]}"
+    ' 2>&1)"
+  # First line with the key
+  local line
+  line="$(printf '%s\n' "$out" | grep -E "^${key}\|" | head -1)"
+  _LAST_KEY="${line%%|*}"
+  local rest="${line#*|}"
+  _LAST_OK="${rest%%|*}"
+  _LAST_DETAIL="${rest#*|}"
+}
+
+# Per-key assertion helpers.
+_assert_ok() {
+  local key="$1" label="$2"
+  if [ "$_LAST_KEY" = "$key" ] && [ "$_LAST_OK" = "true" ]; then
+    _pass "$key OK: $label"
+  else
+    _fail "$key expected ok=true, got ok=$_LAST_OK detail=$_LAST_DETAIL ($label)"
+  fi
+}
+_assert_fail() {
+  local key="$1" label="$2"
+  if [ "$_LAST_KEY" = "$key" ] && [ "$_LAST_OK" = "false" ]; then
+    _pass "$key FAIL (as expected): $label"
+  else
+    _fail "$key expected ok=false, got ok=$_LAST_OK detail=$_LAST_DETAIL ($label)"
+  fi
+}
+_assert_skip() {
+  local key="$1" label="$2"
+  if [ "$_LAST_KEY" = "$key" ] && [ "$_LAST_OK" = "skip" ]; then
+    _pass "$key SKIP (as expected): $label"
+  else
+    _fail "$key expected ok=skip, got ok=$_LAST_OK detail=$_LAST_DETAIL ($label)"
+  fi
+}
+_assert_detail_contains() {
+  local needle="$1" label="$2"
+  if printf '%s' "$_LAST_DETAIL" | grep -qF -- "$needle"; then
+    _pass "detail contains '$needle' ($label)"
+  else
+    _fail "detail missing '$needle': $_LAST_DETAIL ($label)"
+  fi
+}
+
+printf '\n== S1: schema parse + shape-validity ==\n'
+
+S1_DIR="$TEST_ROOT/s1-clean"
+_stage_memory "$S1_DIR" >/dev/null
+# CI fake-env marker prevents S4/S7 from attempting live op
+# (defensive — they should already short-circuit on op_live=0 without
+# VADE_BINDIR_OVERRIDE, but setting it removes any host-op dependency).
+_run_invariant S1 "$S1_DIR" env VADE_BINDIR_OVERRIDE=/tmp
+_assert_ok S1 "clean schema validates"
+
+S1_BAD="$TEST_ROOT/s1-bad"
+_stage_memory "$S1_BAD" >/dev/null
+# Inject a malformed YAML structure — non-array `credentials`.
+sed -i 's/^credentials:/credentials: not-an-array/' "$S1_BAD/operations/secrets/schema.yaml"
+_run_invariant S1 "$S1_BAD" env VADE_BINDIR_OVERRIDE=/tmp
+_assert_fail S1 "malformed schema fails validation"
+
+printf '\n== S2: every declared env-alias set (non-dormant) ==\n'
+
+S2_DIR="$TEST_ROOT/s2-all-set"
+_stage_memory "$S2_DIR" >/dev/null
+_run_invariant S2 "$S2_DIR" env \
+  VADE_BINDIR_OVERRIDE=/tmp \
+  VADE_TEST_GHPAT="ghp_fixturefixturefixturefixturefixturefi" \
+  VADE_TEST_MULTI="multi-fixture-value"
+_assert_ok S2 "all non-dormant aliases set"
+_assert_detail_contains "2/2" "S2 count includes dormant exclusion (test-dormant not counted)"
+
+S2_DIR="$TEST_ROOT/s2-one-unset"
+_stage_memory "$S2_DIR" >/dev/null
+_run_invariant S2 "$S2_DIR" env \
+  VADE_BINDIR_OVERRIDE=/tmp \
+  VADE_TEST_GHPAT="ghp_fixturefixturefixturefixturefixturefi"
+  # VADE_TEST_MULTI deliberately unset.
+_assert_fail S2 "one non-dormant alias missing fails"
+_assert_detail_contains "VADE_TEST_MULTI" "S2 names the missing var"
+
+printf '\n== S3: declared mirror exists ==\n'
+
+S3_DIR="$TEST_ROOT/s3-present"
+_stage_memory "$S3_DIR" >/dev/null
+# Create a settings.json carrying both declared env keys.
+cat > "$S3_DIR/settings.json" <<EOF
+{
+  "env": {
+    "VADE_TEST_GHPAT": "ghp_fixturefixturefixturefixturefixturefi",
+    "VADE_TEST_MULTI": "multi-fixture-value"
+  }
+}
+EOF
+_run_invariant S3 "$S3_DIR" env VADE_BINDIR_OVERRIDE=/tmp
+_assert_ok S3 "both mirrors present in settings.json"
+
+S3_DIR="$TEST_ROOT/s3-missing"
+_stage_memory "$S3_DIR" >/dev/null
+# Settings.json absent — both mirrors should be reported missing.
+_run_invariant S3 "$S3_DIR" env VADE_BINDIR_OVERRIDE=/tmp
+_assert_fail S3 "missing settings.json fails S3"
+_assert_detail_contains "file-absent" "S3 surfaces file-absent"
+
+S3_DIR="$TEST_ROOT/s3-empty-key"
+_stage_memory "$S3_DIR" >/dev/null
+# Settings.json exists but the key has empty value.
+cat > "$S3_DIR/settings.json" <<EOF
+{
+  "env": {
+    "VADE_TEST_GHPAT": "",
+    "VADE_TEST_MULTI": "multi-fixture-value"
+  }
+}
+EOF
+_run_invariant S3 "$S3_DIR" env VADE_BINDIR_OVERRIDE=/tmp
+_assert_fail S3 "empty mirror value fails"
+_assert_detail_contains "env-key-absent" "S3 surfaces env-key-absent"
+
+printf '\n== S4: stale empty credential (CI fake-env skip path) ==\n'
+
+S4_DIR="$TEST_ROOT/s4-skip"
+_stage_memory "$S4_DIR" >/dev/null
+_run_invariant S4 "$S4_DIR" env VADE_BINDIR_OVERRIDE=/tmp
+_assert_skip S4 "skips in CI fake-env (no live op)"
+_assert_detail_contains "op CLI" "S4 skip detail mentions op CLI"
+
+printf '\n== S5: sanctioned paths carry expected secret shapes ==\n'
+
+# S5 reads literal /root/* paths — in CI these don't exist. Pre-stage
+# alternate paths and override via $VADE_RUNTIME_DIR /
+# $VADE_COO_MEMORY_DIR so the coo-harness/coo-memory paths resolve to
+# our fixtures. The literal /root/* paths fall into the "absent (not
+# required on this host)" bucket, which is fine.
+
+S5_DIR="$TEST_ROOT/s5-clean"
+_stage_memory "$S5_DIR" >/dev/null
+# Stage a coo-harness-shape and a coo-memory-shape directory; only
+# the common.sh path needs to carry a secret-shape match per the
+# sanctioned-paths list.
+mkdir -p "$S5_DIR/coo-harness/scripts/lib"
+cat > "$S5_DIR/coo-harness/scripts/lib/common.sh" <<EOF
+# Synthetic common.sh that carries one matching secret shape.
+# Token below matches the github-classic-pat regex from fixture.
+SOME_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+EOF
+mkdir -p "$S5_DIR/coo-memory/.claude"
+# Token below matches ghp_ + 36 alphanumeric chars (the github-classic-pat regex).
+cat > "$S5_DIR/coo-memory/.claude/settings.json" <<EOF
+{"env": {"FOO": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}
+EOF
+_run_invariant S5 "$S5_DIR" env \
+  VADE_BINDIR_OVERRIDE=/tmp \
+  VADE_RUNTIME_DIR="$S5_DIR/coo-harness" \
+  VADE_COO_MEMORY_DIR="$S5_DIR/coo-memory"
+# We expect "ok" — at least one sanctioned-path file has a regex hit.
+# The fixture references $VADE_COO_MEMORY_DIR/operations/secrets/schema.yaml,
+# but _run_invariant overrides $VADE_COO_MEMORY_DIR to $S5_DIR/coo-memory
+# AFTER staging; re-run S5 with the schema located under the same dir.
+# Stage the fixture inside coo-memory subtree as well so the helper finds it.
+mkdir -p "$S5_DIR/coo-memory/operations/secrets"
+_render_fixture "$S5_DIR/coo-memory/operations/secrets/schema.yaml" "$S5_DIR/coo-memory"
+cp "$S5_DIR/operations/secrets/schema.schema.json" "$S5_DIR/coo-memory/operations/secrets/" 2>/dev/null || true
+_run_invariant S5 "$S5_DIR" env \
+  VADE_BINDIR_OVERRIDE=/tmp \
+  VADE_RUNTIME_DIR="$S5_DIR/coo-harness" \
+  VADE_COO_MEMORY_DIR="$S5_DIR/coo-memory"
+_assert_ok S5 "sanctioned path carries secret shape"
+
+S5_DIR="$TEST_ROOT/s5-empty"
+_stage_memory "$S5_DIR" >/dev/null
+mkdir -p "$S5_DIR/coo-harness/scripts/lib" "$S5_DIR/coo-memory/operations/secrets"
+# common.sh exists but contains NO secret-shape matches.
+cat > "$S5_DIR/coo-harness/scripts/lib/common.sh" <<EOF
+# Synthetic common.sh that carries no secret-shape matches.
+echo "just regular shell code"
+EOF
+_render_fixture "$S5_DIR/coo-memory/operations/secrets/schema.yaml" "$S5_DIR/coo-memory"
+cp "$S5_DIR/operations/secrets/schema.schema.json" "$S5_DIR/coo-memory/operations/secrets/" 2>/dev/null || true
+_run_invariant S5 "$S5_DIR" env \
+  VADE_BINDIR_OVERRIDE=/tmp \
+  VADE_RUNTIME_DIR="$S5_DIR/coo-harness" \
+  VADE_COO_MEMORY_DIR="$S5_DIR/coo-memory"
+_assert_fail S5 "sanctioned path with no secret-shape match fails"
+_assert_detail_contains "common.sh" "S5 surfaces the empty path"
+
+printf '\n== S7: orphan-pattern detection (CI fake-env skip path) ==\n'
+
+S7_DIR="$TEST_ROOT/s7-skip"
+_stage_memory "$S7_DIR" >/dev/null
+_run_invariant S7 "$S7_DIR" env VADE_BINDIR_OVERRIDE=/tmp
+_assert_skip S7 "skips in CI fake-env (no live op)"
+_assert_detail_contains "op CLI" "S7 skip detail mentions op CLI"
+
+printf '\n== S8: env-drift classification ==\n'
+
+# Clean env case: only the fixture's declared alias is set; rest map to
+# known buckets. The test process inherits PATH/HOME/etc. from the
+# parent shell, but the fixture allowlists PATH/HOME/LANG/LC_ALL, so
+# they land in declared_allowlist. Unknown vars (e.g. CI-only vars in
+# this shell) land in unknown_other unless they prefix-match.
+S8_DIR="$TEST_ROOT/s8-clean"
+_stage_memory "$S8_DIR" >/dev/null
+# Run in a scrubbed env — only known-allowlisted vars + the fixture's
+# declared alias. env -i wipes the inherited env to remove the noise
+# CI hosts inject (CLAUDE_CODE_*, etc.).
+out_s8="$(
+  env -i PATH="$PATH" HOME="$HOME" LANG=C LC_ALL=C \
+    VADE_TEST_KNOWN=set \
+    VADE_TEST_PFX_FOO=bar \
+    VADE_TEST_GHPAT="ghp_fixturefixturefixturefixturefixturefi" \
+    VADE_TEST_MULTI="multi-fixture-value" \
+    VADE_COO_MEMORY_DIR="$S8_DIR" \
+    VADE_SECRETS_SNAPSHOT_DIR="$S8_DIR/operations/secrets/env-snapshots" \
+    VADE_SECRETS_SNAPSHOT_SKIP=1 \
+    VADE_BINDIR_OVERRIDE=/tmp \
+    bash -c '
+      set -uo pipefail
+      RESULTS=()
+      _add() { RESULTS+=("$1|$2|$3"); }
+      source "'"$HELPER"'"
+      s_check_S8
+      printf "%s\n" "${RESULTS[@]}"
+    '
+)"
+line="$(printf '%s\n' "$out_s8" | grep -E '^S8\|' | head -1)"
+_LAST_KEY="${line%%|*}"; rest="${line#*|}"; _LAST_OK="${rest%%|*}"; _LAST_DETAIL="${rest#*|}"
+# Scrubbed env should not produce unknown_secret_shape — only known
+# bucket counts.
+_assert_ok S8 "scrubbed env classifies cleanly"
+_assert_detail_contains "declared_secret=2" "S8 counts the two declared aliases"
+_assert_detail_contains "prefix_allowlist=1" "S8 counts the VADE_TEST_PFX_FOO via prefix"
+_assert_detail_contains "declared_allowlist=" "S8 counts declared allowlist hits"
+
+# Failure case: inject an unknown env var whose VALUE matches a secret
+# shape (the github-classic-pat regex from the fixture).
+S8_DIR="$TEST_ROOT/s8-leak"
+_stage_memory "$S8_DIR" >/dev/null
+out_s8b="$(
+  env -i PATH="$PATH" HOME="$HOME" LANG=C LC_ALL=C \
+    SOME_UNKNOWN_VAR="ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    VADE_COO_MEMORY_DIR="$S8_DIR" \
+    VADE_SECRETS_SNAPSHOT_DIR="$S8_DIR/operations/secrets/env-snapshots" \
+    VADE_SECRETS_SNAPSHOT_SKIP=1 \
+    VADE_BINDIR_OVERRIDE=/tmp \
+    bash -c '
+      set -uo pipefail
+      RESULTS=()
+      _add() { RESULTS+=("$1|$2|$3"); }
+      source "'"$HELPER"'"
+      s_check_S8
+      printf "%s\n" "${RESULTS[@]}"
+    '
+)"
+line="$(printf '%s\n' "$out_s8b" | grep -E '^S8\|' | head -1)"
+_LAST_KEY="${line%%|*}"; rest="${line#*|}"; _LAST_OK="${rest%%|*}"; _LAST_DETAIL="${rest#*|}"
+_assert_fail S8 "unknown_secret_shape on injected token-shaped value"
+_assert_detail_contains "SOME_UNKNOWN_VAR" "S8 names the offending key"
+
+printf '\n== Summary ==\n'
+printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/ci/test-integrity-group-s.sh
+++ b/scripts/ci/test-integrity-group-s.sh
@@ -73,11 +73,15 @@ _render_fixture() {
 _stage_memory() {
   local dir="$1"
   mkdir -p "$dir/operations/secrets/env-snapshots" "$dir/bin"
-  # Stage a copy of secrets-schema-check.py + schema.schema.json from
-  # the live coo-memory checkout if available. If not, S1 will skip
-  # cleanly (caller decides whether to assert).
+  # Stage a copy of secrets-schema-check.py + schema.schema.json. Prefer
+  # the live coo-memory checkout (when available — local dev surface);
+  # fall back to the CI fixtures committed alongside this test (synced
+  # from coo-memory's Track 1a). The fixtures avoid a cross-repo clone
+  # dependency in CI where coo-memory is private and no PAT is stored.
   local src_validator="${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}/bin/secrets-schema-check.py"
+  [ -f "$src_validator" ] || src_validator="$REPO_ROOT/scripts/ci/fixtures/secrets-schema-check.py"
   local src_schema="${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}/operations/secrets/schema.schema.json"
+  [ -f "$src_schema" ] || src_schema="$REPO_ROOT/scripts/ci/fixtures/secrets-schema.schema.json"
   if [ -f "$src_validator" ]; then
     cp "$src_validator" "$dir/bin/secrets-schema-check.py"
     chmod +x "$dir/bin/secrets-schema-check.py"

--- a/scripts/lib/integrity-group-s.sh
+++ b/scripts/lib/integrity-group-s.sh
@@ -1,0 +1,780 @@
+#!/usr/bin/env bash
+# Group S — secrets-schema invariants for integrity-check.sh.
+#
+# Implements S1-S5, S7, S8 from operations/secrets/README.md §3.4 (Track 1b
+# of the secrets-management implementation epic, coo-memory#871). S6 is
+# demoted to warning per SOP rationalization R-3 and NOT emitted as an
+# invariant from this file.
+#
+# Wired in by integrity-check.sh's Group S section via `_add KEY ok detail`
+# triples. Functions here populate the parent's RESULTS array indirectly:
+# each `s_check_S<N>` function calls `_add` directly (the parent provides
+# that function), and reads from environment-set helpers like
+# $VADE_COO_MEMORY_DIR and $RESULTS via dynamic scope (bash arrays + the
+# `_add` function defined in integrity-check.sh).
+#
+# Probe-not-repair: nothing here mutates state. Failures are reported via
+# `_add false …` and bubble through the JSON output; the script keeps
+# exit 0. Boot-blocking integration is a follow-up PR after Track 1b
+# soaks clean.
+#
+# Skip semantics: every S invariant that relies on a capability not
+# present in the current environment (live `op` CLI, network, etc.) is
+# expected to emit `_add S<N> true "skipped: <reason>"` rather than
+# false. This keeps CI fake-env runs green.
+
+# Detect whether we're inside the bootstrap-regression CI fake env. Same
+# markers as integrity-check.sh's E5/E9 use.
+_s_in_ci_fake_env() {
+  [ -n "${VADE_CI_WORKSPACE_ROOT:-}" ] || [ -n "${VADE_BINDIR_OVERRIDE:-}" ]
+}
+
+# Cheap "is op CLI usable" probe. Live `op whoami` would be authoritative
+# but is expensive and may itself fail for unrelated reasons. We only
+# require the binary to be present and not a CI mock — actual data reads
+# are best-effort below.
+_s_op_live() {
+  if _s_in_ci_fake_env; then return 1; fi
+  command -v op >/dev/null 2>&1 || return 1
+  # When the SA token is unset, op will fail every read regardless.
+  [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] || return 1
+  return 0
+}
+
+# Truncate a detail string to ~200 chars so the JSON output stays
+# readable when validator errors are verbose.
+_s_trunc() {
+  local s="$1" max="${2:-200}"
+  if [ "${#s}" -le "$max" ]; then
+    printf '%s' "$s"
+  else
+    printf '%s…' "${s:0:$max}"
+  fi
+}
+
+# Default schema location resolution. Allows the test runner to override
+# via $VADE_SECRETS_SCHEMA / $VADE_SECRETS_SCHEMA_DIR.
+_s_schema_yaml() {
+  printf '%s' "${VADE_SECRETS_SCHEMA:-$VADE_COO_MEMORY_DIR/operations/secrets/schema.yaml}"
+}
+_s_schema_json() {
+  printf '%s' "${VADE_SECRETS_SCHEMA_JSON:-$VADE_COO_MEMORY_DIR/operations/secrets/schema.schema.json}"
+}
+_s_schema_validator() {
+  printf '%s' "${VADE_SECRETS_VALIDATOR:-$VADE_COO_MEMORY_DIR/bin/secrets-schema-check.py}"
+}
+_s_env_snapshot_dir() {
+  printf '%s' "${VADE_SECRETS_SNAPSHOT_DIR:-$VADE_COO_MEMORY_DIR/operations/secrets/env-snapshots}"
+}
+
+# ── S1: schema.yaml parses + shape-valid ─────────────────────────
+s_check_S1() {
+  local schema validator schemajson
+  schema="$(_s_schema_yaml)"
+  schemajson="$(_s_schema_json)"
+  validator="$(_s_schema_validator)"
+
+  if [ ! -f "$schema" ]; then
+    _add S1 skip "schema.yaml not found at $schema"
+    return
+  fi
+  if [ ! -f "$schemajson" ]; then
+    _add S1 skip "schema.schema.json not found at $schemajson"
+    return
+  fi
+  if [ ! -x "$validator" ] && [ ! -f "$validator" ]; then
+    _add S1 skip "secrets-schema-check.py not found at $validator"
+    return
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    _add S1 skip "python3 not available"
+    return
+  fi
+  # Dependency check — PyYAML + jsonschema. If missing, skip cleanly
+  # (the Track 1a CI installs them; the cloud container has them; CI
+  # fake-env mode without them should not fail S1).
+  if ! python3 -c 'import yaml, jsonschema' >/dev/null 2>&1; then
+    _add S1 skip "PyYAML or jsonschema not importable in python3 — install with pip"
+    return
+  fi
+
+  local out rc
+  out="$(python3 "$validator" "$schema" --schema "$schemajson" 2>&1)"
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    _add S1 true "schema.yaml validates clean against schema.schema.json"
+  else
+    _add S1 false "validator exit=$rc: $(_s_trunc "$out")"
+  fi
+}
+
+# ── S2: every declared env-alias is set (or item is dormant) ─────
+s_check_S2() {
+  local schema; schema="$(_s_schema_yaml)"
+  if [ ! -f "$schema" ]; then
+    _add S2 skip "schema.yaml not found at $schema"
+    return
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    _add S2 skip "yq not available"
+    return
+  fi
+
+  # Emit lines of `<id>|<status>|<alias>` for every non-dormant
+  # credential with at least one env-alias. Dormant entries are
+  # filtered out per SOP §3.4 (env vars may be intentionally unset).
+  local rows
+  rows="$(yq -r '
+    .credentials[]
+    | select(.status != "dormant")
+    | . as $c
+    | (.env_aliases // [])[]
+    | "\($c.id)|\($c.status)|\(.)"' "$schema" 2>/dev/null)" || rows=""
+
+  if [ -z "$rows" ]; then
+    _add S2 true "no non-dormant env-aliases declared"
+    return
+  fi
+
+  local total=0 missing=()
+  while IFS='|' read -r id status alias; do
+    [ -z "$alias" ] && continue
+    total=$((total + 1))
+    eval "val=\${$alias:-}"
+    if [ -z "${val:-}" ]; then
+      missing+=("${id}:${alias}")
+    fi
+  done <<< "$rows"
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    _add S2 true "$total/$total declared env-aliases set in process env"
+  else
+    local list; list="$(IFS=,; echo "${missing[*]}")"
+    _add S2 false "${#missing[@]}/$total env-aliases unset: $(_s_trunc "$list")"
+  fi
+}
+
+# ── S3: declared mirrors exist; sha8 matches canonical where shape allows ─
+s_check_S3() {
+  local schema; schema="$(_s_schema_yaml)"
+  if [ ! -f "$schema" ]; then
+    _add S3 skip "schema.yaml not found at $schema"
+    return
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    _add S3 skip "yq not available"
+    return
+  fi
+
+  # Each row: <cred_id>|<surface>|<path_or_name>|<format>|<op_item>|<op_field>
+  # The trailing op_item/op_field carry the canonical-source pointer so
+  # we can compute sha8 where the mirror surface allows it.
+  local rows
+  rows="$(yq -r '
+    .credentials[]
+    | select(.status != "dormant")
+    | . as $c
+    | (.mirrors // [])[]
+    | "\($c.id)|\(.surface)|\(.path_or_name)|\(.format // "TBD")|\($c.op_item)|\($c.op_field)"' "$schema" 2>/dev/null)" || rows=""
+
+  if [ -z "$rows" ]; then
+    _add S3 true "no non-dormant mirrors declared"
+    return
+  fi
+
+  local total=0 missing=() sha_mismatch=() sha_checked=0
+  local op_live=0
+  if _s_op_live; then op_live=1; fi
+
+  while IFS='|' read -r cred_id surface path_or_name format op_item op_field; do
+    [ -z "$cred_id" ] && continue
+    total=$((total + 1))
+    case "$surface" in
+      container_env)
+        case "$format" in
+          json-key-replace)
+            # path_or_name shape: "<filepath>::env::<KEY>"
+            local file_part key_part
+            file_part="${path_or_name%%::env::*}"
+            key_part="${path_or_name##*::env::}"
+            if [ "$file_part" = "$path_or_name" ] || [ -z "$key_part" ]; then
+              missing+=("${cred_id}:${surface}:malformed-path")
+              continue
+            fi
+            if [ ! -f "$file_part" ]; then
+              missing+=("${cred_id}:${surface}:file-absent:$file_part")
+              continue
+            fi
+            local val
+            val="$(jq -r --arg k "$key_part" '.env[$k] // empty' "$file_part" 2>/dev/null)"
+            if [ -z "$val" ]; then
+              missing+=("${cred_id}:${surface}:env-key-absent:$key_part")
+              continue
+            fi
+            # sha8 compare (only when op live)
+            if [ "$op_live" = 1 ]; then
+              local canon=""
+              canon="$(op read "op://COO/$op_item/$op_field" 2>/dev/null || true)"
+              if [ -n "$canon" ]; then
+                local mirror_sha canon_sha
+                mirror_sha="$(printf '%s' "$val" | sha256sum 2>/dev/null | cut -c1-8)"
+                canon_sha="$(printf '%s' "$canon" | sha256sum 2>/dev/null | cut -c1-8)"
+                if [ -n "$mirror_sha" ] && [ -n "$canon_sha" ]; then
+                  sha_checked=$((sha_checked + 1))
+                  if [ "$mirror_sha" != "$canon_sha" ]; then
+                    sha_mismatch+=("${cred_id}:${key_part}")
+                  fi
+                fi
+              fi
+            fi
+            ;;
+          sh-export-replace)
+            # path_or_name shape: "<filepath>::<KEY>"
+            local file_part2 key_part2
+            file_part2="${path_or_name%%::*}"
+            key_part2="${path_or_name##*::}"
+            if [ "$file_part2" = "$path_or_name" ] || [ -z "$key_part2" ]; then
+              missing+=("${cred_id}:${surface}:malformed-path")
+              continue
+            fi
+            if [ ! -f "$file_part2" ]; then
+              missing+=("${cred_id}:${surface}:file-absent:$file_part2")
+              continue
+            fi
+            if ! grep -qE "^[[:space:]]*(export[[:space:]]+)?${key_part2}=" "$file_part2" 2>/dev/null; then
+              missing+=("${cred_id}:${surface}:export-line-absent:$key_part2")
+            fi
+            if [ "$op_live" = 1 ]; then
+              local canon2 mirror_val2
+              canon2="$(op read "op://COO/$op_item/$op_field" 2>/dev/null || true)"
+              # Extract the value after the `=` on the export line. Strip
+              # surrounding quotes so a shell-quoted form matches the
+              # canonical plain value.
+              mirror_val2="$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key_part2}=" "$file_part2" 2>/dev/null \
+                | head -1 \
+                | sed -E "s/^[[:space:]]*(export[[:space:]]+)?${key_part2}=//" \
+                | sed -E 's/^"(.*)"$/\1/' \
+                | sed -E "s/^'(.*)'$/\1/")"
+              if [ -n "$canon2" ] && [ -n "$mirror_val2" ]; then
+                local m_sha c_sha
+                m_sha="$(printf '%s' "$mirror_val2" | sha256sum 2>/dev/null | cut -c1-8)"
+                c_sha="$(printf '%s' "$canon2" | sha256sum 2>/dev/null | cut -c1-8)"
+                if [ -n "$m_sha" ] && [ -n "$c_sha" ]; then
+                  sha_checked=$((sha_checked + 1))
+                  if [ "$m_sha" != "$c_sha" ]; then
+                    sha_mismatch+=("${cred_id}:${key_part2}")
+                  fi
+                fi
+              fi
+            fi
+            ;;
+          file-replace)
+            # path_or_name is a literal filesystem path (may contain
+            # parenthetical commentary in the schema — strip after first
+            # space).
+            local file_only
+            file_only="${path_or_name%% *}"
+            # Expand ~ to $HOME if present.
+            case "$file_only" in
+              "~/"*) file_only="$HOME/${file_only#~/}" ;;
+            esac
+            if [ -z "$file_only" ] || [ ! -e "$file_only" ]; then
+              missing+=("${cred_id}:${surface}:file-absent:$file_only")
+            fi
+            ;;
+          *)
+            # TBD / unknown format — informational, not a failure.
+            :
+            ;;
+        esac
+        ;;
+      org_secret|repo_secret)
+        # Requires `gh` + PAT; skip cleanly when unavailable. CI mocks
+        # don't include `gh secret list`, so this skips in CI by design.
+        if _s_in_ci_fake_env; then
+          continue
+        fi
+        if ! command -v gh >/dev/null 2>&1; then
+          continue
+        fi
+        # path_or_name is either "SECRET_NAME" (org) or "repo/SECRET_NAME"
+        # (repo). Decide by surface.
+        if [ "$surface" = "org_secret" ]; then
+          # Org-level: check coo-labs org.
+          if ! gh secret list --org coo-labs 2>/dev/null \
+              | awk '{print $1}' | grep -qFx "$path_or_name"; then
+            missing+=("${cred_id}:${surface}:secret-absent:$path_or_name")
+          fi
+        else
+          # repo_secret: path_or_name shape is "repo/SECRET_NAME". The
+          # schema uses bare repo names (without "coo-labs/" prefix);
+          # prepend the org.
+          local repo_part secret_part
+          repo_part="${path_or_name%%/*}"
+          secret_part="${path_or_name##*/}"
+          if [ "$repo_part" = "$path_or_name" ] || [ -z "$secret_part" ]; then
+            missing+=("${cred_id}:${surface}:malformed-path-or-name")
+            continue
+          fi
+          if ! gh secret list --repo "coo-labs/$repo_part" 2>/dev/null \
+              | awk '{print $1}' | grep -qFx "$secret_part"; then
+            missing+=("${cred_id}:${surface}:secret-absent:$path_or_name")
+          fi
+        fi
+        ;;
+      file)
+        # path_or_name is a literal filesystem path. Expand ~ if present.
+        local fpath="$path_or_name"
+        case "$fpath" in
+          "~/"*) fpath="$HOME/${fpath#~/}" ;;
+        esac
+        if [ ! -e "$fpath" ]; then
+          missing+=("${cred_id}:${surface}:file-absent:$fpath")
+        fi
+        ;;
+      *)
+        # codespaces_secret / dependabot_secret are opaque to audit (403);
+        # workflow_op_inline is a documentation surface. Skip silently.
+        :
+        ;;
+    esac
+  done <<< "$rows"
+
+  if [ "${#missing[@]}" -eq 0 ] && [ "${#sha_mismatch[@]}" -eq 0 ]; then
+    local detail="all $total declared mirrors present"
+    if [ "$sha_checked" -gt 0 ]; then
+      detail="${detail}; sha8 match on $sha_checked sampled values"
+    else
+      detail="${detail}; sha8 sampling skipped (op CLI not live or no readable canonical)"
+    fi
+    _add S3 true "$detail"
+  else
+    local parts=()
+    [ "${#missing[@]}" -gt 0 ] && parts+=("missing: $(IFS=,; echo "${missing[*]}")")
+    [ "${#sha_mismatch[@]}" -gt 0 ] && parts+=("sha8-mismatch: $(IFS=,; echo "${sha_mismatch[*]}")")
+    local joined; joined="$(IFS=';'; echo "${parts[*]}")"
+    _add S3 false "$(_s_trunc "$joined")"
+  fi
+}
+
+# ── S4: no multi-field item carries a stale empty `credential` field ─
+s_check_S4() {
+  local schema; schema="$(_s_schema_yaml)"
+  if [ ! -f "$schema" ]; then
+    _add S4 skip "schema.yaml not found at $schema"
+    return
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    _add S4 skip "yq not available"
+    return
+  fi
+  if ! _s_op_live; then
+    _add S4 skip "skipped: requires live op CLI + OP_SERVICE_ACCOUNT_TOKEN (CI fake-env or local)"
+    return
+  fi
+
+  # Multi-field items: op_field is NOT "credential" AND op_alt_fields is
+  # non-empty. For each, query `op item get --format=json` and check
+  # whether a `credential` field exists with non-empty value.
+  local rows
+  rows="$(yq -r '
+    .credentials[]
+    | select(.status != "dormant")
+    | select(.op_field != "credential")
+    | select((.op_alt_fields // []) | length > 0)
+    | "\(.id)|\(.op_item)"' "$schema" 2>/dev/null)" || rows=""
+
+  if [ -z "$rows" ]; then
+    _add S4 true "no multi-field credentials to check"
+    return
+  fi
+
+  local total=0 bad=() unreadable=0
+  while IFS='|' read -r cred_id op_item; do
+    [ -z "$cred_id" ] && continue
+    total=$((total + 1))
+    local raw stale_label stale_value
+    raw="$(op item get --format=json "$op_item" 2>/dev/null || true)"
+    if [ -z "$raw" ]; then
+      unreadable=$((unreadable + 1))
+      continue
+    fi
+    # Look for a field labeled "credential". An EMPTY one is the stale
+    # S-1 fingerprint we're catching.
+    stale_label="$(printf '%s' "$raw" | jq -r '.fields[]? | select(.label=="credential") | .label // empty' 2>/dev/null | head -1)"
+    stale_value="$(printf '%s' "$raw" | jq -r '.fields[]? | select(.label=="credential") | .value // empty' 2>/dev/null | head -1)"
+    if [ "$stale_label" = "credential" ] && [ -z "$stale_value" ]; then
+      bad+=("${cred_id}:${op_item}")
+    fi
+  done <<< "$rows"
+
+  if [ "${#bad[@]}" -eq 0 ]; then
+    local detail="$total multi-field credentials clean (no stale empty 'credential' field)"
+    [ "$unreadable" -gt 0 ] && detail="${detail}; $unreadable unreadable via op (transient)"
+    _add S4 true "$detail"
+  else
+    local list; list="$(IFS=,; echo "${bad[*]}")"
+    _add S4 false "stale empty 'credential' field on: $(_s_trunc "$list")"
+  fi
+}
+
+# ── S5: sanctioned paths carry secret-shaped content (presence check) ─
+#
+# Wording per SOP §3.4: "no plaintext PAT-shape strings in sanctioned
+# paths only". Inverted-shape interpretation per parent dispatch: the
+# sanctioned paths are EXPECTED to carry secrets (they're the only legal
+# place for plaintext bearer values), and the failure mode this catches
+# is a sanctioned path drifting to empty/malformed (no token-shapes
+# present where the schema mirrors expect them).
+#
+# This is a forward defense — TODO when settings.json indirection
+# (#873 / Track 4) lands, S5's polarity changes: at that point
+# /root/.claude/settings.json carries `${TOKEN}` refs, NOT plaintext
+# tokens, and S5 should flip to "no plaintext PAT-shape strings here".
+s_check_S5() {
+  local schema; schema="$(_s_schema_yaml)"
+  if [ ! -f "$schema" ]; then
+    _add S5 skip "schema.yaml not found at $schema"
+    return
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    _add S5 skip "yq not available"
+    return
+  fi
+  if ! command -v grep >/dev/null 2>&1; then
+    _add S5 skip "grep not available"
+    return
+  fi
+
+  # Sanctioned-path set per SOP §3.4. /root/ paths are container-specific;
+  # the coo-harness/coo-memory paths resolve to whatever the live checkouts
+  # are (canonicalized below via $VADE_*_DIR).
+  local sanctioned=(
+    "/root/.claude/settings.json"
+    "/root/.vade/coo-env"
+    "${VADE_RUNTIME_DIR:-$HOME/coo-harness}/scripts/lib/common.sh"
+    "${VADE_COO_MEMORY_DIR:-$HOME/coo-memory}/.claude/settings.json"
+    "${VADE_COO_MEMORY_DIR:-$HOME/coo-memory}/.claude/settings.local.json"
+  )
+
+  # Collect every regex from secret_shapes. Use yq to enumerate.
+  local patterns
+  patterns="$(yq -r '.secret_shapes[].pattern' "$schema" 2>/dev/null \
+    | grep -vE '^TBD' || true)"
+  if [ -z "$patterns" ]; then
+    _add S5 skip "no usable secret_shapes patterns in schema"
+    return
+  fi
+
+  # For each sanctioned path that exists, scan for ≥1 secret_shapes hit.
+  # Per inversion: a sanctioned path with NO hits is the failure (it's
+  # supposed to carry secrets).
+  local checked=0 empty_paths=() present_paths=0 missing_paths=()
+  for p in "${sanctioned[@]}"; do
+    if [ ! -f "$p" ]; then
+      # Missing sanctioned paths are not necessarily a failure — some
+      # are environment-specific (e.g., /root/.vade/coo-env may not
+      # exist on a macOS dev). Track but don't fail on absence.
+      missing_paths+=("${p##*/}")
+      continue
+    fi
+    checked=$((checked + 1))
+    local found=0
+    while IFS= read -r rgx; do
+      [ -z "$rgx" ] && continue
+      if grep -qE "$rgx" "$p" 2>/dev/null; then
+        found=1
+        break
+      fi
+    done <<< "$patterns"
+    if [ "$found" = 1 ]; then
+      present_paths=$((present_paths + 1))
+    else
+      empty_paths+=("${p##*/}")
+    fi
+  done
+
+  if [ "$checked" -eq 0 ]; then
+    _add S5 skip "no sanctioned paths present on this host (env may not require them)"
+    return
+  fi
+  if [ "${#empty_paths[@]}" -eq 0 ]; then
+    local detail="$present_paths/$checked sanctioned paths carry expected secret shapes"
+    if [ "${#missing_paths[@]}" -gt 0 ]; then
+      detail="${detail}; absent (not required on this host): $(IFS=,; echo "${missing_paths[*]}")"
+    fi
+    _add S5 true "$detail"
+  else
+    local list; list="$(IFS=,; echo "${empty_paths[*]}")"
+    _add S5 false "sanctioned paths present but carry NO secret-shape matches: $(_s_trunc "$list") (drift to empty/malformed — investigate)"
+  fi
+}
+
+# ── S7: orphan-pattern detection on secret_shapes regex registry ─
+s_check_S7() {
+  local schema; schema="$(_s_schema_yaml)"
+  if [ ! -f "$schema" ]; then
+    _add S7 skip "schema.yaml not found at $schema"
+    return
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    _add S7 skip "yq not available"
+    return
+  fi
+  if ! _s_op_live; then
+    _add S7 skip "skipped: requires live op CLI + OP_SERVICE_ACCOUNT_TOKEN (CI fake-env or local)"
+    return
+  fi
+
+  # Collect canonical credential values (cred_id + value-from-op).
+  # Skipped on dormant, items with no op_field, or read failures.
+  local cred_rows
+  cred_rows="$(yq -r '
+    .credentials[]
+    | select(.status != "dormant")
+    | "\(.id)|\(.op_item)|\(.op_field)"' "$schema" 2>/dev/null)" || cred_rows=""
+
+  if [ -z "$cred_rows" ]; then
+    _add S7 skip "no readable credentials in schema"
+    return
+  fi
+
+  # Read each value once; cache in a flat string-joined buffer keyed by
+  # credential id. Bash 4 associative arrays are available on every
+  # supported surface so use them.
+  declare -A _s7_values=()
+  while IFS='|' read -r cred_id op_item op_field; do
+    [ -z "$cred_id" ] && continue
+    [ "$op_field" = "(derived)" ] && continue
+    local val
+    val="$(op read "op://COO/$op_item/$op_field" 2>/dev/null || true)"
+    if [ -n "$val" ]; then
+      _s7_values["$cred_id"]="$val"
+    fi
+  done <<< "$cred_rows"
+
+  local total_creds=${#_s7_values[@]}
+  if [ "$total_creds" -eq 0 ]; then
+    _add S7 skip "no credentials readable via op (transient or scope)"
+    return
+  fi
+
+  # Collect every regex from secret_shapes, paired with its name.
+  local pat_rows
+  pat_rows="$(yq -r '.secret_shapes[] | "\(.name)|\(.pattern)"' "$schema" 2>/dev/null)" || pat_rows=""
+
+  # Direction 1: orphan regex — for every pattern, ≥1 credential value
+  # must match. A pattern with zero matches is "orphan".
+  local orphan_patterns=()
+  while IFS='|' read -r pname ppat; do
+    [ -z "$pname" ] && continue
+    [[ "$ppat" == TBD* ]] && continue
+    local hit=0
+    for cred_id in "${!_s7_values[@]}"; do
+      if printf '%s' "${_s7_values[$cred_id]}" | grep -qE "$ppat"; then
+        hit=1
+        break
+      fi
+    done
+    [ "$hit" = 0 ] && orphan_patterns+=("$pname")
+  done <<< "$pat_rows"
+
+  # Direction 2: escape from redactor — every credential value must
+  # match ≥1 pattern.
+  local escapes=()
+  for cred_id in "${!_s7_values[@]}"; do
+    local matched=0
+    while IFS='|' read -r pname ppat; do
+      [ -z "$pname" ] && continue
+      [[ "$ppat" == TBD* ]] && continue
+      if printf '%s' "${_s7_values[$cred_id]}" | grep -qE "$ppat"; then
+        matched=1
+        break
+      fi
+    done <<< "$pat_rows"
+    [ "$matched" = 0 ] && escapes+=("$cred_id")
+  done
+
+  if [ "${#orphan_patterns[@]}" -eq 0 ] && [ "${#escapes[@]}" -eq 0 ]; then
+    _add S7 true "registry clean: all patterns matched ≥1 credential and all $total_creds readable credentials matched ≥1 pattern"
+  else
+    local parts=()
+    [ "${#orphan_patterns[@]}" -gt 0 ] && parts+=("orphan-patterns: $(IFS=,; echo "${orphan_patterns[*]}")")
+    [ "${#escapes[@]}" -gt 0 ] && parts+=("redactor-escapes: $(IFS=,; echo "${escapes[*]}")")
+    local joined; joined="$(IFS=';'; echo "${parts[*]}")"
+    _add S7 false "$(_s_trunc "$joined")"
+  fi
+}
+
+# ── S8: env-drift detection (+ snapshot write) ───────────────────
+s_check_S8() {
+  local schema; schema="$(_s_schema_yaml)"
+  if [ ! -f "$schema" ]; then
+    _add S8 skip "schema.yaml not found at $schema"
+    return
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    _add S8 skip "yq not available"
+    return
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    _add S8 skip "python3 not available"
+    return
+  fi
+
+  # Persist today's env-keyname snapshot. Keynames only — never values.
+  # The S8 invariant fails open on snapshot-write errors (the
+  # classification check below is the load-bearing logic; snapshot is
+  # historical record only).
+  local snap_dir snap_file
+  snap_dir="$(_s_env_snapshot_dir)"
+  snap_file="${snap_dir}/$(date -u +%Y-%m-%d).txt"
+  if [ -n "${VADE_SECRETS_SNAPSHOT_SKIP:-}" ]; then
+    :  # test escape: don't write
+  elif mkdir -p "$snap_dir" 2>/dev/null; then
+    env | cut -d= -f1 | sort -u > "$snap_file" 2>/dev/null || true
+  fi
+
+  # Run the classifier in python3 against the schema + current env.
+  # Returns four counts plus the unknown_secret_shape and unknown_other
+  # keynames (pipe-separated).
+  local out rc
+  out="$(VADE_SCHEMA_YAML="$schema" python3 - <<'PY' 2>&1
+import os, sys, re
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML not importable", file=sys.stderr)
+    sys.exit(2)
+
+schema_path = os.environ["VADE_SCHEMA_YAML"]
+try:
+    with open(schema_path) as fh:
+        s = yaml.safe_load(fh) or {}
+except Exception as exc:
+    print(f"ERROR: schema unreadable: {exc}", file=sys.stderr)
+    sys.exit(2)
+
+declared_secret = set()
+for cred in s.get("credentials", []) or []:
+    if cred.get("status") == "dormant":
+        # Dormant credentials' env aliases SHOULD be unset; if they
+        # happen to be set, classify normally — they'd land in
+        # declared_secret bucket as before, which is fine.
+        pass
+    for alias in cred.get("env_aliases", []) or []:
+        declared_secret.add(alias)
+
+allowlist = set(s.get("non_secret_env_allowlist", []) or [])
+prefixes = list(s.get("non_secret_env_prefixes", []) or [])
+
+shape_patterns = []
+for shape in s.get("secret_shapes", []) or []:
+    pat = shape.get("pattern", "")
+    if pat.startswith("TBD"):
+        continue
+    try:
+        shape_patterns.append((shape.get("name", "?"), re.compile(pat)))
+    except re.error:
+        # malformed regex — schema validator (S1) should catch; skip here
+        continue
+
+order = s.get("env_drift_detection", {}).get("classification_order", [
+    "declared_secret",
+    "declared_allowlist",
+    "prefix_allowlist",
+    "unknown_secret_shape",
+    "unknown_other",
+])
+
+def classify(name, value):
+    for step in order:
+        if step == "declared_secret":
+            if name in declared_secret:
+                return step
+        elif step == "declared_allowlist":
+            if name in allowlist:
+                return step
+        elif step == "prefix_allowlist":
+            if any(name.startswith(p) for p in prefixes):
+                # Defense-in-depth: even a prefix-allowed var graduates
+                # to unknown_secret_shape if its value shapes-as-secret.
+                if value and any(rx.search(value) for _, rx in shape_patterns):
+                    return "unknown_secret_shape"
+                return step
+        elif step == "unknown_secret_shape":
+            if value and any(rx.search(value) for _, rx in shape_patterns):
+                return step
+        elif step == "unknown_other":
+            return step
+    return "unknown_other"
+
+buckets = {k: 0 for k in [
+    "declared_secret", "declared_allowlist", "prefix_allowlist",
+    "unknown_secret_shape", "unknown_other",
+]}
+secret_unknowns = []
+other_unknowns = []
+for name, value in os.environ.items():
+    cls = classify(name, value)
+    buckets[cls] = buckets.get(cls, 0) + 1
+    if cls == "unknown_secret_shape":
+        secret_unknowns.append(name)
+    elif cls == "unknown_other":
+        other_unknowns.append(name)
+
+# Output: tab-separated keys for the bash caller to read.
+def join(lst, n=10):
+    if not lst:
+        return ""
+    head = sorted(lst)[:n]
+    extra = f" (+{len(lst) - n} more)" if len(lst) > n else ""
+    return ",".join(head) + extra
+
+print(f"declared_secret={buckets['declared_secret']}")
+print(f"declared_allowlist={buckets['declared_allowlist']}")
+print(f"prefix_allowlist={buckets['prefix_allowlist']}")
+print(f"unknown_secret_shape={buckets['unknown_secret_shape']}")
+print(f"unknown_other={buckets['unknown_other']}")
+print(f"secret_unknowns_list={join(secret_unknowns)}")
+print(f"other_unknowns_list={join(other_unknowns)}")
+PY
+)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    _add S8 skip "classifier exited rc=$rc: $(_s_trunc "$out")"
+    return
+  fi
+
+  # Parse the python output.
+  local ds da pa us uo us_list uo_list
+  ds="$(printf '%s\n' "$out" | grep -E '^declared_secret=' | cut -d= -f2-)"
+  da="$(printf '%s\n' "$out" | grep -E '^declared_allowlist=' | cut -d= -f2-)"
+  pa="$(printf '%s\n' "$out" | grep -E '^prefix_allowlist=' | cut -d= -f2-)"
+  us="$(printf '%s\n' "$out" | grep -E '^unknown_secret_shape=' | cut -d= -f2-)"
+  uo="$(printf '%s\n' "$out" | grep -E '^unknown_other=' | cut -d= -f2-)"
+  us_list="$(printf '%s\n' "$out" | grep -E '^secret_unknowns_list=' | cut -d= -f2-)"
+  uo_list="$(printf '%s\n' "$out" | grep -E '^other_unknowns_list=' | cut -d= -f2-)"
+
+  local detail="declared_secret=$ds declared_allowlist=$da prefix_allowlist=$pa unknown_secret_shape=$us unknown_other=$uo"
+  if [ "${us:-0}" -gt 0 ]; then
+    _add S8 false "$detail; unknown_secret_shape keys: $(_s_trunc "$us_list")"
+  else
+    if [ "${uo:-0}" -gt 0 ]; then
+      detail="${detail}; unknown_other keys: $(_s_trunc "$uo_list")"
+    fi
+    _add S8 true "$detail"
+  fi
+}
+
+# Dispatch every S invariant. Called from integrity-check.sh.
+s_check_all() {
+  s_check_S1
+  s_check_S2
+  s_check_S3
+  s_check_S4
+  s_check_S5
+  s_check_S7
+  s_check_S8
+}

--- a/scripts/lib/integrity-group-s.sh
+++ b/scripts/lib/integrity-group-s.sh
@@ -129,7 +129,7 @@ s_check_S2() {
     | select(.status != "dormant")
     | . as $c
     | (.env_aliases // [])[]
-    | "\($c.id)|\($c.status)|\(.)"' "$schema" 2>/dev/null)" || rows=""
+    | ($c.id + "|" + $c.status + "|" + .)' "$schema" 2>/dev/null)" || rows=""
 
   if [ -z "$rows" ]; then
     _add S2 true "no non-dormant env-aliases declared"
@@ -175,7 +175,7 @@ s_check_S3() {
     | select(.status != "dormant")
     | . as $c
     | (.mirrors // [])[]
-    | "\($c.id)|\(.surface)|\(.path_or_name)|\(.format // "TBD")|\($c.op_item)|\($c.op_field)"' "$schema" 2>/dev/null)" || rows=""
+    | ($c.id + "|" + .surface + "|" + .path_or_name + "|" + (.format // "TBD") + "|" + $c.op_item + "|" + $c.op_field)' "$schema" 2>/dev/null)" || rows=""
 
   if [ -z "$rows" ]; then
     _add S3 true "no non-dormant mirrors declared"
@@ -382,7 +382,7 @@ s_check_S4() {
     | select(.status != "dormant")
     | select(.op_field != "credential")
     | select((.op_alt_fields // []) | length > 0)
-    | "\(.id)|\(.op_item)"' "$schema" 2>/dev/null)" || rows=""
+    | (.id + "|" + .op_item)' "$schema" 2>/dev/null)" || rows=""
 
   if [ -z "$rows" ]; then
     _add S4 true "no multi-field credentials to check"
@@ -532,7 +532,7 @@ s_check_S7() {
   cred_rows="$(yq -r '
     .credentials[]
     | select(.status != "dormant")
-    | "\(.id)|\(.op_item)|\(.op_field)"' "$schema" 2>/dev/null)" || cred_rows=""
+    | (.id + "|" + .op_item + "|" + .op_field)' "$schema" 2>/dev/null)" || cred_rows=""
 
   if [ -z "$cred_rows" ]; then
     _add S7 skip "no readable credentials in schema"
@@ -561,7 +561,7 @@ s_check_S7() {
 
   # Collect every regex from secret_shapes, paired with its name.
   local pat_rows
-  pat_rows="$(yq -r '.secret_shapes[] | "\(.name)|\(.pattern)"' "$schema" 2>/dev/null)" || pat_rows=""
+  pat_rows="$(yq -r '.secret_shapes[] | (.name + "|" + .pattern)' "$schema" 2>/dev/null)" || pat_rows=""
 
   # Direction 1: orphan regex — for every pattern, ≥1 credential value
   # must match. A pattern with zero matches is "orphan".


### PR DESCRIPTION
Track 1b of the secrets-management implementation epic
(coo-labs/coo-memory#871). Wires the Group S secrets-schema
invariants from `coo-memory/operations/secrets/README.md` §3.4
into the boot integrity probe as informational signals. **S6 is
demoted to warning per SOP rationalization R-3 and intentionally
NOT emitted as an invariant.**

Paired with coo-labs/coo-memory#1188 (initial env-snapshot
baseline).

## What lands

- `scripts/lib/integrity-group-s.sh` — helper file with one
  `s_check_S<N>` function per invariant + `s_check_all` dispatcher.
  Sourced by `integrity-check.sh`; never mutates state.
- `scripts/boot/integrity-check.sh` — Group S section appended
  between Group F and the JSON serializer. Slim — sources helper
  and calls dispatcher.
- `scripts/ci/fixtures/secrets-schema-clean.yaml` — minimal synthetic
  schema fixture matching the live shape, exercising the S
  invariants in isolation.
- `scripts/ci/test-integrity-group-s.sh` — 24 assertions across
  all seven S invariants.
- `.github/workflows/bootstrap-regression.yml` — adds the test
  runner as a step in the standalone test job (committed via
  vade-coo-app since OAuth lacks `workflow` scope).

## Invariant impl notes (one line each)

- **S1**: shells out to `bin/secrets-schema-check.py` (Track 1a
  validator). Skips if PyYAML/jsonschema unavailable.
- **S2**: iterates `credentials[].env_aliases` from schema via yq;
  reports unset aliases on non-dormant items.
- **S3**: parses each declared mirror; checks file/key presence
  for filesystem surfaces (container_env JSON + sh-export + file).
  sha8 sampling layered on top when `op` is live; org/repo secret
  checks via `gh secret list` skip cleanly in CI.
- **S4**: queries `op item get --format=json` for multi-field
  items (op_field != "credential" + alt fields), reports stale
  empty `credential` field. Skips in CI fake-env.
- **S5**: inverted-shape interpretation per parent dispatch — the
  sanctioned-path set is EXPECTED to carry secrets; S5 fails when
  a sanctioned path drifts to empty/malformed (no secret_shapes
  hits). Inline TODO notes polarity flips after settings.json
  indirection (Track 4 / coo-memory#873) lands.
- **S7**: two-direction op-read scan. Direction 1: every
  secret_shapes regex must match ≥1 credential value (no orphan
  regex). Direction 2: every readable credential value must match
  ≥1 regex (no redactor escape). Skips in CI fake-env.
- **S8**: Python classifier reads schema + iterates process env;
  reports per-bucket counts (declared_secret /
  declared_allowlist / prefix_allowlist / unknown_secret_shape /
  unknown_other). Defense-in-depth: a prefix-allowlisted name
  whose VALUE matches a secret_shapes regex graduates to
  unknown_secret_shape. Also writes today's keynames-only
  snapshot to `\$VADE_COO_MEMORY_DIR/operations/secrets/env-snapshots/`.

## Live findings during local validation

Run against the production schema in this container surfaces
known-good-yellow signals — i.e., the S-invariants correctly fire
on real schema gaps the audit has already named:

- **S2 6/19 unset**: GITHUB_APP_PRIVATE_KEY, GH_APP_TOKEN
  (auto-minted; expected unset between mints), R2_TRANSCRIPTS_ENDPOINT/
  _BUCKET, VADE_BEARER_TOKEN, VADE_MCP_URL. Last two flagged in
  the schema notes as "status uncertain 2026-06-04".
- **S3 mirror absences**: VADE_SITE_PAT on vade-canvas /
  VADE_DISCUSSION_PAT on coo-memory etc. — known TBDs per schema
  notes ("TBD: confirm from mirror report §1").
- **S7 orphan patterns**: openai-api-key, aws-access-key-id,
  ghs_/ghu_/ghr_ shapes, op-service-account-token — registry
  carries shapes broader than the current credential set
  (intentional, per fail-open redactor design).
- **S8 unknown_secret_shape**: ANT_IMAGE_TAG, CLAUDE_CODE_CONTAINER_ID,
  CODESIGN_MCP_TOKEN, TRACEPARENT — false-positives matching the
  `cloudflare-api-token` 40-char shape per schema's own
  `false_positive_risk: high` note.

All are findings the SOP intends S-invariants to surface for
operator triage; this PR doesn't fix them (out of scope), just
makes them visible at boot.

## Skip semantics

- **S1**: skip if validator or PyYAML/jsonschema missing.
- **S2**: skip if yq missing.
- **S3**: filesystem mirrors work in CI; sha8 + org/repo secret
  checks skip when op CLI or gh CLI is unavailable.
- **S4**: skip in CI fake-env (requires live op CLI).
- **S5**: filesystem path inspection works everywhere.
- **S7**: skip in CI fake-env (requires live op CLI).
- **S8**: works everywhere; also writes today's keynames snapshot.

CI fake-env is detected via `\$VADE_CI_WORKSPACE_ROOT` or
`\$VADE_BINDIR_OVERRIDE`. Verified by running
`scripts/ci/run-bootstrap-regression.sh` locally — every S
invariant skips cleanly (no degraded result; bootstrap-regression
PASS).

## Test coverage

24 assertions in `test-integrity-group-s.sh`:

- S1: clean → ok; malformed YAML → fail.
- S2: all aliases set → ok (with dormant exclusion verified); one
  alias unset → fail naming the var.
- S3: settings.json carries both keys → ok; missing settings.json
  → fail with file-absent; empty key value → fail with
  env-key-absent.
- S4: skip-path asserted (CI fake-env).
- S5: sanctioned path with secret-shape hit → ok; sanctioned path
  empty of hits → fail.
- S7: skip-path asserted (CI fake-env).
- S8: scrubbed env classifies cleanly (declared_secret=2,
  prefix_allowlist=1, etc.); injected token-shape on unknown
  var → fail naming the var.

S4/S7 live op integration is exercised by the cloud-session soak
(Track 1b objective), not by these unit tests — `op item get`
under the bootstrap-regression mock would require substantial
mock expansion the parent dispatch deemed out of scope.

## Probe-not-repair

`integrity-check.sh` keeps `exit 0` even when S invariants fail.
Failures bubble through the JSON output. Boot-blocking integration
via `boot-deliverables.yml` + `boot-brake-guard.py` is a follow-up
PR after Track 1b soaks clean — per dispatch.

## What this PR does NOT touch

- `boot-deliverables.yml`, `boot-brake-guard.py`, `boot-brake-guard.sh`.
- Track 1a artifacts: `schema.yaml`, `schema.schema.json`,
  `bin/secrets-schema-check.py`,
  `.github/workflows/secrets-schema-check.yml`.

Closes: n/a

https://claude.ai/code/session_01QMqGYtRm3iju8FwpD4GSL2