### PR TITLE
boot: run integrity-check from coo-bootstrap exit trap

### DIFF
--- a/scripts/boot/coo-bootstrap.sh
+++ b/scripts/boot/coo-bootstrap.sh
@@ -66,6 +66,21 @@ except Exception as e:
         ;;
     esac
   fi
+
+  # ── Hoisted integrity-check + finalize signal ─────────────────────
+  # Refresh integrity-check.json here, at the END of coo-bootstrap, so
+  # the JSON reflects FINAL post-bootstrap state instead of a parallel-
+  # hook mid-bootstrap snapshot. coo-identity-digest.sh runs in parallel
+  # under the SessionStart:startup matcher; previously its own integrity-
+  # check call observed bootstrap state mid-mutation and surfaced false-
+  # positive BOOT DEGRADED banners on otherwise-green boots. The digest
+  # now polls for the per-session finalize sentinel below before reading
+  # the JSON.
+  bash "$VADE_RUNTIME_DIR/scripts/boot/integrity-check.sh" >/dev/null 2>&1 || true
+  mkdir -p "$HOME/.vade" 2>/dev/null || true
+  printf '%s\n' "${CLAUDE_CODE_SESSION_ID:-unknown}" \
+    > "$HOME/.vade/.coo-bootstrap-finalized" 2>/dev/null || true
+
   return $rc
 }
 trap _on_exit EXIT

--- a/scripts/boot/session-start-sync.sh
+++ b/scripts/boot/session-start-sync.sh
@@ -85,7 +85,9 @@ ensure_op_coo_wrap "$SCRIPT_DIR/../op-coo-wrap.sh"
 # (no PAT at build time, etc.). Fail-open: if gh/PAT missing or refresh
 # fails, F6 falls back to its own "cache absent" skip path.
 prewarm_external_touch_cache "$WORKSPACE_ROOT_DERIVED" 24
-# integrity-check.sh runs in coo-identity-digest.sh instead of here,
-# so the check fires after the platform's repo-sync has settled
-# (coo-harness#XXX; moved from here to eliminate boot-time false alarms).
+# integrity-check.sh runs from coo-bootstrap.sh's EXIT trap, not here
+# and not from coo-identity-digest.sh. coo-bootstrap is the last hook in
+# the SessionStart:startup chain to mutate state, so deferring the check
+# to its tail eliminates the parallel-hook race that previously surfaced
+# stale BOOT DEGRADED banners on otherwise-green boots.
 boot_log_record session-start-sync end ok

--- a/scripts/ci/run-bootstrap-regression.sh
+++ b/scripts/ci/run-bootstrap-regression.sh
@@ -20,8 +20,10 @@
 #   6. Re-source the env block persisted to $TMP_HOME/.claude/settings.json
 #      (mirroring Claude Code's resume-time injection — tokens etc.),
 #      then run scripts/boot/session-start-sync.sh + integrity-check.sh
-#      explicitly (in live sessions integrity-check.sh runs inside
-#      coo-identity-digest; CI only runs session-start-sync directly).
+#      explicitly (in live sessions integrity-check.sh runs from
+#      coo-bootstrap.sh's EXIT trap; the CI driver re-runs it here so the
+#      JSON reflects the post-session-start-sync mutations the staged
+#      cloud-setup didn't apply).
 #   7. Read integrity-check.json, subtract VADE_CI_ALLOWLIST, fail if any
 #      degraded invariants remain.
 #   8. Render a markdown summary (groups + per-invariant table) to

--- a/scripts/lifecycle/coo-identity-digest.sh
+++ b/scripts/lifecycle/coo-identity-digest.sh
@@ -74,10 +74,29 @@ SKIP_SENTINEL="${HOME}/.vade/.coo-bootstrap-skip-reason"
 # unmissable; combined with CLAUDE.md step 1 reading the JSON file,
 # the agent's first action on a degraded boot is surface-to-BDFL.
 #
-# Run integrity-check FIRST so the file we read below reflects this
-# session. Original position (after Mem0 banner) eliminated to avoid
-# duplication.
-bash "$VADE_RUNTIME_DIR/scripts/boot/integrity-check.sh" || true
+# Wait for coo-bootstrap.sh's per-session finalize sentinel before
+# reading the JSON. Both hooks run in parallel under SessionStart:startup;
+# without this sync the JSON we read below would reflect mid-bootstrap
+# state and produce stale BOOT DEGRADED banners on otherwise-green boots.
+# coo-bootstrap.sh runs integrity-check.sh at the tail of its EXIT trap
+# and writes the sentinel containing CLAUDE_CODE_SESSION_ID; we match on
+# that to avoid picking up a stale sentinel from a prior session.
+_wait_for_bootstrap_finalized() {
+  local sentinel="$HOME/.vade/.coo-bootstrap-finalized"
+  local our_session="${CLAUDE_CODE_SESSION_ID:-unknown}"
+  local timeout="${VADE_DIGEST_BOOTSTRAP_TIMEOUT:-60}"
+  local waited=0
+  while [ "$waited" -lt "$timeout" ]; do
+    if [ -f "$sentinel" ] \
+       && [ "$(cat "$sentinel" 2>/dev/null || true)" = "$our_session" ]; then
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+_wait_for_bootstrap_finalized || true
 
 _integrity_ok="unknown"
 _integrity_passed="?"
@@ -141,7 +160,7 @@ if [ "$_integrity_ok" = "false" ] || [ -f "$SKIP_SENTINEL" ]; then
   echo "  Proven recovery (from 2026-05-13 audit recovery-transcript.txt):"
   echo "    1) git config --file \$HOME/.gitconfig --remove-section user  # clear non-COO gitconfig"
   echo "    2) CLAUDE_CODE_REMOTE=true bash \$VADE_RUNTIME_DIR/scripts/boot/coo-bootstrap.sh"
-  echo "    3) bash \$VADE_RUNTIME_DIR/scripts/boot/integrity-check.sh"
+  echo "       (auto-runs integrity-check at exit; no separate verification step needed)"
   echo "    (Phase 2: coo-env retired; no source step needed)"
   if [[ ",$_integrity_degraded," == *",D4,"* ]]; then
     echo ""
@@ -548,13 +567,13 @@ echo "                            Do NOT add GH_TOKEN=\$GITHUB_MCP_PAT — it de
 echo "                            shim. harness github MCP writes deny-listed (#112 S1)."
 echo "───────────────────────────────────────────────────────────────"
 
-# Note: integrity-check.sh runs at the TOP of the digest now (see
-# the INTEGRITY-CHECK BANNER block above), so the integrity-check.json
-# file is already current by the time this section reads it. Original
-# placement here (after Mem0 banner) was removed by Phase A of
-# coo-memory#762; the integrity-check fires after session-start-sync
-# anyway because this whole script runs after session-start-sync in the
-# SessionStart hook chain.
+# Note: integrity-check.sh runs from coo-bootstrap.sh's EXIT trap.
+# The TOP-of-digest wait (_wait_for_bootstrap_finalized) blocks until
+# that trap has fired for this session, so integrity-check.json is
+# current by the time any block in this script reads it. The previous
+# in-digest invocation (Phase A of coo-memory#762) raced coo-bootstrap
+# under SessionStart:startup parallelism and surfaced stale BOOT
+# DEGRADED banners on otherwise-green boots.
 
 # Mem0 read/write surface — same banner pattern as "GitHub write surface"
 # above. Per coo-harness#109, the hosted Mem0 MCP at mcp.mem0.ai hits


### PR DESCRIPTION
## Problem

SessionStart hooks under `:startup` run **in parallel**, not sequentially.
The integrity-check call lived at the top of `coo-identity-digest.sh`
(hook #5), and it raced `coo-bootstrap.sh` (hook #3): integrity-check
observed bootstrap state mid-mutation, wrote `summary.ok=false` to the
JSON, and the digest rendered a `BOOT DEGRADED` banner warning *DO NOT
START SUBSTANTIVE WORK* — even though, by the time the agent read it,
bootstrap had already finished and the boot was green.

Recurring false alarm. Today's session is the most recent instance:
banner showed degraded (D2, D3, D4, D6, S2, S8); a fresh
`integrity-check.sh` ten seconds later reported `30/30 OK`.

## Fix

Move `integrity-check.sh` into `coo-bootstrap.sh`'s `_on_exit` trap. The
trap fires on **every** exit path — warm-skip, refuse-non-COO-gitconfig,
`CLAUDE_CODE_REMOTE!=true` skip, full-run success, and any failure — so
the check always runs after bootstrap's state mutations are durable.

Synchronization: bootstrap writes a per-session finalize sentinel at
`$HOME/.vade/.coo-bootstrap-finalized` containing `$CLAUDE_CODE_SESSION_ID`.
`coo-identity-digest.sh` polls for the sentinel with matching session ID
(60s timeout, `VADE_DIGEST_BOOTSTRAP_TIMEOUT` override) before reading
`integrity-check.json`. The match-on-session-id avoids picking up a
stale sentinel from a prior session in the same container.

## Trade-off

Bootstrap wall time grows by integrity-check's ~17s, since the two no
longer overlap in parallel. The previous overlap was the bug; this is
deliberate serialization.

## Files

- `scripts/boot/coo-bootstrap.sh` — append integrity-check + finalize
  sentinel to `_on_exit`.
- `scripts/lifecycle/coo-identity-digest.sh` — `_wait_for_bootstrap_finalized`
  at top; drop redundant integrity-check call; drop now-redundant step 3
  from the recovery banner.
- `scripts/boot/session-start-sync.sh` — comment fix (points at the new
  ordering).
- `scripts/ci/run-bootstrap-regression.sh` — comment fix (CI driver still
  invokes integrity-check explicitly because it doesn't run the full
  digest path; documented).

## Pre-merge gating

Verified in the current session by running `coo-bootstrap.sh` standalone
and confirming the trap fires:

```
$ rm -f /home/user/.vade-cloud-state/integrity-check.json \
        /root/.vade/.coo-bootstrap-finalized
$ bash $VADE_RUNTIME_DIR/scripts/boot/coo-bootstrap.sh
... coo-bootstrap: complete (~43s including integrity-check ~17s) ...
$ cat /root/.vade/.coo-bootstrap-finalized
f5936dc8-f955-4bee-b887-7e65ac184f21
$ echo $CLAUDE_CODE_SESSION_ID
f5936dc8-f955-4bee-b887-7e65ac184f21
$ jq '.summary | {ok, passed, total, degraded}' \
       /home/user/.vade-cloud-state/integrity-check.json
{"ok": true, "passed": 35, "total": 35, "degraded": []}
```

Wait function tested with matching sentinel (returns 0s) and mismatched
sentinel (times out at configured budget). Bash syntax checked on all
four edited files.

## Post-merge confirmation

The single qualifying signal is the next fresh-container boot under
the merged `main`. Handoff prompt for the next instance is posted as a
standalone PR comment per `coo-memory/operations/handoff-prompts.md`.

Refs MEMO-2026-06-04-nzxf (boot brake block-on-FAIL) — the boot-brake
flow already requires identity-stack consumption before any tool call,
so the race-fix and the brake interact cleanly.


Closes: n/a

https://claude.ai/code/session_012NhkFs7H819JByBdir8Zc3