### PR TITLE
scripts+workflows: align hardcoded op:// paths to the new 1P names (companion to coo-memory#1205)

### DIFF
--- a/.github/workflows/auto-tag-issues-reusable.yml
+++ b/.github/workflows/auto-tag-issues-reusable.yml
@@ -106,16 +106,16 @@ jobs:
       #
       # To provision: GitHub UI → coo-labs org → Settings → Secrets →
       # Actions → New org secret → Name: OP_SERVICE_ACCOUNT_TOKEN →
-      # Value: (the service account token from op://COO/Service Account
-      # Auth Token: vade-coo/credential). See schema.yaml `op-service-account-token`.
+      # Value: (the service account token from op://COO/op-sa-token-vade-coo
+      # /credential). See schema.yaml `op-service-account-token`.
       - name: Load secrets from 1Password (Track 5 migration)
         id: op_secrets
         if: ${{ env.OP_SERVICE_ACCOUNT_TOKEN != '' }}
         uses: 1password/load-secrets-action@v2
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          ANTHROPIC_API_KEY: op://COO/ANTHROPIC_API_KEY/credential
-          VADE_PROJECT_PAT: op://COO/VADE_PROJECT_PAT/token
+          ANTHROPIC_API_KEY: op://COO/anthropic-api-key/credential
+          VADE_PROJECT_PAT: op://COO/github-pat-vade-project/token
         with:
           export-env: true
 

--- a/.github/workflows/bridge-form-fields-to-natives.yml
+++ b/.github/workflows/bridge-form-fields-to-natives.yml
@@ -20,7 +20,7 @@ name: Bridge issue-form widgets to native fields (reusable)
 #   - `secrets.VADE_FIELDS_ADMIN_PAT` — fine-grained PAT with
 #     org-level Issue fields write scope. Org-level secret slot;
 #     holds the same value as the COO's `GITHUB_MCP_PAT` env var
-#     (the COO PAT at `op://COO/vade-coo-self-2026-04/token`),
+#     (the COO PAT at `op://COO/github-pat-vade-coo/token`),
 #     renamed around the GitHub Actions reserved `GITHUB_*` prefix
 #     per coo-memory#848. When the COO PAT rotates, this org
 #     secret slot needs the new value pasted in too (third rotation
@@ -69,7 +69,7 @@ jobs:
         uses: 1password/load-secrets-action@v2
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          VADE_FIELDS_ADMIN_PAT: op://COO/vade-coo-self-2026-04/token
+          VADE_FIELDS_ADMIN_PAT: op://COO/github-pat-vade-coo/token
         with:
           export-env: true
 

--- a/.github/workflows/sync-issue-templates.yml
+++ b/.github/workflows/sync-issue-templates.yml
@@ -68,7 +68,7 @@ jobs:
         uses: 1password/load-secrets-action@v2
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          VADE_FIELDS_ADMIN_PAT: op://COO/vade-coo-self-2026-04/token
+          VADE_FIELDS_ADMIN_PAT: op://COO/github-pat-vade-coo/token
         with:
           export-env: true
 

--- a/scripts/boot/cloud-setup.sh
+++ b/scripts/boot/cloud-setup.sh
@@ -251,7 +251,7 @@ _resolve_external_touch_secrets() {
   command -v op >/dev/null 2>&1 || return 0
   [ -n "${GITHUB_MCP_PAT:-}" ] && return 0
   local val
-  val="$(op read 'op://COO/vade-coo-self-2026-04/token' 2>/dev/null)" || return 0
+  val="$(op read 'op://COO/github-pat-vade-coo/token' 2>/dev/null)" || return 0
   [ -n "$val" ] && export GITHUB_MCP_PAT="$val"
 }
 _resolve_external_touch_secrets

--- a/scripts/boot/coo-bootstrap.sh
+++ b/scripts/boot/coo-bootstrap.sh
@@ -292,7 +292,7 @@ if [ -n "${OP_SERVICE_ACCOUNT_TOKEN_BACKUP:-}" ]; then
   # non-zero exit so `set -e` doesn't trip on the command substitution.
   _sentinel_out=""
   _sentinel_rc=0
-  _sentinel_out="$(op read 'op://COO/vade-coo-auth/public key' 2>&1 >/dev/null)" || _sentinel_rc=$?
+  _sentinel_out="$(op read 'op://COO/vade-coo-ssh-auth/public key' 2>&1 >/dev/null)" || _sentinel_rc=$?
   if [ "$_sentinel_rc" -ne 0 ] && printf '%s' "$_sentinel_out" | grep -qiE 'rate.?limit|too many requests'; then
     log "coo-bootstrap: standard SA token rate-limited on op read; swapping to OP_SERVICE_ACCOUNT_TOKEN_BACKUP"
     export OP_SERVICE_ACCOUNT_TOKEN="$OP_SERVICE_ACCOUNT_TOKEN_BACKUP"

--- a/scripts/check-pat-freshness.sh
+++ b/scripts/check-pat-freshness.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # check-pat-freshness: detect whether the gh-coo-wrap PAT cache (tmpfs)
 # is current relative to the canonical value in 1Password
-# (op://COO/vade-coo-self-2026-04/token per schema.yaml).
+# (op://COO/github-pat-vade-coo/token per schema.yaml).
 #
 # Use this as the FIRST response when a `gh` write fails silently:
 # exit 1, zero bytes stdout, zero bytes stderr. That signature is the
@@ -41,7 +41,7 @@ set -eu
 # diagnostic path; a schema-fetch dependency would create a chicken-
 # and-egg loop when the schema itself is what we're testing the cache
 # against.
-OP_REF="op://COO/vade-coo-self-2026-04/token"
+OP_REF="op://COO/github-pat-vade-coo/token"
 
 # tmpfs cache location used by gh-coo-wrap.sh _resolve_pat MCP branch.
 # XDG_RUNTIME_DIR is the cloud-container default; fall back to /tmp

--- a/scripts/ci/mocks/op
+++ b/scripts/ci/mocks/op
@@ -43,19 +43,19 @@ case "${1:-}" in
   read)
     ref="${2:-}"
     case "$ref" in
-      "op://COO/vade-coo-self-2026-04/token")
+      "op://COO/github-pat-vade-coo/token")
         echo "ghp_CIMOCK00000000000000000000000000000000"
         ;;
-      "op://COO/GITHUB_PUBLIC_PAT/credential")
+      "op://COO/github-pat-classic-public/credential")
         # Mocked cross-org public-repo PAT (MEMO-2026-05-11-6xv2). Classic
         # `ghp_` prefix; placeholder body so disk content scanners don't
         # match a real-shape token.
         echo "ghp_CIMOCK_PUBLIC_PAT_DO_NOT_USE_000000"
         ;;
-      "op://COO/agentmail-vade-coo/credential")
+      "op://COO/agentmail-api-vade-coo/credential")
         echo "am_CIMOCK_AGENTMAIL_KEY_DO_NOT_USE"
         ;;
-      "op://COO/mem0-vade-coo/credential")
+      "op://COO/mem0-api-vade-coo/credential")
         echo "m0_CIMOCK_MEM0_KEY_DO_NOT_USE"
         ;;
       "op://COO/r2-transcripts/access-key-id")
@@ -74,7 +74,7 @@ case "${1:-}" in
         # and never decrypts a real ciphertext.
         echo "AGE-SECRET-KEY-1CIMOCK000000000000000000000000000000000000000000000000"
         ;;
-      "op://COO/vade-canvas-coo/credential")
+      "op://COO/vade-canvas-bearer-coo/credential")
         # Mocked vade-canvas MCP bearer (vade-core#93). Real value is the
         # operator-shaped opaque bearer that vade-canvas MCP accepts via
         # Fly's VADE_AUTH_TOKENS.agents[]; mock returns a non-shape
@@ -82,32 +82,32 @@ case "${1:-}" in
         # canvas roundtrip.
         echo "vat_CIMOCK_VADE_AUTH_TOKEN_DO_NOT_USE"
         ;;
-      "op://COO/vade-coo-auth/private key")
+      "op://COO/vade-coo-ssh-auth/private key")
         cat "$KEYDIR/vade-coo-auth"
         ;;
-      "op://COO/vade-coo-auth/public key")
+      "op://COO/vade-coo-ssh-auth/public key")
         cat "$KEYDIR/vade-coo-auth.pub"
         ;;
-      "op://COO/vade-coo-sign/private key")
+      "op://COO/vade-coo-ssh-sign/private key")
         cat "$KEYDIR/vade-coo-sign"
         ;;
-      "op://COO/vade-coo-sign/public key")
+      "op://COO/vade-coo-ssh-sign/public key")
         cat "$KEYDIR/vade-coo-sign.pub"
         ;;
-      "op://COO/cloudflare-api-token-vade-coo/account_id")
+      "op://COO/cloudflare-api-vade-coo/account_id")
         # Mocked Cloudflare account ID (non-secret public identifier).
         echo "0000000000000000000000000000cimock"
         ;;
-      "op://COO/vade-coo-app/app_id")
+      "op://COO/github-app-vade-coo/app_id")
         # GitHub App ID (vade-coo-memory#837) — canned numeric for the
         # CI mode. Real value is set in production via Ven's UI work
-        # (Phase 1) and stored in op://COO/vade-coo-app/app_id.
+        # (Phase 1) and stored in op://COO/github-app-vade-coo/app_id.
         echo "999000"
         ;;
-      "op://COO/vade-coo-app/installation_id")
+      "op://COO/github-app-vade-coo/installation_id")
         echo "888777"
         ;;
-      "op://COO/vade-coo-app/private_key")
+      "op://COO/github-app-vade-coo/private_key")
         # Placeholder PEM-shaped string for CI. fetch_coo_secrets only
         # checks for non-empty; the minter (gh-app-token.sh) is not on
         # the bootstrap-regression hot path, so this body is never

--- a/scripts/ci/test-gh-coo-wrap.sh
+++ b/scripts/ci/test-gh-coo-wrap.sh
@@ -532,8 +532,8 @@ fi
 case "${1:-}" in
   read)
     case "${2:-}" in
-      "op://COO/vade-coo-self-2026-04/token")      echo "OPRESOLVED_MCP_PAT_FROM_STUB" ;;
-      "op://COO/GITHUB_PUBLIC_PAT/credential")     echo "OPRESOLVED_PUBLIC_PAT_FROM_STUB" ;;
+      "op://COO/github-pat-vade-coo/token")        echo "OPRESOLVED_MCP_PAT_FROM_STUB" ;;
+      "op://COO/github-pat-classic-public/credential") echo "OPRESOLVED_PUBLIC_PAT_FROM_STUB" ;;
       *) echo "[mock op] unknown ref: ${2:-}" >&2; exit 2 ;;
     esac
     ;;

--- a/scripts/ci/test-materialize-mcp-env.sh
+++ b/scripts/ci/test-materialize-mcp-env.sh
@@ -62,11 +62,11 @@ _stage_templates() {
   cat > "$dir/scripts/lib/mcp-env-templates/mem0.env" <<'EOF'
 # MCP env template for mem0.
 # Comment line preserved.
-MEM0_API_KEY=op://COO/mem0-vade-coo/credential
+MEM0_API_KEY=op://COO/mem0-api-vade-coo/credential
 EOF
   cat > "$dir/scripts/lib/mcp-env-templates/agentmail.env" <<'EOF'
 # MCP env template for agentmail.
-AGENTMAIL_API_KEY=op://COO/agentmail-vade-coo/credential
+AGENTMAIL_API_KEY=op://COO/agentmail-api-vade-coo/credential
 EOF
   cat > "$dir/scripts/lib/mcp-env-templates/1password.env" <<'EOF'
 # No op:// refs — passes through unchanged.
@@ -152,7 +152,7 @@ _run_materialize "$TEST2_DIR" env -u MEM0_API_KEY \
   XDG_RUNTIME_DIR="$TEST_ROOT/runtime2"
 
 mem0_content="$(cat "$_OUT_DIR/mem0.env")"
-_assert_contains "test 2: unresolved MEM0 op:// ref preserved" "MEM0_API_KEY=op://COO/mem0-vade-coo/credential" "$mem0_content"
+_assert_contains "test 2: unresolved MEM0 op:// ref preserved" "MEM0_API_KEY=op://COO/mem0-api-vade-coo/credential" "$mem0_content"
 am_content="$(cat "$_OUT_DIR/agentmail.env")"
 _assert_contains "test 2: AGENTMAIL still resolves" "AGENTMAIL_API_KEY=am_TEST2_VALUE" "$am_content"
 

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -59,10 +59,10 @@ install_id="${GITHUB_APP_INSTALLATION_ID:-}"
 private_key="${GITHUB_APP_PRIVATE_KEY:-}"
 
 if [ -z "$app_id" ]; then
-  app_id="$(op read 'op://COO/vade-coo-app/app_id' 2>/dev/null || true)"
+  app_id="$(op read 'op://COO/github-app-vade-coo/app_id' 2>/dev/null || true)"
 fi
 if [ -z "$install_id" ]; then
-  install_id="$(op read 'op://COO/vade-coo-app/installation_id' 2>/dev/null || true)"
+  install_id="$(op read 'op://COO/github-app-vade-coo/installation_id' 2>/dev/null || true)"
 fi
 # Phase 2 follow-up: check tmpfs cache populated by bootstrap's
 # materialize_app_key_cache before falling back to op-read. The cache is
@@ -79,7 +79,7 @@ if [ -z "$private_key" ]; then
   done
 fi
 if [ -z "$private_key" ]; then
-  private_key="$(op read 'op://COO/vade-coo-app/private_key' 2>/dev/null || true)"
+  private_key="$(op read 'op://COO/github-app-vade-coo/private_key' 2>/dev/null || true)"
 fi
 
 if [ -z "$app_id" ] || [ -z "$install_id" ] || [ -z "$private_key" ]; then

--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -97,7 +97,7 @@ _resolve_pat() {
         printf '%s' "$GITHUB_MCP_PAT"
         return 0
       fi
-      op_path="op://COO/vade-coo-self-2026-04/token"
+      op_path="op://COO/github-pat-vade-coo/token"
       ;;
     PUBLIC)
       if [ -n "${GITHUB_PUBLIC_PAT:-}" ]; then
@@ -110,7 +110,7 @@ _resolve_pat() {
       # surfaced the bug for the first time mid-session. The new S9
       # invariant in integrity-group-s.sh cross-checks hardcoded op-paths
       # like this against schema.yaml::credentials[] to prevent re-regression.
-      op_path="op://COO/GITHUB_PUBLIC_PAT/credential"
+      op_path="op://COO/github-pat-classic-public/credential"
       ;;
     *) return 0 ;;
   esac

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1964,10 +1964,10 @@ install_coo_ssh_keys() {
   chmod 700 "$ssh_dir"
   log "Installing COO SSH keys into $ssh_dir"
 
-  _op_to_file "op://COO/vade-coo-auth/private key" "$ssh_dir/vade-coo-auth"     0600 || return 1
-  _op_to_file "op://COO/vade-coo-auth/public key"  "$ssh_dir/vade-coo-auth.pub" 0644 || return 1
-  _op_to_file "op://COO/vade-coo-sign/private key" "$ssh_dir/vade-coo-sign"     0600 || return 1
-  _op_to_file "op://COO/vade-coo-sign/public key"  "$ssh_dir/vade-coo-sign.pub" 0644 || return 1
+  _op_to_file "op://COO/vade-coo-ssh-auth/private key" "$ssh_dir/vade-coo-auth"     0600 || return 1
+  _op_to_file "op://COO/vade-coo-ssh-auth/public key"  "$ssh_dir/vade-coo-auth.pub" 0644 || return 1
+  _op_to_file "op://COO/vade-coo-ssh-sign/private key" "$ssh_dir/vade-coo-sign"     0600 || return 1
+  _op_to_file "op://COO/vade-coo-ssh-sign/public key"  "$ssh_dir/vade-coo-sign.pub" 0644 || return 1
 
   if ensure_openssh_client; then
     local fp_auth fp_sign

--- a/scripts/lib/integrity-group-s.sh
+++ b/scripts/lib/integrity-group-s.sh
@@ -842,7 +842,7 @@ PY
 # ── S9: shim-vs-schema cross-check ────────────────────────────────
 #
 # Origin: 2026-06-05 secrets-epic close-out (MEMO-2026-06-05-v5qk).
-# The Ven-found bug `op://COO/GITHUB_PUBLIC_PAT/token` in gh-coo-wrap.sh
+# The Ven-found bug (op://COO/GITHUB_PUBLIC_PAT, /token vs /credential) in gh-coo-wrap.sh
 # (schema declared `credential`; shim hardcoded `token`; silently
 # returned empty) was invisible to S1–S8 because each S-check inspects
 # either the schema OR the live op-state in isolation. S9 closes the

--- a/scripts/lib/mcp-env-templates/agentmail.env
+++ b/scripts/lib/mcp-env-templates/agentmail.env
@@ -5,4 +5,4 @@
 #
 # op:// refs are resolved by `op run` using OP_SERVICE_ACCOUNT_TOKEN
 # from the parent shell env at spawn time.
-AGENTMAIL_API_KEY=op://COO/agentmail-vade-coo/credential
+AGENTMAIL_API_KEY=op://COO/agentmail-api-vade-coo/credential

--- a/scripts/lib/mcp-env-templates/mem0.env
+++ b/scripts/lib/mcp-env-templates/mem0.env
@@ -5,4 +5,4 @@
 #
 # op:// refs are resolved by `op run` using OP_SERVICE_ACCOUNT_TOKEN
 # from the parent shell env at spawn time.
-MEM0_API_KEY=op://COO/mem0-vade-coo/credential
+MEM0_API_KEY=op://COO/mem0-api-vade-coo/credential

--- a/scripts/lifecycle/session-end-transcript-export.sh
+++ b/scripts/lifecycle/session-end-transcript-export.sh
@@ -87,7 +87,7 @@ _resolve_transcript_secrets() {
   _maybe_set R2_TRANSCRIPTS_ENDPOINT          op://COO/r2-transcripts/endpoint
   _maybe_set R2_TRANSCRIPTS_BUCKET            op://COO/r2-transcripts/bucket
   _maybe_set TRANSCRIPTS_AGE_IDENTITY         op://COO/transcripts-age-key/credential
-  _maybe_set GITHUB_MCP_PAT                   op://COO/vade-coo-self-2026-04/token
+  _maybe_set GITHUB_MCP_PAT                   op://COO/github-pat-vade-coo/token
 }
 _resolve_transcript_secrets
 


### PR DESCRIPTION
## What

Script + workflow companion to [coo-labs/coo-memory#1205](https://github.com/coo-labs/coo-memory/pull/1205) (schema's `op_item` rename sweep). Updates every hardcoded `op://COO/<item>/<field>` reference in the harness to point at the new canonical 1P titles. Ven completes the 1P UI renames in the same session; this PR + #1205 merge alongside.

## Coverage

13 non-workflow files + 3 workflow files (the workflows pushed via App-token Contents API since OAuth lacks `workflow` scope).

**Path changes**:

| Old | New |
|---|---|
| `op://COO/vade-coo-self-2026-04/token` | `op://COO/github-pat-vade-coo/token` |
| `op://COO/GITHUB_PUBLIC_PAT/credential` | `op://COO/github-pat-classic-public/credential` |
| `op://COO/VADE_PROJECT_PAT/token` | `op://COO/github-pat-vade-project/token` |
| `op://COO/ANTHROPIC_API_KEY/credential` | `op://COO/anthropic-api-key/credential` |
| `op://COO/vade-coo-app/{app_id,installation_id,private_key}` | `op://COO/github-app-vade-coo/...` |
| `op://COO/Service Account Auth Token: vade-coo/credential` | `op://COO/op-sa-token-vade-coo/credential` |
| `op://COO/vade-coo-{auth,sign}/{private key,public key}` | `op://COO/vade-coo-ssh-{auth,sign}/...` |
| `op://COO/mem0-vade-coo/credential` | `op://COO/mem0-api-vade-coo/credential` |
| `op://COO/agentmail-vade-coo/credential` | `op://COO/agentmail-api-vade-coo/credential` |
| `op://COO/cloudflare-api-token-vade-coo/account_id` | `op://COO/cloudflare-api-vade-coo/account_id` |
| `op://COO/vade-canvas-coo/credential` | `op://COO/vade-canvas-bearer-coo/credential` |

**Files touched** (production):
- `scripts/gh-coo-wrap.sh` — both PAT routes
- `scripts/check-pat-freshness.sh` — `OP_REF` constant + header comment
- `scripts/gh-app-token.sh` — App-token mint (3 reads)
- `scripts/boot/cloud-setup.sh` — prewarm-cache resolver
- `scripts/boot/coo-bootstrap.sh` — sentinel-swap probe
- `scripts/lib/common.sh` — 4 SSH key installers
- `scripts/lib/mcp-env-templates/{agentmail,mem0}.env` — MCP-spawn op-refs
- `scripts/lifecycle/session-end-transcript-export.sh` — resolver `GITHUB_MCP_PAT`
- `.github/workflows/{bridge-form-fields-to-natives,sync-issue-templates,auto-tag-issues-reusable}.yml` — 6 op_ref values

**CI test parity**:
- `scripts/ci/mocks/op` — matched mock paths
- `scripts/ci/test-gh-coo-wrap.sh` — matched test stubs
- `scripts/ci/test-materialize-mcp-env.sh` — matched fixtures

**Comment refresh**:
- `scripts/lib/integrity-group-s.sh:845` — S9's historical-bug description clarified (the bug-class doesn't reference the post-rename name).

## Coordination

1. Ven completes 1P UI renames (~10 min) per the mapping in [coo-memory#1205](https://github.com/coo-labs/coo-memory/pull/1205).
2. Merge `coo-memory#1205`.
3. Merge this PR.
4. Fresh boot integrity check confirms: `S9` reports "14 op://COO/ refs in scripts all map to schema", schema-fetch warns disappear.

Merging this PR before either of the above leaves cross-org `gh` + every op-read broken at boot until 1P UI catches up. Merging after 1P renames but before this PR leaves the same window in reverse.

## Verification

Local (this branch, with coo-memory on #1205 head):
```
S9=true:14 op://COO/ refs in scripts all map to schema credentials[].(op_field|op_alt_fields[])
```

After 1P UI + both PR merges, the canonical proof is a fresh-container boot showing `summary.ok=true (N/N)` with no schema-fetch WARN.

## Refs

- Companion: [coo-labs/coo-memory#1205](https://github.com/coo-labs/coo-memory/pull/1205)
- Origin: 2026-06-06 session continuation of secrets-epic closeout

Closes: n/a — 1P UI standardization companion.

https://claude.ai/code/session_01KBwv8ejhPJbXXVYYFikYzq