### PR TITLE
op-coo-wrap: transparent SA-token rate-limit fallback

### DIFF
--- a/scripts/boot/coo-bootstrap.sh
+++ b/scripts/boot/coo-bootstrap.sh
@@ -282,6 +282,15 @@ if [ -n "${OP_SERVICE_ACCOUNT_TOKEN_BACKUP:-}" ]; then
       exit 1
     fi
     log "coo-bootstrap: BACKUP SA token active"
+    # Persist the swap for the rest of the session. The op-coo-wrap shim
+    # (installed by session-start-sync.sh ensure_op_coo_wrap, runs before
+    # this hook) reads this marker on every `op` invocation to choose the
+    # active token. Without this, every Bash-tool subprocess would re-probe
+    # the rate-limit on its first op-read. Tmpfs, container-ephemeral.
+    _op_pref_dir="${XDG_RUNTIME_DIR:-/tmp}/coo-op-wrap"
+    mkdir -p "$_op_pref_dir" 2>/dev/null || true
+    chmod 0700 "$_op_pref_dir" 2>/dev/null || true
+    printf B > "$_op_pref_dir/active" 2>/dev/null || true
     # Auto-append BACKUP's identity to the allowlist on first successful
     # swap. Authorization signal is the operator setting the BACKUP env
     # var; this avoids a FATAL on the identity-check immediately below

--- a/scripts/boot/session-start-sync.sh
+++ b/scripts/boot/session-start-sync.sh
@@ -72,6 +72,12 @@ ensure_gh_symlink_on_path
 # auto-carries the Claude Code session URL. MEMO 2026-04-26-02
 # (issue #150). Idempotent via marker grep.
 ensure_gh_coo_wrap "$SCRIPT_DIR/../gh-coo-wrap.sh"
+# Path-shadow op with op-coo-wrap so every `op` consumer gets
+# transparent rate-limit fallback between OP_SERVICE_ACCOUNT_TOKEN
+# and OP_SERVICE_ACCOUNT_TOKEN_BACKUP. Installs before
+# coo-bootstrap.sh runs (next in the SessionStart hook chain), so
+# bootstrap's own op-reads go through the shim from the start.
+ensure_op_coo_wrap "$SCRIPT_DIR/../op-coo-wrap.sh"
 # Refresh the external-touch (F6) cache when it's older than 24h.
 # Build-time prewarm in cloud-setup.sh handles the fresh-snapshot case;
 # this catches snapshots resumed after the cache has gone stale and

--- a/scripts/ci/test-op-coo-wrap.sh
+++ b/scripts/ci/test-op-coo-wrap.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# test-op-coo-wrap: smoke-test the op wrapper that transparently
+# falls back from OP_SERVICE_ACCOUNT_TOKEN to
+# OP_SERVICE_ACCOUNT_TOKEN_BACKUP on 1Password rate-limit.
+#
+# Strategy: install a mock `op-real` whose behavior is controlled by
+# env vars (MOCK_OP_FAIL_TOKEN_A / _B set to one of {rate_limit,
+# other_error, ok}; MOCK_OP_ECHO_TOKEN_NAME=1 makes it print which
+# token bucket it received on stdout). Then run the wrapper with
+# various marker / env-var permutations and assert the swap behavior.
+#
+# Run: bash scripts/ci/test-op-coo-wrap.sh
+# Exit: 0 if all assertions pass, non-zero otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/../op-coo-wrap.sh"
+
+[ -x "$WRAPPER" ] || { echo "FAIL: wrapper not executable at $WRAPPER"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Mock op-real: behaves per env switches.
+#   MOCK_OP_TOKEN_A_VALUE / _B_VALUE — the strings the test will set
+#     OP_SERVICE_ACCOUNT_TOKEN / OP_SERVICE_ACCOUNT_TOKEN_BACKUP to.
+#     Mock reports which bucket the actual OP_SERVICE_ACCOUNT_TOKEN
+#     matches ("A", "B", or "OTHER") by comparing values.
+#   MOCK_OP_FAIL_A / _B — set to "rate_limit" / "other_error" / "ok".
+#     Controls exit code + stderr based on which bucket was passed.
+cat > "$WORK/op-real" <<'EOF'
+#!/usr/bin/env bash
+got="${OP_SERVICE_ACCOUNT_TOKEN:-<unset>}"
+if   [ "$got" = "${MOCK_OP_TOKEN_A_VALUE:-__no_a__}" ]; then bucket="A"
+elif [ "$got" = "${MOCK_OP_TOKEN_B_VALUE:-__no_b__}" ]; then bucket="B"
+else bucket="OTHER"
+fi
+printf 'TOKEN_BUCKET=%s\n' "$bucket"
+printf 'ARGV=%s\n' "$*"
+
+# Behavior per bucket.
+case "$bucket" in
+  A) fail_mode="${MOCK_OP_FAIL_A:-ok}" ;;
+  B) fail_mode="${MOCK_OP_FAIL_B:-ok}" ;;
+  *) fail_mode="${MOCK_OP_FAIL_OTHER:-ok}" ;;
+esac
+
+case "$fail_mode" in
+  rate_limit)
+    printf '[ERROR] could not read secret: Too many requests. Your client has been rate-limited. Try again in 60 seconds\n' >&2
+    exit 1
+    ;;
+  other_error)
+    printf '[ERROR] could not read secret: not found\n' >&2
+    exit 1
+    ;;
+  ok)
+    printf '[OK] mock op-real succeeded with bucket=%s\n' "$bucket" >&2
+    exit 0
+    ;;
+esac
+EOF
+chmod 0755 "$WORK/op-real"
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS+1))
+    printf '  PASS  %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+    printf '         expected to contain: %s\n' "$needle"
+    printf '         got:\n'
+    printf '%s\n' "$haystack" | sed 's/^/           /'
+  fi
+}
+
+assert_eq() {
+  local name="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1))
+    printf '  PASS  %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+    printf '         want: %s\n' "$want"
+    printf '         got:  %s\n' "$got"
+  fi
+}
+
+# Fresh marker dir per test so state doesn't bleed.
+fresh_env() {
+  XDG_RUNTIME_DIR="$(mktemp -d)"
+  export XDG_RUNTIME_DIR
+}
+
+# Common env: real-binary path + token values.
+export COO_OP_REAL="$WORK/op-real"
+export MOCK_OP_TOKEN_A_VALUE="primary_token_AAAAAA"
+export MOCK_OP_TOKEN_B_VALUE="backup_token_BBBBBB"
+
+# ---- TEST 1: primary OK → uses A, no marker write ----
+fresh_env
+unset MOCK_OP_FAIL_A MOCK_OP_FAIL_B
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "primary OK: bucket=A" "$out" "TOKEN_BUCKET=A"
+assert_eq "primary OK: rc=0" "$rc" "0"
+assert_eq "primary OK: marker not written" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null || echo NONE)" "NONE"
+
+# ---- TEST 2: primary rate-limited, backup OK → swap, marker=B ----
+fresh_env
+export MOCK_OP_FAIL_A="rate_limit"; unset MOCK_OP_FAIL_B
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "RL primary: attempted A" "$out" "TOKEN_BUCKET=A"
+assert_contains "RL primary: swapped to B" "$out" "TOKEN_BUCKET=B"
+assert_eq "RL primary: final rc=0" "$rc" "0"
+assert_eq "RL primary: marker=B" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null)" "B"
+
+# ---- TEST 3: marker=B + backup OK → uses B straight away, no probe of A ----
+fresh_env
+unset MOCK_OP_FAIL_A MOCK_OP_FAIL_B
+mkdir -p "$XDG_RUNTIME_DIR/coo-op-wrap"
+printf B > "$XDG_RUNTIME_DIR/coo-op-wrap/active"
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "marker=B: uses bucket=B" "$out" "TOKEN_BUCKET=B"
+# Should NOT have probed A.
+if printf '%s' "$out" | grep -q "TOKEN_BUCKET=A"; then
+  FAIL=$((FAIL+1)); FAILURES+=("marker=B: should not probe A")
+  printf '  FAIL  marker=B: should not probe A\n'
+else
+  PASS=$((PASS+1)); printf '  PASS  marker=B: no A probe\n'
+fi
+assert_eq "marker=B: rc=0" "$rc" "0"
+
+# ---- TEST 4: marker=B + backup rate-limited, primary OK → swap back to A, marker=A ----
+fresh_env
+unset MOCK_OP_FAIL_A; export MOCK_OP_FAIL_B="rate_limit"
+mkdir -p "$XDG_RUNTIME_DIR/coo-op-wrap"
+printf B > "$XDG_RUNTIME_DIR/coo-op-wrap/active"
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "RL backup: attempted B first" "$out" "TOKEN_BUCKET=B"
+assert_contains "RL backup: swapped to A" "$out" "TOKEN_BUCKET=A"
+assert_eq "RL backup: rc=0" "$rc" "0"
+assert_eq "RL backup: marker=A" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null)" "A"
+
+# ---- TEST 5: both rate-limited → both attempted, final rc=1, marker unchanged ----
+fresh_env
+export MOCK_OP_FAIL_A="rate_limit"; export MOCK_OP_FAIL_B="rate_limit"
+mkdir -p "$XDG_RUNTIME_DIR/coo-op-wrap"
+printf A > "$XDG_RUNTIME_DIR/coo-op-wrap/active"
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "both RL: attempted A" "$out" "TOKEN_BUCKET=A"
+assert_contains "both RL: attempted B" "$out" "TOKEN_BUCKET=B"
+assert_eq "both RL: rc=1" "$rc" "1"
+assert_eq "both RL: marker unchanged=A" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null)" "A"
+assert_contains "both RL: stderr replayed" "$out" "Too many requests"
+
+# ---- TEST 6: non-rate-limit error → no swap, surface error ----
+fresh_env
+export MOCK_OP_FAIL_A="other_error"; unset MOCK_OP_FAIL_B
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "non-RL err: attempted A" "$out" "TOKEN_BUCKET=A"
+# Must NOT swap.
+if printf '%s' "$out" | grep -q "TOKEN_BUCKET=B"; then
+  FAIL=$((FAIL+1)); FAILURES+=("non-RL err: should not swap")
+  printf '  FAIL  non-RL err: should not swap\n'
+else
+  PASS=$((PASS+1)); printf '  PASS  non-RL err: no swap\n'
+fi
+assert_eq "non-RL err: rc=1" "$rc" "1"
+assert_eq "non-RL err: marker untouched" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null || echo NONE)" "NONE"
+
+# ---- TEST 7: only primary set, RL → no swap available, single attempt ----
+fresh_env
+export MOCK_OP_FAIL_A="rate_limit"; unset MOCK_OP_FAIL_B
+unset OP_SERVICE_ACCOUNT_TOKEN_BACKUP
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+attempts="$(printf '%s' "$out" | grep -c '^TOKEN_BUCKET=' || true)"
+assert_eq "only A set: exactly 1 attempt" "$attempts" "1"
+assert_eq "only A set: rc=1" "$rc" "1"
+
+# ---- TEST 8: COO_OP_WRAP_DISABLE=1 → exec real, no shim logic ----
+fresh_env
+unset MOCK_OP_FAIL_A MOCK_OP_FAIL_B
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+COO_OP_WRAP_DISABLE=1 \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "disable=1: still uses A (no marker check)" "$out" "TOKEN_BUCKET=A"
+assert_eq "disable=1: marker not created" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null || echo NONE)" "NONE"
+
+# ---- TEST 9: idempotent stderr replay (rate-limit + retry) ----
+# The wrapper replays only the FINAL attempt's stderr — the primary's
+# rate-limit chatter should not leak through on a successful retry.
+fresh_env
+export MOCK_OP_FAIL_A="rate_limit"; unset MOCK_OP_FAIL_B
+rc=0
+out_stderr="$(OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+              OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+              "$WRAPPER" read 'op://fake/x' 2>&1 1>/dev/null)" || rc=$?
+assert_eq "RL swap success: rc=0" "$rc" "0"
+assert_contains "RL swap success: B stderr present" "$out_stderr" "bucket=B"
+if printf '%s' "$out_stderr" | grep -q "Too many requests"; then
+  FAIL=$((FAIL+1)); FAILURES+=("RL swap success: should not leak primary stderr")
+  printf '  FAIL  RL swap success: should not leak primary RL stderr\n'
+else
+  PASS=$((PASS+1)); printf '  PASS  RL swap success: primary RL stderr suppressed\n'
+fi
+
+# ---- Summary ----
+echo
+echo "----------------------------------------"
+echo "op-coo-wrap test summary: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failing tests:"
+  for f in "${FAILURES[@]}"; do echo "  - $f"; done
+  exit 1
+fi
+exit 0

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1395,6 +1395,42 @@ ensure_gh_coo_wrap() {
   log "gh-coo-wrap: installed (wrapper at $gh_path, real binary at $real_path)"
 }
 
+# Install the op-coo-wrap shim at /home/user/.local/bin/op so every
+# `op` invocation gets transparent rate-limit fallback between
+# OP_SERVICE_ACCOUNT_TOKEN and OP_SERVICE_ACCOUNT_TOKEN_BACKUP. The
+# real op binary moves to /home/user/.local/bin/op-real.
+#
+# Closes the gap left by coo-bootstrap's in-process swap, which
+# doesn't propagate to subsequent Bash-tool subprocesses. Same
+# install pattern as ensure_gh_coo_wrap; marker grep keeps it
+# idempotent. Cloud-only path guard (root + /home/user); macOS/local
+# uses brew/system op and is left untouched.
+ensure_op_coo_wrap() {
+  [ "$(id -u)" = "0" ] && [ -d /home/user ] || return 0
+  local op_path="/home/user/.local/bin/op"
+  local real_path="/home/user/.local/bin/op-real"
+  local wrapper_src="${1:-}"
+  if [ -z "$wrapper_src" ] || [ ! -f "$wrapper_src" ]; then
+    log "op-coo-wrap: source script missing; skipping"
+    return 0
+  fi
+  if [ ! -x "$op_path" ]; then
+    log "op-coo-wrap: $op_path missing; skipping (ensure_op_cli installs op)"
+    return 0
+  fi
+  if grep -q 'COO-OP-COO-WRAP-MARKER-v1' "$op_path" 2>/dev/null; then
+    install -m 0755 "$wrapper_src" "$op_path"
+    return 0
+  fi
+  if [ ! -x "$real_path" ]; then
+    mv "$op_path" "$real_path"
+  else
+    rm -f "$op_path"
+  fi
+  install -m 0755 "$wrapper_src" "$op_path"
+  log "op-coo-wrap: installed (wrapper at $op_path, real binary at $real_path)"
+}
+
 # Fetch COO secrets from 1Password via a schema-driven iterator.
 #
 # Reads operations/secrets/schema.yaml (Track 4 Phase 1 refactor,

--- a/scripts/op-coo-wrap.sh
+++ b/scripts/op-coo-wrap.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# op-coo-wrap: transparent 1Password SA-token rate-limit fallback.
+#
+# 1Password enforces a per-SA 24h read/write quota. Once the standard
+# OP_SERVICE_ACCOUNT_TOKEN trips it, every `op read` returns rc=1 with
+# stderr "Too many requests. Your client has been rate-limited" — which
+# breaks gh-coo-wrap's _resolve_pat, breaks the schema-driven secret
+# fetch in coo-bootstrap.sh, and breaks every consumer that does an
+# on-demand op-read.
+#
+# Phase 2 (#873) made the latency exposure worse because it retired
+# the settings.json::env mirror — every gh / Bash-tool subprocess now
+# has to op-read at call time, multiplying the rate-limit blast radius.
+#
+# The structural fix: a second SA token (OP_SERVICE_ACCOUNT_TOKEN_BACKUP)
+# is already provisioned. Its SA identity sits in the .op-sa-identity
+# allowlist alongside the primary's. coo-bootstrap.sh swaps to it
+# in-process when the primary is rate-limited at session start, but
+# the swap doesn't escape the bootstrap's process tree — every
+# subsequent Bash-tool subprocess sees the rate-limited primary again.
+#
+# This shim closes that gap. It path-shadows `op` at
+# /home/user/.local/bin/op; the real binary moves to
+# /home/user/.local/bin/op-real (mirrors gh-coo-wrap). On every
+# invocation:
+#
+#   1. Pick a token by marker preference (or primary if no marker).
+#   2. Run op-real. If rc=0 or non-rate-limit error, exit through.
+#   3. On rate-limit AND a different alternate token is available,
+#      swap to the alternate, retry once. On retry success (or any
+#      non-rate-limit retry outcome) update the marker so subsequent
+#      invocations skip the probe. On retry rate-limit, leave the
+#      marker untouched (no point ping-ponging) and surface the error.
+#
+# The shim is transparent to callers: stdout streams as-is, stderr is
+# buffered then replayed verbatim, exit code is the real op's exit
+# code (from the final attempt). The only externally observable
+# behavior change is "rate-limit no longer breaks calls when the
+# alternate token has budget."
+#
+# Marker: tmpfs file at $XDG_RUNTIME_DIR/coo-op-wrap/active (falls back
+# to /tmp/coo-op-wrap/active). Contents: "A" (use OP_SERVICE_ACCOUNT_TOKEN)
+# or "B" (use OP_SERVICE_ACCOUNT_TOKEN_BACKUP). Container-ephemeral by
+# design: rebooting the container forgets the preference, which is fine
+# — fresh probe on first call, the rate-limit clears on a 24h window
+# anyway.
+#
+# Caller overrides:
+#   COO_OP_REAL=/path/to/op-real   — alternate real-binary path
+#   COO_OP_WRAP_DISABLE=1          — bypass the shim entirely (exec op-real)
+#   COO_OP_WRAP_TRACE=1            — write decisions to /dev/shm/coo-op-wrap.trace
+#
+# Marker (DO NOT REMOVE): COO-OP-COO-WRAP-MARKER-v1
+
+set -u
+
+WRAPPER_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+WRAPPER_DIR="$(dirname "$WRAPPER_PATH")"
+
+# Resolve the real op binary.
+REAL_OP="${COO_OP_REAL:-/home/user/.local/bin/op-real}"
+if [ ! -x "$REAL_OP" ]; then
+  REAL_OP=""
+  oldifs="$IFS"; IFS=:
+  for d in $PATH; do
+    IFS="$oldifs"
+    [ "$d" = "$WRAPPER_DIR" ] && { IFS=:; continue; }
+    if [ -x "$d/op" ] && ! grep -q 'COO-OP-COO-WRAP-MARKER-v1' "$d/op" 2>/dev/null; then
+      REAL_OP="$d/op"
+      break
+    fi
+    IFS=:
+  done
+  IFS="$oldifs"
+fi
+
+if [ -z "$REAL_OP" ] || [ ! -x "$REAL_OP" ]; then
+  printf 'op-coo-wrap: real op binary not found (COO_OP_REAL=%s); refusing to run.\n' "${COO_OP_REAL:-unset}" >&2
+  exit 127
+fi
+
+# Bypass on request — used by self-tests of the real op binary.
+if [ "${COO_OP_WRAP_DISABLE:-0}" = "1" ]; then
+  exec "$REAL_OP" "$@"
+fi
+
+# Marker setup.
+PREF_DIR="${XDG_RUNTIME_DIR:-/tmp}/coo-op-wrap"
+PREF_FILE="$PREF_DIR/active"
+mkdir -p "$PREF_DIR" 2>/dev/null || true
+chmod 0700 "$PREF_DIR" 2>/dev/null || true
+
+# Capture both candidate tokens as locals so we can swap freely without
+# losing track of either. If only one is set, we degrade to single-attempt.
+_token_a="${OP_SERVICE_ACCOUNT_TOKEN:-}"
+_token_b="${OP_SERVICE_ACCOUNT_TOKEN_BACKUP:-}"
+
+# Read marker preference. Default to A (the env's OP_SERVICE_ACCOUNT_TOKEN).
+_pref="A"
+if [ -f "$PREF_FILE" ]; then
+  _pref="$(cat "$PREF_FILE" 2>/dev/null || echo A)"
+  case "$_pref" in A|B) ;; *) _pref="A" ;; esac
+fi
+
+# Decide first-try and fallback tokens based on preference + availability.
+if [ "$_pref" = "B" ] && [ -n "$_token_b" ]; then
+  _first="$_token_b" ; _first_name="B"
+  _second="$_token_a" ; _second_name="A"
+else
+  _first="$_token_a" ; _first_name="A"
+  _second="$_token_b" ; _second_name="B"
+fi
+
+_trace() {
+  [ "${COO_OP_WRAP_TRACE:-0}" = "1" ] || return 0
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> /dev/shm/coo-op-wrap.trace 2>/dev/null || true
+}
+
+# Rate-limit shape detection.
+_is_rate_limit() {
+  printf '%s' "${1:-}" | grep -qiE 'rate.?limit|too many requests'
+}
+
+# Buffer stderr so we can inspect for rate-limit while still replaying
+# verbatim. Stdout flows through directly — op's interesting payload is
+# on stdout, and capturing it would risk truncating large reads.
+_err_tmp=""
+_cleanup() { [ -n "$_err_tmp" ] && rm -f "$_err_tmp" || true; }
+trap _cleanup EXIT
+
+_err_tmp="$(mktemp 2>/dev/null || echo "/tmp/op-coo-wrap.$$.err")"
+: > "$_err_tmp"
+
+# First attempt.
+_trace "attempt 1: token=$_first_name argv=$*"
+if [ -n "$_first" ]; then
+  OP_SERVICE_ACCOUNT_TOKEN="$_first" "$REAL_OP" "$@" 2>"$_err_tmp"
+  _rc=$?
+else
+  # No token in slot A and pref says A. Run anyway — op will surface its
+  # own auth error, which is more useful than a synthetic one from us.
+  "$REAL_OP" "$@" 2>"$_err_tmp"
+  _rc=$?
+fi
+
+# Swap-and-retry path: non-zero exit, rate-limit shape, alternate exists
+# and differs from the first.
+if [ "$_rc" -ne 0 ] \
+   && [ -n "$_second" ] \
+   && [ "$_second" != "$_first" ] \
+   && _is_rate_limit "$(cat "$_err_tmp" 2>/dev/null)"; then
+  _trace "attempt 1 rate-limited; swapping $_first_name -> $_second_name"
+  : > "$_err_tmp"
+  OP_SERVICE_ACCOUNT_TOKEN="$_second" "$REAL_OP" "$@" 2>"$_err_tmp"
+  _rc=$?
+  # Update marker iff the retry didn't also rate-limit. If both
+  # are rate-limited, leave the marker untouched.
+  if [ "$_rc" -eq 0 ] || ! _is_rate_limit "$(cat "$_err_tmp" 2>/dev/null)"; then
+    printf '%s' "$_second_name" > "$PREF_FILE" 2>/dev/null || true
+    _trace "attempt 2 success/non-rl; marker -> $_second_name"
+  else
+    _trace "attempt 2 also rate-limited; marker unchanged ($_pref)"
+  fi
+fi
+
+# Replay stderr verbatim.
+cat "$_err_tmp" >&2 2>/dev/null || true
+exit "$_rc"


### PR DESCRIPTION
## What

Path-shadow `op` at `/home/user/.local/bin/op` with a shim that transparently swaps between the primary and backup 1Password Service Account tokens on rate-limit. Real binary moves to `op-real` (mirrors `gh` → `gh-real`).

## Why

`coo-bootstrap.sh` already detects the standard SA token's 24h rate-limit at session-start and swaps to the backup token via in-process `export`. But that export only lives within the bootstrap's process tree — every subsequent Bash-tool subprocess (gh-coo-wrap's PAT resolver, direct `op read` in scripts, `schema-fetch-secrets.py`, integrity-check probes) sees the original rate-limited token again.

Live diagnosis this session: `op whoami` worked (no read cost), `op read 'op://COO/...'` returned `Too many requests`, `gh api user` fell through to `gh auth login`. The standard SA's rate-limit window has ~hours left to clear. Without the shim, the only recovery is container reboot or wait. With the shim, the alternate token absorbs the load transparently.

Diagnostic improvement after manual shim install in current session: integrity-check went 26/28 → 28/29 (S3 DEGRADED → OK because mirror-presence checks could now do op-reads; S7 SKIP → OK because credential probe could succeed). Confirms the rate-limit was masking real visibility, not just my specific gh call.

## Mechanism

1. Capture both candidate tokens as locals at shim entry.
2. Pick a "first try" by tmpfs marker preference (`$XDG_RUNTIME_DIR/coo-op-wrap/active`, contents `A` or `B`; default `A`).
3. Run `op-real`. Stdout streams through; stderr is buffered.
4. If exit non-zero AND stderr contains `rate.?limit|too many requests` AND the alternate token differs from the first → swap, retry once. Update the marker on a non-rate-limit retry outcome; leave it alone if both rate-limited.
5. Replay the final attempt's stderr only — primary RL chatter doesn't leak through on successful retry.

Install order: `session-start-sync.sh ensure_op_coo_wrap` runs before `coo-bootstrap.sh` in the SessionStart hook chain, so bootstrap's own op-reads go through the shim from boot 0. coo-bootstrap.sh's existing in-process swap also writes the marker (single new line), so the shim and bootstrap agree from the first call.

## Files

- `scripts/op-coo-wrap.sh` (new, 158 lines) — the shim itself.
- `scripts/lib/common.sh` — `ensure_op_coo_wrap()` install function, same shape as `ensure_gh_coo_wrap()`.
- `scripts/boot/session-start-sync.sh` — call it.
- `scripts/boot/coo-bootstrap.sh` — write the marker after the existing in-process swap (9 lines added).
- `scripts/ci/test-op-coo-wrap.sh` (new, 30 assertions) — covers happy path, swap-on-RL, marker-respected, swap-back when alternate RLs, both-RL fail-through, non-RL error no-swap, single-token degradation, `COO_OP_WRAP_DISABLE=1` bypass, stderr-suppression on successful retry.

## Test plan

Pre-merge (this session):

```
bash scripts/ci/test-op-coo-wrap.sh
# expect: 30 passed, 0 failed
```

Post-merge (fresh container): see handoff comment below.

## References

- `op-coo-wrap.sh` header — design notes inline.
- `coo-memory/operations/secrets/README.md §3.6` — two-token model the shim leans on.
- Phase 2 of MEMO-2026-05-22-3678 (coo-memory#873) — the secrets-scrub-from-settings.json change that made the rate-limit blast radius larger by moving op-reads to call-time.

Closes: n/a

https://claude.ai/code/session_01C3ujDgjC6263jTWSWqEZ5r