### PR TITLE
secrets(track-4): app-key + schema-fetch session caches

### DIFF
--- a/scripts/boot/coo-bootstrap.sh
+++ b/scripts/boot/coo-bootstrap.sh
@@ -361,6 +361,14 @@ merge_coo_settings_paths
 COO_BOOTSTRAP_STEP="materialize_mcp_env_files"
 materialize_mcp_env_files
 
+# Cache the GitHub App private key to tmpfs so gh-app-token.sh's installation-
+# token mints don't cost an op-read per re-mint. App private key rotates
+# yearly; installation tokens last 1 hour; the GitHub App token cache already
+# amortizes mints but each cache-miss currently costs 1 op-read of the App
+# private key. Tmpfs cache eliminates that per-mint cost for the session.
+COO_BOOTSTRAP_STEP="materialize_app_key_cache"
+materialize_app_key_cache
+
 COO_BOOTSTRAP_STEP="summarize_coo_identity"
 summarize_coo_identity
 

--- a/scripts/ci/test-bootstrap-op-caches.sh
+++ b/scripts/ci/test-bootstrap-op-caches.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# test-bootstrap-op-caches: unit-tests for the bootstrap-side op-read
+# cache functions added as Phase 2 follow-ups to coo-memory#871:
+#
+#   - materialize_app_key_cache (in common.sh) — writes GITHUB_APP_PRIVATE_KEY
+#     to tmpfs at boot so gh-app-token.sh's installation-token cache misses
+#     don't cost an op-read per re-mint.
+#
+#   - schema-fetch session cache (in fetch_coo_secrets in common.sh) —
+#     caches the python iterator's eval-able output in tmpfs for the
+#     session. Re-bootstraps within TTL use the cache instead of re-running
+#     ~12 op-reads. Schema-hash-keyed so schema edits invalidate.
+#
+# Companions to test-materialize-mcp-env.sh (#437) which covers the MCP
+# env-file pre-materialization. Same tmpfs posture across all three.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMMON="$REPO_ROOT/scripts/lib/common.sh"
+
+[ -r "$COMMON" ] || { echo "FAIL: common.sh not readable at $COMMON"; exit 1; }
+
+TEST_ROOT="${TEST_ROOT:-/tmp/test-bootstrap-op-caches-$$}"
+mkdir -p "$TEST_ROOT"
+trap 'rm -rf "$TEST_ROOT" /dev/shm/coo-app-key-cache /dev/shm/coo-secret-cache' EXIT
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+_pass() { PASS=$((PASS + 1)); printf '  ok: %s\n' "$1"; }
+_fail() { FAIL=$((FAIL + 1)); FAILURES+=("$1"); printf '  FAIL: %s\n' "$1"; }
+_assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  [ "$expected" = "$actual" ] && _pass "$label" || _fail "$label (expected=$expected actual=$actual)"
+}
+_assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  printf '%s' "$haystack" | grep -qF "$needle" && _pass "$label" || _fail "$label (needle=$needle not in: ${haystack:0:80})"
+}
+
+# ============================================================
+# Part 1 — materialize_app_key_cache
+# ============================================================
+printf '\n== materialize_app_key_cache ==\n'
+
+# Test A1 — env unset: skip cleanly, no file written.
+rm -rf /dev/shm/coo-app-key-cache
+out="$(
+  env -u GITHUB_APP_PRIVATE_KEY bash -c "
+    set -uo pipefail
+    log() { :; }
+    source '$COMMON' 2>/dev/null
+    materialize_app_key_cache
+    printf 'exit=%s' \$?
+  " 2>&1
+)"
+_assert_contains "A1: function exits 0 when env unset" "exit=0" "$out"
+[ ! -e /dev/shm/coo-app-key-cache/private_key ] && _pass "A1: no file created" || _fail "A1: file created when env unset"
+
+# Test A2 — env set: file written with 0600, dir 0700.
+rm -rf /dev/shm/coo-app-key-cache
+out="$(
+  GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+FAKE_KEY_FOR_TEST_A2_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+-----END RSA PRIVATE KEY-----" bash -c "
+    set -uo pipefail
+    log() { :; }
+    source '$COMMON' 2>/dev/null
+    materialize_app_key_cache
+  " 2>&1
+)"
+[ -f /dev/shm/coo-app-key-cache/private_key ] && _pass "A2: file created" || _fail "A2: file not created"
+if [ -f /dev/shm/coo-app-key-cache/private_key ]; then
+  file_mode="$(stat -c '%a' /dev/shm/coo-app-key-cache/private_key 2>/dev/null || stat -f '%Lp' /dev/shm/coo-app-key-cache/private_key 2>/dev/null)"
+  dir_mode="$(stat -c '%a' /dev/shm/coo-app-key-cache 2>/dev/null || stat -f '%Lp' /dev/shm/coo-app-key-cache 2>/dev/null)"
+  _assert_eq "A2: file mode" "600" "$file_mode"
+  _assert_eq "A2: dir mode" "700" "$dir_mode"
+  body="$(cat /dev/shm/coo-app-key-cache/private_key)"
+  _assert_contains "A2: body preserved" "FAKE_KEY_FOR_TEST_A2" "$body"
+fi
+
+# Test A3 — idempotency.
+out="$(
+  GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+SECOND_RUN_KEY_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+-----END RSA PRIVATE KEY-----" bash -c "
+    set -uo pipefail
+    log() { :; }
+    source '$COMMON' 2>/dev/null
+    materialize_app_key_cache
+  " 2>&1
+)"
+body="$(cat /dev/shm/coo-app-key-cache/private_key 2>/dev/null)"
+_assert_contains "A3: re-run overwrites with second value" "SECOND_RUN_KEY_" "$body"
+if printf '%s' "$body" | grep -q "FAKE_KEY_FOR_TEST_A2"; then
+  _fail "A3: stale first value still present"
+else
+  _pass "A3: first value overwritten cleanly"
+fi
+
+# ============================================================
+# Part 2 — schema-fetch session cache (in fetch_coo_secrets)
+# ============================================================
+# We stub the python iterator helper to emit known output, then call
+# fetch_coo_secrets twice — first call populates cache, second hits it
+# (verified by removing the helper so any python invocation would fail).
+printf '\n== schema-fetch session cache ==\n'
+
+STUB_ROOT="$TEST_ROOT/schema-stub"
+mkdir -p "$STUB_ROOT/scripts/boot"
+mkdir -p "$STUB_ROOT/operations/secrets"
+
+# Stub helper: emit known eval-able output + SCHEMA_FETCH_GOT marker.
+cat > "$STUB_ROOT/scripts/boot/schema-fetch-secrets.py" <<'EOF'
+#!/usr/bin/env python3
+import sys
+sys.stdout.write("export TEST_FETCHED_VAR='stub_value_from_helper'\n")
+sys.stdout.write("SCHEMA_FETCH_GOT=1\n")
+sys.exit(0)
+EOF
+chmod +x "$STUB_ROOT/scripts/boot/schema-fetch-secrets.py"
+
+# Stub schema file.
+cat > "$STUB_ROOT/operations/secrets/schema.yaml" <<'EOF'
+# stub schema for test
+credentials: []
+EOF
+
+# Clean cache.
+rm -rf /dev/shm/coo-secret-cache
+
+# Test B1 — first call: cache miss, helper runs, cache written.
+out="$(
+  env -u TEST_FETCHED_VAR bash -c "
+    set -uo pipefail
+    log() { printf '[log] %s\n' \"\$*\" >&2; }
+    check_cmd() { command -v \"\$1\" >/dev/null 2>&1; }
+    retry() { shift; \"\$@\"; }
+    source '$COMMON' 2>/dev/null
+    VADE_RUNTIME_DIR='$STUB_ROOT'
+    VADE_COO_MEMORY_DIR='$STUB_ROOT'
+    fetch_coo_secrets
+    printf 'GOT=%s VAR=%s\n' \"\${SCHEMA_FETCH_GOT:-0}\" \"\${TEST_FETCHED_VAR:-unset}\"
+  " 2>&1
+)"
+_assert_contains "B1: SCHEMA_FETCH_GOT set" "GOT=1" "$out"
+_assert_contains "B1: TEST_FETCHED_VAR exported from helper" "VAR=stub_value_from_helper" "$out"
+[ -f /dev/shm/coo-secret-cache/schema-fetch.sh ] && _pass "B1: cache file created" || _fail "B1: cache file not created"
+[ -f /dev/shm/coo-secret-cache/schema-fetch.meta ] && _pass "B1: cache meta created" || _fail "B1: cache meta not created"
+
+# Test B2 — second call: cache hit, helper NOT invoked.
+# Proof: replace the helper with one that exits non-zero. If cache works,
+# fetch_coo_secrets still succeeds because it doesn't call the helper.
+cat > "$STUB_ROOT/scripts/boot/schema-fetch-secrets.py" <<'EOF'
+#!/usr/bin/env python3
+import sys
+sys.stderr.write("HELPER SHOULD NOT BE CALLED\n")
+sys.exit(99)
+EOF
+chmod +x "$STUB_ROOT/scripts/boot/schema-fetch-secrets.py"
+
+out="$(
+  env -u TEST_FETCHED_VAR bash -c "
+    set -uo pipefail
+    log() { printf '[log] %s\n' \"\$*\" >&2; }
+    check_cmd() { command -v \"\$1\" >/dev/null 2>&1; }
+    retry() { shift; \"\$@\"; }
+    source '$COMMON' 2>/dev/null
+    VADE_RUNTIME_DIR='$STUB_ROOT'
+    VADE_COO_MEMORY_DIR='$STUB_ROOT'
+    fetch_coo_secrets
+    printf 'GOT=%s VAR=%s\n' \"\${SCHEMA_FETCH_GOT:-0}\" \"\${TEST_FETCHED_VAR:-unset}\"
+  " 2>&1
+)"
+_assert_contains "B2: SCHEMA_FETCH_GOT set from cache" "GOT=1" "$out"
+_assert_contains "B2: TEST_FETCHED_VAR from cached eval" "VAR=stub_value_from_helper" "$out"
+_assert_contains "B2: cache-hit log line emitted" "schema-fetch cache hit" "$out"
+if printf '%s' "$out" | grep -q "HELPER SHOULD NOT BE CALLED"; then
+  _fail "B2: helper was invoked despite cache hit"
+else
+  _pass "B2: helper not invoked (cache served the eval)"
+fi
+
+# Test B3 — schema hash changes invalidate the cache.
+# Edit the schema (any change → different sha256). The next call should
+# bypass the cache and re-run the (now-failing) helper, surfacing the
+# bypass via the helper's exit-99 path.
+echo "# new content" >> "$STUB_ROOT/operations/secrets/schema.yaml"
+out="$(
+  env -u TEST_FETCHED_VAR bash -c "
+    set -uo pipefail
+    log() { printf '[log] %s\n' \"\$*\" >&2; }
+    check_cmd() { command -v \"\$1\" >/dev/null 2>&1; }
+    retry() { shift; \"\$@\"; }
+    source '$COMMON' 2>/dev/null
+    VADE_RUNTIME_DIR='$STUB_ROOT'
+    VADE_COO_MEMORY_DIR='$STUB_ROOT'
+    fetch_coo_secrets || true
+  " 2>&1
+)"
+if printf '%s' "$out" | grep -q "schema-fetch cache hit"; then
+  _fail "B3: cache hit despite schema change (sha-keying broken)"
+else
+  _pass "B3: cache invalidated on schema change"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+printf '\n== Summary ==\n'
+printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -64,6 +64,20 @@ fi
 if [ -z "$install_id" ]; then
   install_id="$(op read 'op://COO/vade-coo-app/installation_id' 2>/dev/null || true)"
 fi
+# Phase 2 follow-up: check tmpfs cache populated by bootstrap's
+# materialize_app_key_cache before falling back to op-read. The cache is
+# in-memory tmpfs, written once at boot, container-ephemeral. Avoids 1
+# op-read per gh-app-token cache miss (which was previously the only
+# op-read in the App-token mint hot path after the installation-token
+# cache landed).
+if [ -z "$private_key" ]; then
+  for cache_path in /dev/shm/coo-app-key-cache/private_key /tmp/coo-app-key-cache/private_key; do
+    if [ -r "$cache_path" ]; then
+      private_key="$(cat "$cache_path" 2>/dev/null || true)"
+      [ -n "$private_key" ] && break
+    fi
+  done
+fi
 if [ -z "$private_key" ]; then
   private_key="$(op read 'op://COO/vade-coo-app/private_key' 2>/dev/null || true)"
 fi

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1449,9 +1449,57 @@ fetch_coo_secrets() {
   # Capture stdout; let stderr flow to the caller's log (same as retry's
   # log_err pattern). Fail-open on individual credential failures (each
   # warn is emitted by the helper); fail-closed only on schema error (rc=1).
-  local fetch_output
+  #
+  # Phase 2 follow-up cache: schema-fetch output is cached in tmpfs for
+  # the session. Re-bootstraps (stale-PAT detection, settings.json env
+  # incomplete) within the TTL eval the cache instead of re-running the
+  # python iterator's ~12 op-reads. Cache invalidates on schema hash
+  # change or TTL expiry. Container-ephemeral; dies on reboot.
+  local fetch_cache_dir
+  if [ -d /dev/shm ] && [ -w /dev/shm ]; then
+    fetch_cache_dir="/dev/shm/coo-secret-cache"
+  else
+    fetch_cache_dir="/tmp/coo-secret-cache"
+  fi
+  local fetch_cache="$fetch_cache_dir/schema-fetch.sh"
+  local fetch_cache_meta="$fetch_cache_dir/schema-fetch.meta"
+  local fetch_cache_ttl=86400
+  local fetch_output=""
   local fetch_rc=0
-  fetch_output="$(python3 "$helper" --schema "$schema_path")" || fetch_rc=$?
+  local fetch_now
+  fetch_now="$(date +%s 2>/dev/null || echo 0)"
+  local schema_sha
+  schema_sha="$(sha256sum "$schema_path" 2>/dev/null | cut -c1-16)"
+  local cache_hit=0
+
+  if [ -f "$fetch_cache" ] && [ -f "$fetch_cache_meta" ]; then
+    local meta_sha meta_expiry
+    meta_sha="$(awk -F= '$1=="schema_sha"{print $2; exit}' "$fetch_cache_meta" 2>/dev/null)"
+    meta_expiry="$(awk -F= '$1=="expiry"{print $2; exit}' "$fetch_cache_meta" 2>/dev/null)"
+    if [ "$meta_sha" = "$schema_sha" ] && [ "${meta_expiry:-0}" -gt "$fetch_now" ] 2>/dev/null; then
+      fetch_output="$(cat "$fetch_cache" 2>/dev/null || true)"
+      [ -n "$fetch_output" ] && cache_hit=1
+    fi
+  fi
+
+  if [ "$cache_hit" -eq 0 ]; then
+    fetch_output="$(python3 "$helper" --schema "$schema_path")" || fetch_rc=$?
+    # Populate cache on a successful fetch with output.
+    if [ -n "$fetch_output" ] && [ "$fetch_rc" -ne 1 ]; then
+      mkdir -p "$fetch_cache_dir" 2>/dev/null || true
+      chmod 0700 "$fetch_cache_dir" 2>/dev/null || true
+      local umask_save; umask_save="$(umask)"
+      umask 0177
+      printf '%s' "$fetch_output" > "$fetch_cache" 2>/dev/null || true
+      {
+        printf 'schema_sha=%s\n' "$schema_sha"
+        printf 'expiry=%s\n' "$((fetch_now + fetch_cache_ttl))"
+      } > "$fetch_cache_meta" 2>/dev/null || true
+      umask "$umask_save"
+    fi
+  else
+    log "  schema-fetch cache hit (TTL ${fetch_cache_ttl}s, schema sha8 ${schema_sha:0:8})"
+  fi
 
   if [ "$fetch_rc" -eq 1 ] && [ -z "$fetch_output" ]; then
     # Schema parse error: the helper printed nothing useful and exited 1.
@@ -1609,6 +1657,43 @@ materialize_mcp_env_files() {
   else
     log "  materialized $count MCP env file(s) to $out_dir (all op:// refs pre-resolved)"
   fi
+}
+
+# Cache the GitHub App private key to tmpfs so gh-app-token.sh can mint
+# installation tokens without an op-read per re-mint. The private key
+# rotates ~yearly; the installation-token mint cycle is hourly. Without
+# this cache, every gh-app-token cache miss costs one op-read.
+#
+# Bootstrap calls this AFTER fetch_coo_secrets has populated
+# GITHUB_APP_PRIVATE_KEY in process env. Writes to a tmpfs path
+# gh-app-token.sh checks before its own op-read fallback.
+#
+# Same Phase-2-spirit posture as materialize_mcp_env_files: in-memory,
+# container-ephemeral, 0600 file inside 0700 dir.
+materialize_app_key_cache() {
+  local key="${GITHUB_APP_PRIVATE_KEY:-}"
+  if [ -z "$key" ]; then
+    log "  materialize_app_key_cache: GITHUB_APP_PRIVATE_KEY not in env; skip"
+    return 0
+  fi
+
+  local cache_dir
+  if [ -d /dev/shm ] && [ -w /dev/shm ]; then
+    cache_dir="/dev/shm/coo-app-key-cache"
+  else
+    cache_dir="/tmp/coo-app-key-cache"
+  fi
+
+  mkdir -p "$cache_dir" 2>/dev/null || true
+  chmod 0700 "$cache_dir" 2>/dev/null || true
+
+  local umask_save; umask_save="$(umask)"
+  umask 0177
+  printf '%s' "$key" > "$cache_dir/private_key" 2>/dev/null || true
+  umask "$umask_save"
+
+  export VADE_APP_KEY_CACHE_DIR="$cache_dir"
+  log "  materialized App private key to $cache_dir/private_key"
 }
 
 # Write non-secret COO identifier vars into ~/.claude/settings.json "env".


### PR DESCRIPTION
Phase 2 ([#435](https://github.com/coo-labs/coo-harness/pull/435)) follow-up, third in the cache-everywhere sequence after [#436](https://github.com/coo-labs/coo-harness/pull/436) (gh-coo-wrap PAT cache) and [#437](https://github.com/coo-labs/coo-harness/pull/437) (MCP env-file pre-materialization).

## Remaining op-read cost centers post-#437

1. **`gh-app-token.sh` cache misses.** The installation-token cache already amortizes mints (1hr TTL), but each cache miss costs 1 op-read of the App private key — which Phase 2 scrubbed from `settings.json::env`, so the cache-miss fallback is always the `op://` path.
2. **`schema-fetch-secrets.py` re-execution.** Phase 2's marker-stale check at `coo-bootstrap.sh:198` (`_cached_pat_still_valid` → checks env `GITHUB_MCP_PAT`) fires when `GITHUB_MCP_PAT` is missing — which is exactly the post-Phase-2 default state. So every session re-runs the full schema iterator's ~12 op-reads after the marker shortcut fails.

## What this PR ships

- **`materialize_app_key_cache()`** in `common.sh` — writes `GITHUB_APP_PRIVATE_KEY` to `/dev/shm/coo-app-key-cache/private_key` after `fetch_coo_secrets` populates env. 0600 file inside 0700 dir. Idempotent on re-bootstrap.

- **`gh-app-token.sh`** — when env `GITHUB_APP_PRIVATE_KEY` is unset, check `/dev/shm/coo-app-key-cache/private_key` (and `/tmp/` fallback) BEFORE the op-read fallback. Lets the installation token mint complete with zero op-reads on the App-key resolution path. Preserves the existing op-read as last resort.

- **`fetch_coo_secrets`** (in `common.sh`) — cache the python iterator's output at `/dev/shm/coo-secret-cache/schema-fetch.sh` (eval-able shell lines) plus a meta file with schema-sha256 and expiry stamp. TTL 24h. On re-bootstrap within TTL with matching schema hash, eval cache instead of re-running the iterator's ~12 op-reads. **Schema-hash-keyed** so schema edits naturally invalidate.

- **`coo-bootstrap.sh`** — call `materialize_app_key_cache` after `materialize_mcp_env_files`. New `COO_BOOTSTRAP_STEP`.

- **`test-bootstrap-op-caches.sh`** — 17 unit tests covering both caches:
  - app-key: env-unset skip, env-set write, idempotency
  - schema-fetch: cache miss writes both cache + meta, cache hit serves eval (proven by replacing helper with exit-99 stub), cache invalidation on schema-hash change

## Cost reduction (cumulative across #436/#437/this PR)

| Scenario | Pre-Phase-2 | Phase 2 only | + #436 | + #437 | + this PR |
|---|---|---|---|---|---|
| Boot | ~10 reads | ~10 | ~10 | ~10 | ~10 |
| Stale-PAT re-bootstrap | ~10 | ~10 | ~10 | ~10 | **0** (cache hit) |
| MCP respawn | 0 | N per spawn | N | **0** | 0 |
| `gh` Bash-tool call | 0 | 1 per call | **0** (cache) | 0 | 0 |
| `gh-app-token` cache miss | 0 | 1 read | 1 | 1 | **0** (cache hit) |

Substrate should sit well under the 5000/24h account quota under normal multi-session VADE work.

## Same Phase-2-spirit posture

All three caches in this PR write to `/dev/shm/` (tmpfs, in-memory, container-ephemeral). Dies on container reboot. No disk persistence, no backup surface. Comparable to MCP server in-process secret residence and to #436's gh-pat cache and #437's MCP env-file materialization — uniform model across all secret-materialization points.

## Verification

- `test-bootstrap-op-caches.sh`: 17/17 pass locally
- `test-materialize-mcp-env.sh`: 19/19 (no regression from #437)
- `test-gh-coo-wrap.sh`: 99/99 (no regression from #436)
- End-to-end on fresh boot deferred to next session per the handoff prompt (next comment).

## Out-of-scope follow-ups noted during today's work

- **`gh-coo-wrap.sh` App-token fallback**: when `gh-app-token.sh` mint fails, the wrapper currently doesn't fall through to the PAT route — observed today on `gh pr checks` against the throttled token. Separate small fix.
- **`subscribe-pr-watch.sh` op-read fallback**: requires `GITHUB_MCP_PAT` in env directly (doesn't benefit from `gh-coo-wrap` tmpfs cache). Either teach it to op-read or document `GH_TOKEN` setup.
- **`m0-*` (hyphen) form in PostToolUse redactor**: mem0 keys now ship with hyphen separator; `transcript-redaction.json`'s regex still expects underscore. Coverage gap surfaced when testing sandbox SA reads today.
- **`OP_SERVICE_ACCOUNT_TOKEN_BACKUP` fallback** at every op-read callsite: today's mid-day rate-limit hit demonstrated the value of the backup-SA-token mechanism. The wrapper's `_resolve_pat` and bootstrap's op-using helpers should automatically failover. Worth a follow-up issue.

## Refs

- Umbrella: [coo-labs/coo-memory#871](https://github.com/coo-labs/coo-memory/issues/871)
- Sibling caches: [#436](https://github.com/coo-labs/coo-harness/pull/436) (gh PAT), [#437](https://github.com/coo-labs/coo-harness/pull/437) (MCP env-file)
- Phase 2: [#435](https://github.com/coo-labs/coo-harness/pull/435)

https://claude.ai/code/session_01ScN2pdkYKkm5YdKhxZWrRN