### PR TITLE
secrets-epic closeout: gh-coo-wrap PUBLIC fix + Phase 2 cleanup + S1/S4 fixes + new S9 invariant

### DIFF
--- a/.claude/output-styles/coo.md
+++ b/.claude/output-styles/coo.md
@@ -21,7 +21,9 @@ These override harness defaults that would otherwise compete:
    in `.claude/settings.json`. Raw `curl`/`wget`/`python` to `api.github.com` is refused by the
    `bash-github-api-guard.sh` PreToolUse hook. When a `gh` write fails silently (exit 1, zero
    bytes stdout, zero bytes stderr), the canonical first response is
-   `bash coo-harness/scripts/check-pat-freshness.sh`.
+   `bash coo-harness/scripts/check-pat-freshness.sh` — exits `OK` (cache current), `STALE`
+   (rm `$XDG_RUNTIME_DIR/coo-gh-pat-cache/MCP*` and retry), `CACHE-MISS` (fresh session;
+   trigger any `gh` call to populate), or `OP-UNREACHABLE` (SA-token rate-limit or network).
 
 2. **PR open is deliberate, not automatic.** Do not open a PR after every push. Multiple commits
    on a `claude/*` feature branch are normal. Open the PR when the change is review-ready, using

--- a/README.md
+++ b/README.md
@@ -80,10 +80,14 @@ invokes `scripts/coo-bootstrap.sh`, which:
    creds from the 1Password `COO` vault
 4. Writes `~/.ssh/vade-coo-{auth,sign}`, `~/.ssh/allowed_signers`,
    `~/.gitconfig` with COO identity + signed-commit config
-5. Writes `~/.vade/coo-env` (sourceable) and merges vars into
-   `~/.claude/settings.json` so `.mcp.json` `${GITHUB_MCP_PAT}`,
-   `${AGENTMAIL_API_KEY}`, `${MEM0_API_KEY}`,
-   `${OP_SERVICE_ACCOUNT_TOKEN}` substitutions resolve
+5. Exports the credentials into the bootstrap process env (Phase 2;
+   coo-memory#873). Secrets are NOT persisted to `~/.vade/coo-env`
+   (retired) or `~/.claude/settings.json::env` (scrubbed). MCP children
+   receive secrets via `op run --env-file=/dev/shm/coo-mcp-env/*.env`;
+   gh-coo-wrap caches PAT values in tmpfs (`$XDG_RUNTIME_DIR/coo-gh-pat-cache/`)
+   with a 5-minute TTL. Wrapper scripts that need a secret at call
+   time use an inline `op read` resolver (pattern in
+   `scripts/lifecycle/session-end-transcript-export.sh`)
 6. Validates the PAT is actually for `vade-coo` — aborts loudly on
    mismatch
 

--- a/lib/transcripts/r2.py
+++ b/lib/transcripts/r2.py
@@ -80,7 +80,8 @@ def r2_coordinates() -> R2Coordinates:
     if not access_key or not secret_key:
         raise R2Error(
             "R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY "
-            "missing — source ~/.vade/coo-env first"
+            "missing — ensure the bash wrapper ran its op-read resolver "
+            "(Phase 2 post-coo-memory#873) or set both vars explicitly"
         )
     endpoint = _op_read("op://COO/r2-transcripts/endpoint")
     bucket = _op_read("op://COO/r2-transcripts/bucket")

--- a/scripts/boot/cloud-setup.sh
+++ b/scripts/boot/cloud-setup.sh
@@ -234,7 +234,27 @@ fi
 # is exported; fail-open if either is missing or external-touch.py is
 # absent (CI fake-env stages a stub coo-memory without it).
 # coo-memory#429 cache-refresh follow-up.
-. "$HOME/.vade/coo-env" 2>/dev/null || true
+#
+# Phase 2 (coo-memory#873) retired ~/.vade/coo-env. The legacy source
+# line below stays as belt-and-suspenders for Phase-1-staged snapshots;
+# in the Phase-2 path the inline resolver does the work. Pattern mirrors
+# coo-harness#446's session-end-transcript-export.sh resolver — op-read
+# routed through op-coo-wrap so primary→BACKUP SA-token failover is
+# absorbed transparently. Fail-open: missing op CLI, op-read failure, or
+# empty value all leave $GITHUB_MCP_PAT unset and external-touch
+# degrades to its no-PAT path.
+if [ -f "${HOME}/.vade/coo-env" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$HOME/.vade/coo-env" 2>/dev/null || true
+fi
+_resolve_external_touch_secrets() {
+  command -v op >/dev/null 2>&1 || return 0
+  [ -n "${GITHUB_MCP_PAT:-}" ] && return 0
+  local val
+  val="$(op read 'op://COO/vade-coo-self-2026-04/token' 2>/dev/null)" || return 0
+  [ -n "$val" ] && export GITHUB_MCP_PAT="$val"
+}
+_resolve_external_touch_secrets
 prewarm_external_touch_cache "$WORKSPACE_ROOT"
 
 # Durable receipt so sessions can diagnose build-time state without

--- a/scripts/check-pat-freshness.sh
+++ b/scripts/check-pat-freshness.sh
@@ -1,38 +1,67 @@
 #!/usr/bin/env bash
-# check-pat-freshness: detect whether the in-process COO PAT
-# (env GITHUB_MCP_PAT) is stale relative to the canonical value in
-# 1Password (op://COO/vade-coo-self-2026-04/token).
+# check-pat-freshness: detect whether the gh-coo-wrap PAT cache (tmpfs)
+# is current relative to the canonical value in 1Password
+# (op://COO/vade-coo-self-2026-04/token per schema.yaml).
 #
 # Use this as the FIRST response when a `gh` write fails silently:
 # exit 1, zero bytes stdout, zero bytes stderr. That signature is the
 # canonical fingerprint of a stale-PAT mid-session — see
 # MEMO-2026-05-21-r9rt and coo-labs/coo-memory#820.
 #
+# Phase 2 (coo-memory#873) retired GITHUB_MCP_PAT from process env;
+# gh-coo-wrap.sh now caches the resolved PAT in tmpfs at
+# $XDG_RUNTIME_DIR/coo-gh-pat-cache/MCP with a 5-minute TTL. This script
+# inspects that cache rather than process env (which is structurally
+# empty post-Phase-2; see integrity-group-s.sh S2 comment).
+#
 # Output (single line) one of:
-#   OK <sha8>                          — env matches 1Password
-#   STALE env=<sha8> op=<sha8>         — env differs; rotate session
-#   OP-UNREACHABLE <reason>            — could not read 1Password
-#   ENV-MISSING                        — GITHUB_MCP_PAT not in env
+#   OK <sha8>                            — cache matches 1Password
+#   STALE cache=<sha8> op=<sha8>         — cache drifted; rm cache + retry gh call
+#   CACHE-MISS                           — tmpfs cache absent (fresh session);
+#                                          trigger any `gh` call to populate
+#   OP-UNREACHABLE <reason>              — could not read 1Password
 #
-# Exit codes: 0 OK, 1 STALE, 2 OP-UNREACHABLE, 3 ENV-MISSING.
+# Exit codes: 0 OK, 1 STALE, 2 OP-UNREACHABLE, 3 CACHE-MISS.
 #
-# Recovery on STALE: refresh the env in this session via
-#   eval "$(op signin --account ...)"  # if running locally, or
-#   export GITHUB_MCP_PAT="$(op read op://COO/vade-coo-self-2026-04/token)"
-# and re-run the failed gh write. In cloud, a fresh session inherits
-# the rotated value at boot.
+# Recovery on STALE: rm "$XDG_RUNTIME_DIR/coo-gh-pat-cache/MCP*" and
+# re-run the failed `gh` call. The wrap shim's _resolve_pat MCP path
+# will op-read fresh and re-populate.
 #
-# Source: issue coo-labs/coo-memory#820.
+# Recovery on CACHE-MISS: this is the expected first-call state of a
+# fresh session. Trigger any `gh` invocation; the cache populates on
+# the next _resolve_pat call.
+#
+# Sources: coo-labs/coo-memory#820, #873 (Phase 2), 2026-06-05 epic
+# closeout.
 
 set -eu
 
-env_pat="${GITHUB_MCP_PAT:-}"
-if [ -z "$env_pat" ]; then
-  printf 'ENV-MISSING\n'
+# The schema's canonical reference for vade-coo's PAT. Hardcoded here
+# rather than re-read from schema.yaml because this script is the
+# diagnostic path; a schema-fetch dependency would create a chicken-
+# and-egg loop when the schema itself is what we're testing the cache
+# against.
+OP_REF="op://COO/vade-coo-self-2026-04/token"
+
+# tmpfs cache location used by gh-coo-wrap.sh _resolve_pat MCP branch.
+# XDG_RUNTIME_DIR is the cloud-container default; fall back to /tmp
+# only if unset (matches the shim's own fallback at gh-coo-wrap.sh:112).
+CACHE_DIR="${XDG_RUNTIME_DIR:-/tmp}/coo-gh-pat-cache"
+CACHE_FILE="$CACHE_DIR/MCP"
+
+if [ ! -f "$CACHE_FILE" ]; then
+  printf 'CACHE-MISS\n'
   exit 3
 fi
 
-env_sha=$(printf '%s' "$env_pat" | sha256sum | cut -c1-8)
+cache_pat=$(cat "$CACHE_FILE" 2>/dev/null || true)
+if [ -z "$cache_pat" ]; then
+  # Cache file exists but is empty — same operational meaning as miss.
+  printf 'CACHE-MISS\n'
+  exit 3
+fi
+
+cache_sha=$(printf '%s' "$cache_pat" | sha256sum | cut -c1-8)
 
 if ! command -v op >/dev/null 2>&1; then
   printf 'OP-UNREACHABLE op-cli-missing\n'
@@ -43,7 +72,7 @@ if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
   exit 2
 fi
 
-if ! op_pat=$(op read "op://COO/vade-coo-self-2026-04/token" 2>/dev/null); then
+if ! op_pat=$(op read "$OP_REF" 2>/dev/null); then
   printf 'OP-UNREACHABLE op-read-failed\n'
   exit 2
 fi
@@ -54,10 +83,10 @@ fi
 
 op_sha=$(printf '%s' "$op_pat" | sha256sum | cut -c1-8)
 
-if [ "$env_sha" = "$op_sha" ]; then
-  printf 'OK %s\n' "$env_sha"
+if [ "$cache_sha" = "$op_sha" ]; then
+  printf 'OK %s\n' "$cache_sha"
   exit 0
 else
-  printf 'STALE env=%s op=%s\n' "$env_sha" "$op_sha"
+  printf 'STALE cache=%s op=%s\n' "$cache_sha" "$op_sha"
   exit 1
 fi

--- a/scripts/ci/test-gh-coo-wrap.sh
+++ b/scripts/ci/test-gh-coo-wrap.sh
@@ -532,8 +532,8 @@ fi
 case "${1:-}" in
   read)
     case "${2:-}" in
-      "op://COO/vade-coo-self-2026-04/token") echo "OPRESOLVED_MCP_PAT_FROM_STUB" ;;
-      "op://COO/GITHUB_PUBLIC_PAT/token")     echo "OPRESOLVED_PUBLIC_PAT_FROM_STUB" ;;
+      "op://COO/vade-coo-self-2026-04/token")      echo "OPRESOLVED_MCP_PAT_FROM_STUB" ;;
+      "op://COO/GITHUB_PUBLIC_PAT/credential")     echo "OPRESOLVED_PUBLIC_PAT_FROM_STUB" ;;
       *) echo "[mock op] unknown ref: ${2:-}" >&2; exit 2 ;;
     esac
     ;;

--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -104,7 +104,13 @@ _resolve_pat() {
         printf '%s' "$GITHUB_PUBLIC_PAT"
         return 0
       fi
-      op_path="op://COO/GITHUB_PUBLIC_PAT/token"
+      # Field is `credential` (confirmed 2026-06-05 via `op item get
+      # GITHUB_PUBLIC_PAT`). The audit-era `/token` path silently returned
+      # empty since the schema renamed the field; cross-org gh writes
+      # surfaced the bug for the first time mid-session. The new S9
+      # invariant in integrity-group-s.sh cross-checks hardcoded op-paths
+      # like this against schema.yaml::credentials[] to prevent re-regression.
+      op_path="op://COO/GITHUB_PUBLIC_PAT/credential"
       ;;
     *) return 0 ;;
   esac

--- a/scripts/lib/integrity-group-s.sh
+++ b/scripts/lib/integrity-group-s.sh
@@ -86,21 +86,26 @@ s_check_S1() {
     _add S1 skip "secrets-schema-check.py not found at $validator"
     return
   fi
-  if ! command -v python3 >/dev/null 2>&1; then
-    _add S1 skip "python3 not available"
-    return
-  fi
-  # Dependency check — PyYAML + jsonschema. If missing, skip cleanly
-  # (the Track 1a CI installs them; the cloud container has them; CI
-  # fake-env mode without them should not fail S1).
-  if ! python3 -c 'import yaml, jsonschema' >/dev/null 2>&1; then
-    _add S1 skip "PyYAML or jsonschema not importable in python3 — install with pip"
-    return
-  fi
-
+  # Prefer `uv run --script` if available — the validator carries PEP 723
+  # inline metadata declaring PyYAML + jsonschema as dependencies, so uv
+  # resolves them transparently (warm-cache after first run). Falls back
+  # to plain python3 + import probe if uv is absent (CI fake-env mode
+  # without uv stays clean by skipping).
   local out rc
-  out="$(python3 "$validator" "$schema" --schema "$schemajson" 2>&1)"
-  rc=$?
+  if command -v uv >/dev/null 2>&1; then
+    out="$(uv run --script "$validator" "$schema" --schema "$schemajson" 2>&1)"
+    rc=$?
+  elif command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c 'import yaml, jsonschema' >/dev/null 2>&1; then
+      _add S1 skip "uv unavailable AND PyYAML/jsonschema not importable in python3 — install uv or pip-install both"
+      return
+    fi
+    out="$(python3 "$validator" "$schema" --schema "$schemajson" 2>&1)"
+    rc=$?
+  else
+    _add S1 skip "neither uv nor python3 available"
+    return
+  fi
   if [ "$rc" -eq 0 ]; then
     _add S1 true "schema.yaml validates clean against schema.schema.json"
   else
@@ -413,7 +418,24 @@ s_check_S4() {
     [ -z "$cred_id" ] && continue
     total=$((total + 1))
     local raw stale_label stale_value
-    raw="$(op item get --format=json "$op_item" 2>/dev/null || true)"
+    # --vault COO required: service accounts refuse unqualified `op item get`
+    # ("a vault query must be provided when this command is called by a
+    # service account"). The pre-2026-06-05 S4 code omitted --vault and
+    # every item read failed silently, reporting all multi-field items as
+    # "unreadable via op (transient)" — masking the real S4 failure mode
+    # the invariant exists to catch.
+    raw="$(op item get --vault COO --format=json "$op_item" 2>/dev/null || true)"
+    # Schema-side known-exception: if op_field_notes for this credential
+    # contains the marker "S4-known-stale-empty", skip the check. Used
+    # for known-empty fields whose deletion is queued (op-side delete
+    # blocked by SA rate-limit or permission scope). Marker is a literal
+    # string, must appear in the .op_field_notes block to take effect.
+    local notes_marker
+    notes_marker="$(yq -r --arg op "$op_item" '.credentials[] | select(.op_item == $op) | .op_field_notes // ""' "$schema" 2>/dev/null | grep -c 'S4-known-stale-empty' || true)"
+    if [ "${notes_marker:-0}" -gt 0 ]; then
+      total=$((total - 1))  # exclude from total so the count stays meaningful
+      continue
+    fi
     if [ -z "$raw" ]; then
       unreadable=$((unreadable + 1))
       continue
@@ -817,6 +839,122 @@ PY
   fi
 }
 
+# ── S9: shim-vs-schema cross-check ────────────────────────────────
+#
+# Origin: 2026-06-05 secrets-epic close-out (MEMO-2026-06-05-v5qk).
+# The Ven-found bug `op://COO/GITHUB_PUBLIC_PAT/token` in gh-coo-wrap.sh
+# (schema declared `credential`; shim hardcoded `token`; silently
+# returned empty) was invisible to S1–S8 because each S-check inspects
+# either the schema OR the live op-state in isolation. S9 closes the
+# gap by cross-checking the script corpus's `op://COO/<item>/<field>`
+# references against the schema's declared `credentials[].op_item ×
+# (op_field ∪ op_alt_fields)` pairs.
+#
+# Exclusions per scope: test fixtures and CI mocks legitimately
+# contain synthetic op-paths (e.g. `scripts/ci/mocks/op` has the
+# stubbed responses; `scripts/ci/test-*.sh` parrot the shim's paths
+# for fixture purposes). False-positives on these would make S9
+# noisy without catching real bugs.
+s_check_S9() {
+  local schema; schema="$(_s_schema_yaml)"
+  if [ ! -f "$schema" ]; then
+    _add S9 skip "schema.yaml not found at $schema"
+    return
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    _add S9 skip "yq not available"
+    return
+  fi
+
+  # Resolve the scripts root. Default to the shipped coo-harness checkout;
+  # tests can override via $VADE_SECRETS_S9_SCRIPTS_ROOT.
+  local scripts_root
+  scripts_root="${VADE_SECRETS_S9_SCRIPTS_ROOT:-${VADE_RUNTIME_DIR:-/home/user/coo-harness}/scripts}"
+  if [ ! -d "$scripts_root" ]; then
+    _add S9 skip "scripts root not found at $scripts_root"
+    return
+  fi
+
+  # Build the allowed-set: every credentials[].op_item × (op_field ∪
+  # op_alt_fields[]) pair. Emit one `<item>|<field>` line per pair.
+  # Filters out the placeholder op_items that contain `(` (e.g.
+  # "(env-only — ...)", "(none — minted from ...)") since those are
+  # not real 1P items and no script should op-read them anyway.
+  local allowed
+  allowed="$(yq -r '
+    .credentials[]
+    | select(.op_item | test("^[^(]") )
+    | . as $c
+    | ($c.op_item + "|" + $c.op_field),
+      ( ($c.op_alt_fields // [])[] | ($c.op_item + "|" + .) )
+  ' "$schema" 2>/dev/null | sort -u)" || allowed=""
+
+  if [ -z "$allowed" ]; then
+    _add S9 skip "schema produced no op-paths to cross-check (parse failure?)"
+    return
+  fi
+
+  # Grep the scripts corpus for op://COO/<item>/<field> references.
+  # Exclude:
+  #   - **/test-*.sh / test-*.py    (test fixtures)
+  #   - **/ci/mocks/**              (CI op-mocks with synthetic responses)
+  #   - **/_archive/**              (historical, not live)
+  #   - comment lines (^[[:space:]]*#)   — doc/example refs are not bugs
+  # Item char class allows colon (e.g. "Service Account Auth Token:
+  # vade-coo"), period (date stamps), space (none today, but safe),
+  # underscore, hyphen, alnum. Field char class allows space (SSH keys
+  # use "private key" / "public key"), underscore, hyphen, alnum.
+  # `<`, `>`, `$`, `{`, `}`, `*`, backtick are excluded — those signal
+  # documentation placeholders, not real op-paths.
+  local raw_lines found
+  raw_lines="$(grep -rEhn 'op://COO/' "$scripts_root" \
+    --include='*.sh' --include='*.py' \
+    --exclude='test-*.sh' --exclude='test-*.py' \
+    --exclude-dir='mocks' --exclude-dir='_archive' \
+    2>/dev/null)" || raw_lines=""
+  # Strip the leading `<linenum>:` from each grep hit, drop comment
+  # lines, then extract op://COO/<item>/<field> tokens with the tight
+  # char classes. Sort+uniq for dedup.
+  found="$(printf '%s\n' "$raw_lines" \
+    | sed -E 's/^[0-9]+://' \
+    | awk '/^[[:space:]]*#/ { next } { print }' \
+    | grep -oE "op://COO/[A-Za-z0-9 _:.-]+/[A-Za-z0-9_-]+( [A-Za-z0-9_-]+)?" \
+    | sed -E 's/[[:space:]]+$//' \
+    | sort -u)" || found=""
+
+  if [ -z "$found" ]; then
+    # No op-paths found in scripts — green by absence (everything goes
+    # through the schema-driven fetcher).
+    _add S9 true "no hardcoded op://COO/ paths in scripts (schema-driven only)"
+    return
+  fi
+
+  # For each found <item>/<field>, check membership in allowed-set.
+  local bad=() checked=0
+  local item field key
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    checked=$((checked + 1))
+    # Strip the op://COO/ prefix and split on the LAST slash so item
+    # names containing slashes (none today, but future-proof) work.
+    local rest="${ref#op://COO/}"
+    item="${rest%/*}"
+    field="${rest##*/}"
+    key="${item}|${field}"
+    if ! printf '%s\n' "$allowed" | grep -qFx "$key"; then
+      bad+=("${item}/${field}")
+    fi
+  done <<< "$found"
+
+  if [ "${#bad[@]}" -eq 0 ]; then
+    _add S9 true "$checked op://COO/ refs in scripts all map to schema credentials[].(op_field|op_alt_fields[])"
+  else
+    # De-dup the bad list (multiple files can reference the same bad path).
+    local uniq_bad; uniq_bad="$(printf '%s\n' "${bad[@]}" | sort -u | tr '\n' ',' | sed 's/,$//')"
+    _add S9 false "shim/script op-paths not in schema: $(_s_trunc "$uniq_bad")"
+  fi
+}
+
 # Dispatch every S invariant. Called from integrity-check.sh.
 s_check_all() {
   s_check_S1
@@ -826,4 +964,5 @@ s_check_all() {
   s_check_S5
   s_check_S7
   s_check_S8
+  s_check_S9
 }

--- a/scripts/lib/integrity-group-s.sh
+++ b/scripts/lib/integrity-group-s.sh
@@ -856,6 +856,15 @@ PY
 # for fixture purposes). False-positives on these would make S9
 # noisy without catching real bugs.
 s_check_S9() {
+  # In CI fake-env mode the staged coo-memory is a stub (minimal schema
+  # without renames or alt-field declarations); cross-checking the real
+  # scripts/* corpus against it would false-positive. Same skip-pattern
+  # as S4/S7 (which gate via _s_op_live). The live-env run still
+  # exercises S9 fully.
+  if _s_in_ci_fake_env; then
+    _add S9 skip "skipped: CI fake-env stub coo-memory lacks the full schema; live-env probe only"
+    return
+  fi
   local schema; schema="$(_s_schema_yaml)"
   if [ ! -f "$schema" ]; then
     _add S9 skip "schema.yaml not found at $schema"

--- a/scripts/lib/list-r2-transcripts.py
+++ b/scripts/lib/list-r2-transcripts.py
@@ -58,7 +58,8 @@ def _r2_creds() -> tuple[str, str, str, str]:
     if not access_key or not secret_key:
         raise RuntimeError(
             "R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY "
-            "missing — source ~/.vade/coo-env first"
+            "missing — ensure the bash wrapper ran its op-read resolver "
+            "(Phase 2 post-coo-memory#873) or set both vars explicitly"
         )
     endpoint = _op_read("op://COO/r2-transcripts/endpoint")
     bucket = _op_read("op://COO/r2-transcripts/bucket")

--- a/scripts/lib/transcript-fetch.py
+++ b/scripts/lib/transcript-fetch.py
@@ -39,7 +39,8 @@ cache directory can accumulate. Per the security review for #64,
 decrypted jsonl is "strictly more revealing than session summaries"
 and should not sit on disk indefinitely.
 
-Required env (sourced from ~/.vade/coo-env by the bash wrapper):
+Required env (exported by the bash wrapper's inline op-read resolver;
+Phase 2 — `~/.vade/coo-env` retired per coo-memory#873):
   R2_TRANSCRIPTS_ACCESS_KEY_ID, R2_TRANSCRIPTS_SECRET_ACCESS_KEY
   TRANSCRIPTS_AGE_IDENTITY      — full AGE-SECRET-KEY-1... line
 Read at run time via op (no env exposure):

--- a/scripts/lib/transcript-meta-backfill.py
+++ b/scripts/lib/transcript-meta-backfill.py
@@ -50,7 +50,8 @@ supplying both narrows the R2 prefix (--date) AND filters during iteration
 date+id pair. The coo-harness#150 PR body mis-stated this as mutually-
 exclusive (refs coo-harness#151).
 
-Env (sourced from ~/.vade/coo-env, mirroring the export hook):
+Env (exported by the bash wrapper's inline op-read resolver, mirroring
+the export hook; Phase 2 — `~/.vade/coo-env` retired per coo-memory#873):
   R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY
 Read at run time via `op read`:
   op://COO/r2-transcripts/endpoint
@@ -134,7 +135,8 @@ def _r2_creds() -> tuple[str, str, str, str]:
     if not access_key or not secret_key:
         raise RuntimeError(
             "R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY "
-            "missing — source ~/.vade/coo-env first"
+            "missing — ensure the bash wrapper ran its op-read resolver "
+            "(Phase 2 post-coo-memory#873) or set both vars explicitly"
         )
     endpoint = _op_read("op://COO/r2-transcripts/endpoint")
     bucket = _op_read("op://COO/r2-transcripts/bucket")

--- a/scripts/lifecycle/session-end-transcript-export.py
+++ b/scripts/lifecycle/session-end-transcript-export.py
@@ -52,7 +52,8 @@ Acceptable for a Stop hook (operator perceives session-end as already
 "the slow part"); flagged here so an operator who notices the pause
 on first session knows it's expected, not stuck.
 
-Required env (sourced from ~/.vade/coo-env by the bash wrapper):
+Required env (exported by the bash wrapper's inline op-read resolver;
+Phase 2 — `~/.vade/coo-env` retired per coo-memory#873):
   R2_TRANSCRIPTS_ACCESS_KEY_ID      — R2 API token access key (32 hex)
   R2_TRANSCRIPTS_SECRET_ACCESS_KEY  — R2 API token secret key (64 hex)
 Read at run time via `op read` (no env exposure):

--- a/versions.lock
+++ b/versions.lock
@@ -121,6 +121,28 @@ boto3               >=1.34,<2 # AWS SDK for Python. Used by
                               # silently break the script via API
                               # change. uv resolves on first run; cache
                               # warm afterward.
+PyYAML              >=6.0     # YAML loader. Used by
+                              # coo-memory/bin/secrets-schema-check.py
+                              # (S1 invariant validator, run via
+                              # `uv run --script` per its PEP 723
+                              # metadata) and by the inline python3
+                              # heredoc in
+                              # scripts/lib/integrity-group-s.sh's S8
+                              # env-drift classifier. >=6.0 for the
+                              # unified safe_load API.
+jsonschema          >=4.0     # JSON Schema validator (Draft 2020-12).
+                              # Used by
+                              # coo-memory/bin/secrets-schema-check.py
+                              # to validate operations/secrets/schema.yaml
+                              # against operations/secrets/schema.schema.json
+                              # (S1 invariant). Without this the S1
+                              # check silently skipped and schema drift
+                              # surfaced only at CI time; integrity-
+                              # group-s.sh:S1 now switches to `uv run
+                              # --script` so the PEP 723 metadata
+                              # resolves both deps transparently.
+                              # Documented gap closed by 2026-06-05
+                              # epic close-out.
 
 # Deferred (not in image yet, listed so the absence is explicit):
 # rust       — planned for Phase 3+ performance modules per vade-core


### PR DESCRIPTION
## What

End-of-epic closeout for [coo-labs/coo-memory#871](https://github.com/coo-labs/coo-memory/issues/871) — the script-side companion to [coo-labs/coo-memory#1201](https://github.com/coo-labs/coo-memory/pull/1201) (schema + docs + memo, merged) and [#1203](https://github.com/coo-labs/coo-memory/pull/1203) (schema fixup, in flight). Three logical changes:

1. **The Ven-found bug:** `gh-coo-wrap.sh` hardcoded `op://COO/GITHUB_PUBLIC_PAT/token` but the live 1P field is `credential`. Silent cross-org `gh` failures since the field rename. Live-verified post-fix:

   ```bash
   unset GH_TOKEN GITHUB_TOKEN GITHUB_PUBLIC_PAT
   gh api repos/anthropics/claude-code   # → anthropics/claude-code public
   ```

2. **Phase-2 closure:** `cloud-setup.sh` still sourced `~/.vade/coo-env` (retired by coo-memory#873) before `prewarm_external_touch_cache` (needs `GITHUB_MCP_PAT`). Now uses the inline op-read resolver pattern from coo-harness#446. Also: `check-pat-freshness.sh` was designed for env-resident PAT and always returned `ENV-MISSING` post-Phase-2 — rewritten for the tmpfs-cache model (`OK / STALE / CACHE-MISS / OP-UNREACHABLE`). Plus prose sweep across `README.md` + 5 python docstrings/error-messages that still named `~/.vade/coo-env` as the source.

3. **Integrity-check teeth (S1, S4, new S9):**
   - **S1** was silently skipping (jsonschema not importable). Switched to `uv run --script` on the validator (which carries PEP 723 inline metadata declaring both deps); PyYAML + jsonschema pinned in `versions.lock` for discoverability.
   - **S4** was silently broken — every `op item get` failed because service accounts require `--vault COO`. Fix adds the flag. The check now correctly flags `vade-coo-app`'s known empty `credential` field (deletion blocked today by SA-token rate-limit). Schema marker `S4-known-stale-empty:` honored to skip documented exceptions; declared in [#1203](https://github.com/coo-labs/coo-memory/pull/1203).
   - **S9 NEW**: cross-checks `op://COO/<item>/<field>` patterns in scripts against `schema.yaml::credentials[].(op_field ∪ op_alt_fields[])`. Anti-regression for the Ven-found bug class — it would have caught the `/token` drift at the boot integrity check. Excludes test fixtures, CI mocks, archives, comment lines.

## Verification

Live S-group results post-edits (this session, after every change applied):

```
S1: true   schema.yaml validates clean against schema.schema.json
S2: true   20/20 declared env-aliases set
S3: true   all 25 declared mirrors present
S4: true   3 multi-field credentials clean
S5: true   settings.json secret-free; coo-env retired
S7: true   registry clean (cf-tunnel-token covered post-#1201)
S8: true   declared_secret=6 unknown_secret_shape=0
S9: true   14 op://COO/ refs in scripts all map to schema
```

Live `gh-coo-wrap` fix proven against the upstream sample target (anthropics/claude-code). S9 falsifier: synthetic `op://COO/<bad-item>/<bad-field>` reference in a non-test script is caught.

## What this PR does NOT do

- **The `vade-coo-app.credential` field deletion** — primary SA token is rate-limited by an undocumented per-IP throttle; backup SA lacks write scope on this item. The schema's `S4-known-stale-empty:` marker (declared in #1203) suppresses S4 noise until the deletion succeeds via `/rotate-credential` in a future session.
- **The cf-tunnel-token relocation** — the `r2-transcripts.credential` field houses a Cloudflare Tunnel token discovered during this session's verification. Schema notes updated in #1201; physical relocation to a dedicated `cf-tunnel-*` op item is a follow-up.

## Boot-impacting changes

Three (`cloud-setup.sh`, `integrity-group-s.sh`, `check-pat-freshness.sh`) — all are boot-invoked or boot-diagnostic. Verification on a fresh container boot is the canonical proof. See handoff comment below.

## Refs

- Epic: [coo-labs/coo-memory#871](https://github.com/coo-labs/coo-memory/issues/871) (closed 2026-06-04; this PR is the actual end-of-epic closeout)
- Memo: [MEMO-2026-06-05-v5qk](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-05-v5qk.md)
- Companion: [coo-labs/coo-memory#1201](https://github.com/coo-labs/coo-memory/pull/1201) (merged), [#1203](https://github.com/coo-labs/coo-memory/pull/1203) (in flight)
- Track 6 op-read follow-ups: [coo-labs/coo-memory#1194](https://github.com/coo-labs/coo-memory/issues/1194) §1 (the Ven-found bug's framing)

Closes: n/a — companion to coo-memory#1201/#1203.

https://claude.ai/code/session_01KBwv8ejhPJbXXVYYFikYzq