### PR TITLE
secrets(track-4): patch op whoami JSON key list for op 2.31+ schema

### DIFF
--- a/scripts/boot/coo-bootstrap.sh
+++ b/scripts/boot/coo-bootstrap.sh
@@ -301,12 +301,15 @@ _whoami_json=""
 if _whoami_json="$(op whoami --format=json 2>/dev/null)"; then
   # Extract service account identifier from JSON output. op whoami --format=json
   # returns different schemas across versions; try multiple field names.
+  # op 2.31+ live: {'url','URL','user_uuid','account_uuid','user_type','ServiceAccountType'}
+  # — `user_uuid` is the stable per-integration identifier and the right
+  # unit for SA-rotation detection. Older schemas exposing `ServiceAccount`
+  # / `name` are kept for forward-compat across CLI versions.
   _sa_name="$(printf '%s' "$_whoami_json" | python3 -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
-    # op 2.x: {'ServiceAccount': 'name', 'URL': ..., 'UserUUID': ...}
-    for key in ['ServiceAccount', 'service_account', 'name', 'email', 'user_email']:
+    for key in ['user_uuid', 'account_uuid', 'ServiceAccount', 'service_account', 'name', 'email', 'user_email']:
         if key in d and d[key]:
             print(d[key]); break
 except Exception:

--- a/scripts/ci/mocks/op
+++ b/scripts/ci/mocks/op
@@ -26,11 +26,13 @@ case "${1:-}" in
     ;;
   whoami)
     # Track 4 Phase 1: support --format=json for SA identity check.
-    # Return the same ServiceAccount name in both text and JSON forms
-    # so the identity file is written and compared correctly in CI.
+    # Returns op 2.31+ live schema (url/URL/user_uuid/account_uuid/user_type/
+    # ServiceAccountType) so the CI mock matches the production CLI shape;
+    # `ServiceAccount` is kept in parallel so forward-compat across CLI
+    # versions stays exercised in CI.
     case "${2:-}" in
       --format=json|--format)
-        printf '{"ServiceAccount":"ci-mock-coo-bootstrap","URL":"https://ci.mock","UserUUID":"00000000-0000-0000-0000-000000000000"}\n'
+        printf '{"url":"https://ci.mock","URL":"https://ci.mock","user_uuid":"CIMOCKCIMOCKCIMOCKCIMOCKCI","account_uuid":"CIMOCKACCOUNTCIMOCKACCOUNTC","user_type":"SERVICE_ACCOUNT","ServiceAccountType":"SERVICE_ACCOUNT","ServiceAccount":"ci-mock-coo-bootstrap"}\n'
         ;;
       *)
         echo "ServiceAccount: ci-mock-coo-bootstrap"


### PR DESCRIPTION
Phase 1 (#433) follow-up. The SA-identity self-discovery check it introduced silently no-ops on the production op CLI version; the break-glass safeguard it was meant to install is non-functional.

## The bug

`scripts/boot/coo-bootstrap.sh:299` calls `op whoami --format=json` and parses the result with a Python fallback list:

```python
for key in ['ServiceAccount', 'service_account', 'name', 'email', 'user_email']:
```

That list matches the bootstrap-regression CI mock at `scripts/ci/mocks/op` but not the live op 2.31+ schema:

```json
{"url":"...","URL":"...","user_uuid":"...","account_uuid":"...","user_type":"SERVICE_ACCOUNT","ServiceAccountType":"SERVICE_ACCOUNT"}
```

No key in the parser list exists in the live JSON. `_sa_name` is empty, the else branch fires:

```
1Password service account authenticated (identity field not found in JSON; skipping identity check)
```

`~/.vade/.op-sa-identity` is never written. The comparison logic that's supposed to detect SA-token-identity rotation never runs. CI passes (mock returns `ServiceAccount`); production silently skips.

## The fix

- Prepend `user_uuid`, `account_uuid` to the key list. `user_uuid` is the stable per-integration identifier — the right unit for SA-rotation detection. `account_uuid` as a secondary fallback if op ever renames the integration field.
- Update the schema comment in the parser to reflect the live op 2.31+ shape.
- Update `scripts/ci/mocks/op` so `--format=json` emits the live schema. Legacy `ServiceAccount` is kept in parallel so forward-compat across CLI versions stays exercised.

## Verification (locally, before push)

Cold-bootstrap on the production container:

1. Deleted `/root/.vade/.coo-bootstrap-done`.
2. Ran `CLAUDE_CODE_REMOTE=true bash scripts/boot/coo-bootstrap.sh` end-to-end. Completed clean (`coo-bootstrap: complete`).
3. `/root/.vade/.op-sa-identity` now exists, contents = the `user_uuid` returned by live `op whoami --format=json`.
4. Re-ran `integrity-check.sh`: 30/35 DEGRADED — exact same `F1,S2,S3,S7,S8` baseline as before. No new degradation introduced.

## Why this matters

Track 4 Phase 1's premise is that SA-token rotation can be detected and refused at boot. With the silent skip, any SA token whose `op whoami` succeeds will pass, regardless of whether it's the expected `vade-coo` SA or a different one. Phase 2 stacks more secrets-flow changes on top; fixing this before Phase 2 lands keeps Phase 2's blast radius narrower.

## Refs

- Umbrella: coo-labs/coo-memory#871
- Phase 1 PR: #433 (introduced the parser)
- SOP: [`operations/secrets/README.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/secrets/README.md) §3.6 (recovery doc — referenced from the bootstrap when identity mismatch fires)

https://claude.ai/code/session_01ScN2pdkYKkm5YdKhxZWrRN