### PR TITLE
gh-coo-wrap: emit multi-line bodies as --body-file

### DIFF
--- a/scripts/ci/test-gh-coo-wrap.sh
+++ b/scripts/ci/test-gh-coo-wrap.sh
@@ -158,6 +158,34 @@ out="$(printf 'from stdin' | "$WRAPPER" pr create --title t --body-file -)"
 assert_contains "--body-file=stdin augments" "$out" "$EXPECTED_URL"
 assert_contains "--body-file=stdin preserves" "$out" "from stdin"
 
+# ---- TEST 14a: multi-line --body materializes to --body-file (coo-memory#1052) ----
+# Multi-line --body values lose backslash + escape literal characters through
+# `gh`'s argv-to-JSON path on some transport edges (heredoc-mangling shape).
+# The wrap re-emits multi-line bodies as --body-file <tmp> so the body is
+# byte-exact downstream.
+multiline_body=$'first line\nsecond line with \\backslash\nthird line'
+out="$("$WRAPPER" pr create --title t --body "$multiline_body")"
+assert_contains "multi-line --body emits --body-file ARG" "$out" "ARG[5]=--body-file"
+assert_contains "multi-line --body content: line 1 preserved" "$out" "first line"
+assert_contains "multi-line --body content: literal backslash preserved" "$out" "\\backslash"
+assert_contains "multi-line --body content: line 3 preserved" "$out" "third line"
+assert_contains "multi-line --body content augmented" "$out" "$EXPECTED_URL"
+
+# ---- TEST 14b: single-line --body stays inline when not augmented ----
+# The augment function returns the body unchanged when it already carries
+# a session URL (idempotency path). A single-line idempotent body should
+# stay inline as --body <text>, not be lifted into --body-file.
+out="$("$WRAPPER" pr create --title t --body "already has $EXPECTED_URL inline")"
+assert_contains "single-line idempotent --body keeps --body ARG" "$out" "ARG[5]=--body"
+assert_not_contains "single-line idempotent --body does NOT emit --body-file" "$out" "ARG[5]=--body-file"
+
+# ---- TEST 14c: multi-line --body= form also materializes ----
+out="$("$WRAPPER" pr create --title t --body="alpha
+beta")"
+assert_contains "multi-line --body= emits --body-file" "$out" "ARG[5]=--body-file"
+assert_contains "multi-line --body= content preserved" "$out" "alpha"
+assert_contains "multi-line --body= content preserved (line 2)" "$out" "beta"
+
 # ---- TEST 15: outside-Claude (no session env) — pass-through ----
 out="$(env -u CLAUDE_CODE_REMOTE_SESSION_ID -u CLAUDE_CODE_SESSION_ID \
        COO_GH_REAL="$WORK/gh-real" "$WRAPPER" pr create --title t --body "hi")"

--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -638,28 +638,50 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Append a body value to new_args as either inline --body <text> (single
+# line) or staged --body-file <tmp> (multi-line). Multi-line --body inputs
+# travel through `gh`'s argv → HTTP-JSON path and lose literal backslashes
+# / newline escapes on some transport edges (the heredoc-mangling shape
+# of coo-memory#1052). Staging to a file makes the body byte-exact.
+# Temp file lifetime is bound to the cleanup trap above.
+emit_body_value() {
+  local val="$1"
+  case "$val" in
+    *$'\n'*)
+      local tmp
+      tmp="$(mktemp)"
+      tmp_files+=("$tmp")
+      printf '%s' "$val" > "$tmp"
+      new_args+=("--body-file" "$tmp")
+      ;;
+    *)
+      new_args+=("--body" "$val")
+      ;;
+  esac
+}
+
 while [ $# -gt 0 ]; do
   a="$1"
   case "$a" in
     --body|-b)
       shift
       body="${1:-}"
-      new_args+=("$a" "$(augment "$body")")
+      emit_body_value "$(augment "$body")"
       ;;
     --body=*)
       body="${a#--body=}"
-      new_args+=("--body=$(augment "$body")")
+      emit_body_value "$(augment "$body")"
       ;;
     -b=*)
       body="${a#-b=}"
-      new_args+=("-b=$(augment "$body")")
+      emit_body_value "$(augment "$body")"
       ;;
     --body-file)
       shift
       bf="${1:-}"
       if [ "$bf" = "-" ]; then
         body="$(cat)"
-        new_args+=("--body" "$(augment "$body")")
+        emit_body_value "$(augment "$body")"
       elif [ -f "$bf" ]; then
         body="$(cat "$bf")"
         tmp="$(mktemp)"
@@ -674,7 +696,7 @@ while [ $# -gt 0 ]; do
       bf="${a#--body-file=}"
       if [ "$bf" = "-" ]; then
         body="$(cat)"
-        new_args+=("--body" "$(augment "$body")")
+        emit_body_value "$(augment "$body")"
       elif [ -f "$bf" ]; then
         body="$(cat "$bf")"
         tmp="$(mktemp)"


### PR DESCRIPTION
## Summary

Final piece of the github-ops consolidation arc: extends `gh-coo-wrap.sh`'s arg-walk so multi-line `--body` values stage to a tempfile and re-emit as `--body-file <tmp>` before reaching `gh-real`. Practically, since the session-URL augmentation appends `\n\n<URL>` to every covered body, **every augmented body** now lands on the `--body-file` path — byte-exact transport with no caller-side awareness needed.

## Why

`gh`'s argv → HTTP-JSON encoder loses literal backslashes and certain escape characters on multi-line `--body` values when routed through the cloud-proxy transport. The recurring shape (`gh issue comment --body "$(cat <<EOF ... \backslash ... EOF)"` → rendered comment shows mangled output) is what [coo-labs/coo-memory#1052](https://github.com/coo-labs/coo-memory/issues/1052) tracked. `--body-file` is byte-exact because `gh` reads the file synchronously and posts the bytes; there's no shell-escaping intermediate.

## What landed

One file changed (production), one file changed (tests):

`scripts/gh-coo-wrap.sh`:
- New helper `emit_body_value` decides between `--body <text>` (single-line) and `--body-file <tmp>` (multi-line) per emission
- Four arg-walk branches now route through it: `--body|-b`, `--body=`, `-b=`, `--body-file -` (stdin)
- The two `--body-file <real-file>` branches already staged to temp + emitted `--body-file <tmp>`; unchanged
- Temp files registered with the existing `tmp_files` array — existing `cleanup` EXIT trap handles lifetime

`scripts/ci/test-gh-coo-wrap.sh`:
- Test 14a — multi-line `--body` emits `--body-file <tmp>` with byte-exact content including literal backslashes (`\backslash` round-trip)
- Test 14b — single-line idempotent `--body` (body already contains the session URL → augment no-ops) stays inline as `--body <text>`
- Test 14c — multi-line `--body=` form also materializes to `--body-file`

## Verification

```
Total: 108 pass, 1 fail
```

The single failing test (`GITHUB_PUBLIC_PAT unset: no swap, keeps MCP_PAT`) is pre-existing on main, unrelated to this change. Verified by running the same test suite on main before applying this PR (also 1 fail, same name).

## Architectural fit

This is **Move 4 of the github-ops consolidation arc** planned at [coo-labs/coo-memory#1213](https://github.com/coo-labs/coo-memory/pull/1213) and re-scoped by [MEMO-2026-06-05-ctgh](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-05-ctgh.md). The memo narrowed #1052's "centralized router" framing to just the body-normalization transform that belongs in `gh-coo-wrap.sh` — composed with the per-op wrappers (`gh-pr-create.sh`, `gh-issue-create.sh` from Move 3 / coo-labs/coo-harness#469).

Arc state after this PR:
- ✅ Move 1: hygiene-workflow regex + registry-driven slug derivation (coo-labs/coo-harness#462, coo-labs/coo-memory#976 + #1010 closed)
- ✅ Move 2: architectural memo (coo-labs/coo-memory#1220, [MEMO-2026-06-05-ctgh](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-05-ctgh.md))
- ✅ Move 3: `gh-issue-create.sh` (coo-labs/coo-harness#469, coo-labs/coo-memory#912 closed)
- 🟡 Move 4: this PR — closes narrowed coo-labs/coo-memory#1052
- 📝 Doc sweep (coo-labs/coo-memory#914): follows in a sibling PR against coo-memory

Closes coo-labs/coo-memory#1052

https://claude.ai/code/session_01EdNgXPHaExPYAduC72BzSs