### PR TITLE
fix(docs+scripts+tests): correct stale repo refs (F30-F33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ ritual.
 
 What runs:
 1. `scripts/ci/run-bootstrap-regression.sh` stages
-   `$VADE_CI_WORKSPACE_ROOT/{vade-runtime,vade-coo-memory}` from the
+   `$VADE_CI_WORKSPACE_ROOT/{coo-harness,coo-memory}` from the
    PR checkout (sibling repos are stubbed).
 2. Generates fixture ed25519 keys per run; their fingerprints are
    exported as `COO_AUTH_FP_EXPECTED` / `COO_SIGN_FP_EXPECTED` so
@@ -92,7 +92,7 @@ What runs:
 
 Allowlist defaults to empty. E1–E4 (live MCP probes) skip in CI by
 design; F1–F4 (culture-substrate invariants) skip cleanly because
-the staged `vade-coo-memory` is a stub without `.git`. Bump the
+the staged `coo-memory` is a stub without `.git`. Bump the
 allowlist via the workflow's `VADE_CI_ALLOWLIST` env or the
 `workflow_dispatch` input — cite the reason in the commit so the
 next operator can audit.

--- a/scripts/ci/test-read-boot-inlined-guard.sh
+++ b/scripts/ci/test-read-boot-inlined-guard.sh
@@ -71,7 +71,7 @@ assert_block "Read memo_index.json (relative path)" \
   "$(run_hook_read coo-memory/memos/memo_index.json)"
 
 assert_block "Read memo_index.json (sibling-checkout path)" \
-  "$(run_hook_read /workspace/vade-coo-memory/memos/memo_index.json)"
+  "$(run_hook_read /workspace/coo-memory/memos/memo_index.json)"
 
 assert_block "Read identity_layer.md (absolute canonical path)" \
   "$(run_hook_read /home/user/coo-memory/identity/identity_layer.md)"

--- a/scripts/transcript-url-backfill.py
+++ b/scripts/transcript-url-backfill.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.10"
 # dependencies = ["boto3>=1.34,<2"]
 # ///
+# migration-sweep: skip — this script handles the org-rename URL backfill; its mapping table and regexes intentionally carry vade-app/* and coo-labs/* literals.
 """
 transcript-url-backfill.py — coo-labs/coo-console#23 (post-comment algorithm).
 


### PR DESCRIPTION
## Substrate drift audit — coo-harness fixes

Three files. No workflow files (no API PUT needed). One marker addition + two real fixes.

## `CLAUDE.md` (2 real fixes, F30)

Bootstrap-CI staging description was stale — the actual `scripts/ci/run-bootstrap-regression.sh:48-49` stages `coo-harness` and `coo-memory` (not the old `vade-runtime`/`vade-coo-memory` names). Doc now matches reality.

```diff
-   `$VADE_CI_WORKSPACE_ROOT/{vade-runtime,vade-coo-memory}` from the
+   `$VADE_CI_WORKSPACE_ROOT/{coo-harness,coo-memory}` from the
...
-the staged `vade-coo-memory` is a stub without `.git`. Bump the
+the staged `coo-memory` is a stub without `.git`. Bump the
```

## `scripts/ci/test-read-boot-inlined-guard.sh` (1 real fix, F33)

The "sibling-checkout path" test fixture at L73 used the old repo name. Per the hook's own L27 comment (`scripts/hooks/read-boot-inlined-guard.sh`), it uses tail-suffix match — repo prefix is irrelevant — so updating the prefix to current canonical preserves the test's intent without changing semantics.

```diff
-  "$(run_hook_read /workspace/vade-coo-memory/memos/memo_index.json)"
+  "$(run_hook_read /workspace/coo-memory/memos/memo_index.json)"
```

## `scripts/transcript-url-backfill.py` (skip-marker addition, F31, F32)

Added `# migration-sweep: skip` marker per the tool's `MIGRATION_SWEEP_SKIP_RE` convention. **This script IS the org-rename URL backfill** — its mapping table at L114-122 and regexes at L102/L105/L108 intentionally carry both `vade-app/*` and `coo-labs/*` literals. Rewriting them would destroy the script's purpose. The marker tells future audits to skip the file.

Verified: post-marker, `migration-sweep --mode detect --root .` returns zero SWEEP+BOOT-FILE refs for this script.

## What this PR does NOT change

- The `vade-app/vade-governance` → `coo-labs/vade-governance` mapping in L122 stays. vade-governance is archived but the URL still resolves at `coo-labs/vade-governance` (per `coo-labs/.github/repos.yaml` archived entry); URL backfill correctly redirects historical URLs there.
- C6 `VADE_*` env-var names (e.g., `$VADE_CI_WORKSPACE_ROOT`, `$VADE_COO_MEMORY_DIR`) — out of scope per briefing 038.

## Live carve-outs preserved

`$VADE_CI_WORKSPACE_ROOT`, `$VADE_CI_ALLOWLIST`, `VADE_BOOT_INLINED_READ_GUARD_BYPASS=1`, all `VADE_*` env-var names — out of scope per briefing 038 C6 (coordinated env-var rename).

## References

- coo-labs/coo-memory#1212 — audit record (F30-F33)
- coo-harness#86 — bootstrap regression suite (CLAUDE.md context)
- coo-harness#399 — read-boot-inlined-guard hook (test context)
- briefing 038 — C6 env-var rename out of scope

Closes: n/a

https://claude.ai/code/session_017hSom1HxwbstPu9qBNwZSQ