### PR TITLE
secrets: harden env-snapshot writer + add S10 audit

### DIFF
--- a/scripts/lib/integrity-group-s.sh
+++ b/scripts/lib/integrity-group-s.sh
@@ -694,16 +694,22 @@ s_check_S8() {
   fi
 
   # Persist today's env-keyname snapshot. Keynames only — never values.
-  # The S8 invariant fails open on snapshot-write errors (the
-  # classification check below is the load-bearing logic; snapshot is
-  # historical record only).
+  # NUL-separated records (`env -0`) keep multi-line values (PEM keys,
+  # cert chains) attached to their keyname instead of bleeding
+  # base64 chunks through `cut -d=` as fake keynames. The awk pattern
+  # then drops any record that doesn't start with a valid env-name —
+  # second line of defense if a future container injects junk records.
+  # S10 audits the resulting file; if value-bleed regresses here, the
+  # next integrity run catches it.
   local snap_dir snap_file
   snap_dir="$(_s_env_snapshot_dir)"
   snap_file="${snap_dir}/$(date -u +%Y-%m-%d).txt"
   if [ -n "${VADE_SECRETS_SNAPSHOT_SKIP:-}" ]; then
     :  # test escape: don't write
   elif mkdir -p "$snap_dir" 2>/dev/null; then
-    env | cut -d= -f1 | sort -u > "$snap_file" 2>/dev/null || true
+    env -0 2>/dev/null \
+      | awk -v RS='\0' -F= '/^[A-Za-z_][A-Za-z0-9_]*=/ {print $1}' \
+      | sort -u > "$snap_file" 2>/dev/null || true
   fi
 
   # Run the classifier in python3 against the schema + current env.
@@ -964,6 +970,50 @@ s_check_S9() {
   fi
 }
 
+# ── S10: env-snapshot integrity — keynames-only ──────────────────
+#
+# Origin: 2026-06-05 near-miss. `env | cut -d= -f1 | sort -u` in S8's
+# snapshot writer let multi-line values (the `vade-coo-app` PEM) bleed
+# as fake keynames into the working-tree snapshot. Stop-hook caught it
+# pre-commit; nothing was pushed. S8 producer fixed in same change;
+# S10 is the defensive layer — any future regression (producer
+# rewrite, manual edit, an Anthropic-injected container var with a
+# pathological shape) is caught at the next integrity-check fire
+# rather than waiting for an alert reader of `git status`.
+#
+# Test: every line of every file under env-snapshots/*.txt must match
+# the strict env-name regex `^[A-Za-z_][A-Za-z0-9_]*$`. Anything else
+# is value-bleed.
+s_check_S10() {
+  local snap_dir; snap_dir="$(_s_env_snapshot_dir)"
+  if [ ! -d "$snap_dir" ]; then
+    _add S10 skip "no snapshot dir at $snap_dir"
+    return
+  fi
+  local bad=() total=0
+  local f n base
+  for f in "$snap_dir"/*.txt; do
+    [ -f "$f" ] || continue
+    total=$((total + 1))
+    # grep -c always prints a count to stdout; exit code is 1 on
+    # zero matches, which `|| true` swallows so command-subst captures
+    # only the count.
+    n=$(grep -cvE '^[A-Za-z_][A-Za-z0-9_]*$' "$f" 2>/dev/null || true)
+    : "${n:=0}"
+    if [ "$n" -gt 0 ]; then
+      base="$(basename "$f")"
+      bad+=("${base}:${n}")
+    fi
+  done
+  if [ "$total" -eq 0 ]; then
+    _add S10 skip "no snapshot files in $snap_dir"
+  elif [ "${#bad[@]}" -eq 0 ]; then
+    _add S10 true "$total snapshot files keynames-only"
+  else
+    _add S10 false "snapshot value-bleed (file:invalid_lines): ${bad[*]}"
+  fi
+}
+
 # Dispatch every S invariant. Called from integrity-check.sh.
 s_check_all() {
   s_check_S1
@@ -974,4 +1024,5 @@ s_check_all() {
   s_check_S7
   s_check_S8
   s_check_S9
+  s_check_S10
 }


### PR DESCRIPTION
## Summary

Hardens the S8 env-snapshot writer against multi-line env-value bleed and adds S10 as the defensive guard.

## Context

2026-06-05 boot wrote the `vade-coo-app` RSA private key as fake "keynames" into the working-tree snapshot at `operations/secrets/env-snapshots/2026-06-05.txt`. Stop-hook caught it pre-commit, nothing pushed. Past committed snapshots are clean (verified by full git-history scan). Near-miss, not a leak.

Root cause: `env | cut -d= -f1` lets multi-line env values (PEM, cert chains) emit their continuation lines as if they were variable names.

## Changes

**S8 producer** (`scripts/lib/integrity-group-s.sh:706`):

```diff
-env | cut -d= -f1 | sort -u > "$snap_file"
+env -0 | awk -v RS='\0' -F= '/^[A-Za-z_][A-Za-z0-9_]*=/ {print $1}' | sort -u > "$snap_file"
```

NUL-separated records keep multi-line values attached to their keyname; the awk regex drops anything that isn't a valid env-name assignment.

**S10 invariant** (new): audits every `operations/secrets/env-snapshots/*.txt`. Every line must match `^[A-Za-z_][A-Za-z0-9_]*$`. Anything else is value-bleed; FAIL. Catches future regressions of the producer or manual contamination.

## Verification

Local fixture test (synthetic PEM-in-env):
- producer output: keyname preserved (count=1), zero PEM-body lines, zero non-name lines
- S10 verdict: `true 1 snapshot files keynames-only`

Synthetic contaminated file:
- S10 verdict: `false snapshot value-bleed (file:invalid_lines): contaminated.txt:2`

Empty snapshot dir: `S10 skip no snapshot files in <dir>`.

## Memo

Binding case-law follow-up: secret-snapshot producers must filter by valid-env-name regex; raw `cut -d=` over `env` output is the failure mode. (Coming in coo-memory PR.)

Closes coo-labs/coo-memory#1206
Refs: coo-labs/coo-memory#871

https://claude.ai/code/session_011jWFmZEHHUsDUYVgKZdNoz