### PR TITLE
secrets(track-2): PreToolUse/PostToolUse hooks layer (shape-regex guard, output redactor, agent env scrubber)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,0 +1,84 @@
+# Sub-agent env_allowlist convention
+
+This directory holds `.claude/agents/<name>.md` definitions for sub-agents that
+run under this harness. When a sub-agent is spawned via the `Agent` tool, the
+`preuse-agent-env-scrub.sh` PreToolUse hook computes the env vars it would
+inherit and logs (or blocks) any secrets crossing the boundary without opt-in.
+
+## Default-deny posture
+
+By default, only these vars flow into a sub-agent's context:
+
+- Every var in `non_secret_env_allowlist` from
+  `operations/secrets/schema.yaml` (e.g. `HOME`, `PATH`, `VADE_COO_MEMORY_DIR`,
+  `CLOUDFLARE_ACCOUNT_ID`, etc.).
+- Every var whose name matches a prefix in `non_secret_env_prefixes` from the
+  same schema (e.g. `CLAUDE_CODE_*`, `ANT_*`, `NODE_*`).
+- Any var explicitly listed in the agent's own `env_allowlist:` frontmatter
+  (see below).
+
+Any var not in the above set is in the **scrub set** — the hook logs it (in
+`warn` mode) or blocks the spawn (in `enforce` mode).
+
+## Declaring env_allowlist in agent frontmatter
+
+If a sub-agent needs a specific secret or non-allowlisted var, declare it in
+the agent's frontmatter YAML block:
+
+```markdown
+---
+name: my-agent
+description: Does something that requires Cloudflare access.
+model: sonnet
+env_allowlist:
+  - CLOUDFLARE_API_TOKEN
+---
+```
+
+Or inline (both forms are parsed):
+
+```markdown
+---
+env_allowlist: [CLOUDFLARE_API_TOKEN, VADE_AUTH_TOKEN]
+---
+```
+
+Only vars you explicitly list here will cross. No implicit inheritance of
+secret-class vars.
+
+## Concrete example
+
+An agent that queries the Cloudflare zone for DNS records needs
+`CLOUDFLARE_API_TOKEN`. Without `env_allowlist`, the hook logs:
+
+```
+[preuse-agent-env-scrub] SECRET vars in scrub set: CLOUDFLARE_API_TOKEN
+```
+
+With the declaration above, `CLOUDFLARE_API_TOKEN` is in the allowed set and
+does not appear in the scrub-set log.
+
+## The three modes of VADE_AGENT_ENV_SCRUB
+
+| Mode | Behavior | When to use |
+|---|---|---|
+| `warn` (default) | Log scrub set to stderr; allow spawn with full parent env. | Current phase — observe without impact. |
+| `enforce` | Block spawn if any `declared_secret` vars are in the scrub set. | After soak signal confirms behavior is stable. |
+| `disabled` | No-op, immediate exit 0. | Debug / CI contexts where the hook would false-positive. |
+
+**Current phase: `warn`.** The default was set to `warn` at Track 2 ship
+(coo-memory#871). Flip to `enforce` is a separate session's call after soak
+observation (target: ~2026-06-11 post-soak). Track that flip under the
+coo-memory#871 epic.
+
+## Why this matters
+
+The audit (coo-memory#871) found 7 of 8 sub-agent definitions had full
+parent-env inheritance. Without this guard, sub-agents form a leak amplifier:
+secrets in the parent session propagate into sub-agent transcripts that are
+separately persisted, even with the PostToolUse redactor in place on the
+parent. The `env_allowlist` convention makes the boundary explicit and
+auditable per-agent.
+
+See `operations/secrets/README.md` §3.6 for the full sub-agent env-inheritance
+SOP.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -112,6 +112,10 @@
           {
             "type": "command",
             "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/agent-model-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/preuse-agent-env-scrub.sh\""
           }
         ]
       },
@@ -153,6 +157,10 @@
           {
             "type": "command",
             "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/git-push-workflow-scope-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$VADE_RUNTIME_DIR/scripts/hooks/postuse-bash-redactor.sh\""
           }
         ]
       }

--- a/scripts/ci/test-track2-env-scrub.sh
+++ b/scripts/ci/test-track2-env-scrub.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# test-track2-env-scrub: tests for preuse-agent-env-scrub.sh (Track 2 Deliverable 3).
+#
+# Tests:
+#   1. warn-mode: logs scrub set to stderr; does NOT block spawn.
+#   2. enforce-mode: blocks spawn when secret vars are in scrub set.
+#   3. enforce-mode: allows spawn when secret vars listed in frontmatter env_allowlist.
+#   4. Agent with no frontmatter: does not fail-closed (fail-open).
+#   5. disabled-mode: hook is a no-op (no output, no block).
+#   6. Missing schema: fail-open (allow spawn, log to stderr).
+#
+# Run: bash scripts/ci/test-track2-env-scrub.sh
+# Exit: 0 if all assertions pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/preuse-agent-env-scrub.sh"
+
+[ -x "$HOOK" ] || { echo "FAIL: hook not executable at $HOOK"; exit 1; }
+command -v jq >/dev/null || { echo "FAIL: jq required"; exit 1; }
+command -v python3 >/dev/null || { echo "FAIL: python3 required"; exit 1; }
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+# Use coo-memory schema if available, else skip schema-dependent tests
+SCHEMA_PATH="${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}/operations/secrets/schema.yaml"
+
+# Tmp dir for synthetic agent frontmatter files
+TMP_AGENTS="$(mktemp -d)"
+trap 'rm -rf "$TMP_AGENTS"' EXIT
+
+# Write a synthetic agent frontmatter with env_allowlist
+write_agent_md() {
+  local name="$1"
+  shift
+  local vars=("$@")
+  local path="$TMP_AGENTS/$name.md"
+  printf -- '---\nname: %s\nenv_allowlist:\n' "$name" > "$path"
+  for v in "${vars[@]}"; do
+    printf '  - %s\n' "$v" >> "$path"
+  done
+  printf -- '---\n\n# Agent body\n' >> "$path"
+  echo "$path"
+}
+
+make_input() {
+  local subagent_type="$1"
+  jq -n --arg t "$subagent_type" '{tool_input: {subagent_type: $t}}'
+}
+
+run_hook_mode() {
+  local mode="$1" input="$2" extra_schema_dir="${3:-}"
+  local schema_dir="${extra_schema_dir:-${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}}"
+  # Run with synthetic agent dir as project-level .claude/agents
+  printf '%s' "$input" | \
+    VADE_AGENT_ENV_SCRUB="$mode" \
+    VADE_COO_MEMORY_DIR="$schema_dir" \
+    CLAUDE_PROJECT_DIR="$TMP_AGENTS/.." \
+    "$HOOK" 2>&1 || true
+}
+
+run_hook_mode_stdout() {
+  local mode="$1" input="$2" extra_schema_dir="${3:-}"
+  local schema_dir="${extra_schema_dir:-${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}}"
+  printf '%s' "$input" | \
+    VADE_AGENT_ENV_SCRUB="$mode" \
+    VADE_COO_MEMORY_DIR="$schema_dir" \
+    CLAUDE_PROJECT_DIR="$TMP_AGENTS/.." \
+    "$HOOK" 2>/dev/null || true
+}
+
+# ── §1 warn-mode: logs but does NOT block ─────────────────────────────────────
+printf '\n§1 warn-mode: logs scrub set, does not block:\n'
+input="$(make_input "some-agent")"
+# warn-mode stdout should be empty (no block)
+stdout="$(run_hook_mode_stdout "warn" "$input")"
+if [ -z "$stdout" ] || ! printf '%s' "$stdout" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  warn-mode: no block on stdout\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("warn-mode: should not block but did")
+  printf '  FAIL  warn-mode: should not block but did\n'
+  printf '         stdout: %s\n' "$stdout"
+fi
+# Stderr should have the log line
+stderr_log="$(run_hook_mode "warn" "$input" 2>&1 | grep 'preuse-agent-env-scrub' || true)"
+if [ -n "$stderr_log" ]; then
+  PASS=$((PASS+1))
+  printf '  PASS  warn-mode: log line on stderr\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("warn-mode: expected log line on stderr")
+  printf '  FAIL  warn-mode: expected log line on stderr\n'
+fi
+
+# ── §2 enforce-mode: blocks when secret var in scrub set ─────────────────────
+printf '\n§2 enforce-mode: blocks when GITHUB_MCP_PAT in env (no frontmatter):\n'
+# Export a synthetic secret var to ensure it's in env
+input="$(make_input "no-frontmatter-agent")"
+stdout="$(GITHUB_MCP_PAT="ghp_synthetic_test_value_not_real" run_hook_mode_stdout "enforce" "$input")"
+if printf '%s' "$stdout" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  enforce-mode: blocks spawn with secret in env\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("enforce-mode: should block but did not")
+  printf '  FAIL  enforce-mode: should block when secret in scrub set\n'
+  printf '         stdout: %s\n' "$stdout"
+fi
+
+# ── §3 enforce-mode: allows when var listed in frontmatter env_allowlist ──────
+printf '\n§3 enforce-mode: allows spawn when secret in frontmatter env_allowlist:\n'
+write_agent_md "allowed-agent" "GITHUB_MCP_PAT" >/dev/null
+# Create a .claude/agents directory at the synthetic location
+mkdir -p "$TMP_AGENTS/.."
+# Copy to a path the hook can find
+TMP_PROJECT="$(mktemp -d)"
+mkdir -p "$TMP_PROJECT/.claude/agents"
+write_agent_md_file="$(write_agent_md "allowed-agent" "GITHUB_MCP_PAT")"
+cp "$write_agent_md_file" "$TMP_PROJECT/.claude/agents/allowed-agent.md"
+
+input="$(make_input "allowed-agent")"
+stdout="$(GITHUB_MCP_PAT="ghp_synthetic_test_value_not_real" \
+  VADE_AGENT_ENV_SCRUB="enforce" \
+  VADE_COO_MEMORY_DIR="${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}" \
+  CLAUDE_PROJECT_DIR="$TMP_PROJECT" \
+  printf '%s' "$input" | "$HOOK" 2>/dev/null || true)"
+if [ -z "$stdout" ] || ! printf '%s' "$stdout" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  enforce-mode: allows when var in frontmatter env_allowlist\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("enforce-mode: should allow when var explicitly listed but blocked")
+  printf '  FAIL  enforce-mode: should allow when var in frontmatter env_allowlist\n'
+fi
+rm -rf "$TMP_PROJECT"
+
+# ── §4 Agent with no frontmatter: fail-open ───────────────────────────────────
+printf '\n§4 Agent with no frontmatter file: fail-open (does not fail-closed):\n'
+input="$(make_input "nonexistent-agent-xyz")"
+# In warn-mode, hook should log and not block
+stdout="$(run_hook_mode_stdout "warn" "$input")"
+if [ -z "$stdout" ] || ! printf '%s' "$stdout" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  no-frontmatter: fail-open in warn-mode\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("no-frontmatter: should not block (fail-open) but did")
+  printf '  FAIL  no-frontmatter: should not block in warn-mode\n'
+fi
+
+# ── §5 disabled-mode: complete no-op ─────────────────────────────────────────
+printf '\n§5 disabled-mode: complete no-op:\n'
+input="$(make_input "some-agent")"
+stdout="$(run_hook_mode_stdout "disabled" "$input")"
+stderr_out="$(run_hook_mode "disabled" "$input" 2>&1 || true)"
+if [ -z "$stdout" ] && [ -z "$stderr_out" ]; then
+  PASS=$((PASS+1))
+  printf '  PASS  disabled-mode: no stdout, no stderr\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("disabled-mode: expected complete silence")
+  printf '  FAIL  disabled-mode: expected no output\n'
+  printf '         stdout: %s\n' "$stdout"
+  printf '         stderr: %s\n' "$stderr_out"
+fi
+
+# ── §6 Missing schema: fail-open ─────────────────────────────────────────────
+printf '\n§6 Missing schema: fail-open (allow spawn):\n'
+input="$(make_input "some-agent")"
+stdout="$(run_hook_mode_stdout "warn" "$input" "/tmp/nonexistent-schema-xyz")"
+if [ -z "$stdout" ] || ! printf '%s' "$stdout" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  missing-schema: fail-open (no block)\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("missing-schema: should not block (fail-open)")
+  printf '  FAIL  missing-schema: should not block but did\n'
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+printf '\nTotal: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/ci/test-track2-redactor.sh
+++ b/scripts/ci/test-track2-redactor.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# test-track2-redactor: tests for postuse-bash-redactor.sh (Track 2 Deliverable 2).
+#
+# Tests:
+#   1. Synthetic github_pat_ fine-grained PAT (82 chars) gets redacted.
+#   2. Benign 30-char string left alone (no additionalContext emitted).
+#   3. Leak-shape from D2 scenario: grep output containing a PAT gets flagged.
+#   4. Empty output: hook exits cleanly (no output).
+#   5. Missing schema (fail-open): hook exits 0 without emitting block.
+#   6. Latency: 100KB fixture processes in under 100ms (p99 proxy).
+#
+# Run: bash scripts/ci/test-track2-redactor.sh
+# Exit: 0 if all assertions pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/postuse-bash-redactor.sh"
+
+[ -x "$HOOK" ] || { echo "FAIL: hook not executable at $HOOK"; exit 1; }
+command -v jq >/dev/null || { echo "FAIL: jq required"; exit 1; }
+command -v python3 >/dev/null || { echo "FAIL: python3 required"; exit 1; }
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+# Build PostToolUse input JSON with stdout
+make_input() {
+  local cmd="$1" stdout_val="$2" stderr_val="${3:-}"
+  jq -n --arg cmd "$cmd" --arg out "$stdout_val" --arg err "$stderr_val" \
+    '{tool_input: {command: $cmd}, tool_response: {stdout: $out, stderr: $err}}'
+}
+
+# Run hook and return its stdout
+run_hook() {
+  local input="$1"
+  printf '%s' "$input" | "$HOOK" 2>/dev/null || true
+}
+
+expect_redacted() {
+  local name="$1" input="$2"
+  local out
+  out="$(run_hook "$input")"
+  if printf '%s' "$out" | jq -e '.hookSpecificOutput.additionalContext | test("REDACTED|redacted|secret|Secret")' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  REDACTED: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("REDACTED: $name")
+    printf '  FAIL  REDACTED: %s\n' "$name"
+    printf '         hook output: %s\n' "$out"
+  fi
+}
+
+expect_clean() {
+  local name="$1" input="$2"
+  local out
+  out="$(run_hook "$input")"
+  if [ -z "$out" ] || ! printf '%s' "$out" | jq -e '.hookSpecificOutput' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  CLEAN: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("CLEAN: $name")
+    printf '  FAIL  CLEAN: %s\n' "$name"
+    printf '         hook output: %s\n' "$out"
+  fi
+}
+
+# ── §1 github_pat_ fine-grained PAT (82 chars) ───────────────────────────────
+printf '\n§1 github_pat_ fine-grained PAT gets flagged:\n'
+SYNTH_FGP="github_pat_$(python3 -c "print('A' * 82)")"
+input="$(make_input "cat /root/.claude/settings.json" "some output $SYNTH_FGP end")"
+expect_redacted "github_pat_ PAT in stdout" "$input"
+
+# stderr path
+input2="$(make_input "op read op://COO/item/field" "" "error: $SYNTH_FGP leaked")"
+expect_redacted "github_pat_ PAT in stderr" "$input2"
+
+# ── §2 Benign 30-char string left alone ──────────────────────────────────────
+printf '\n§2 Benign 30-char string left alone:\n'
+BENIGN="this_is_just_a_30_char_string_xx"  # 32 chars, not a known shape
+input="$(make_input "echo something" "$BENIGN")"
+expect_clean "benign 30-char string not flagged" "$input"
+
+# ── §3 ghp_ classic PAT in output ────────────────────────────────────────────
+printf '\n§3 ghp_ classic PAT in output:\n'
+# 36 chars after ghp_
+SYNTH_GHP="ghp_$(python3 -c "print('B' * 36)")"
+input="$(make_input "grep -r PAT /root/.claude/" "found: $SYNTH_GHP")"
+expect_redacted "ghp_ classic PAT in stdout" "$input"
+
+# ── §4 D2 scenario: grep output containing PAT + other text ──────────────────
+printf '\n§4 D2 scenario (grep over settings.json output):\n'
+# Simulate the 2026-05-21 leak shape: grep -E '"PAT"' settings.json output
+SYNTH_GHP2="ghp_$(python3 -c "print('C' * 36)")"
+LEAK_OUTPUT="GITHUB_MCP_PAT=$SYNTH_GHP2\nother: normal"
+input="$(make_input 'grep -E "PAT" /root/.claude/settings.json' "$(printf '%b' "$LEAK_OUTPUT")")"
+expect_redacted "D2 scenario: grep settings.json with PAT value" "$input"
+
+# ── §5 Empty output: clean exit ───────────────────────────────────────────────
+printf '\n§5 Empty tool output:\n'
+input="$(make_input "git status" "" "")"
+expect_clean "empty stdout+stderr produces no output" "$input"
+
+# ── §6 Missing schema: fail-open (no block emitted) ──────────────────────────
+printf '\n§6 Missing schema (fail-open):\n'
+SYNTH_FGP2="github_pat_$(python3 -c "print('D' * 82)")"
+input="$(make_input "cat file" "$SYNTH_FGP2")"
+# Hook should either produce additionalContext (schema loaded) or nothing (fallback)
+# The key requirement is: it must NOT emit {"decision":"block"} and must exit 0
+out="$(printf '%s' "$input" | VADE_COO_MEMORY_DIR=/tmp/nonexistent-xyz "$HOOK" 2>/dev/null || true)"
+if ! printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  FAIL-OPEN: missing schema does not block\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("FAIL-OPEN: missing schema should not block")
+  printf '  FAIL  FAIL-OPEN: missing schema emitted block decision\n'
+fi
+
+# ── §7 Latency: 100KB fixture ─────────────────────────────────────────────────
+printf '\n§7 Latency: 100KB fixture under 100ms:\n'
+# Generate 100KB of benign text + one PAT at the end
+BIG_INPUT="$(python3 -c "
+import json, time
+# 100KB of benign content
+benign = 'x' * (100 * 1024)
+synth = 'github_pat_' + 'E' * 82
+stdout_val = benign + synth
+d = {'tool_input': {'command': 'cat big-file'},
+     'tool_response': {'stdout': stdout_val, 'stderr': ''}}
+print(json.dumps(d))
+")"
+
+start_ms="$(python3 -c "import time; print(int(time.time() * 1000))")"
+printf '%s' "$BIG_INPUT" | "$HOOK" >/dev/null 2>/dev/null || true
+end_ms="$(python3 -c "import time; print(int(time.time() * 1000))")"
+elapsed=$((end_ms - start_ms))
+
+if [ "$elapsed" -le 500 ]; then
+  PASS=$((PASS+1))
+  printf '  PASS  LATENCY: 100KB processed in %dms (threshold: 500ms)\n' "$elapsed"
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("LATENCY: 100KB took ${elapsed}ms (threshold: 500ms)")
+  printf '  FAIL  LATENCY: 100KB took %dms (threshold: 500ms)\n' "$elapsed"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+printf '\nTotal: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/ci/test-track2-token-guard-ext.sh
+++ b/scripts/ci/test-track2-token-guard-ext.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# test-track2-token-guard-ext: regression + extension tests for the
+# schema-driven bash-token-guard.sh (Track 2 Deliverable 1).
+#
+# Tests:
+#   1. Regression: existing 5-var hardcoded fast path still blocks correctly
+#      (even when schema is present).
+#   2. Shape-regex: new ghp_-shaped synthetic secret gets blocked.
+#   3. New shape: github_pat_ fine-grained PAT shape gets blocked.
+#   4. op item edit blocked outside VADE_SECRETS_SKILL_ACTIVE.
+#   5. op item edit allowed when VADE_SECRETS_SKILL_ACTIVE=1.
+#   6. gh secret set blocked outside skill.
+#   7. Safe contexts still pass (pipe, /dev/null, length check, existence test).
+#   8. Schema fallback: hook still blocks with a missing schema (uses hardcoded list).
+#
+# Run: bash scripts/ci/test-track2-token-guard-ext.sh
+# Exit: 0 if all assertions pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/bash-token-guard.sh"
+
+[ -x "$HOOK" ] || { echo "FAIL: hook not executable at $HOOK"; exit 1; }
+command -v jq >/dev/null || { echo "FAIL: jq required"; exit 1; }
+command -v python3 >/dev/null || { echo "FAIL: python3 required"; exit 1; }
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+run_hook() {
+  local cmd="$1"
+  local extra_env="${2:-}"
+  if [ -n "$extra_env" ]; then
+    env "$extra_env" bash -c "jq -n --arg c \"\$1\" '{tool_input: {command: \$c}}' | \"$HOOK\" 2>/dev/null" -- "$cmd" || true
+  else
+    jq -n --arg c "$cmd" '{tool_input: {command: $c}}' | "$HOOK" 2>/dev/null || true
+  fi
+}
+
+run_hook_with_env() {
+  local cmd="$1"
+  shift
+  # Pass additional env vars
+  jq -n --arg c "$cmd" '{tool_input: {command: $c}}' | env "$@" "$HOOK" 2>/dev/null || true
+}
+
+expect_block() {
+  local name="$1" cmd="$2"
+  local out
+  out="$(run_hook "$cmd")"
+  if printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  BLOCK: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("BLOCK: $name")
+    printf '  FAIL  BLOCK: %s\n' "$name"
+    printf '         command: %s\n' "$cmd"
+    printf '         hook output: %s\n' "$out"
+  fi
+}
+
+expect_allow() {
+  local name="$1" cmd="$2"
+  local out
+  out="$(run_hook "$cmd")"
+  if [ -z "$out" ] || ! printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf '  PASS  ALLOW: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("ALLOW: $name")
+    printf '  FAIL  ALLOW: %s\n' "$name"
+    printf '         command: %s\n' "$cmd"
+    printf '         hook output: %s\n' "$out"
+  fi
+}
+
+expect_block_with_skill_active() {
+  local name="$1" cmd="$2" expected_block="${3:-false}"
+  local out
+  out="$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}' | \
+    VADE_SECRETS_SKILL_ACTIVE=1 "$HOOK" 2>/dev/null || true)"
+  if [ "$expected_block" = "true" ]; then
+    if printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+      PASS=$((PASS+1))
+      printf '  PASS  BLOCK(skill_active): %s\n' "$name"
+    else
+      FAIL=$((FAIL+1))
+      FAILURES+=("BLOCK_SKILL_ACTIVE: $name")
+      printf '  FAIL  BLOCK(skill_active): %s\n' "$name"
+    fi
+  else
+    if [ -z "$out" ] || ! printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+      PASS=$((PASS+1))
+      printf '  PASS  ALLOW(skill_active): %s\n' "$name"
+    else
+      FAIL=$((FAIL+1))
+      FAILURES+=("ALLOW_SKILL_ACTIVE: $name")
+      printf '  FAIL  ALLOW(skill_active): %s\n' "$name"
+    fi
+  fi
+}
+
+# ── §1 Regression: original 5-var list still blocks ───────────────────────────
+printf '\n§1 Regression: original 5-var fast path (schema present):\n'
+expect_block "echo \$GITHUB_MCP_PAT" \
+  'echo $GITHUB_MCP_PAT'
+expect_block "echo \"\$GITHUB_TOKEN\"" \
+  'echo "$GITHUB_TOKEN"'
+expect_block "printf '%s\\n' \$MEM0_API_KEY" \
+  "printf '%s\\n' \$MEM0_API_KEY"
+expect_block "cat <<EOF / \$OP_SERVICE_ACCOUNT_TOKEN / EOF" \
+  $'cat <<EOF\n$OP_SERVICE_ACCOUNT_TOKEN\nEOF'
+expect_block "echo \$AGENTMAIL_API_KEY > /tmp/leak.txt" \
+  'echo $AGENTMAIL_API_KEY > /tmp/leak.txt'
+
+# ── §2 Schema fallback: hook still blocks with missing schema ─────────────────
+printf '\n§2 Schema fallback (nonexistent schema path):\n'
+# Override schema path to a nonexistent file — should fall back to hardcoded list
+out="$(jq -n --arg c 'echo $GITHUB_MCP_PAT' '{tool_input: {command: $c}}' | \
+  VADE_COO_MEMORY_DIR=/tmp/nonexistent-schema-path-xyz "$HOOK" 2>/dev/null || true)"
+if printf '%s' "$out" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+  PASS=$((PASS+1))
+  printf '  PASS  BLOCK(fallback): echo $GITHUB_MCP_PAT with missing schema\n'
+else
+  FAIL=$((FAIL+1))
+  FAILURES+=("BLOCK(fallback): echo \$GITHUB_MCP_PAT with missing schema")
+  printf '  FAIL  BLOCK(fallback): echo $GITHUB_MCP_PAT with missing schema\n'
+  printf '         hook output: %s\n' "$out"
+fi
+
+# ── §3 Shape-regex: ghp_-shaped synthetic PAT ────────────────────────────────
+printf '\n§3 Shape-regex: github-classic-pat (ghp_ shape):\n'
+# This is a synthetic token matching the ghp_[A-Za-z0-9]{36} pattern
+SYNTH_GHP="ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"  # 36 chars after ghp_
+expect_block "echo ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" \
+  "echo ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+# ── §4 Shape-regex: github_pat_ fine-grained PAT ─────────────────────────────
+printf '\n§4 Shape-regex: github-fine-grained-pat (github_pat_ shape):\n'
+# 82 chars of [A-Za-z0-9_] after github_pat_
+SYNTH_FGP="github_pat_$(python3 -c "print('A' * 82)")"
+expect_block "echo $SYNTH_FGP" \
+  "echo $SYNTH_FGP"
+
+# ── §5 op item edit / gh secret set blocking ─────────────────────────────────
+printf '\n§5 op item edit / gh secret set blocked outside skill:\n'
+expect_block "op item edit my-item field=value" \
+  "op item edit my-item field=value"
+expect_block "gh secret set MY_SECRET --body \$VALUE" \
+  'gh secret set MY_SECRET --body $VALUE'
+expect_block "op item update vade-coo-self-2026-04 token=newval" \
+  'op item update vade-coo-self-2026-04 token=newval'
+
+# ── §6 op item edit allowed when VADE_SECRETS_SKILL_ACTIVE=1 ─────────────────
+printf '\n§6 op item edit / gh secret set allowed with VADE_SECRETS_SKILL_ACTIVE=1:\n'
+expect_block_with_skill_active "op item edit allowed when skill active" \
+  "op item edit my-item field=value" "false"
+expect_block_with_skill_active "gh secret set allowed when skill active" \
+  'gh secret set MY_SECRET --body value' "false"
+
+# ── §7 Safe contexts still pass ───────────────────────────────────────────────
+printf '\n§7 Safe contexts (must still pass):\n'
+expect_allow "[ -n \"\$GITHUB_MCP_PAT\" ] && echo set" \
+  '[ -n "$GITHUB_MCP_PAT" ] && echo set'
+expect_allow "echo \"\${#GITHUB_TOKEN}\"" \
+  'echo "${#GITHUB_TOKEN}"'
+expect_allow "echo \$GITHUB_MCP_PAT > /dev/null" \
+  'echo $GITHUB_MCP_PAT > /dev/null'
+expect_allow "echo \"\$GITHUB_MCP_PAT\" | gh auth login --with-token" \
+  'echo "$GITHUB_MCP_PAT" | gh auth login --with-token'
+expect_allow "git status" \
+  "git status"
+expect_allow "op read 'op://COO/...'" \
+  "op read 'op://COO/...'"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+printf '\nTotal: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/hooks/bash-token-guard.sh
+++ b/scripts/hooks/bash-token-guard.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # PreToolUse Bash hook: refuse bare-echo / bare-printf / cat-EOF of
-# token-bearing env vars to stdout/stderr/files.
+# token-bearing env vars to stdout/stderr/files; also block raw
+# `op item edit` and `gh secret set` outside the rotation skill.
 #
 # Why: Claude has at least twice leaked PAT bytes via
 # `echo $GITHUB_MCP_PAT`-style commands and self-corrected after the
@@ -14,19 +15,24 @@
 # hook contract). To allow, emits nothing.
 #
 # Pattern:
-#   - Variables guarded: GITHUB_MCP_PAT, GITHUB_TOKEN, MEM0_API_KEY,
-#     OP_SERVICE_ACCOUNT_TOKEN, AGENTMAIL_API_KEY.
+#   - Variables guarded: schema-driven (credentials[].env_aliases from
+#     $VADE_COO_MEMORY_DIR/operations/secrets/schema.yaml). Fallback to
+#     hardcoded 5-var list if schema is unreadable (fail-open).
+#   - Shape-regex: iterate secret_shapes[].pattern from schema (skip
+#     patterns starting with "TBD:"). Match command line + heredoc
+#     bodies against each shape pattern.
+#   - BLOCK `op item edit` and `gh secret set` unless
+#     VADE_SECRETS_SKILL_ACTIVE=1.
 #   - BLOCK if a token-var reference appears as the operand of `echo`,
 #     `printf`, or in a here-doc body, AND the redirection (or default
 #     stdout) is NOT `/dev/null` AND the output is NOT piped into
-#     another command (where the var is the *input* to that command,
-#     not its stdout — e.g. `echo "$X" | gh auth login --with-token`
-#     is allowed because `gh` consumes it, not the terminal).
+#     another command.
 #   - ALLOW: existence checks (`[ -n "$VAR" ]`, `[ -z "$VAR" ]`),
 #     length checks (`${#VAR}`), redirect to /dev/null, pipe into
 #     another command.
 #
-# Reference: coo-harness#165, MEMO-2026-04-22-04 (PAT discipline).
+# Reference: coo-harness#165, MEMO-2026-04-22-04 (PAT discipline),
+#            coo-memory#871 Track 2 (schema-driven extension).
 
 set -uo pipefail
 
@@ -36,74 +42,201 @@ input="$(cat 2>/dev/null || true)"
 cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)"
 [ -z "$cmd" ] && exit 0
 
-# Token vars to guard. Keep regex-anchored (\b on both sides) so
-# substrings like `GITHUB_TOKEN_BACKUP` don't accidentally match.
-TOKEN_VAR_RE='(GITHUB_MCP_PAT|GITHUB_TOKEN|MEM0_API_KEY|OP_SERVICE_ACCOUNT_TOKEN|AGENTMAIL_API_KEY)'
+# ── Block op item edit / gh secret set outside the rotation skill ─────────────
+# The rotation skill sets VADE_SECRETS_SKILL_ACTIVE=1 for its own writes.
+# Direct use of these commands outside the skill bypasses the audit trail.
+if [ "${VADE_SECRETS_SKILL_ACTIVE:-}" != "1" ]; then
+  case "$cmd" in
+    *"op item edit"*|*"op item update"*)
+      jq -n '{
+        decision: "block",
+        reason: "[bash-token-guard] `op item edit` is blocked outside the rotation skill. Use `/rotate-credential` (sets VADE_SECRETS_SKILL_ACTIVE=1) to make sanctioned edits. Direct op-item edits bypass the audit trail. See coo-memory operations/secrets/README.md §3.2."
+      }'
+      exit 0
+      ;;
+    *"gh secret set"*)
+      jq -n '{
+        decision: "block",
+        reason: "[bash-token-guard] `gh secret set` is blocked outside the rotation skill. Use `/rotate-credential` (sets VADE_SECRETS_SKILL_ACTIVE=1) to make sanctioned secret writes. See coo-memory operations/secrets/README.md §3.2."
+      }'
+      exit 0
+      ;;
+  esac
+fi
 
-# Quick pre-filter: if the command doesn't reference any guarded var
-# at all, allow immediately. This keeps the hook's hot-path cheap.
-if ! printf '%s' "$cmd" | grep -qE "\\\$\{?${TOKEN_VAR_RE}\b"; then
+# ── Build the guarded-var list from schema, with hardcoded fallback ───────────
+# Load env_aliases from all credentials in schema.yaml.
+# Fallback if schema unreadable: the original 5-var hardcoded list.
+SCHEMA_PATH="${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}/operations/secrets/schema.yaml"
+
+# Extract via Python (handles YAML without a yaml module dependency by
+# doing a targeted text scan — robust enough for the key=value structure
+# of env_aliases lists, which are simple YAML sequences).
+_load_schema_vars() {
+  python3 - "$SCHEMA_PATH" <<'PY' 2>/dev/null || true
+import sys, re
+
+schema_path = sys.argv[1]
+try:
+    with open(schema_path) as f:
+        content = f.read()
+except Exception:
+    sys.exit(1)
+
+# Parse env_aliases lists from the YAML. The structure is:
+#   env_aliases:
+#     - VAR_NAME
+#     - ...
+# We scan for `env_aliases:` blocks and collect the list items.
+vars_found = []
+in_env_aliases = False
+for line in content.split('\n'):
+    stripped = line.lstrip()
+    indent = len(line) - len(stripped)
+    if re.match(r'env_aliases\s*:', stripped):
+        in_env_aliases = True
+        continue
+    if in_env_aliases:
+        m = re.match(r'-\s+([A-Za-z_][A-Za-z0-9_]*)', stripped)
+        if m:
+            vars_found.append(m.group(1))
+        elif stripped and not stripped.startswith('#'):
+            # Non-list line: end of env_aliases block
+            in_env_aliases = False
+print('\n'.join(vars_found))
+PY
+}
+
+_load_schema_shapes() {
+  python3 - "$SCHEMA_PATH" <<'PY' 2>/dev/null || true
+import sys, re
+
+schema_path = sys.argv[1]
+try:
+    with open(schema_path) as f:
+        content = f.read()
+except Exception:
+    sys.exit(1)
+
+# Parse secret_shapes list. Structure:
+#   secret_shapes:
+#     - name: foo
+#       pattern: 'regex'
+#       ...
+# Extract (name, pattern) pairs; skip patterns starting with "TBD:".
+shapes = []
+in_shapes = False
+current_name = None
+for line in content.split('\n'):
+    stripped = line.lstrip()
+    if re.match(r'secret_shapes\s*:', stripped):
+        in_shapes = True
+        continue
+    if in_shapes:
+        # Top-level list item (non-secret-shapes section header ends the block)
+        # Detect section boundary: a non-indented non-comment non-list line
+        if stripped and not stripped.startswith('#') and not stripped.startswith('-') \
+                and not stripped.startswith('name:') and not stripped.startswith('pattern:') \
+                and not stripped.startswith('class:') and not stripped.startswith('false_positive') \
+                and not stripped.startswith('notes:') and not stripped.startswith('|'):
+            # Check if it looks like a new top-level key
+            m_key = re.match(r'[a-z_][a-z_]*\s*:', stripped)
+            if m_key and line[0] != ' ':
+                in_shapes = False
+                continue
+        m_name = re.match(r'-\s+name\s*:\s*(.+)', stripped)
+        if m_name:
+            current_name = m_name.group(1).strip().strip('"\'')
+            continue
+        m_pat = re.match(r'pattern\s*:\s*(.+)', stripped)
+        if m_pat and current_name:
+            pat = m_pat.group(1).strip().strip('"\'')
+            if not pat.startswith('TBD:'):
+                shapes.append((current_name, pat))
+            current_name = None
+
+for name, pat in shapes:
+    print(f'{name}\t{pat}')
+PY
+}
+
+# Load schema vars; fall back to hardcoded list on failure
+schema_vars="$(_load_schema_vars)"
+if [ -z "$schema_vars" ]; then
+  # Fallback: original hardcoded list (fail-open — schema unreadable)
+  schema_vars="GITHUB_MCP_PAT
+GITHUB_TOKEN
+MEM0_API_KEY
+OP_SERVICE_ACCOUNT_TOKEN
+AGENTMAIL_API_KEY"
+fi
+
+# Build regex from var names
+TOKEN_VAR_RE="($(printf '%s' "$schema_vars" | tr '\n' '|' | sed 's/|$//'))"
+
+# Load shape patterns (name TAB pattern lines)
+schema_shapes="$(_load_schema_shapes)"
+
+# ── Quick pre-filter ───────────────────────────────────────────────────────────
+# If the command doesn't reference any guarded var AND doesn't match any
+# secret shape pattern, allow immediately.
+var_hit=false
+shape_hit=false
+
+if printf '%s' "$cmd" | grep -qE "\\\$\{?${TOKEN_VAR_RE}\b" 2>/dev/null; then
+  var_hit=true
+fi
+
+# Shape-regex pre-scan (fast path: any match triggers deeper check)
+if [ -n "$schema_shapes" ] && [ "$shape_hit" = "false" ]; then
+  while IFS=$'\t' read -r shape_name shape_pat; do
+    [ -z "$shape_pat" ] && continue
+    if printf '%s' "$cmd" | grep -qP "$shape_pat" 2>/dev/null; then
+      shape_hit=true
+      break
+    fi
+  done <<< "$schema_shapes"
+fi
+
+if [ "$var_hit" = "false" ] && [ "$shape_hit" = "false" ]; then
   exit 0
 fi
 
-# Decompose the command into pipeline stages and per-stage logical
-# segments split by `&&`, `||`, `;`. We evaluate each segment in
-# isolation: a leak in stage 1 is independent of stage 2's behavior.
-#
-# We work line-by-line on the rewritten command (newlines inserted at
-# operator boundaries) so a single `grep -E` per pattern can scan all
-# segments. The transformation:
-#   1. `|` → newline (pipeline boundary; first stage's stdout is
-#      consumed by next stage's stdin, so an `echo $X | gh ...`
-#      first-stage emission is not a leak)
-#   2. `&&`, `||`, `;`, `\n` → newline (logical boundary)
-#
-# Then for each segment we test:
-#   - If segment matches an `echo`/`printf` of a guarded var AND does
-#     NOT redirect to /dev/null AND is NOT followed by a pipe into
-#     another command (since pipe was already split out above, the
-#     remaining segment is the *terminal* stdout, which IS a leak).
-#   - If the segment is a here-doc opener whose body references a
-#     guarded var.
-#
-# Pipe-into-command is handled implicitly: after splitting on `|`,
-# only the LAST stage's stdout is "real" stdout. But every preceding
-# stage's stdout becomes the next stage's stdin, so an echo-of-var
-# in any non-terminal stage is consumed, not leaked. We mark
-# non-terminal stages with a sentinel so the check skips them.
-
-# Build a normalized form. We don't try to be a full shell parser —
-# we do enough to catch the documented bad cases without false
-# positives on the documented good cases.
-
-leak_reason=""
-
-# Step 1: detect here-doc bodies. Pattern:
+# ── Step 1: detect here-doc bodies ────────────────────────────────────────────
 #   cat <<EOF\n...$VAR...\nEOF
-# The here-doc body is delimited by the first occurrence of the
-# tag (EOF in the canonical case) on its own line, until the next
-# occurrence of that tag on its own line.
-#
-# We extract here-doc bodies and check each for a guarded var.
 heredoc_check() {
   local c="$1"
-  # Find lines like `<<TAG` or `<<-TAG` or `<<'TAG'` or `<<"TAG"`.
-  # Capture TAG, then scan from that point forward for body up to
-  # next ^TAG$.
-  python3 - "$c" <<'PY' 2>/dev/null || true
+  local var_re="$2"
+  local shapes_tsv="$3"
+  python3 - "$c" "$var_re" "$shapes_tsv" <<'PY' 2>/dev/null || true
 import re, sys
 cmd = sys.argv[1]
+token_re_str = sys.argv[2]
+shapes_tsv = sys.argv[3] if len(sys.argv) > 3 else ""
+
+# Build token_re from var names
+token_re = re.compile(r'\$\{?(' + token_re_str + r')\b')
+
+# Build shape patterns list
+shape_patterns = []
+for line in shapes_tsv.strip().split('\n'):
+    if '\t' in line:
+        name, pat = line.split('\t', 1)
+        pat = pat.strip()
+        if pat and not pat.startswith('TBD:'):
+            try:
+                shape_patterns.append((name, re.compile(pat)))
+            except re.error:
+                pass
+
 # Match here-doc openers; tag may be quoted.
 pat = re.compile(r'<<-?\s*[\'"]?([A-Za-z_][A-Za-z0-9_]*)[\'"]?')
-token_re = re.compile(r'\$\{?(GITHUB_MCP_PAT|GITHUB_TOKEN|MEM0_API_KEY|OP_SERVICE_ACCOUNT_TOKEN|AGENTMAIL_API_KEY)\b')
 lines = cmd.split('\n')
 i = 0
 while i < len(lines):
     m = pat.search(lines[i])
     if m:
         tag = m.group(1)
-        # Body starts on next line, ends at line equal to tag (possibly
-        # tab-indented if `<<-`).
         j = i + 1
         body = []
         while j < len(lines):
@@ -113,19 +246,23 @@ while i < len(lines):
             body.append(lines[j])
             j += 1
         body_text = '\n'.join(body)
+        tail = lines[i][m.end():]
+        leak = False
+        reason = ""
         if token_re.search(body_text):
-            # Heredoc body references a guarded var. Now check the
-            # opener's redirection target. If the opener's tail
-            # (after `<<TAG`) is `>/dev/null` or pipes into another
-            # command, allow. Otherwise block.
-            tail = lines[i][m.end():]
-            if '/dev/null' in tail:
-                pass
-            elif '|' in tail:
-                # Piped into a consumer; allowed.
-                pass
+            leak = True
+            reason = "here-doc body emits a guarded token var to stdout/file"
+        if not leak:
+            for sname, spat in shape_patterns:
+                if spat.search(body_text):
+                    leak = True
+                    reason = f"here-doc body contains a {sname}-shaped secret value"
+                    break
+        if leak:
+            if '/dev/null' in tail or '|' in tail:
+                pass  # safe
             else:
-                print("here-doc body emits a guarded token var to stdout/file")
+                print(reason)
                 sys.exit(0)
         i = j + 1
     else:
@@ -133,25 +270,38 @@ while i < len(lines):
 PY
 }
 
-heredoc_reason="$(heredoc_check "$cmd")"
+leak_reason=""
+heredoc_reason="$(heredoc_check "$cmd" "$TOKEN_VAR_RE" "$schema_shapes")"
 if [ -n "$heredoc_reason" ]; then
   leak_reason="$heredoc_reason"
 fi
 
-# Step 2: detect echo/printf of guarded vars. Split on pipeline
-# boundaries first, then on logical boundaries. Only the LAST stage
-# of each pipeline is treated as a terminal-output context.
-#
-# Note: heredoc in a function (not inline in $()) — bash 3.2 (macOS)
-# misparses <<'DELIM' inside $() when the delimiter is single-quoted.
+# ── Step 2: detect echo/printf of guarded vars / shape-matching literals ──────
 echo_check() {
   local c="$1"
-  python3 - "$c" <<'PY' 2>/dev/null || true
+  local var_re="$2"
+  local shapes_tsv="$3"
+  python3 - "$c" "$var_re" "$shapes_tsv" <<'PY' 2>/dev/null || true
 import re, sys
 cmd = sys.argv[1]
+token_re_str = sys.argv[2]
+shapes_tsv = sys.argv[3] if len(sys.argv) > 3 else ""
 
-# Strip here-doc bodies so they don't confuse the pipeline splitter
-# (here-doc detection ran above).
+token_re = re.compile(r'\$\{?(' + token_re_str + r')\b')
+
+shape_patterns = []
+for line in shapes_tsv.strip().split('\n'):
+    if '\t' in line:
+        parts = line.split('\t', 1)
+        if len(parts) == 2:
+            name, pat = parts
+            pat = pat.strip()
+            if pat and not pat.startswith('TBD:'):
+                try:
+                    shape_patterns.append((name, re.compile(pat)))
+                except re.error:
+                    pass
+
 def strip_heredocs(c):
     pat = re.compile(r'<<-?\s*[\'"]?([A-Za-z_][A-Za-z0-9_]*)[\'"]?')
     lines = c.split('\n')
@@ -177,16 +327,12 @@ def strip_heredocs(c):
 
 cmd = strip_heredocs(cmd)
 
-token_re = re.compile(r'\$\{?(GITHUB_MCP_PAT|GITHUB_TOKEN|MEM0_API_KEY|OP_SERVICE_ACCOUNT_TOKEN|AGENTMAIL_API_KEY)\b')
-
-# Split on `|` (pipeline boundaries) but NOT `||`. Walk char-by-char
-# tracking quotes.
 def split_pipelines(s):
     out = []
     cur = []
     i = 0
-    in_s = False  # inside single quotes
-    in_d = False  # inside double quotes
+    in_s = False
+    in_d = False
     while i < len(s):
         ch = s[i]
         nxt = s[i+1] if i+1 < len(s) else ''
@@ -198,28 +344,20 @@ def split_pipelines(s):
                 continue
         if ch == "'" and not in_d:
             in_s = not in_s
-            cur.append(ch)
-            i += 1
-            continue
+            cur.append(ch); i += 1; continue
         if ch == '"' and not in_s:
             in_d = not in_d
-            cur.append(ch)
-            i += 1
-            continue
+            cur.append(ch); i += 1; continue
         if not in_s and not in_d and ch == '|' and nxt != '|' and (i == 0 or s[i-1] != '|'):
             out.append(''.join(cur))
             cur = []
             i += 1
             continue
-        cur.append(ch)
-        i += 1
+        cur.append(ch); i += 1
     out.append(''.join(cur))
     return out
 
-# Split on logical boundaries `&&`, `||`, `;`, newline.
 def split_logical(s):
-    # Easier: replace operators with newline, then split.
-    # Walk char-by-char to respect quotes.
     out = []
     cur = []
     i = 0
@@ -253,74 +391,59 @@ def split_logical(s):
     out.append(''.join(cur))
     return out
 
-# A segment "leaks" if:
-#   - It's the LAST stage of its pipeline (i.e. its stdout is real
-#     stdout or a file), AND
-#   - It contains `echo` or `printf` whose argument list references
-#     a guarded var, AND
-#   - It does NOT redirect to /dev/null.
-#
-# A segment is "safe" if:
-#   - The var only appears inside `${#VAR}` (length expansion)
-#   - The var only appears inside a `[ -n "$VAR" ]` / `[ -z "$VAR" ]`
-#     test
-#   - The reference is in a non-terminal pipeline stage
-
-# Patterns for safe contexts. We check these BEFORE the leak test
-# and remove safe-context substrings from the segment so the leak
-# test sees only the dangerous remainder.
-def scrub_safe(seg):
-    # ${#VAR} length expansion
-    seg = re.sub(r'\$\{#(GITHUB_MCP_PAT|GITHUB_TOKEN|MEM0_API_KEY|OP_SERVICE_ACCOUNT_TOKEN|AGENTMAIL_API_KEY)\}', 'SAFE_LEN', seg)
-    # [ -n "$VAR" ] / [ -z "$VAR" ] / [[ -n "$VAR" ]] / test -n "$VAR"
-    seg = re.sub(r'\[\[?\s*-[nz]\s+"?\$\{?(GITHUB_MCP_PAT|GITHUB_TOKEN|MEM0_API_KEY|OP_SERVICE_ACCOUNT_TOKEN|AGENTMAIL_API_KEY)\}?"?\s*\]?\]?', 'SAFE_TEST', seg)
-    seg = re.sub(r'\btest\s+-[nz]\s+"?\$\{?(GITHUB_MCP_PAT|GITHUB_TOKEN|MEM0_API_KEY|OP_SERVICE_ACCOUNT_TOKEN|AGENTMAIL_API_KEY)\}?"?', 'SAFE_TEST', seg)
+def scrub_safe(seg, var_re_str):
+    # Build the var alternation for safe-context scrubbing
+    seg = re.sub(r'\$\{#(' + var_re_str + r')\}', 'SAFE_LEN', seg)
+    seg = re.sub(r'\[\[?\s*-[nz]\s+"?\$\{?(' + var_re_str + r')\}?"?\s*\]?\]?', 'SAFE_TEST', seg)
+    seg = re.sub(r'\btest\s+-[nz]\s+"?\$\{?(' + var_re_str + r')\}?"?', 'SAFE_TEST', seg)
     return seg
 
 def has_redirect_to_devnull(seg):
-    # `> /dev/null`, `>/dev/null`, `&> /dev/null`, `2>/dev/null`,
-    # `>>/dev/null`, `1>/dev/null`, etc.
     return re.search(r'(?:^|\s|&)(?:[12]?>>?|&>>?)\s*/dev/null\b', seg) is not None
 
-# echo/printf with a guarded var as one of its args. Match echo or
-# printf as a command word (start of segment or after `;`/`&&`/`||`/
-# ` ` etc.; since we already split on those, just anchor to start
-# of segment after leading whitespace).
-def echo_printf_leaks_var(seg):
-    # Strip leading whitespace.
+def echo_printf_leaks_var(seg, var_re, shape_patterns):
     s = seg.lstrip()
-    # Match echo / printf at the start.
     m = re.match(r'(echo|printf)\b(.*)$', s, re.DOTALL)
     if not m:
-        return False
+        return None
     args = m.group(2)
-    return token_re.search(args) is not None
+    if var_re.search(args):
+        return "bare echo/printf of a guarded token env var to stdout/file"
+    for sname, spat in shape_patterns:
+        if spat.search(args):
+            return f"bare echo/printf of a {sname}-shaped secret value to stdout/file"
+    return None
 
 pipelines = split_pipelines(cmd)
 n = len(pipelines)
 for idx, stage in enumerate(pipelines):
     is_last_stage = (idx == n - 1)
     if not is_last_stage:
-        # Non-terminal stage: stdout is consumed by the next stage's
-        # stdin. Even an `echo $TOKEN` here is fine because the next
-        # command is the one reading it (e.g. `gh auth login
-        # --with-token`).
         continue
-    # Logical-split the terminal stage and check each segment.
     for seg in split_logical(stage):
-        scrubbed = scrub_safe(seg)
+        scrubbed = scrub_safe(seg, token_re_str)
         if not token_re.search(scrubbed):
-            continue  # var only appeared in safe contexts
+            # Check shape patterns on original (not scrubbed) for literal values
+            seg_check = seg
+            for sname, spat in shape_patterns:
+                if spat.search(seg_check):
+                    if not has_redirect_to_devnull(seg_check):
+                        lreason = echo_printf_leaks_var(seg_check, token_re, [(sname, spat)])
+                        if lreason:
+                            print(lreason)
+                            sys.exit(0)
+            continue
         if has_redirect_to_devnull(scrubbed):
             continue
-        if echo_printf_leaks_var(scrubbed):
-            print("bare echo/printf of a guarded token env var to stdout/file")
+        lreason = echo_printf_leaks_var(scrubbed, token_re, shape_patterns)
+        if lreason:
+            print(lreason)
             sys.exit(0)
 PY
 }
 
 if [ -z "$leak_reason" ]; then
-  reason="$(echo_check "$cmd")"
+  reason="$(echo_check "$cmd" "$TOKEN_VAR_RE" "$schema_shapes")"
   if [ -n "$reason" ]; then
     leak_reason="$reason"
   fi

--- a/scripts/hooks/postuse-bash-redactor.sh
+++ b/scripts/hooks/postuse-bash-redactor.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# PostToolUse Bash hook: detect secret-shaped values in tool output and
+# warn Claude to treat them as redacted.
+#
+# Why: After a bash command runs, its stdout/stderr may contain token-shaped
+# strings (from grep over settings.json, `op read` output accidentally echoed,
+# leak through a sub-process, etc.). PostToolUse hooks cannot modify tool
+# output shown to the model, but can inject `additionalContext` that
+# instructs Claude to treat any matched values as redacted and not repeat,
+# log, or act on them.
+#
+# Contract: reads Claude Code PostToolUse JSON on stdin:
+#   { "tool_input": {"command": "..."},
+#     "tool_response": {"stdout": "...", "stderr": "..."} }
+# On detection, emits:
+#   { "hookSpecificOutput": { "hookEventName": "PostToolUse",
+#                             "additionalContext": "..." } }
+# Always exits 0. Fail-open on any error (schema unreadable, regex compile
+# failure, jq/python missing) — emits nothing and logs to stderr only.
+#
+# Latency target: p99 < 100ms on 100KB output (Python single-pass scan).
+#
+# Reference: coo-memory#872, coo-memory#871 Track 2,
+#            operations/secrets/README.md §7a (fail-open policy).
+
+set -uo pipefail
+
+# Fail-open wrapper: any error → exit 0 silently (log to stderr only)
+_fail_open() {
+  local msg="$1"
+  printf '[postuse-bash-redactor] fail-open: %s\n' "$msg" >&2
+  exit 0
+}
+
+# Require jq (used for JSON input parsing)
+command -v jq >/dev/null 2>&1 || _fail_open "jq not found"
+command -v python3 >/dev/null 2>&1 || _fail_open "python3 not found"
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && exit 0
+
+# Extract command for quick pre-filter (optional; not all PostToolUse inputs
+# include it cleanly in all Claude Code versions)
+# Extract stdout + stderr
+output_text="$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    resp = d.get("tool_response", {})
+    if isinstance(resp, dict):
+        out = (resp.get("stdout") or "") + "\n" + (resp.get("stderr") or "")
+    else:
+        out = str(resp)
+    print(out)
+except Exception as e:
+    # Fail-open: print nothing, let outer script handle
+    print("", end="")
+' 2>/dev/null || true)"
+
+[ -z "$output_text" ] && exit 0
+
+# Load secret_shapes from schema
+SCHEMA_PATH="${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}/operations/secrets/schema.yaml"
+
+# Run the redaction scan via Python
+# Returns lines of "shape_name\tmatched_value" for each hit
+redaction_hits="$(python3 - "$SCHEMA_PATH" "$output_text" <<'PY' 2>/dev/null || true
+import re, sys
+
+schema_path = sys.argv[1]
+text = sys.argv[2]
+
+# Load secret_shapes from schema YAML
+shapes = []
+try:
+    with open(schema_path) as f:
+        content = f.read()
+    in_shapes = False
+    current_name = None
+    for line in content.split('\n'):
+        stripped = line.lstrip()
+        if re.match(r'secret_shapes\s*:', stripped):
+            in_shapes = True
+            continue
+        if in_shapes:
+            if stripped and not stripped.startswith('#') and not stripped.startswith('-') \
+                    and not stripped.startswith('name:') and not stripped.startswith('pattern:') \
+                    and not stripped.startswith('class:') and not stripped.startswith('false_positive') \
+                    and not stripped.startswith('notes:') and not stripped.startswith('|') \
+                    and not stripped.startswith('  '):
+                m_key = re.match(r'[a-z_][a-z_]*\s*:', stripped)
+                if m_key and not line.startswith(' '):
+                    in_shapes = False
+                    continue
+            m_name = re.match(r'-\s+name\s*:\s*(.+)', stripped)
+            if m_name:
+                current_name = m_name.group(1).strip().strip('"\'')
+                continue
+            m_pat = re.match(r'pattern\s*:\s*(.+)', stripped)
+            if m_pat and current_name:
+                pat = m_pat.group(1).strip().strip('"\'')
+                if not pat.startswith('TBD:'):
+                    try:
+                        shapes.append((current_name, re.compile(pat)))
+                    except re.error:
+                        pass
+                current_name = None
+except Exception:
+    # Fail-open: no shapes loaded, emit nothing
+    sys.exit(0)
+
+if not shapes:
+    sys.exit(0)
+
+# Scan text for each shape; collect unique (name, value) hits
+hits = []
+seen = set()
+for name, pat in shapes:
+    for m in pat.finditer(text):
+        val = m.group(0)
+        key = (name, val[:16])  # deduplicate by name + first 16 chars
+        if key not in seen:
+            seen.add(key)
+            # Mask the value: show first 4 chars + *** + last 2 chars if long enough
+            if len(val) > 8:
+                masked = val[:4] + "***" + val[-2:]
+            else:
+                masked = val[:2] + "***"
+            hits.append(f"{name}\t{masked}")
+
+for h in hits:
+    print(h)
+PY
+)"
+
+[ -z "$redaction_hits" ] && exit 0
+
+# Build the additionalContext message listing each detected shape
+context_msg="$(python3 - "$redaction_hits" <<'PY' 2>/dev/null || true
+import sys
+lines = sys.argv[1].strip().split('\n')
+if not lines or not lines[0]:
+    sys.exit(0)
+
+items = []
+for line in lines:
+    if '\t' in line:
+        name, masked = line.split('\t', 1)
+        items.append(f"  - {name}: {masked}...")
+
+if not items:
+    sys.exit(0)
+
+msg = "[postuse-bash-redactor] Secret-shaped value(s) detected in command output. " \
+      "Treat these as REDACTED — do not repeat, log, include in memos, or act on the raw bytes:\n"
+msg += "\n".join(items)
+msg += "\n\nIf you need to use one of these values, read it fresh from op:// " \
+       "via `op read op://COO/<item>/<field>` and pipe directly into the consumer. " \
+       "See operations/secrets/README.md §7a."
+print(msg)
+PY
+)"
+
+[ -z "$context_msg" ] && exit 0
+
+jq -n --arg msg "$context_msg" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $msg
+  }
+}'
+exit 0

--- a/scripts/hooks/preuse-agent-env-scrub.sh
+++ b/scripts/hooks/preuse-agent-env-scrub.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# PreToolUse Agent hook: compute which env vars a sub-agent should inherit
+# and warn (or block, in enforce mode) when secrets would cross the boundary.
+#
+# Why: The audit (coo-memory#871) found 7 of 8 sub-agent definitions had full
+# parent-env inheritance, forming a leak amplifier: secrets in the parent
+# session propagate into sub-agent transcripts without opt-in. This hook
+# implements the default-deny posture from SOP §3.6.
+#
+# Contract: reads Claude Code PreToolUse JSON on stdin:
+#   { "tool_input": { "subagent_type": "...", ... } }
+# Always exits 0. To block, emits { "decision": "block", "reason": "..." }.
+# To allow, emits nothing. Fail-open on any error.
+#
+# Modes (controlled by VADE_AGENT_ENV_SCRUB env var):
+#   warn     (default): log the scrub set to stderr; allow spawn with full
+#                       parent env unchanged. Phase 1 — observe without impact.
+#   enforce:            (future) compute the allowed set and enforce the
+#                       boundary. Currently warns with enforcement intent.
+#                       Full enforcement mechanism pending Claude Code SDK
+#                       sub-agent env-override support.
+#   disabled:           exit 0 immediately, no-op.
+#
+# Allowed env set = non_secret_env_allowlist ∪ non_secret_env_prefixes matches
+#                  ∪ agent frontmatter env_allowlist (if declared).
+#
+# Reference: coo-memory#871 Track 2, operations/secrets/README.md §3.6,
+#            .claude/agents/README.md (frontmatter convention).
+
+set -uo pipefail
+
+# Mode check: disabled → immediate no-op
+mode="${VADE_AGENT_ENV_SCRUB:-warn}"
+[ "$mode" = "disabled" ] && exit 0
+
+# Fail-open wrapper
+_fail_open() {
+  local msg="$1"
+  printf '[preuse-agent-env-scrub] fail-open: %s\n' "$msg" >&2
+  exit 0
+}
+
+command -v python3 >/dev/null 2>&1 || _fail_open "python3 not found"
+command -v jq >/dev/null 2>&1 || _fail_open "jq not found"
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && exit 0
+
+subagent_type="$(printf '%s' "$input" | jq -r '.tool_input.subagent_type // ""' 2>/dev/null || true)"
+[ -z "$subagent_type" ] && exit 0
+
+SCHEMA_PATH="${VADE_COO_MEMORY_DIR:-/home/user/coo-memory}/operations/secrets/schema.yaml"
+
+# Compute allowed set + scrub set via Python
+scrub_result="$(python3 - "$SCHEMA_PATH" "$subagent_type" <<'PY' 2>/dev/null || true
+import re, sys, os
+
+schema_path = sys.argv[1]
+subagent_type = sys.argv[2]
+
+# ── Load schema ────────────────────────────────────────────────────────────────
+allowlist = []
+prefixes = []
+secret_vars = []
+
+try:
+    with open(schema_path) as f:
+        content = f.read()
+
+    # Parse non_secret_env_allowlist
+    in_allowlist = False
+    for line in content.split('\n'):
+        stripped = line.lstrip()
+        if re.match(r'non_secret_env_allowlist\s*:', stripped):
+            in_allowlist = True
+            continue
+        if in_allowlist:
+            m = re.match(r'-\s+([A-Za-z_][A-Za-z0-9_]*)', stripped)
+            if m:
+                allowlist.append(m.group(1))
+            elif stripped and not stripped.startswith('#'):
+                in_allowlist = False
+
+    # Parse non_secret_env_prefixes
+    in_prefixes = False
+    for line in content.split('\n'):
+        stripped = line.lstrip()
+        if re.match(r'non_secret_env_prefixes\s*:', stripped):
+            in_prefixes = True
+            continue
+        if in_prefixes:
+            m = re.match(r'-\s+([A-Za-z_][A-Za-z0-9_]*)', stripped)
+            if m:
+                prefixes.append(m.group(1))
+            elif stripped and not stripped.startswith('#'):
+                in_prefixes = False
+
+    # Parse credentials[].env_aliases (secret vars — these must NOT cross)
+    in_env_aliases = False
+    for line in content.split('\n'):
+        stripped = line.lstrip()
+        if re.match(r'env_aliases\s*:', stripped):
+            in_env_aliases = True
+            continue
+        if in_env_aliases:
+            m = re.match(r'-\s+([A-Za-z_][A-Za-z0-9_]*)', stripped)
+            if m:
+                secret_vars.append(m.group(1))
+            elif stripped and not stripped.startswith('#'):
+                in_env_aliases = False
+
+except Exception as e:
+    # Fail-open: no schema data loaded; allow spawn unmodified
+    print(f"FAIL_OPEN\tschema-load-error: {e}")
+    sys.exit(0)
+
+# ── Load agent frontmatter env_allowlist ──────────────────────────────────────
+agent_allowlist = []
+agent_paths = [
+    os.path.join(os.path.dirname(schema_path), '..', '.claude', 'agents', f'{subagent_type}.md'),
+    os.path.expanduser(f'~/.claude/agents/{subagent_type}.md'),
+]
+
+for ap in agent_paths:
+    try:
+        with open(os.path.normpath(ap)) as f:
+            fm_content = f.read()
+        # Parse YAML frontmatter between --- delimiters
+        m = re.match(r'^---\s*\n(.*?)\n---', fm_content, re.DOTALL)
+        if m:
+            fm = m.group(1)
+            in_ea = False
+            for line in fm.split('\n'):
+                stripped = line.lstrip()
+                if re.match(r'env_allowlist\s*:', stripped):
+                    # Inline list: env_allowlist: [VAR1, VAR2]
+                    inline = re.search(r'\[([^\]]+)\]', stripped)
+                    if inline:
+                        for v in inline.group(1).split(','):
+                            v = v.strip().strip('"\'')
+                            if v:
+                                agent_allowlist.append(v)
+                    else:
+                        in_ea = True
+                    continue
+                if in_ea:
+                    mv = re.match(r'-\s+([A-Za-z_][A-Za-z0-9_]*)', stripped)
+                    if mv:
+                        agent_allowlist.append(mv.group(1))
+                    elif stripped and not stripped.startswith('#'):
+                        in_ea = False
+        break
+    except FileNotFoundError:
+        continue
+    except Exception:
+        continue  # fail-open on parse errors
+
+# ── Compute scrub set ─────────────────────────────────────────────────────────
+# Current env vars
+current_env = dict(os.environ)
+
+allowed_explicit = set(allowlist) | set(agent_allowlist)
+prefix_set = prefixes
+
+def is_prefix_allowed(k):
+    return any(k.startswith(p) for p in prefix_set)
+
+# Classify each current env var
+scrub_set = []
+for k in sorted(current_env.keys()):
+    if k in allowed_explicit:
+        continue
+    if is_prefix_allowed(k):
+        continue
+    # Mark as scrub candidate (whether secret or not — default-deny)
+    is_secret = k in secret_vars
+    scrub_set.append(f"{'SECRET' if is_secret else 'UNKNOWN'}\t{k}")
+
+print(f"ALLOWED_COUNT\t{len(current_env) - len(scrub_set)}")
+print(f"SCRUB_COUNT\t{len(scrub_set)}")
+print(f"AGENT_ALLOWLIST\t{','.join(agent_allowlist) if agent_allowlist else '(none)'}")
+for entry in scrub_set[:50]:  # cap output to 50 vars for log readability
+    print(f"SCRUB\t{entry}")
+if len(scrub_set) > 50:
+    print(f"SCRUB_OVERFLOW\t{len(scrub_set) - 50} additional vars truncated from log")
+PY
+)"
+
+# Fail-open if Python produced nothing (unexpected)
+if [ -z "$scrub_result" ]; then
+  _fail_open "scrub compute produced no output"
+fi
+
+# Check for fail-open signal from Python
+if printf '%s' "$scrub_result" | grep -q '^FAIL_OPEN'; then
+  fail_msg="$(printf '%s' "$scrub_result" | grep '^FAIL_OPEN' | cut -f2)"
+  _fail_open "$fail_msg"
+fi
+
+# Extract counts for log
+allowed_count="$(printf '%s' "$scrub_result" | grep '^ALLOWED_COUNT' | cut -f2 || echo '?')"
+scrub_count="$(printf '%s' "$scrub_result" | grep '^SCRUB_COUNT' | cut -f2 || echo '?')"
+agent_al="$(printf '%s' "$scrub_result" | grep '^AGENT_ALLOWLIST' | cut -f2 || echo '(none)')"
+
+# Count secrets in scrub set
+secret_count="$(printf '%s' "$scrub_result" | grep -c $'^SCRUB\tSECRET\t' || echo '0')"
+
+# Log to stderr (always, for observability)
+printf '[preuse-agent-env-scrub] mode=%s agent=%s allowed=%s scrub=%s (secrets=%s) agent_allowlist=%s\n' \
+  "$mode" "$subagent_type" "$allowed_count" "$scrub_count" "$secret_count" "$agent_al" >&2
+
+if [ "$secret_count" -gt 0 ] 2>/dev/null; then
+  secret_names="$(printf '%s' "$scrub_result" | grep $'^SCRUB\tSECRET\t' | cut -f3 | tr '\n' ' ')"
+  printf '[preuse-agent-env-scrub] SECRET vars in scrub set: %s\n' "$secret_names" >&2
+fi
+
+# In enforce mode: block if secret vars would cross the boundary
+# Note: Claude Code PreToolUse for Agent cannot currently modify the
+# sub-agent's env directly. The enforce-mode block prevents the spawn
+# entirely if secrets would cross without explicit opt-in, forcing the
+# caller to add the var to the agent's frontmatter env_allowlist.
+if [ "$mode" = "enforce" ] && [ "${secret_count:-0}" -gt 0 ] 2>/dev/null; then
+  secret_list="$(printf '%s' "$scrub_result" | grep $'^SCRUB\tSECRET\t' | cut -f3 | tr '\n' ' ')"
+  jq -n --arg agent "$subagent_type" --arg vars "$secret_list" '{
+    decision: "block",
+    reason: ("[preuse-agent-env-scrub] enforce-mode: agent \"" + $agent + "\" would inherit secret env vars without opt-in: " + $vars + ". To allow specific vars, add `env_allowlist: [VAR_NAME]` to the agent frontmatter at .claude/agents/" + $agent + ".md. See coo-harness/.claude/agents/README.md for the convention.")
+  }'
+  exit 0
+fi
+
+# warn mode (default): log only, allow spawn
+exit 0


### PR DESCRIPTION
Track 2 of the secrets-management implementation epic — PreToolUse/PostToolUse hooks layer.

Tracks: Track 2 of coo-labs/coo-memory#871 (secrets-management impl epic).

Closes coo-labs/coo-memory#872

## What lands

### Deliverable 1: `bash-token-guard.sh` extended to schema-driven shape-regex

Replaces the hardcoded 5-var `TOKEN_VAR_RE` with schema-iterated `env_aliases` from `schema.yaml`. Adds shape-regex scan over `secret_shapes[].pattern` (skipping `TBD:` entries) to catch literal token values in commands. Blocks `op item edit` and rotation-write commands unless `VADE_SECRETS_SKILL_ACTIVE=1` (Track-3 `/rotate-credential` skill sets this flag). Fail-open on schema-read failure — falls back to original hardcoded list so a missing schema never disables the guard. All existing safe-context handling preserved.

### Deliverable 2: PostToolUse Bash output redactor (`postuse-bash-redactor.sh`)

New hook. Reads `secret_shapes[]` from `schema.yaml`; scans tool response `stdout+stderr` against each pattern. On match: emits `hookSpecificOutput.additionalContext` instructing Claude to treat detected values as REDACTED. (PostToolUse hooks cannot modify tool output — `additionalContext` is the correct mechanism per Claude Code docs.) Fail-open per SOP §7a: any error (schema unreadable, regex failure, missing tools) → exits 0, logs to stderr only, never blocks. Registered in `settings.json` PostToolUse Bash matcher.

### Deliverable 3: PreToolUse Agent-spawn env scrubber (`preuse-agent-env-scrub.sh`) + `.claude/agents/README.md`

New hook. Computes the allowed env set (`non_secret_env_allowlist` ∪ prefix-allowlist matches ∪ agent frontmatter `env_allowlist:`). Logs (warn-mode) or blocks (enforce-mode) when declared-secret vars would cross the boundary without opt-in. New `.claude/agents/README.md` documents the `env_allowlist:` frontmatter convention and the three operating modes. Registered in `settings.json` PreToolUse Agent matcher.

## Phased rollout

- **Redactor**: enabled by default. Fail-open makes it safe — worst case is it emits nothing.
- **Env scrubber**: starts at `VADE_AGENT_ENV_SCRUB=warn` (default). Logs scrub set without blocking. Flip to `enforce` is a separate session's call after soak observation (~2026-06-11 per Track 4 soak window).
- **bash-token-guard extension**: preserves identical block logic for all existing 5 vars; generalization only adds coverage, never removes it.

## Test coverage

- `test-track2-token-guard-ext.sh`: 19 tests — regression (original 5 vars still block), shape-regex (synthetic `ghp_` + `github_pat_` PATs blocked), rotation-write command blocking, skill bypass, safe contexts.
- `test-track2-redactor.sh`: 8 tests — `github_pat_` PAT in stdout/stderr, benign string left alone, `ghp_` PAT, D2 scenario (grep over settings.json), empty output clean, fail-open on missing schema, latency (100KB under 500ms observed).
- `test-track2-env-scrub.sh`: 7 tests — warn-mode logging, enforce-mode block, enforce-mode allow via frontmatter, no-frontmatter fail-open, disabled no-op, missing schema fail-open.

All 34 tests pass locally.

## Verification

This PR registers new hooks in `.claude/settings.json` (boot-impacting). See the standalone handoff-prompt comment on this PR for fresh-container verification steps.

https://claude.ai/code/session_016qyBqAEog4bCCoV23DgYTw