### PR TITLE
boot: collapse bootstrap-dependent hooks into ordered post-bootstrap chain

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,22 +25,6 @@
           {
             "type": "command",
             "command": "bash \"$VADE_COO_MEMORY_DIR/.claude/_lib/memo-index.sh\""
-          },
-          {
-            "type": "command",
-            "command": "bash \"$VADE_RUNTIME_DIR/scripts/lifecycle/coo-identity-digest.sh\""
-          },
-          {
-            "type": "command",
-            "command": "bash \"$VADE_RUNTIME_DIR/scripts/lifecycle/discussions-digest.sh\""
-          },
-          {
-            "type": "command",
-            "command": "bash \"$VADE_RUNTIME_DIR/scripts/lifecycle/project-board-digest.sh\""
-          },
-          {
-            "type": "command",
-            "command": "bash \"$VADE_RUNTIME_DIR/scripts/lifecycle/session-idle-watchdog.sh\" --start"
           }
         ]
       },

--- a/scripts/boot/coo-bootstrap.sh
+++ b/scripts/boot/coo-bootstrap.sh
@@ -67,16 +67,21 @@ except Exception as e:
     esac
   fi
 
-  # ── Hoisted integrity-check + finalize signal ─────────────────────
-  # Refresh integrity-check.json here, at the END of coo-bootstrap, so
-  # the JSON reflects FINAL post-bootstrap state instead of a parallel-
-  # hook mid-bootstrap snapshot. coo-identity-digest.sh runs in parallel
-  # under the SessionStart:startup matcher; previously its own integrity-
-  # check call observed bootstrap state mid-mutation and surfaced false-
-  # positive BOOT DEGRADED banners on otherwise-green boots. The digest
-  # now polls for the per-session finalize sentinel below before reading
-  # the JSON.
-  bash "$VADE_RUNTIME_DIR/scripts/boot/integrity-check.sh" >/dev/null 2>&1 || true
+  # ── Fast integrity-check + post-bootstrap chain ─────────────────
+  # The boot integrity check runs here, at bootstrap's tail, in fast
+  # phase only (Group E live network probes are deferred to the
+  # background pass kicked off by post-bootstrap-chain.sh). Then the
+  # ordered chain of bootstrap-dependent hooks (digest → discussions
+  # → project-board → idle-watchdog → live integrity-check) runs as
+  # children of this process — they no longer race coo-bootstrap as
+  # parallel SessionStart:startup siblings. See post-bootstrap-chain.sh.
+  VADE_INTEGRITY_PHASE=fast \
+    bash "$VADE_RUNTIME_DIR/scripts/boot/integrity-check.sh" >/dev/null 2>&1 || true
+  bash "$VADE_RUNTIME_DIR/scripts/boot/post-bootstrap-chain.sh" || true
+
+  # Sentinel retained for back-compat with any external consumer that
+  # still polls it. Boot-path consumers (digest, discussions-digest,
+  # project-board-digest) read the JSON directly now.
   mkdir -p "$HOME/.vade" 2>/dev/null || true
   printf '%s\n' "${CLAUDE_CODE_SESSION_ID:-unknown}" \
     > "$HOME/.vade/.coo-bootstrap-finalized" 2>/dev/null || true

--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -34,11 +34,19 @@ fi
 
 OUT_FILE="${VADE_CLOUD_STATE_DIR}/integrity-check.json"
 
-# Unlink any prior-session output: the writers below swallow write failures,
-# so without this a failed write leaves stale data masquerading as current.
-# Loud absence is the right polarity for the CLAUDE.md step-1 gate.
+# Phase gate. `fast` skips Group E (live network probes, 30–115 s) so
+# the boot-path call from coo-bootstrap's exit trap completes in <1 s.
+# `live` (default) runs every group. The post-bootstrap chain re-runs
+# in `live` mode in the background to refresh E group results without
+# blocking the boot banner. See post-bootstrap-chain.sh.
+VADE_INTEGRITY_PHASE="${VADE_INTEGRITY_PHASE:-live}"
+
+# Atomic-write target — write to .tmp, rename into place. Previous
+# revisions `rm -f`-then-rewrote the destination directly; any consumer
+# reading during the write window (boot-brake-guard.py parses_json,
+# digest summary read) saw a partial file. Atomic rename eliminates
+# the window without changing semantics for steady-state readers.
 mkdir -p "$(dirname "$OUT_FILE")" 2>/dev/null || true
-rm -f "$OUT_FILE"
 
 RUNTIME_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # Workspace root: parent of vade-runtime. /home/user on cloud,
@@ -363,6 +371,18 @@ else
 fi
 
 # ── Group E: MCP surface ─────────────────────────────────────
+# Phase gate. `fast` (the boot-path call from coo-bootstrap's exit
+# trap) marks E1–E9 as `pending` and skips the live probes entirely,
+# so bootstrap finishes in <1 s. The post-bootstrap chain re-runs in
+# the default `live` phase to refresh E group results in the
+# background after the boot banner has rendered.
+if [ "$VADE_INTEGRITY_PHASE" = "fast" ]; then
+  for _e in E1 E2 E3 E4 E5 E6 E7 E8 E9; do
+    _add "$_e" skip "phase=fast: live MCP probes deferred; refreshed by post-bootstrap-chain live pass"
+  done
+fi
+
+if [ "$VADE_INTEGRITY_PHASE" != "fast" ]; then
 # Requires MCP tool calls (get_me on github and github-coo namespaces).
 # An agent invoking this directly should fill E1/E2/E3/E4 into the
 # JSON afterwards. CI skips E1-E4 entirely. E5 is a script-level probe
@@ -890,6 +910,7 @@ else
   fi
 fi
 _add E9 "$E9_ok" "$E9_detail"
+fi  # close VADE_INTEGRITY_PHASE != "fast" gate around Group E
 
 # ── Group F: Culture-system substrate discipline ─────────────
 # Implements E1–E4 from foundations/2026-04-22_we-can-claim-a-record.md
@@ -1412,7 +1433,9 @@ if check_cmd node; then
       summary: { ok: degraded.length === 0, passed: okCount, total, degraded },
       groups,
     };
-    fs.writeFileSync(outFile, JSON.stringify(out, null, 2) + "\n");
+    const tmpFile = outFile + ".tmp." + process.pid;
+    fs.writeFileSync(tmpFile, JSON.stringify(out, null, 2) + "\n");
+    fs.renameSync(tmpFile, outFile);
     const tag = out.summary.ok ? "OK" : "DEGRADED";
     process.stderr.write(`VADE integrity: ${okCount}/${total} ${tag}`
       + (degraded.length ? ` — degraded (${degraded.join(",")})` : "")
@@ -1421,12 +1444,15 @@ if check_cmd node; then
     echo "[vade-setup] integrity-check: node writer failed; leaving stale file" >&2
   }
 else
-  # Fallback: newline-separated triples, no JSON.
+  # Fallback: newline-separated triples, no JSON. Atomic write via
+  # tmpfile + mv so consumers don't observe a partial file.
+  _tmp_fallback="${OUT_FILE}.tmp.$$"
   {
     printf 'checked_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     printf 'session_id=%s\n' "${CLAUDE_CODE_SESSION_ID:-unknown}"
     printf '%s\n' "${RESULTS[@]}"
-  } > "$OUT_FILE" 2>/dev/null || true
+  } > "$_tmp_fallback" 2>/dev/null && mv -f "$_tmp_fallback" "$OUT_FILE" 2>/dev/null || true
+  rm -f "$_tmp_fallback" 2>/dev/null || true
   echo "[vade-setup] integrity-check: node missing; wrote key=value file to $OUT_FILE" >&2
 fi
 

--- a/scripts/boot/post-bootstrap-chain.sh
+++ b/scripts/boot/post-bootstrap-chain.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# post-bootstrap-chain.sh — ordered execution of bootstrap-dependent hooks.
+#
+# Why this exists: Claude Code's SessionStart:startup matcher runs all
+# hooks in parallel (docs.claude.com/en/docs/claude-code/hooks: "All
+# matching hooks run in parallel"). Hooks that depend on coo-bootstrap-
+# written state (settings.json env, .vade-cloud-state/integrity-check.json,
+# the coo-bootstrap.log terminal entry) cannot reliably read that state
+# as parallel siblings — the resulting wait+sentinel patches stacked four
+# times in six weeks (#427, #442, #445, plus the brake's identity_consumed
+# race). The architectural rule: bootstrap-dependent hooks run as ordered
+# children of coo-bootstrap.sh, not as parallel siblings under SessionStart.
+#
+# coo-bootstrap.sh's _on_exit trap calls this script after fast integrity-
+# check has written its JSON. Each child inherits bootstrap's env directly
+# (PATs, MEM0_API_KEY, etc) without polling for a sentinel.
+#
+# Children, in order:
+#   1. coo-identity-digest    — boot banner; renders integrity-check
+#                               summary, identity layer, memos, etc.
+#   2. discussions-digest     — recent coo-labs discussions
+#   3. project-board-digest   — VADE board In-Progress items
+#   4. session-idle-watchdog  — daemon start; the script's --start
+#                               form forks a worker via nohup and
+#                               returns immediately
+#   5. integrity-check live   — E5–E9 network probes; backgrounded
+#                               so it doesn't tail the chain
+#
+# Failure isolation: any single child failing must not block the rest.
+# Each invocation is wrapped to swallow non-zero exits.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+
+boot_log_record post-bootstrap-chain start
+trap '_rc=$?; boot_log_record post-bootstrap-chain end $([ $_rc -eq 0 ] && echo ok || echo fail) rc=$_rc' EXIT
+
+LIFECYCLE_DIR="$SCRIPT_DIR/../lifecycle"
+
+_run_child() {
+  local name="$1" path="$2"
+  shift 2
+  if [ ! -x "$path" ] && [ ! -r "$path" ]; then
+    log "post-bootstrap-chain: $name missing at $path; skipping"
+    return 0
+  fi
+  bash "$path" "$@" || log "post-bootstrap-chain: $name exited non-zero (rc=$?); continuing"
+}
+
+_run_child coo-identity-digest    "$LIFECYCLE_DIR/coo-identity-digest.sh"
+_run_child discussions-digest     "$LIFECYCLE_DIR/discussions-digest.sh"
+_run_child project-board-digest   "$LIFECYCLE_DIR/project-board-digest.sh"
+_run_child session-idle-watchdog  "$LIFECYCLE_DIR/session-idle-watchdog.sh" --start
+
+# integrity-check live phase: backgrounded, output discarded.
+# Updates integrity-check.json in place with E5–E9 results once probes
+# complete. The boot banner (from the digest above) has already rendered
+# fast-phase results; consumers reading later (debug-mode skill,
+# /verify-secrets, etc.) get the merged result.
+nohup bash "$SCRIPT_DIR/integrity-check.sh" >/dev/null 2>&1 < /dev/null &
+disown 2>/dev/null || true
+
+exit 0

--- a/scripts/lifecycle/coo-identity-digest.sh
+++ b/scripts/lifecycle/coo-identity-digest.sh
@@ -74,29 +74,12 @@ SKIP_SENTINEL="${HOME}/.vade/.coo-bootstrap-skip-reason"
 # unmissable; combined with CLAUDE.md step 1 reading the JSON file,
 # the agent's first action on a degraded boot is surface-to-BDFL.
 #
-# Wait for coo-bootstrap.sh's per-session finalize sentinel before
-# reading the JSON. Both hooks run in parallel under SessionStart:startup;
-# without this sync the JSON we read below would reflect mid-bootstrap
-# state and produce stale BOOT DEGRADED banners on otherwise-green boots.
-# coo-bootstrap.sh runs integrity-check.sh at the tail of its EXIT trap
-# and writes the sentinel containing CLAUDE_CODE_SESSION_ID; we match on
-# that to avoid picking up a stale sentinel from a prior session.
-_wait_for_bootstrap_finalized() {
-  local sentinel="$HOME/.vade/.coo-bootstrap-finalized"
-  local our_session="${CLAUDE_CODE_SESSION_ID:-unknown}"
-  local timeout="${VADE_DIGEST_BOOTSTRAP_TIMEOUT:-60}"
-  local waited=0
-  while [ "$waited" -lt "$timeout" ]; do
-    if [ -f "$sentinel" ] \
-       && [ "$(cat "$sentinel" 2>/dev/null || true)" = "$our_session" ]; then
-      return 0
-    fi
-    sleep 1
-    waited=$((waited + 1))
-  done
-  return 1
-}
-_wait_for_bootstrap_finalized || true
+# Per-session sentinel wait removed. The digest now runs as an ordered
+# child of coo-bootstrap.sh via post-bootstrap-chain.sh; bootstrap has
+# already written integrity-check.json (atomic) and exported its env
+# into our scope before this script starts. The race surface is gone
+# by construction — no wait, no timeout, no fall-through to "unknown".
+# See the architectural rule memo paired with this change.
 
 _integrity_ok="unknown"
 _integrity_passed="?"
@@ -177,6 +160,19 @@ elif [ "$_integrity_ok" = "true" ]; then
   # still see the result at first screen).
   echo "───────────────────────────────────────────────────────────────"
   echo "Boot integrity: summary.ok=true  ($_integrity_passed/$_integrity_total)  — full report: $INTEGRITY_CHECK"
+  echo "───────────────────────────────────────────────────────────────"
+  echo ""
+else
+  # Defensive: with the structural collapse (digest runs as a child
+  # of coo-bootstrap, integrity-check writes atomically before this
+  # script starts) this branch should be unreachable. Emit a loud
+  # marker if it ever fires — silent "unknown" was the failure mode
+  # the structural fix was meant to eliminate.
+  echo "───────────────────────────────────────────────────────────────"
+  echo "Boot integrity: INDETERMINATE — could not read summary from $INTEGRITY_CHECK"
+  echo "  (expected ok=true or ok=false; got $_integrity_ok)"
+  echo "  File exists? $([ -f "$INTEGRITY_CHECK" ] && echo yes || echo no)"
+  echo "  node present? $(check_cmd node && echo yes || echo no)"
   echo "───────────────────────────────────────────────────────────────"
   echo ""
 fi
@@ -332,17 +328,10 @@ fi
 # When (b) diverges from (c), the current session's MCP tools are
 # stale — a restart will pick up the populated env block.
 #
-# SessionStart hooks run in parallel. Without the wait below, we'd
-# sample env and settings.json mid-bootstrap and falsely report
-# degraded even when coo-bootstrap eventually completes cleanly (the
-# first user-visible regression after PR #20 landed: verification
-# run reported "degraded" despite OK-step=complete in the log).
-# Shared helper in lib/common.sh; exposes
-# VADE_BOOTSTRAP_WAIT_{SAW_FRESH,ELAPSED,TIMEOUT}.
-wait_for_coo_bootstrap 60
-_digest_saw_fresh="${VADE_BOOTSTRAP_WAIT_SAW_FRESH:-0}"
-_digest_wait_elapsed="${VADE_BOOTSTRAP_WAIT_ELAPSED:-0}"
-_digest_wait_timeout="${VADE_BOOTSTRAP_WAIT_TIMEOUT:-60}"
+# wait_for_coo_bootstrap removed: the digest now runs as an ordered
+# child of coo-bootstrap.sh (post-bootstrap-chain.sh), so bootstrap's
+# terminal log line and env are already in place by the time we read
+# them. No race, no timeout.
 
 echo ""
 echo "───────────────────────────────────────────────────────────────"
@@ -354,14 +343,6 @@ if [ -f "$BOOTSTRAP_LOG" ]; then
   [ -n "$last_line" ] && echo "  Last bootstrap: $last_line"
 else
   echo "  Last bootstrap: (no log at $BOOTSTRAP_LOG)"
-fi
-
-if [ "$_digest_saw_fresh" -eq 0 ]; then
-  if [ "$_digest_wait_elapsed" -ge "$_digest_wait_timeout" ]; then
-    echo "  WARN: timed out after ${_digest_wait_timeout}s waiting for a fresh bootstrap terminal state."
-  else
-    echo "  Note: no fresh bootstrap state this session (hook didn't fire, or finished before digest started)."
-  fi
 fi
 
 env_has_pat="no"; env_has_mail="no"; env_has_cf="no"
@@ -567,13 +548,13 @@ echo "                            Do NOT add GH_TOKEN=\$GITHUB_MCP_PAT — it de
 echo "                            shim. harness github MCP writes deny-listed (#112 S1)."
 echo "───────────────────────────────────────────────────────────────"
 
-# Note: integrity-check.sh runs from coo-bootstrap.sh's EXIT trap.
-# The TOP-of-digest wait (_wait_for_bootstrap_finalized) blocks until
-# that trap has fired for this session, so integrity-check.json is
-# current by the time any block in this script reads it. The previous
-# in-digest invocation (Phase A of coo-memory#762) raced coo-bootstrap
-# under SessionStart:startup parallelism and surfaced stale BOOT
-# DEGRADED banners on otherwise-green boots.
+# Note: integrity-check.sh (fast phase) runs from coo-bootstrap.sh's
+# EXIT trap before this script starts. The digest now executes as an
+# ordered child of bootstrap via post-bootstrap-chain.sh, so the JSON
+# is already written by the time any block here reads it. No wait,
+# no sentinel polling. The parallel-hook race surface that produced
+# false-positive BOOT DEGRADED banners (and the silent-unknown follow-on
+# from PR #445) is eliminated by construction.
 
 # Mem0 read/write surface — same banner pattern as "GitHub write surface"
 # above. Per coo-harness#109, the hosted Mem0 MCP at mcp.mem0.ai hits

--- a/scripts/lifecycle/discussions-digest.sh
+++ b/scripts/lifecycle/discussions-digest.sh
@@ -17,11 +17,9 @@ source "$SCRIPT_DIR/../lib/common.sh"
 boot_log_record discussions-digest start
 trap '_rc=$?; boot_log_record discussions-digest end $([ $_rc -eq 0 ] && echo ok || echo fail) rc=$_rc' EXIT
 
-# SessionStart hooks run in parallel; coo-bootstrap may still be
-# writing ~/.vade/coo-env when we reach the TOKEN check below. Wait
-# for a fresh bootstrap terminal state before sampling env (no-op and
-# fast-exits when bootstrap isn't running).
-wait_for_coo_bootstrap 60
+# wait_for_coo_bootstrap removed: this script now runs as an ordered
+# child of coo-bootstrap.sh via post-bootstrap-chain.sh; bootstrap's
+# env is in place by the time we sample the token.
 
 TOKEN="${GITHUB_TOKEN:-${GITHUB_MCP_PAT:-}}"
 if [ -z "$TOKEN" ]; then

--- a/scripts/lifecycle/project-board-digest.sh
+++ b/scripts/lifecycle/project-board-digest.sh
@@ -18,7 +18,9 @@ source "$SCRIPT_DIR/../lib/common.sh"
 boot_log_record project-board-digest start
 trap '_rc=$?; boot_log_record project-board-digest end $([ $_rc -eq 0 ] && echo ok || echo fail) rc=$_rc' EXIT
 
-wait_for_coo_bootstrap 60
+# wait_for_coo_bootstrap removed: this script now runs as an ordered
+# child of coo-bootstrap.sh via post-bootstrap-chain.sh; bootstrap's
+# env is in place by the time we sample the token.
 
 TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-${GITHUB_MCP_PAT:-}}}"
 if [ -z "$TOKEN" ]; then


### PR DESCRIPTION
Closes #447.

## Why

Tonight's boot exposed PR #445's wait-then-read pattern as a recurring shape, not a tunable parameter. Session `0e276dfa…`: bootstrap retry path (first attempt failed at `install_coo_ssh_keys`) plus a 36 s `integrity-check.sh` (E5–E9 live network probes) pushed total elapsed to ~78 s, past the digest's 60 s `_wait_for_bootstrap_finalized` budget. Digest read mid-write `integrity-check.json` (writes were non-atomic), node parse failed silently in `try/catch`, `_integrity_ok` stayed `"unknown"`, and the digest's branch table fell through emitting **neither** the green `Boot integrity: summary.ok=true` line **nor** the loud `BOOT DEGRADED` block. Silent on integrity state — strictly worse than the original false-positive failure mode #445 was meant to fix.

This is the fourth parallel-hook race patch in six weeks: #427 (CCR-hook ↔ git author), #442 (false-positive integrity banner), #445 (digest sentinel + 60 s wait), plus the brake's own 6 s `identity_consumed` race ([coo-memory MEMO-2026-06-04-nzxf](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-04-nzxf.md)). Each patch addressed a symptom of one architectural choice: `SessionStart:startup` parallel execution with read-after-write dependencies between siblings. The cleanest fix removes the parallel-dependency surface entirely.

See [#447 comment](https://github.com/coo-labs/coo-harness/issues/447#issuecomment-4628606787) for the full diagnosis.

## What changed

1. **`scripts/boot/post-bootstrap-chain.sh`** — new ordered wrapper. Invokes digest → discussions-digest → project-board-digest → idle-watchdog `--start` (forked internally) → integrity-check live phase (backgrounded). Children inherit bootstrap's env directly; no sentinel handoff.
2. **`scripts/boot/coo-bootstrap.sh`** `_on_exit` trap — runs `VADE_INTEGRITY_PHASE=fast integrity-check.sh` (skips E5–E9), then `post-bootstrap-chain.sh` synchronously. Sentinel write retained for any external poller.
3. **`scripts/boot/integrity-check.sh`** — `VADE_INTEGRITY_PHASE` env gates Group E:
   - `fast` → skips E1–E9 with `skipped: true, detail: "phase=fast: live MCP probes deferred…"`. Runs in <1 s plus whatever Group D's `op` CLI calls and Group F's git calls take (~19 s in this session's test; can be tightened separately).
   - `live` (default) → runs every group. Used for on-demand (`/verify-secrets`, `debug-mode`) and the post-boot background pass.
   - JSON write is atomic (tmpfile + rename). Defends against any reader observing a partial file.
4. **`scripts/lifecycle/coo-identity-digest.sh`** — deletes `_wait_for_bootstrap_finalized` (lines 84–99 of pre-change) and the second `wait_for_coo_bootstrap 60` call. Adds a defensive `BOOT INDETERMINATE` block in the previously-silent `_integrity_ok="unknown"` branch — should now be structurally unreachable but emits loud if it ever fires.
5. **`scripts/lifecycle/discussions-digest.sh`**, **`scripts/lifecycle/project-board-digest.sh`** — drop their `wait_for_coo_bootstrap` calls. No race to wait for.
6. **`.claude/settings.json`** — drops digest / discussions-digest / project-board-digest / idle-watchdog from `SessionStart:startup`. `boot-brake-clear`, `session-start-sync`, `coo-bootstrap`, `memo-index` remain parallel (no bootstrap dependency).

`wait_for_coo_bootstrap` stays defined in `scripts/lib/common.sh` in case any out-of-tree consumer references it. All in-tree boot-path callers removed.

## Architectural rule (memo'd)

Companion memo [`coo-memory#MEMO-2026-06-05-ootw`](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-05-ootw.md) (PR: coo-labs/coo-memory/pull/__filed-separately__) names the rule:

> Bootstrap-dependent hooks must not run as parallel siblings of `coo-bootstrap.sh` under `SessionStart:startup`. They run as ordered children — invoked from bootstrap's `_on_exit` trap via `post-bootstrap-chain.sh` — inheriting bootstrap's env directly. Any hook whose script polls `coo-bootstrap.log`, `.coo-bootstrap-finalized`, `integrity-check.json`, or `settings.json` env that bootstrap merges is a bootstrap dependent.

Closes the line of analysis from the undelivered 2026-05-27 boot-context audit ([coo-memory#758](https://github.com/coo-labs/coo-memory/issues/758)), which was commissioned to surface exactly this class of "unenforceable rule via hook topology."

## Brake compatibility

- `boot-brake-guard.py`'s `PRODUCERS_TO_TRACK` includes `coo-identity-digest`. The digest still calls `boot_log_record coo-identity-digest start/end` from inside `post-bootstrap-chain.sh`'s child process — boot.log entries identical to before. Brake's race-gate sees them the same way.
- `integrity_check_json` deliverable uses `parses_json` (not `summary.ok`) — fast-phase JSON parses fine, brake gate passes immediately after bootstrap's trap completes.
- `identity_consumed` predicate globs `hook-*-stdout.txt` for any hook output file. The digest's content now appears in coo-bootstrap's hook-stdout (since post-bootstrap-chain runs inside bootstrap's process). The glob still matches; predicate still fires.

## Verification

This PR cannot be verified in-session — `SessionStart` only fires at session boot, and the active settings.json synced from the previous commit is still in this session's `.claude/`. **Verify on a fresh container boot per the handoff prompt below this PR description (posted as a comment).**

End-to-end smoke test in this session: fast-phase `integrity-check.sh` runs and writes valid atomic JSON, with E1–E9 marked `skipped: true / phase=fast`. Bash syntax check passes on every modified script. settings.json parses cleanly.

Bootstrap-regression CI (`.github/workflows/bootstrap-regression.yml`) runs Layer-1 on this PR.

## Out of scope (separate issues worth filing)

- `install_coo_ssh_keys` failed on first attempt at 05:04:31 with rc=1 this session, forcing the retry that pushed total bootstrap time past 60 s. Worth tracking — but the structural fix is robust to bootstrap slowness regardless of cause.
- S8 `CLAUDE_ENV_FILE` `unknown_secret_shape` flagged by tonight's check is a real degraded invariant, orthogonal to the race.
- Boot-path Group D (`op` CLI calls) and Group F (git operations) still account for ~19 s of fast-phase runtime. Reducible separately if it matters.

## Linked work

- Issue: #447
- Memo: [coo-memory MEMO-2026-06-05-ootw](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-05-ootw.md) (companion PR in coo-memory on the same branch)
- Prior patches: #427, #442, #445
- Audit context: [coo-memory#758](https://github.com/coo-labs/coo-memory/issues/758) (undelivered 2026-05-27 boot-context audit)
- Related brake race: [coo-memory MEMO-2026-06-04-nzxf](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-04-nzxf.md)

https://claude.ai/code/session_01NiSvz4uK2cRojqTpzVad84