### PR TITLE
secrets(track-4): pre-materialize MCP env files to tmpfs at bootstrap

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
       "args": [
         "run",
         "--env-file",
-        "/home/user/coo-harness/scripts/lib/mcp-env-templates/mem0.env",
+        "/dev/shm/coo-mcp-env/mem0.env",
         "--",
         "/home/user/coo-harness/scripts/mcp/mem0-mcp-projection.py"
       ],
@@ -19,7 +19,7 @@
       "args": [
         "run",
         "--env-file",
-        "/home/user/coo-harness/scripts/lib/mcp-env-templates/agentmail.env",
+        "/dev/shm/coo-mcp-env/agentmail.env",
         "--",
         "npx",
         "-y",

--- a/scripts/boot/coo-bootstrap.sh
+++ b/scripts/boot/coo-bootstrap.sh
@@ -352,6 +352,15 @@ merge_coo_settings_env
 COO_BOOTSTRAP_STEP="merge_coo_settings_paths"
 merge_coo_settings_paths
 
+# Pre-materialize MCP env-file templates to tmpfs with op:// refs replaced
+# by the values fetch_coo_secrets just exported. Phase 2 follow-up: kills
+# the per-MCP-spawn op-read load (each `op run --env-file` now sees a file
+# with no op:// refs and passes through without API calls). 1P account-level
+# rate-limit (1000 read+write per 24h on Personal/Teams) was being approached
+# by the per-spawn pattern. coo-memory#871 follow-up.
+COO_BOOTSTRAP_STEP="materialize_mcp_env_files"
+materialize_mcp_env_files
+
 COO_BOOTSTRAP_STEP="summarize_coo_identity"
 summarize_coo_identity
 

--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -248,16 +248,26 @@ fi
 # D4: Phase 2 (coo-memory#873): MCP tokens no longer live in settings.json env.
 # MCP children receive secrets via `op run --env-file` at spawn time.
 # The check now verifies:
-#   1. MCP env-template files are present (op run --env-file targets exist).
-#   2. settings.json env does NOT contain secret keys (Phase 2 scrub).
-#   3. VADE_*_DIR vars are in process env (container UI .env-block source).
+#   1. MCP env-template files are present (op run --env-file SOURCE).
+#   2. Materialized MCP env files are present at the .mcp.json-pinned path
+#      (op run --env-file TARGET). Phase 2 follow-up: pre-materialization at
+#      bootstrap eliminates per-spawn op-reads against the 1P account-level
+#      rate-limit.
+#   3. settings.json env does NOT contain secret keys (Phase 2 scrub).
+#   4. VADE_*_DIR vars are in process env (container UI .env-block source).
 if check_cmd node && [ -f "$HOME/.claude/settings.json" ]; then
   _MCP_TEMPLATE_DIR="${VADE_RUNTIME_DIR:-/home/user/coo-harness}/scripts/lib/mcp-env-templates"
+  _MCP_MATERIALIZED_DIR="/dev/shm/coo-mcp-env"
   D4_missing_templates=""
   for t in mem0.env agentmail.env; do
     [ -f "$_MCP_TEMPLATE_DIR/$t" ] || D4_missing_templates="${D4_missing_templates}${t},"
   done
   D4_missing_templates="${D4_missing_templates%,}"
+  D4_missing_materialized=""
+  for t in mem0.env agentmail.env; do
+    [ -f "$_MCP_MATERIALIZED_DIR/$t" ] || D4_missing_materialized="${D4_missing_materialized}${t},"
+  done
+  D4_missing_materialized="${D4_missing_materialized%,}"
   D4_stale_secrets="$(node -e '
     const fs = require("fs");
     let c = {};
@@ -276,11 +286,12 @@ if check_cmd node && [ -f "$HOME/.claude/settings.json" ]; then
     [ -z "$val" ] && D4_missing_dirs="${D4_missing_dirs}${v},"
   done
   D4_missing_dirs="${D4_missing_dirs%,}"
-  if [ -z "$D4_missing_templates" ] && [ -z "$D4_stale_secrets" ] && [ -z "$D4_missing_dirs" ]; then
-    _add D4 true "MCP env-templates present; settings.json env secret-free; VADE_*_DIR in process env"
+  if [ -z "$D4_missing_templates" ] && [ -z "$D4_missing_materialized" ] && [ -z "$D4_stale_secrets" ] && [ -z "$D4_missing_dirs" ]; then
+    _add D4 true "MCP templates + materialized present; settings.json env secret-free; VADE_*_DIR in process env"
   else
     detail=""
     [ -n "$D4_missing_templates" ] && detail="MCP templates missing: $D4_missing_templates"
+    [ -n "$D4_missing_materialized" ] && detail="${detail:+$detail; }MCP materialized files missing at $_MCP_MATERIALIZED_DIR: $D4_missing_materialized"
     [ -n "$D4_stale_secrets" ] && detail="${detail:+$detail; }secrets still in settings.json: $D4_stale_secrets"
     [ -n "$D4_missing_dirs" ] && detail="${detail:+$detail; }process env missing: $D4_missing_dirs"
     _add D4 false "$detail"

--- a/scripts/ci/test-materialize-mcp-env.sh
+++ b/scripts/ci/test-materialize-mcp-env.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# test-materialize-mcp-env: unit-test materialize_mcp_env_files() from
+# scripts/lib/common.sh.
+#
+# Phase 2 follow-up (coo-memory#871): pre-materializes MCP env templates
+# to tmpfs at bootstrap time so subsequent `op run --env-file` invocations
+# see a file with no op:// refs and pass through without API calls. The
+# function is called from coo-bootstrap.sh after fetch_coo_secrets has
+# populated the secret env vars.
+#
+# Tests:
+#   1. Resolves op:// refs from the current process env.
+#   2. Passes through comments and blank lines unchanged.
+#   3. Writes files with 0600 mode, directory 0700.
+#   4. Sets VADE_MCP_ENV_DIR to the chosen tmpfs path.
+#   5. Handles templates with no op:// refs (passes through unchanged).
+#   6. Keeps op:// ref intact when the env var is unset (visible failure
+#      mode so op run can either resolve at spawn or fail loudly).
+#   7. Idempotent: re-running overwrites without error.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMMON="$REPO_ROOT/scripts/lib/common.sh"
+
+[ -r "$COMMON" ] || { echo "FAIL: common.sh not readable at $COMMON"; exit 1; }
+
+TEST_ROOT="${TEST_ROOT:-/tmp/test-materialize-mcp-env-$$}"
+mkdir -p "$TEST_ROOT"
+trap 'rm -rf "$TEST_ROOT" /dev/shm/test-coo-mcp-env-$$' EXIT
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+_pass() { PASS=$((PASS + 1)); printf '  ok: %s\n' "$1"; }
+_fail() { FAIL=$((FAIL + 1)); FAILURES+=("$1"); printf '  FAIL: %s\n' "$1"; }
+
+_assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    _pass "$label"
+  else
+    _fail "$label (expected=$expected actual=$actual)"
+  fi
+}
+
+_assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    _pass "$label"
+  else
+    _fail "$label (needle=$needle not found in: ${haystack:0:80})"
+  fi
+}
+
+# Stage a fake VADE_RUNTIME_DIR with mcp-env-templates/.
+_stage_templates() {
+  local dir="$1"
+  mkdir -p "$dir/scripts/lib/mcp-env-templates"
+  cat > "$dir/scripts/lib/mcp-env-templates/mem0.env" <<'EOF'
+# MCP env template for mem0.
+# Comment line preserved.
+MEM0_API_KEY=op://COO/mem0-vade-coo/credential
+EOF
+  cat > "$dir/scripts/lib/mcp-env-templates/agentmail.env" <<'EOF'
+# MCP env template for agentmail.
+AGENTMAIL_API_KEY=op://COO/agentmail-vade-coo/credential
+EOF
+  cat > "$dir/scripts/lib/mcp-env-templates/1password.env" <<'EOF'
+# No op:// refs — passes through unchanged.
+# OP_SERVICE_ACCOUNT_TOKEN inherited from process env.
+EOF
+}
+
+# Run materialize in a subshell with the function loaded and env staged.
+# Sets _OUT_DIR to the resulting VADE_MCP_ENV_DIR.
+_run_materialize() {
+  local stage_dir="$1"
+  shift
+  local out
+  out="$(
+    "$@" bash -c "
+      set -uo pipefail
+      # Stub log() to no-op (function uses log() for status output).
+      log() { :; }
+      source '$COMMON' 2>/dev/null
+      VADE_RUNTIME_DIR='$stage_dir'
+      materialize_mcp_env_files
+      printf 'VADE_MCP_ENV_DIR=%s\n' \"\$VADE_MCP_ENV_DIR\"
+    " 2>&1
+  )"
+  _OUT_DIR="$(printf '%s\n' "$out" | grep -E '^VADE_MCP_ENV_DIR=' | head -1 | cut -d= -f2-)"
+}
+
+# ============================================================
+# TEST 1 — happy path: op:// refs resolved from env
+# ============================================================
+printf '\n== test 1: op:// refs resolved from env ==\n'
+TEST1_DIR="$TEST_ROOT/test1"
+_stage_templates "$TEST1_DIR"
+TEST1_TMPFS="/dev/shm/test-coo-mcp-env-$$/test1"
+rm -rf "$TEST1_TMPFS"
+mkdir -p "$TEST1_TMPFS"
+
+_run_materialize "$TEST1_DIR" env \
+  MEM0_API_KEY="m0_FAKE_TEST_MEM0_aaaaaaaaaa" \
+  AGENTMAIL_API_KEY="am_FAKE_TEST_AGENTMAIL_bbb" \
+  XDG_RUNTIME_DIR="$TEST1_TMPFS"
+
+# materialize_mcp_env_files writes to /dev/shm/coo-mcp-env if /dev/shm is
+# writable; check that path.
+[ -f "$_OUT_DIR/mem0.env" ] && _pass "mem0.env created at $_OUT_DIR" || _fail "mem0.env missing at $_OUT_DIR"
+[ -f "$_OUT_DIR/agentmail.env" ] && _pass "agentmail.env created" || _fail "agentmail.env missing"
+[ -f "$_OUT_DIR/1password.env" ] && _pass "1password.env created" || _fail "1password.env missing"
+
+mem0_content="$(cat "$_OUT_DIR/mem0.env")"
+_assert_contains "mem0.env: MEM0_API_KEY resolved" "MEM0_API_KEY=m0_FAKE_TEST_MEM0_aaaaaaaaaa" "$mem0_content"
+_assert_contains "mem0.env: comment preserved" "# MCP env template for mem0." "$mem0_content"
+if printf '%s' "$mem0_content" | grep -q "op://COO/mem0"; then
+  _fail "mem0.env: op:// ref should be replaced, not preserved"
+else
+  _pass "mem0.env: op:// ref replaced"
+fi
+
+am_content="$(cat "$_OUT_DIR/agentmail.env")"
+_assert_contains "agentmail.env: AGENTMAIL_API_KEY resolved" "AGENTMAIL_API_KEY=am_FAKE_TEST_AGENTMAIL_bbb" "$am_content"
+
+# 1password.env has no op:// refs — passes through verbatim.
+op_content="$(cat "$_OUT_DIR/1password.env")"
+_assert_contains "1password.env: comment preserved" "# No op:// refs" "$op_content"
+
+# Permissions: dir 0700, files 0600.
+dir_mode="$(stat -c '%a' "$_OUT_DIR" 2>/dev/null || stat -f '%Lp' "$_OUT_DIR" 2>/dev/null)"
+_assert_eq "out dir mode" "700" "$dir_mode"
+for f in mem0.env agentmail.env 1password.env; do
+  file_mode="$(stat -c '%a' "$_OUT_DIR/$f" 2>/dev/null || stat -f '%Lp' "$_OUT_DIR/$f" 2>/dev/null)"
+  _assert_eq "$f mode" "600" "$file_mode"
+done
+
+# ============================================================
+# TEST 2 — env var unset: op:// ref preserved (fallback)
+# ============================================================
+printf '\n== test 2: missing env var preserves op:// ref ==\n'
+TEST2_DIR="$TEST_ROOT/test2"
+_stage_templates "$TEST2_DIR"
+
+# Run with MEM0_API_KEY unset (env -u) to simulate fetch_coo_secrets gap.
+_run_materialize "$TEST2_DIR" env -u MEM0_API_KEY \
+  AGENTMAIL_API_KEY="am_TEST2_VALUE" \
+  XDG_RUNTIME_DIR="$TEST_ROOT/runtime2"
+
+mem0_content="$(cat "$_OUT_DIR/mem0.env")"
+_assert_contains "test 2: unresolved MEM0 op:// ref preserved" "MEM0_API_KEY=op://COO/mem0-vade-coo/credential" "$mem0_content"
+am_content="$(cat "$_OUT_DIR/agentmail.env")"
+_assert_contains "test 2: AGENTMAIL still resolves" "AGENTMAIL_API_KEY=am_TEST2_VALUE" "$am_content"
+
+# ============================================================
+# TEST 3 — idempotency: re-run overwrites cleanly
+# ============================================================
+printf '\n== test 3: idempotency ==\n'
+TEST3_DIR="$TEST_ROOT/test3"
+_stage_templates "$TEST3_DIR"
+
+# First materialization with one set of values.
+_run_materialize "$TEST3_DIR" env \
+  MEM0_API_KEY="m0_FIRST_RUN_VALUE" \
+  AGENTMAIL_API_KEY="am_FIRST_RUN_VALUE" \
+  XDG_RUNTIME_DIR="$TEST_ROOT/runtime3"
+OUT_DIR_1="$_OUT_DIR"
+mem0_first="$(cat "$OUT_DIR_1/mem0.env")"
+_assert_contains "first run: MEM0 has first value" "MEM0_API_KEY=m0_FIRST_RUN_VALUE" "$mem0_first"
+
+# Second run with different values (simulates stale-PAT re-bootstrap).
+_run_materialize "$TEST3_DIR" env \
+  MEM0_API_KEY="m0_SECOND_RUN_VALUE" \
+  AGENTMAIL_API_KEY="am_SECOND_RUN_VALUE" \
+  XDG_RUNTIME_DIR="$TEST_ROOT/runtime3"
+OUT_DIR_2="$_OUT_DIR"
+mem0_second="$(cat "$OUT_DIR_2/mem0.env")"
+_assert_contains "second run: MEM0 has second value" "MEM0_API_KEY=m0_SECOND_RUN_VALUE" "$mem0_second"
+_assert_eq "second run: same output dir" "$OUT_DIR_1" "$OUT_DIR_2"
+
+if printf '%s' "$mem0_second" | grep -q "m0_FIRST_RUN_VALUE"; then
+  _fail "second run: stale first value still present"
+else
+  _pass "second run: first value overwritten cleanly"
+fi
+
+# ============================================================
+# TEST 4 — templates dir absent: skip cleanly
+# ============================================================
+printf '\n== test 4: missing templates dir ==\n'
+TEST4_DIR="$TEST_ROOT/test4"
+mkdir -p "$TEST4_DIR"
+# Do NOT create $TEST4_DIR/scripts/lib/mcp-env-templates/ — exercise the
+# templates-absent skip path.
+out4="$(
+  env XDG_RUNTIME_DIR="$TEST_ROOT/runtime4" bash -c "
+    set -uo pipefail
+    log() { :; }
+    source '$COMMON' 2>/dev/null
+    VADE_RUNTIME_DIR='$TEST4_DIR'
+    materialize_mcp_env_files
+    printf 'exit=%s\n' \$?
+  " 2>&1
+)"
+_assert_contains "test 4: function exits 0 cleanly when templates dir absent" "exit=0" "$out4"
+
+# ============================================================
+# Summary
+# ============================================================
+printf '\n== Summary ==\n'
+printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1524,6 +1524,93 @@ merge_coo_settings_paths() {
   _write_claude_settings_paths "$VADE_CLOUD_STATE_DIR" "$bindir"
 }
 
+# Pre-materialize MCP env-file templates to tmpfs, replacing op:// refs
+# with the already-fetched values in the current process env. Called
+# AFTER fetch_coo_secrets so $MEM0_API_KEY etc. are populated.
+#
+# Phase 2 follow-up to coo-memory#871: the per-MCP-spawn `op run --env-file`
+# pattern resolves every op:// ref on each spawn, hitting 1P's account-level
+# rate-limit (1000 read+write per 24h on Personal/Teams plans, undocumented).
+# MCP servers respawn under disconnect/reconnect, sub-agent spawns, and
+# stale-PAT re-bootstraps — compounding. Pre-materializing the resolved
+# env-file once at boot means subsequent `op run` invocations see a file
+# with no op:// refs and pass through without API calls.
+#
+# Output: $VADE_MCP_ENV_DIR/<basename>.env (one per template). The directory
+# is tmpfs (/dev/shm on Linux containers), 0700, files 0600 — within Phase 2's
+# "no plaintext at rest" spirit: in-memory, container-ephemeral, dies on reboot,
+# no backup surface. Same security posture as MCP server in-process secret residence.
+#
+# Idempotent: re-running on stale-PAT-detected re-bootstrap simply re-writes
+# the resolved files.
+materialize_mcp_env_files() {
+  local templates_dir="${VADE_RUNTIME_DIR:-/home/user/coo-harness}/scripts/lib/mcp-env-templates"
+  if [ ! -d "$templates_dir" ]; then
+    log "  materialize_mcp_env_files: templates dir absent at $templates_dir; skip"
+    return 0
+  fi
+
+  # Pick tmpfs target: /dev/shm preferred (typical Linux container tmpfs),
+  # fall back to /tmp. Both are container-ephemeral.
+  local out_dir
+  if [ -d /dev/shm ] && [ -w /dev/shm ]; then
+    out_dir="/dev/shm/coo-mcp-env"
+  else
+    out_dir="/tmp/coo-mcp-env"
+  fi
+
+  mkdir -p "$out_dir" 2>/dev/null || true
+  chmod 0700 "$out_dir" 2>/dev/null || true
+
+  local count=0 missing=0
+  local umask_save; umask_save="$(umask)"
+  umask 0177
+
+  local template
+  for template in "$templates_dir"/*.env; do
+    [ -f "$template" ] || continue
+    local basename="${template##*/}"
+    local out_file="$out_dir/$basename"
+
+    {
+      local line key resolved
+      while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+          \#*|"")
+            printf '%s\n' "$line"
+            ;;
+          *=op://*)
+            key="${line%%=*}"
+            resolved="${!key:-}"
+            if [ -n "$resolved" ]; then
+              printf '%s=%s\n' "$key" "$resolved"
+            else
+              # Resolution missing — keep the op:// ref so `op run` either
+              # resolves it at spawn (fallback) or fails loudly (visible gap).
+              printf '%s\n' "$line"
+              missing=$((missing + 1))
+            fi
+            ;;
+          *)
+            printf '%s\n' "$line"
+            ;;
+        esac
+      done < "$template"
+    } > "$out_file"
+
+    count=$((count + 1))
+  done
+
+  umask "$umask_save"
+
+  export VADE_MCP_ENV_DIR="$out_dir"
+  if [ "$missing" -gt 0 ]; then
+    log "  materialized $count MCP env file(s) to $out_dir ($missing op:// ref(s) unresolved — will fall back to op run)"
+  else
+    log "  materialized $count MCP env file(s) to $out_dir (all op:// refs pre-resolved)"
+  fi
+}
+
 # Write non-secret COO identifier vars into ~/.claude/settings.json "env".
 # Phase 2 (coo-memory#873): secrets removed from settings.json entirely.
 # Only public identifiers (GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID,


### PR DESCRIPTION
Phase 2 ([#435](https://github.com/coo-labs/coo-harness/pull/435)) follow-up. Companion to [#436](https://github.com/coo-labs/coo-harness/pull/436) — same caching pattern, one layer out.

## The hit

Phase 2's per-spawn `op run --env-file <template>` resolves every `op://` ref on each MCP spawn. MCP servers respawn under disconnect/reconnect cycles, sub-agent spawns, and stale-PAT-detected re-bootstraps. Today the cumulative cost crossed the 1P account-level `read_write` quota (1000/24h on Personal/Teams, undocumented in marketing pages), surfaced via `op service-account ratelimit`. Substrate was paralyzed on `op_read` for the day; mitigated mid-day by Team Starter Pack upgrade (raised cap to 5000/24h) and by failing over to the sandbox SA token.

## The fix

Pre-materialize each MCP env-file template once at bootstrap, replacing `op://` refs with the values `fetch_coo_secrets` has already populated in process env. Resolved files land at `/dev/shm/coo-mcp-env/<name>.env` (tmpfs, in-memory, container-ephemeral). `.mcp.json` now points `--env-file` at the materialized path. Op sees a file with no `op://` refs and passes through with zero API calls.

Same in-memory-at-rest posture as [#436](https://github.com/coo-labs/coo-harness/pull/436)'s wrapper cache: within Phase 2's spirit of no plaintext on disk (no persistence, no backup surface). Comparable to MCP server in-process secret residence post-spawn.

## Changes

- `scripts/lib/common.sh` — new `materialize_mcp_env_files()` iterates templates, replaces `KEY=op://...` lines with `KEY=$KEY` from env, passes comments/blanks/non-op lines through, 0700 dir + 0600 files. Idempotent on re-bootstrap. Preserves unresolved `op://` refs (visible failure mode if env was unpopulated — op run fallback or loud failure).
- `scripts/boot/coo-bootstrap.sh` — call `materialize_mcp_env_files` after `merge_coo_settings_paths`. New `COO_BOOTSTRAP_STEP`.
- `.mcp.json` — mem0 and agentmail `--env-file` targets now point at `/dev/shm/coo-mcp-env/<name>.env`. 1password unchanged (already not using `op://`).
- `scripts/boot/integrity-check.sh` — D4 invariant extended to check materialized files exist in addition to source templates. New failure mode surfaced as `MCP materialized files missing at <path>`.
- `scripts/ci/test-materialize-mcp-env.sh` — 19 unit tests covering happy-path resolution, missing-env-var op:// preservation, idempotency on re-run, and graceful skip on missing templates dir.

## Cost reduction

| Scenario | Pre-Phase-2 | Phase 2 (no cache) | This PR |
|---|---|---|---|
| Boot | ~10 reads | ~10 reads | ~10 reads |
| MCP respawn | 0 | N per respawn | **0** |
| Sub-agent spawn | 0 | N per spawn | **0** |
| Stale-PAT re-bootstrap | 0 | ~10 | **0** |

## Verification

Unit tests pass locally (19/19). End-to-end verification needs a fresh container boot, which is queued for tomorrow's first session per the boot-impact handoff prompt (next comment on this PR).

## Refs

- Umbrella: [coo-labs/coo-memory#871](https://github.com/coo-labs/coo-memory/issues/871)
- Sibling cache layer: [#436](https://github.com/coo-labs/coo-harness/pull/436)
- Phase 2 (the gap this addresses): [#435](https://github.com/coo-labs/coo-harness/pull/435)

https://claude.ai/code/session_01ScN2pdkYKkm5YdKhxZWrRN