### PR TITLE
Fix S9 op-path extraction over-capturing trailing shell tokens

### DIFF
--- a/scripts/ci/test-integrity-group-s.sh
+++ b/scripts/ci/test-integrity-group-s.sh
@@ -22,6 +22,10 @@
 #   - S8: env classification — known alias goes to declared_secret;
 #         unknown allowlisted prefix → prefix_allowlist; injected
 #         token-shape value on an unknown name → unknown_secret_shape.
+#   - S9: shim-vs-schema op-path cross-check — clean corpus (incl. the
+#         unquoted-path + redirect / error-string over-capture
+#         regression and quoted space-fields) → ok; undeclared field →
+#         fail. Forces the live (non-fake-env) path via env -u.
 #
 # Skips:
 #   - S4 + S7 live `op` integration is exercised in the cloud session
@@ -361,6 +365,62 @@ line="$(printf '%s\n' "$out_s8b" | grep -E '^S8\|' | head -1)"
 _LAST_KEY="${line%%|*}"; rest="${line#*|}"; _LAST_OK="${rest%%|*}"; _LAST_DETAIL="${rest#*|}"
 _assert_fail S8 "unknown_secret_shape on injected token-shaped value"
 _assert_detail_contains "SOME_UNKNOWN_VAR" "S8 names the offending key"
+
+printf '\n== S9: shim-vs-schema op-path cross-check ==\n'
+
+# S9 reads the schema's credentials[] and greps a scripts corpus for
+# op://COO/<item>/<field> refs, flagging any not declared. It runs only
+# in a live (non-CI-fake) env, so these cases clear VADE_BINDIR_OVERRIDE
+# / VADE_CI_WORKSPACE_ROOT (which would force the fake-env skip) and
+# route schema + scripts root at dedicated synthetic fixtures.
+mkdir -p "$TEST_ROOT/s9-mem"
+S9_SCHEMA="$TEST_ROOT/s9-schema.yaml"
+cat > "$S9_SCHEMA" <<'EOF'
+schema_version: 1
+vault: COO
+credentials:
+  - id: s9-pat
+    op_item: s9-pat
+    op_field: token
+  - id: s9-ssh
+    op_item: s9-ssh
+    op_field: private key
+    op_alt_fields:
+      - public key
+EOF
+
+# Clean corpus encodes the regression. Line 1 is an UNQUOTED op-path
+# followed by `2>/dev/null`; line 2 an error string ending "... failed";
+# both previously over-captured as "token 2" / "token failed". The
+# quoted space-field paths must still resolve. All four refs are
+# declared → S9 must report ok=true.
+S9_CLEAN="$TEST_ROOT/s9-corpus-clean"
+mkdir -p "$S9_CLEAN"
+cat > "$S9_CLEAN/wired.sh" <<'EOF'
+#!/usr/bin/env bash
+val="$(op read op://COO/s9-pat/token 2>/dev/null || true)"
+echo "error: op read op://COO/s9-pat/token failed" >&2
+_op_to_file "op://COO/s9-ssh/private key" /tmp/auth
+pub="$(op read 'op://COO/s9-ssh/public key')"
+EOF
+_run_invariant S9 "$TEST_ROOT/s9-mem" env -u VADE_BINDIR_OVERRIDE -u VADE_CI_WORKSPACE_ROOT \
+  VADE_SECRETS_SCHEMA="$S9_SCHEMA" \
+  VADE_SECRETS_S9_SCRIPTS_ROOT="$S9_CLEAN"
+_assert_ok S9 "unquoted-path+redirect / error-string / quoted space-field all resolve (no over-capture)"
+
+# Drift corpus: a genuinely undeclared field must still be flagged —
+# the fix must not blunt S9's detection.
+S9_DRIFT="$TEST_ROOT/s9-corpus-drift"
+mkdir -p "$S9_DRIFT"
+cat > "$S9_DRIFT/wired.sh" <<'EOF'
+#!/usr/bin/env bash
+val="$(op read op://COO/s9-pat/wrongfield 2>/dev/null)"
+EOF
+_run_invariant S9 "$TEST_ROOT/s9-mem" env -u VADE_BINDIR_OVERRIDE -u VADE_CI_WORKSPACE_ROOT \
+  VADE_SECRETS_SCHEMA="$S9_SCHEMA" \
+  VADE_SECRETS_S9_SCRIPTS_ROOT="$S9_DRIFT"
+_assert_fail S9 "undeclared op-path field is flagged as drift"
+_assert_detail_contains "s9-pat/wrongfield" "S9 names the drifted path"
 
 printf '\n== Summary ==\n'
 printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"

--- a/scripts/lib/integrity-group-s.sh
+++ b/scripts/lib/integrity-group-s.sh
@@ -915,12 +915,6 @@ s_check_S9() {
   #   - **/ci/mocks/**              (CI op-mocks with synthetic responses)
   #   - **/_archive/**              (historical, not live)
   #   - comment lines (^[[:space:]]*#)   — doc/example refs are not bugs
-  # Item char class allows colon (e.g. "Service Account Auth Token:
-  # vade-coo"), period (date stamps), space (none today, but safe),
-  # underscore, hyphen, alnum. Field char class allows space (SSH keys
-  # use "private key" / "public key"), underscore, hyphen, alnum.
-  # `<`, `>`, `$`, `{`, `}`, `*`, backtick are excluded — those signal
-  # documentation placeholders, not real op-paths.
   local raw_lines found
   raw_lines="$(grep -rEhn 'op://COO/' "$scripts_root" \
     --include='*.sh' --include='*.py' \
@@ -928,12 +922,29 @@ s_check_S9() {
     --exclude-dir='mocks' --exclude-dir='_archive' \
     2>/dev/null)" || raw_lines=""
   # Strip the leading `<linenum>:` from each grep hit, drop comment
-  # lines, then extract op://COO/<item>/<field> tokens with the tight
-  # char classes. Sort+uniq for dedup.
+  # lines, then extract op://COO/<item>/<field> tokens. Sort+uniq dedup.
+  #
+  # Field-boundary discipline (the quoted/unquoted split below) closes a
+  # false-positive class. A 1P field may legitimately contain a space —
+  # the SSH items declare "private key" / "public key" — but such fields
+  # are ALWAYS quoted in the corpus, since an unquoted space would
+  # terminate the shell word. So two alternatives, longest-match:
+  #   1. Quoted    ['"]op://COO/<item>/<field with spaces>['"]
+  #      — field may contain spaces; the closing quote bounds the match.
+  #   2. Unquoted  op://COO/<item>/<field>
+  #      — field is [A-Za-z0-9_-]+, NO space. A trailing " 2>/dev/null"
+  #        or "|| echo failed" is the next shell token, not the field;
+  #        an earlier ( [word])? tail ate it and mis-reported
+  #        "<field> 2" / "<field> failed" as schema drift (the S9
+  #        false-positive class fixed here).
+  # Item char class allows colon ("Service Account Auth Token: vade-coo"),
+  # period (date stamps), space, underscore, hyphen, alnum. `<`,`>`,`$`,
+  # `{`,`}`,`*`,backtick stay excluded — documentation-placeholder shapes.
   found="$(printf '%s\n' "$raw_lines" \
     | sed -E 's/^[0-9]+://' \
     | awk '/^[[:space:]]*#/ { next } { print }' \
-    | grep -oE "op://COO/[A-Za-z0-9 _:.-]+/[A-Za-z0-9_-]+( [A-Za-z0-9_-]+)?" \
+    | grep -oE "['\"]op://COO/[A-Za-z0-9 _:.-]+/[A-Za-z0-9_ -]+['\"]|op://COO/[A-Za-z0-9 _:.-]+/[A-Za-z0-9_-]+" \
+    | sed -E "s/^['\"]//; s/['\"]$//" \
     | sed -E 's/[[:space:]]+$//' \
     | sort -u)" || found=""
 

--- a/scripts/lib/integrity-group-s.sh
+++ b/scripts/lib/integrity-group-s.sh
@@ -891,18 +891,24 @@ s_check_S9() {
   fi
 
   # Build the allowed-set: every credentials[].op_item × (op_field ∪
-  # op_alt_fields[]) pair. Emit one `<item>|<field>` line per pair.
-  # Filters out the placeholder op_items that contain `(` (e.g.
-  # "(env-only — ...)", "(none — minted from ...)") since those are
-  # not real 1P items and no script should op-read them anyway.
+  # op_alt_fields[]) pair, emitted as `<item>|<field>` lines. Filters
+  # out placeholder op_items containing `(` (e.g. "(env-only — ...)",
+  # "(none — minted from ...)") — not real 1P items, never op-read.
+  #
+  # Two passes (op_field, then op_alt_fields) rather than one
+  # comma-union expression: mikefarah yq drops the iterated second
+  # branch of a `A, (B[] | C)` union (verified v4.44.3) while python-yq
+  # keeps it, so the union form silently lost every op_alt_field under
+  # the Go yq — a false-positive on the SSH "public key" paths in any
+  # environment running mikefarah (CI, notably). The two-pass form is
+  # byte-identical across both implementations.
   local allowed
-  allowed="$(yq -r '
-    .credentials[]
-    | select(.op_item | test("^[^(]") )
-    | . as $c
-    | ($c.op_item + "|" + $c.op_field),
-      ( ($c.op_alt_fields // [])[] | ($c.op_item + "|" + .) )
-  ' "$schema" 2>/dev/null | sort -u)" || allowed=""
+  allowed="$(
+    {
+      yq -r '.credentials[] | select(.op_item | test("^[^(]")) | .op_item + "|" + .op_field' "$schema" 2>/dev/null
+      yq -r '.credentials[] | select(.op_item | test("^[^(]")) | .op_item as $i | .op_alt_fields[]? | $i + "|" + .' "$schema" 2>/dev/null
+    } | sort -u
+  )" || allowed=""
 
   if [ -z "$allowed" ]; then
     _add S9 skip "schema produced no op-paths to cross-check (parse failure?)"


### PR DESCRIPTION
## What

Fixes the **S9** false-positive that has degraded every fresh boot since S9 shipped this morning (MEMO-2026-06-05-v5qk, secrets-epic closeout). The boot brake is at block-on-FAIL (MEMO-2026-06-04-nzxf), so this degrades real sessions now — the session that wrote this PR booted on it.

## Root cause

S9 cross-checks every `op://COO/<item>/<field>` reference in the scripts corpus against `schema.yaml`. Its extractor used a field regex with an optional ` ( [word])?` tail — added so it could match the SSH items' space-bearing fields (`private key` / `public key`). On an **unquoted** op-path that tail greedily captured the *next shell token*:

| Source | Extracted | Verdict |
|---|---|---|
| `op read op://COO/x/credential 2>/dev/null` | `credential 2` | not in schema → flagged |
| `echo "... op read op://COO/x/credential failed"` | `credential failed` | not in schema → flagged |

Enumerated bad-set: **6 over-captures, 0 real misses.** Every base path (`.../credential`, `.../token`) is correctly declared. The credentials are sound; only the extraction was broken.

## Fix

A quoted/unquoted split in the extractor:

- **Quoted** op-paths may carry space-bearing fields; the closing quote bounds the match (preserves `private key` / `public key`).
- **Unquoted** op-paths take a no-space field, so a trailing `2>/dev/null` or `|| echo failed` is left as the shell token it is.

## Verification

- `bash scripts/ci/test-integrity-group-s.sh` → **29/29 pass**, incl. 3 new S9 cases: regression (unquoted+redirect / error-string / quoted space-field all resolve) and drift (undeclared field still flagged + named).
- Live S9 against the real corpus + `schema.yaml` → `S9|true|15 op://COO/ refs … all map to schema credentials[]`.
- Adversarial: four synthetic drift cases (unquoted typo, quoted typo, bad item, bad space-field) all still caught — detection not blunted.

Final proof requires a fresh container boot showing `summary.ok=true`; handoff prompt posted as a follow-up comment.

## Scope

S9 only. The S8 sibling (#450, same over-eager-regex class) is **separately resolved** by the schema allowlist in coo-labs/coo-memory#1208 — this PR does not touch it. Whether the secret-shape regexes themselves should be anchored is noted as out-of-scope in #463.

Closes #463.

https://claude.ai/code/session_01VDNth9n9tn8fytZW5UkmRM