### PR TITLE
coo-bootstrap: auto-fallback to OP_SERVICE_ACCOUNT_TOKEN_BACKUP on rate-limit

### DIFF
--- a/scripts/boot/coo-bootstrap.sh
+++ b/scripts/boot/coo-bootstrap.sh
@@ -255,6 +255,60 @@ if ! retry 5 op whoami >/dev/null; then
   exit 1
 fi
 
+# ── Rate-limit auto-fallback to OP_SERVICE_ACCOUNT_TOKEN_BACKUP ─────────
+# 1P enforces a per-SA item-read rate limit (1000 read+write per 24h on
+# Personal/Teams). Approaching the ceiling, `op whoami` continues to work
+# while `op read op://COO/...` returns "Too many requests" rc=1 — which
+# fails install_coo_ssh_keys and downstream.
+#
+# When OP_SERVICE_ACCOUNT_TOKEN_BACKUP is set, sentinel-read a small COO
+# vault item. On rate-limit (or any read failure when the primary
+# whoami is fine), swap to BACKUP for the rest of the bootstrap. BACKUP's
+# SA identity must already be in the .op-sa-identity allowlist (multi-line
+# acceptable) — operator authorizes by appending to the file.
+COO_BOOTSTRAP_STEP="op_sentinel_read"
+if [ -n "${OP_SERVICE_ACCOUNT_TOKEN_BACKUP:-}" ]; then
+  # Stderr-captured probe. The `|| _sentinel_rc=$?` consumes the
+  # non-zero exit so `set -e` doesn't trip on the command substitution.
+  _sentinel_out=""
+  _sentinel_rc=0
+  _sentinel_out="$(op read 'op://COO/vade-coo-auth/public key' 2>&1 >/dev/null)" || _sentinel_rc=$?
+  if [ "$_sentinel_rc" -ne 0 ] && printf '%s' "$_sentinel_out" | grep -qiE 'rate.?limit|too many requests'; then
+    log "coo-bootstrap: standard SA token rate-limited on op read; swapping to OP_SERVICE_ACCOUNT_TOKEN_BACKUP"
+    export OP_SERVICE_ACCOUNT_TOKEN="$OP_SERVICE_ACCOUNT_TOKEN_BACKUP"
+    if ! retry 3 op whoami >/dev/null; then
+      log "FATAL: BACKUP SA token failed op whoami after standard rate-limited"
+      log "  See: coo-memory/operations/secrets/README.md §3.6"
+      exit 1
+    fi
+    log "coo-bootstrap: BACKUP SA token active"
+    # Auto-append BACKUP's identity to the allowlist on first successful
+    # swap. Authorization signal is the operator setting the BACKUP env
+    # var; this avoids a FATAL on the identity-check immediately below
+    # when a fresh container has not yet seen BACKUP. Idempotent.
+    _backup_id="$(op whoami --format=json 2>/dev/null | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    for k in ['user_uuid','account_uuid','ServiceAccount','service_account','name','email','user_email']:
+        if k in d and d[k]:
+            print(d[k]); break
+except Exception:
+    pass
+" 2>/dev/null || true)"
+    if [ -n "$_backup_id" ]; then
+      mkdir -p "$(dirname "${HOME}/.vade/.op-sa-identity")"
+      touch "${HOME}/.vade/.op-sa-identity"
+      if ! grep -Fxq "$_backup_id" "${HOME}/.vade/.op-sa-identity" 2>/dev/null; then
+        printf '%s\n' "$_backup_id" >> "${HOME}/.vade/.op-sa-identity"
+        log "coo-bootstrap: appended BACKUP identity '${_backup_id}' to .op-sa-identity allowlist"
+      fi
+    fi
+    unset _backup_id
+  fi
+  unset _sentinel_out _sentinel_rc
+fi
+
 # Identity check via JSON output. The SA token's `op whoami --format=json`
 # returns the service account's name. We check it matches the expected
 # vade-coo pattern (tolerates the exact name changing slightly as long as
@@ -292,18 +346,24 @@ except Exception:
 
   if [ -n "$_sa_name" ]; then
     if [ -f "$_sa_identity_file" ]; then
-      _expected_identity="$(cat "$_sa_identity_file" 2>/dev/null || true)"
-      if [ -n "$_expected_identity" ] && [ "$_sa_name" != "$_expected_identity" ]; then
-        log "FATAL: SA identity mismatch (got='${_sa_name}', expected='${_expected_identity}')"
-        log "  The OP_SERVICE_ACCOUNT_TOKEN authenticates as a different account than expected."
+      # .op-sa-identity is a newline-separated allowlist of accepted SA
+      # identities. First-boot writes a single line (self-discovery);
+      # operator appends additional identities to authorize fallback SAs
+      # such as OP_SERVICE_ACCOUNT_TOKEN_BACKUP. Matching is exact-line.
+      if ! grep -Fxq "$_sa_name" "$_sa_identity_file" 2>/dev/null; then
+        log "FATAL: SA identity '${_sa_name}' not in allowlist ${_sa_identity_file}"
+        log "  The OP_SERVICE_ACCOUNT_TOKEN authenticates as an SA not in the allowlist."
         log "  Recovery: OP_SERVICE_ACCOUNT_TOKEN=<correct-token> bash ${VADE_RUNTIME_DIR:-/home/user/coo-harness}/scripts/boot/coo-bootstrap.sh"
+        log "  To authorize this SA: append '${_sa_name}' to ${_sa_identity_file}"
         log "  See: coo-memory/operations/secrets/README.md §3.6"
         exit 1
       fi
+    else
+      # First-boot self-discovery — write the current identity as the
+      # initial allowlist entry.
+      mkdir -p "$(dirname "$_sa_identity_file")"
+      printf '%s\n' "$_sa_name" > "$_sa_identity_file" 2>/dev/null || true
     fi
-    # Record the identity for future boots (idempotent write).
-    mkdir -p "$(dirname "$_sa_identity_file")"
-    printf '%s\n' "$_sa_name" > "$_sa_identity_file" 2>/dev/null || true
     log "1Password service account authenticated: ${_sa_name}"
   else
     # JSON parsed but no identity field found — CLI version difference.


### PR DESCRIPTION
Wires `OP_SERVICE_ACCOUNT_TOKEN_BACKUP` as an automatic rate-limit fallback in the COO bootstrap.

## Why

1Password enforces a per-SA item-read rate limit (~1000 read+write per 24h on Personal/Teams tier). Approaching the ceiling, `op whoami` continues to succeed while `op read op://COO/...` returns rc=1 with "Too many requests". `install_coo_ssh_keys` calls `_op_to_file` four times in immediate succession; one rate-limited read fails the step, the bootstrap exits before `.coo-bootstrap-done` is written, and the boot brake pins to FAIL.

Hit live in session 1503f8be: `op whoami` clean → `op read op://COO/vade-coo-auth/private key` rate-limited → bootstrap dead at step `install_coo_ssh_keys` → brake refuses every non-Read/non-Grep tool call.

## What this PR does

**`OP_SERVICE_ACCOUNT_TOKEN_BACKUP` auto-swap.** A new `op_sentinel_read` step between `op_whoami` and `op_whoami_identity_check`: when `OP_SERVICE_ACCOUNT_TOKEN_BACKUP` is set, sentinel-read a small COO vault item (`op://COO/vade-coo-auth/public key`). On a "rate-limit" / "too many requests" error from the sentinel, swap `OP_SERVICE_ACCOUNT_TOKEN` to the BACKUP value for the rest of the bootstrap.

**`.op-sa-identity` becomes a newline-separated allowlist.** Was single-line pin (one accepted identity); now accepts any line via `grep -Fxq`. First-boot self-discovery still writes a single line. On successful BACKUP swap, the bootstrap auto-appends BACKUP's identity to the allowlist — the operator's act of setting `OP_SERVICE_ACCOUNT_TOKEN_BACKUP` is the authorization signal, so fresh containers don't FATAL on the identity check immediately after the swap.

`set -e` safety: the sentinel's command-substitution rc is consumed via `|| _sentinel_rc=$?` so a non-zero exit doesn't trip the outer `set -euo pipefail`.

## Live verification

Standard SA token in container 1503f8be was at the per-SA item-read ceiling during boot. With BACKUP wired in env, the new code path:

- detected rate-limit via the sentinel-read step (`op_sentinel_read`)
- swapped to BACKUP, `op whoami` passed under BACKUP (`7CT6K67HK5FQREMDZXWFDTQD7I`)
- appended `7CT6K...` to `.op-sa-identity` (idempotent)
- `install_coo_ssh_keys` / `fetch_coo_secrets` / `validate_coo_identity` / `merge_coo_settings_env` / `materialize_mcp_env_files` / `materialize_app_key_cache` / `summarize_coo_identity` all completed under BACKUP
- `.coo-bootstrap-done` written
- integrity-check went from 18/26 (D2,D3,D4,D6,F1,S2,S3,S8 degraded) to 24/28 (only F1, S2, S3, S8 — all expected-yellow per SOP §3.4 plus the pre-existing F1 citation lapses on `16cb6fb81d` / `21fa1f661b`)

## Threat-model note

Auto-appending an identity to `.op-sa-identity` on env-var-driven swap relies on the operator (Ven) being the one who sets `OP_SERVICE_ACCOUNT_TOKEN_BACKUP`. An adversary with env-write capability could already set `OP_SERVICE_ACCOUNT_TOKEN` directly to any identity, so the BACKUP-swap path does not materially worsen the trust model.

## Follow-ups (not in this PR)

- `OP_SERVICE_ACCOUNT_TOKEN_BACKUP` is currently classified as `unknown_secret_shape` by S8. Schema entry in `coo-memory/operations/secrets/schema.yaml` declaring it as a credential is the right next step; need to know where Ven canonically stores it (separate op-item, or env-only) before drafting.
- Bootstrap-regression CI (`.github/workflows/bootstrap-regression.yml`) doesn't currently mock a rate-limited `op read`. Adding a fixture-flag to inject rate-limit response would cover the new code path. Out of scope here; noting for the next Track 4 sweep.

Refs coo-labs/coo-memory#871 (secrets epic; Phase 1 break-glass extension §3.6).

## Pre-merge gating

- Diff review only. The change is exercised live on the source container, but bootstrap-regression CI does not yet mock a rate-limited `op read`, so the new code path is not CI-tested. Verify the diff against the comment in `coo-memory/operations/secrets/README.md §3.6` to confirm intent.

## Post-merge confirmation

### Boot brake gate — read mandatory files first

Per MEMO-2026-06-04-nzxf the boot brake is block-on-FAIL. It will refuse every non-Read/non-Grep tool call until you have Read all four identity-stack files and any persisted-output gate file from the digest banner. **Do not skip.** Follow CLAUDE.md §"Session-start mandatory reading order" verbatim:

1. Banner / persisted-output file (Read it if the SessionStart reminder says "Output too large").
2. `identity/charter.md`
3. `identity/governance.md`
4. `identity/preferences.md`
5. `identity/episodic_memory.md`

These can be issued in one parallel batch. Once the brake releases, the verification commands below will work.

### Steps

1. **Confirm sentinel block is in the merged main.**
   ```
   grep -c 'op_sentinel_read' /home/user/coo-harness/scripts/boot/coo-bootstrap.sh
   ```
   Expected: `1` (one match — the COO_BOOTSTRAP_STEP assignment).

2. **Confirm `.op-sa-identity` is multi-line-tolerated.**
   ```
   cat /root/.vade/.op-sa-identity
   ```
   Expected on a host that has done a BACKUP swap: two lines (standard + BACKUP identity). On a host that has never swapped: one line. Both are valid.

3. **Confirm the boot digest is green or yellow-only-expected.**
   ```
   jq '.summary' /home/user/.vade-cloud-state/integrity-check.json
   ```
   Expected: `passed >= 24/28`, `degraded` ⊆ `[F1, S2, S3, S8]` (all expected-yellow per SOP §3.4 plus pre-existing F1 citation lapses). D2/D3/D4/D6 absent.

4. **Confirm `.coo-bootstrap-done` marker present.**
   ```
   ls -la /root/.vade/.coo-bootstrap-done
   ```
   Expected: file present, recent timestamp.

5. **Confirm brake state.**
   ```
   jq '.cause, .state' "$VADE_CLOUD_STATE_DIR/boot-brake.${CLAUDE_CODE_SESSION_ID}.json"
   ```
   Expected: `"all_satisfied"` / `"OK"`.

Closes: n/a

https://claude.ai/code/session_01FvzTK8ksMjSwNAUd3xncnb