### PR TITLE
docs: drop transient issue refs from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,15 +66,12 @@ cloud-style workspace under `/home/user`, runs `scripts/boot/cloud-setup.sh`
 `scripts/ci/mocks/`), then asserts the integrity-check report has no
 degraded invariants modulo the `VADE_CI_ALLOWLIST` env. Catches
 script-level regressions at PR-open time without burning a Claude
-Code session per check. Tracked at
-[coo-harness#86](https://github.com/coo-labs/coo-harness/issues/86).
+Code session per check.
 
-Layer-2 (SDK-driven harness load test) is sibling work at
-[coo-harness#85](https://github.com/coo-labs/coo-harness/issues/85).
 This Layer-1 suite does not exercise Claude Code reading
 `settings.json`, MCP startup, skill loading, or live 1Password /
 GitHub PAT round-trips — those stay in the manual fresh-container
-ritual until #85 closes.
+ritual.
 
 What runs:
 1. `scripts/ci/run-bootstrap-regression.sh` stages


### PR DESCRIPTION
## What

Drops two transient issue refs (#85, #86) from CLAUDE.md's "Bootstrap CI" section:

- The `Tracked at coo-harness#86` sentence at the end of the first paragraph.
- The `Layer-2 (...) is sibling work at coo-harness#85 ... until #85 closes` paragraph — rewritten without the issue ref, keeping the steady-state statement that Layer-1 doesn't exercise Claude Code reading settings.json / MCP startup / skill loading / live PAT round-trips.

## Why

Per Ven (2026-06-05 post-infra triage): "CLAUDE.md should never reference such transient work info." The two issues referenced are both CLOSED ancient items; their tracking purpose was served when they shipped. CLAUDE.md is the steady-state boot doc — pointers to specific tracking issues belong in operations docs or PR bodies, not here.

The operational description of how `bootstrap-regression.yml` runs stays — that's current behavior, not transient.

Surfaced by [coo-memory audits/2026-06-05_post-infra-issue-triage/](https://github.com/coo-labs/coo-memory/tree/main/audits/2026-06-05_post-infra-issue-triage).

Closes: n/a — doc cleanup.

https://claude.ai/code/session_01KrfstodC5X9xg6HLndzuAE