### PR TITLE
subscribe-*.sh: op:// fallback when PAT/key env var unset

### DIFF
--- a/scripts/subscribe-agentmail.sh
+++ b/scripts/subscribe-agentmail.sh
@@ -20,11 +20,14 @@
 # outbound `sent` from the same inbox; webhook noise (drafts, etc.)
 # is excluded by the same filter.
 #
-# Authentication: AGENTMAIL_API_KEY required in env.
+# Authentication: AGENTMAIL_API_KEY if set; otherwise falls back to
+# `op read op://COO/agentmail-api-vade-coo/credential` (the canonical key
+# path), so Monitor-tool subshells — which post-Phase-2 (coo-memory#873)
+# don't inherit the key in their env — still authenticate.
 #
 # Exit codes:
 #   0  graceful shutdown (SIGINT/SIGTERM)
-#   1  missing AGENTMAIL_API_KEY
+#   1  no AgentMail key (env unset and op-read fallback failed)
 #   2  argument error
 
 set -eu
@@ -41,7 +44,8 @@ Arguments:
   [poll_seconds]   Polling interval, default 60
 
 Environment:
-  AGENTMAIL_API_KEY     AgentMail API key (required)
+  AGENTMAIL_API_KEY     AgentMail API key (preferred)
+  (unset)               Falls back to op read op://COO/agentmail-api-vade-coo/credential
   VADE_CLOUD_STATE_DIR  State directory root (defaults to ~/.vade-cloud-state)
 
 Examples:
@@ -69,8 +73,14 @@ if ! [[ "$poll" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+if [ -z "${AGENTMAIL_API_KEY:-}" ] && command -v op >/dev/null 2>&1; then
+  # Post-Phase-2 (coo-memory#873) the key is not in tool-subshell env;
+  # the MCP env materializer resolves it from 1Password, but this Monitor
+  # script reads the env directly. Single-shot op-read fallback, no retry.
+  AGENTMAIL_API_KEY="$(op read op://COO/agentmail-api-vade-coo/credential 2>/dev/null || true)"
+fi
 if [ -z "${AGENTMAIL_API_KEY:-}" ]; then
-  echo "error: AGENTMAIL_API_KEY must be set" >&2
+  echo "error: no AgentMail key — AGENTMAIL_API_KEY unset and op read op://COO/agentmail-api-vade-coo/credential failed" >&2
   exit 1
 fi
 

--- a/scripts/subscribe-discussion.sh
+++ b/scripts/subscribe-discussion.sh
@@ -21,11 +21,14 @@
 # don't re-emit history. First run records the current state silently
 # (no events emitted) and only future activity surfaces.
 #
-# Authentication: relies on GITHUB_MCP_PAT or GH_TOKEN being set.
+# Authentication: GITHUB_MCP_PAT or GH_TOKEN if set; otherwise falls back
+# to `op read op://COO/github-pat-vade-coo/token` (the canonical PAT path
+# used by gh-coo-wrap.sh) so Monitor-tool subshells, which post-Phase-2
+# (coo-memory#873) don't inherit the PAT, still authenticate.
 #
 # Exit codes:
 #   0  graceful shutdown (SIGINT/SIGTERM)
-#   1  missing GitHub token
+#   1  no GitHub token (env unset and op-read fallback failed)
 #   2  argument error
 
 set -eu
@@ -45,6 +48,7 @@ Arguments:
 Environment:
   GITHUB_MCP_PAT   GitHub PAT (preferred)
   GH_TOKEN         Fallback if MCP PAT unset
+  (neither set)    Falls back to op read op://COO/github-pat-vade-coo/token
   VADE_CLOUD_STATE_DIR  State directory root (defaults to ~/.vade-cloud-state)
 
 Examples:
@@ -81,8 +85,15 @@ owner="${repo%%/*}"
 name="${repo##*/}"
 
 token="${GITHUB_MCP_PAT:-${GH_TOKEN:-}}"
+if [ -z "$token" ] && command -v op >/dev/null 2>&1; then
+  # Post-Phase-2 (coo-memory#873) the PAT is not in tool-subshell env;
+  # gh-coo-wrap.sh resolves it from 1Password at call time, but this
+  # script's env-check runs before any wrapped `gh` call, so Monitor-tool
+  # invocations see no PAT. Single-shot op-read fallback (no retry).
+  token="$(op read op://COO/github-pat-vade-coo/token 2>/dev/null || true)"
+fi
 if [ -z "$token" ]; then
-  echo "error: GITHUB_MCP_PAT or GH_TOKEN must be set" >&2
+  echo "error: no GitHub token — GITHUB_MCP_PAT/GH_TOKEN unset and op read op://COO/github-pat-vade-coo/token failed" >&2
   exit 1
 fi
 

--- a/scripts/subscribe-pr-watch.sh
+++ b/scripts/subscribe-pr-watch.sh
@@ -44,11 +44,14 @@
 # while it recomputes after a push. Transitions through UNKNOWN are not
 # emitted; only transitions between concrete states fire events.
 #
-# Authentication: relies on GITHUB_MCP_PAT or GH_TOKEN being set.
+# Authentication: GITHUB_MCP_PAT or GH_TOKEN if set; otherwise falls back
+# to `op read op://COO/github-pat-vade-coo/token` (the canonical PAT path
+# used by gh-coo-wrap.sh). The fallback covers Monitor-tool subshells,
+# which post-Phase-2 (coo-memory#873) don't inherit the PAT in their env.
 #
 # Exit codes:
 #   0  graceful shutdown (SIGINT/SIGTERM) or terminal state (MERGED/CLOSED)
-#   1  missing GitHub token
+#   1  no GitHub token (env unset and op-read fallback failed)
 #   2  argument error
 
 set -eu
@@ -74,6 +77,7 @@ Arguments:
 Environment:
   GITHUB_MCP_PAT        GitHub PAT (preferred)
   GH_TOKEN              Fallback if MCP PAT unset
+  (neither set)         Falls back to op read op://COO/github-pat-vade-coo/token
   VADE_CLOUD_STATE_DIR  State directory root (defaults to ~/.vade-cloud-state)
 
 Examples:
@@ -110,8 +114,16 @@ owner="${repo%%/*}"
 name="${repo##*/}"
 
 token="${GITHUB_MCP_PAT:-${GH_TOKEN:-}}"
+if [ -z "$token" ] && command -v op >/dev/null 2>&1; then
+  # Post-Phase-2 (coo-memory#873) the PAT is not in tool-subshell env;
+  # gh-coo-wrap.sh resolves it from 1Password at call time, but this
+  # script's env-check runs before any wrapped `gh` call, so Monitor-tool
+  # invocations see no PAT. Single-shot op-read fallback (no retry — the
+  # poll loop's gh calls have their own per-call failure handling).
+  token="$(op read op://COO/github-pat-vade-coo/token 2>/dev/null || true)"
+fi
 if [ -z "$token" ]; then
-  echo "error: GITHUB_MCP_PAT or GH_TOKEN must be set" >&2
+  echo "error: no GitHub token — GITHUB_MCP_PAT/GH_TOKEN unset and op read op://COO/github-pat-vade-coo/token failed" >&2
   exit 1
 fi
 

--- a/scripts/subscribe-vade-coo-notifications.sh
+++ b/scripts/subscribe-vade-coo-notifications.sh
@@ -35,11 +35,14 @@
 # (not the org). GITHUB_MCP_PAT — the org-scoped fine-grained PAT used for
 # attributable writes — only exposes Repository + Organization permissions
 # and returns 403 on /notifications. GH_TOKEN is the final fallback for
-# non-COO contexts. Script detects 403 and exits with a FATAL message.
+# non-COO contexts. When none of these is in the env (e.g. a Monitor-tool
+# subshell post-Phase-2, coo-memory#873), the script falls back to
+# `op read op://COO/github-pat-classic-public/credential` — the classic
+# PAT's canonical path. Script detects 403 and exits with a FATAL message.
 #
 # Exit codes:
 #   0  graceful shutdown (SIGINT/SIGTERM)
-#   1  missing GitHub token  OR  token lacks notifications scope
+#   1  no GitHub token (env unset and op-read fallback failed)  OR  token lacks notifications scope
 #   2  argument error
 
 set -eu
@@ -60,6 +63,7 @@ Environment:
                         endpoint is a user-level API and GITHUB_MCP_PAT
                         lacks the scope; see header comment)
   GH_TOKEN              Final fallback for non-COO contexts
+  (none set)            Falls back to op read op://COO/github-pat-classic-public/credential
   VADE_CLOUD_STATE_DIR  State directory root (defaults to ~/.vade-cloud-state)
 
 Examples:
@@ -78,8 +82,14 @@ if ! [[ "$poll" =~ ^[0-9]+$ ]]; then
 fi
 
 token="${GITHUB_PUBLIC_PAT:-${GH_TOKEN:-}}"
+if [ -z "$token" ] && command -v op >/dev/null 2>&1; then
+  # Post-Phase-2 (coo-memory#873) the PAT is not in tool-subshell env;
+  # this endpoint needs the classic public-repo PAT (see header), so fall
+  # back to its canonical 1Password path. Single-shot, no retry.
+  token="$(op read op://COO/github-pat-classic-public/credential 2>/dev/null || true)"
+fi
 if [ -z "$token" ]; then
-  echo "error: GITHUB_PUBLIC_PAT or GH_TOKEN must be set" >&2
+  echo "error: no GitHub token — GITHUB_PUBLIC_PAT/GH_TOKEN unset and op read op://COO/github-pat-classic-public/credential failed" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Adds an `op://` PAT/key fallback to the four Monitor-tool `subscribe-*.sh` scripts so they authenticate when their secret env var is unset — the post-Phase-2 (coo-memory#873) state in any tool-spawned subshell, which is the canonical PR-watch / discussion-watch / notifications-watch / agentmail-watch invocation surface.

## Problem

Each script reads its auth secret straight from the process env and exits 1 if unset (e.g. `token="${MCP_PAT:-${GH:-}}"` then a hard-fail when empty). Post-Phase-2 the PAT/key is no longer exported into tool subshells — `gh-coo-wrap.sh` resolves it from 1Password at call time, but these scripts' env-check runs *before* any wrapped `gh` call. Under the Monitor tool the gate fails immediately, so the watch never starts. Confirmed live: in a Bash/Monitor subshell the GitHub PAT env vars and the AgentMail key are all unset.

## Fix

A single-shot `op read` fallback in each env-check block: when the env var is unset **and** `op` is on PATH, resolve the secret from its canonical 1Password path; the existing hard-fail fires only if both env and op-read fail. No retry — the poll loops' own calls handle transient failure. Paths mirror the resolvers already used by `gh-coo-wrap.sh` and `check-pat-freshness.sh`.

| Script | op path |
|---|---|
| `subscribe-pr-watch.sh` | `op://COO/github-pat-vade-coo/token` |
| `subscribe-discussion.sh` | `op://COO/github-pat-vade-coo/token` |
| `subscribe-vade-coo-notifications.sh` | `op://COO/github-pat-classic-public/credential` |
| `subscribe-agentmail.sh` | `op://COO/agentmail-api-vade-coo/credential` |

`subscribe-agentmail.sh` was surfaced by the audit (#456 asked for one) — it's the 4th member of the same Monitor-tool cluster, "Analog to subscribe-discussion.sh" by its own header, with the identical gap on the AgentMail key.

## Verification

Live, in a PAT/key-less env (env vars stripped with `env -u …`):

- `subscribe-pr-watch.sh coo-labs/coo-harness 455` → resolves via op, `gh pr view` + reviews + comments authenticate, detects MERGED, exits 0.
- `subscribe-discussion.sh coo-labs/vade-canvas 12` → resolves, GraphQL authenticates, enters poll loop.
- `subscribe-vade-coo-notifications.sh` → resolves classic PAT, `/notifications` returns (no 403/FATAL), enters poll loop.
- `subscribe-agentmail.sh vade-coo@agentmail.to` → resolves key, AgentMail API returns inbox state ("20 existing items"), enters poll loop.

No secret values appear in output or error messages (errors name only the op path). `bash -n` clean on all four.

## Audit follow-up

`git-push-with-fallback.sh` shares the root cause (direct-env PAT read, fallback silently dead post-Phase-2) but is a credential-leak-hardened push-critical path whose regression test is unwired from CI — tracked in #457 rather than ridden in here.

Closes #456

https://claude.ai/code/session_01ErULzJpB9tUynMFE8ryUcJ