### PR TITLE
Route setup-script log() to stderr to keep boot digest clean

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -2,11 +2,14 @@
 # Shared functions for VADE environment setup scripts.
 # Sourced by bootstrap.sh (devcontainer) and cloud-setup.sh (web).
 
-log() { echo "[vade-setup] $*"; }
-
-# Stderr-only variant so the message doesn't pollute stdout captures.
-# Used inside retry loops where the caller wraps us in $(...) to grab
-# a secret off stdout.
+# Status messages from setup scripts go to stderr, not stdout. SessionStart
+# hooks capture stdout into the agent's persisted-output digest; routing
+# `log` through stderr keeps boot chatter (29+ lines per coo-bootstrap run,
+# plus session-start-sync.sh, etc.) out of context while preserving the
+# meaningful digest banners (which `echo` to stdout directly). Shell
+# convention: stderr for logs, stdout for data. `log_err` is kept as an
+# alias for callers that document a stderr-only intent explicitly.
+log() { echo "[vade-setup] $*" >&2; }
 log_err() { echo "[vade-setup] $*" >&2; }
 
 # Persistent bootstrap log. Every coo-bootstrap invocation appends one


### PR DESCRIPTION
## Why

Every SessionStart, the coo-bootstrap.sh hook emits ~29 `[vade-setup]` chatter lines on stdout (op CLI present, SSH keys installed, secrets fetched, identity active, etc.). Claude Code captures hook stdout into the persisted-output digest that lands in the agent's first-turn context. The chatter precedes the actually-useful boot banner (Boot integrity, COO identity, Identity layer, Latest memos, Bootstrap posture, GitHub write surface, Mem0 surface, Cloud receipt) and is pure noise from the agent's POV — the structured outcome already lives in `~/.vade/coo-bootstrap.log` via `bootstrap_log_record`, and every important state surfaces in the boot digest banner itself.

`session-start-sync.sh` has the same shape (`[vade-setup] Synced ...`, `[vade-setup] Aggregated workspace .claude/ ...`, etc.); both hooks share `log()` from `scripts/lib/common.sh`.

## What

One-line semantic flip in `scripts/lib/common.sh`:

```diff
-log() { echo "[vade-setup] $*"; }
+log() { echo "[vade-setup] $*" >&2; }
```

Aligns `log()` with shell convention (logs to stderr, data to stdout). `log_err()` is preserved as an explicit-intent alias for callers that document a stderr-only intent.

The boot digest banners themselves (the meaningful output) `echo` directly to stdout — unaffected. Interactive runs (Mac `local-setup.sh`, terminal `coo-bootstrap.sh` for recovery) keep showing the chatter because terminals render stderr inline.

## Safety check

Grep across `scripts/` for any caller capturing `log()` output via `$(...)`: none. Only `git log` subshells and `node console.log` hits. CI suite (`scripts/ci/run-bootstrap-regression.sh` + bootstrap-regression workflow) doesn't assert on `[vade-setup]` stdout. `boot-brake-clear.sh`, `discussions-digest.sh`, `project-board-digest.sh` use `log()` only for skip/error paths that we want suppressed from the digest anyway.

## Verification

This is boot-impacting and can only be checked on a fresh container. After merge:

1. Start a fresh Claude Code on the web session against `main`.
2. Inspect the SessionStart persisted-output digest. Expected: no `[vade-setup]` prefix lines anywhere; first non-blank line is the green `Boot integrity:` banner (or the `BOOT DEGRADED` block on failure).
3. Inspect the first system reminder from `session-start-sync.sh`. Expected: no `[vade-setup] Synced ...` chatter either.
4. Run `tail -5 ~/.vade/coo-bootstrap.log` — structured `OK step=complete rc=0` line should still be there.

Closes none — tactical fix raised by Ven during a session.


Closes: n/a

https://claude.ai/code/session_015nR9GAPrCY61JeJRNDx59t