### PR TITLE
boot: idempotent install_coo_ssh_keys — skip op-read when disk matches

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -137,6 +137,9 @@ jobs:
       - name: op-read retry recovery — install_coo_ssh_keys path (coo-harness#451)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-op-retry-recovery.sh"
 
+      - name: install_coo_ssh_keys idempotent skip (coo-harness#473)
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/test-install-coo-ssh-keys-idempotent.sh"
+
       - name: Git push fallback — op:// PAT resolution + leak hardening (coo-harness#457, #124)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-git-push-fallback.sh"
 

--- a/scripts/ci/test-install-coo-ssh-keys-idempotent.sh
+++ b/scripts/ci/test-install-coo-ssh-keys-idempotent.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# test-install-coo-ssh-keys-idempotent: lock in the skip-when-clean
+# behavior of install_coo_ssh_keys (coo-harness#473).
+#
+# When the four COO SSH key files already exist on disk and their
+# fingerprints match the expected values, install_coo_ssh_keys should
+# not call `op read` at all — the disk content would be identical, and
+# every avoided op-read saves wall time + 1P quota.
+#
+# Strategy: source common.sh, override `op` as a bash function that
+# tracks whether it was called. Pre-stage $HOME/.ssh with fixture
+# ed25519 keys; set COO_AUTH_FP_EXPECTED / COO_SIGN_FP_EXPECTED to the
+# matching values. Run install_coo_ssh_keys and assert op was never
+# invoked. Then mutate one expected fingerprint and assert the function
+# falls through to the op path.
+#
+# Run: bash scripts/ci/test-install-coo-ssh-keys-idempotent.sh
+# Exit: 0 if all assertions pass, non-zero otherwise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMMON="$REPO_ROOT/scripts/lib/common.sh"
+
+[ -f "$COMMON" ] || { echo "FAIL: common.sh not found at $COMMON" >&2; exit 1; }
+
+command -v ssh-keygen >/dev/null 2>&1 || {
+  echo "SKIP: ssh-keygen not on PATH; idempotent skip relies on it" >&2
+  exit 0
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+export HOME="$WORK/home"
+mkdir -p "$HOME/.ssh" "$HOME/.vade"
+chmod 700 "$HOME/.ssh"
+
+export VADE_RUNTIME_DIR="$REPO_ROOT"
+export VADE_COO_MEMORY_DIR="${VADE_COO_MEMORY_DIR:-$REPO_ROOT/../coo-memory}"
+export VADE_CLOUD_STATE_DIR="$WORK/cloud-state"
+mkdir -p "$VADE_CLOUD_STATE_DIR"
+
+# Generate fixture ed25519 keys; capture their fingerprints as the
+# "expected" values for the skip path. Same pattern the bootstrap-
+# regression runner uses (scripts/ci/run-bootstrap-regression.sh).
+ssh-keygen -t ed25519 -N "" -C "test-auth" -f "$HOME/.ssh/vade-coo-auth"  >/dev/null
+ssh-keygen -t ed25519 -N "" -C "test-sign" -f "$HOME/.ssh/vade-coo-sign"  >/dev/null
+chmod 0600 "$HOME/.ssh/vade-coo-auth" "$HOME/.ssh/vade-coo-sign"
+chmod 0644 "$HOME/.ssh/vade-coo-auth.pub" "$HOME/.ssh/vade-coo-sign.pub"
+
+COO_AUTH_FP_EXPECTED="$(ssh-keygen -lf "$HOME/.ssh/vade-coo-auth.pub" | awk '{print $2}')"
+COO_SIGN_FP_EXPECTED="$(ssh-keygen -lf "$HOME/.ssh/vade-coo-sign.pub" | awk '{print $2}')"
+export COO_AUTH_FP_EXPECTED COO_SIGN_FP_EXPECTED
+
+# shellcheck disable=SC1090
+source "$COMMON"
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+_pass() { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+_fail() { FAIL=$((FAIL+1)); FAILURES+=("$1"); printf '  FAIL  %s\n' "$1"; }
+
+OP_CALL_LOG="$WORK/op-calls.log"
+: > "$OP_CALL_LOG"
+
+# Snapshot the on-disk key material at setup so the mock can return
+# stable content even after test 3 deletes one of the files. Without
+# this, the mock's `cat` would return empty content on the deleted
+# file, _op_to_file's empty-content guard would trip, and the test
+# would fail for the wrong reason (mock plumbing, not the skip-branch
+# fall-through we're checking).
+SNAP_AUTH_PRIV="$(cat "$HOME/.ssh/vade-coo-auth")"
+SNAP_AUTH_PUB="$(cat "$HOME/.ssh/vade-coo-auth.pub")"
+SNAP_SIGN_PRIV="$(cat "$HOME/.ssh/vade-coo-sign")"
+SNAP_SIGN_PUB="$(cat "$HOME/.ssh/vade-coo-sign.pub")"
+export SNAP_AUTH_PRIV SNAP_AUTH_PUB SNAP_SIGN_PRIV SNAP_SIGN_PUB
+
+# Tracking op stub — records each invocation. The success branch echoes
+# the snapshotted content so _op_to_file's empty-content guard doesn't
+# trip and the rewritten disk content matches the original fingerprints.
+op() {
+  printf '%s\n' "$*" >> "$OP_CALL_LOG"
+  if [ "${1:-}" = "read" ]; then
+    case "${2:-}" in
+      "op://COO/vade-coo-ssh-auth/private key") printf '%s' "$SNAP_AUTH_PRIV" ;;
+      "op://COO/vade-coo-ssh-auth/public key")  printf '%s' "$SNAP_AUTH_PUB" ;;
+      "op://COO/vade-coo-ssh-sign/private key") printf '%s' "$SNAP_SIGN_PRIV" ;;
+      "op://COO/vade-coo-ssh-sign/public key")  printf '%s' "$SNAP_SIGN_PUB" ;;
+      *) echo "test-mock-op-$2" ;;
+    esac
+  fi
+  return 0
+}
+export -f op
+
+# ── Test 1: skip path when disk matches expected ─────────────────
+printf '\nTest 1: install_coo_ssh_keys skips op-read when fingerprints match\n'
+: > "$OP_CALL_LOG"
+RC1=0
+install_coo_ssh_keys >"$WORK/log1" 2>&1 || RC1=$?
+
+if [ "$RC1" -eq 0 ]; then
+  _pass "skip path: rc=0"
+else
+  _fail "skip path: rc=$RC1 (expected 0). Log: $(cat "$WORK/log1")"
+fi
+
+OP_CALLS="$(wc -l < "$OP_CALL_LOG" | tr -d ' ')"
+if [ "$OP_CALLS" = "0" ]; then
+  _pass "skip path: op never called (0 invocations)"
+else
+  _fail "skip path: op called $OP_CALLS time(s). Calls: $(cat "$OP_CALL_LOG")"
+fi
+
+if grep -qF "skipping op-read" "$WORK/log1"; then
+  _pass "skip path: skip-line logged"
+else
+  _fail "skip path: 'skipping op-read' missing from log"
+fi
+
+if [ -f "$HOME/.ssh/allowed_signers" ] \
+   && grep -q '^coo@vade-app.dev ' "$HOME/.ssh/allowed_signers"; then
+  _pass "skip path: allowed_signers refreshed (derived state still runs)"
+else
+  _fail "skip path: allowed_signers missing or malformed"
+fi
+
+# ── Test 2: refetch when one fingerprint mismatches ──────────────
+printf '\nTest 2: install_coo_ssh_keys falls through to op-read on fingerprint mismatch\n'
+: > "$OP_CALL_LOG"
+# Mutate expected auth fingerprint so disk no longer matches; signing
+# stays matching to confirm the AND-of-both-match gate is correct.
+COO_AUTH_FP_EXPECTED="SHA256:thisDoesNotMatchAnyOnDiskKeyAtAll0000000000"
+export COO_AUTH_FP_EXPECTED
+
+RC2=0
+install_coo_ssh_keys >"$WORK/log2" 2>&1 || RC2=$?
+
+# The fetch path overwrites disk with mock content matching the
+# original disk fingerprints, so the post-fetch fingerprint check
+# rejects them against the (now-different) expected — rc=1 is correct.
+# The point of this test is: op WAS called (skip path correctly didn't
+# fire), not that the overall function succeeded.
+if [ "$RC2" -ne 0 ]; then
+  _pass "mismatch path: rc=$RC2 (non-zero — fetch path's fingerprint check rejects mismatched expected)"
+else
+  _fail "mismatch path: rc=0 (expected non-zero; fingerprint check should reject)"
+fi
+
+if grep -qF "refetching" "$WORK/log2"; then
+  _pass "mismatch path: 'refetching' line logged"
+else
+  _fail "mismatch path: 'refetching' line missing"
+fi
+
+OP_CALLS2="$(wc -l < "$OP_CALL_LOG" | tr -d ' ')"
+if [ "$OP_CALLS2" -ge 4 ]; then
+  _pass "mismatch path: op called ≥4 times (one per key file: $OP_CALLS2)"
+else
+  _fail "mismatch path: op called only $OP_CALLS2 times (expected ≥4)"
+fi
+
+# ── Test 3: missing files fall through to op-read ────────────────
+printf '\nTest 3: install_coo_ssh_keys falls through when a key file is missing\n'
+rm -f "$HOME/.ssh/vade-coo-sign"
+: > "$OP_CALL_LOG"
+# Restore matching expected fingerprints so the post-fetch check passes
+# (mock writes the original-fingerprint content).
+COO_AUTH_FP_EXPECTED="$(ssh-keygen -lf "$HOME/.ssh/vade-coo-auth.pub" | awk '{print $2}')"
+COO_SIGN_FP_EXPECTED="$(ssh-keygen -lf "$HOME/.ssh/vade-coo-sign.pub" | awk '{print $2}')"
+export COO_AUTH_FP_EXPECTED COO_SIGN_FP_EXPECTED
+
+RC3=0
+install_coo_ssh_keys >"$WORK/log3" 2>&1 || RC3=$?
+
+if [ "$RC3" -eq 0 ]; then
+  _pass "missing-file path: rc=0 (fetch path succeeds, fingerprints match)"
+else
+  _fail "missing-file path: rc=$RC3 (expected 0). Log: $(cat "$WORK/log3")"
+fi
+
+if ! grep -qF "skipping op-read" "$WORK/log3"; then
+  _pass "missing-file path: did not take skip branch"
+else
+  _fail "missing-file path: incorrectly took skip branch despite missing file"
+fi
+
+OP_CALLS3="$(wc -l < "$OP_CALL_LOG" | tr -d ' ')"
+if [ "$OP_CALLS3" -ge 4 ]; then
+  _pass "missing-file path: op called ≥4 times ($OP_CALLS3)"
+else
+  _fail "missing-file path: op called only $OP_CALLS3 times (expected ≥4)"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failures:\n'
+  for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f"; done
+  exit 1
+fi
+exit 0

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -2048,37 +2048,12 @@ _fingerprint_of() {
   ssh-keygen -lf "$pub" 2>/dev/null | awk '{print $2}' || true
 }
 
-# Install COO SSH keys from 1Password into ~/.ssh/. Validates
-# fingerprints against expected values when ssh-keygen is available;
-# logs a warning and continues when it is not (see ensure_openssh_client).
-install_coo_ssh_keys() {
-  local ssh_dir="${HOME}/.ssh"
-  mkdir -p "$ssh_dir"
-  chmod 700 "$ssh_dir"
-  log "Installing COO SSH keys into $ssh_dir"
-
-  _op_to_file "op://COO/vade-coo-ssh-auth/private key" "$ssh_dir/vade-coo-auth"     0600 || return 1
-  _op_to_file "op://COO/vade-coo-ssh-auth/public key"  "$ssh_dir/vade-coo-auth.pub" 0644 || return 1
-  _op_to_file "op://COO/vade-coo-ssh-sign/private key" "$ssh_dir/vade-coo-sign"     0600 || return 1
-  _op_to_file "op://COO/vade-coo-ssh-sign/public key"  "$ssh_dir/vade-coo-sign.pub" 0644 || return 1
-
-  if ensure_openssh_client; then
-    local fp_auth fp_sign
-    fp_auth="$(_fingerprint_of "$ssh_dir/vade-coo-auth.pub")"
-    fp_sign="$(_fingerprint_of "$ssh_dir/vade-coo-sign.pub")"
-    if [ "$fp_auth" != "$COO_AUTH_FP_EXPECTED" ]; then
-      log "FATAL: auth key fingerprint mismatch (got '${fp_auth:-empty}', expected $COO_AUTH_FP_EXPECTED)"
-      return 1
-    fi
-    if [ "$fp_sign" != "$COO_SIGN_FP_EXPECTED" ]; then
-      log "FATAL: signing key fingerprint mismatch (got '${fp_sign:-empty}', expected $COO_SIGN_FP_EXPECTED)"
-      return 1
-    fi
-    log "SSH key fingerprints validated"
-  else
-    log "WARNING: skipping SSH key fingerprint validation (ssh-keygen unavailable)"
-  fi
-
+# Refresh allowed_signers + known_hosts from current ~/.ssh state.
+# Idempotent — writes the same bytes given the same pubkeys, so both
+# the op-read and the disk-skip paths in install_coo_ssh_keys reach
+# identical disk state by calling it (coo-harness#473).
+_install_coo_ssh_keys_derived_state() {
+  local ssh_dir="$1"
   local allowed="$ssh_dir/allowed_signers"
   {
     echo "coo@vade-app.dev $(cat "$ssh_dir/vade-coo-auth.pub")"
@@ -2101,6 +2076,64 @@ install_coo_ssh_keys() {
       log "WARNING: ssh-keyscan github.com returned nothing (port 22 blocked?); SSH git ops will fail in this environment"
     fi
   fi
+}
+
+# Install COO SSH keys from 1Password into ~/.ssh/. Validates
+# fingerprints against expected values when ssh-keygen is available;
+# logs a warning and continues when it is not (see ensure_openssh_client).
+#
+# Skip-when-clean: if the four key files are already on disk with
+# fingerprints matching the expected values, the four op-reads below
+# would just rewrite the same bytes — skip them entirely. coo-harness#473.
+# Saves ~1.6 s of wall time + 4 quota units per marker-stale re-bootstrap.
+# Falls through on missing files, missing ssh-keygen (no way to validate),
+# or fingerprint mismatch (refetch overwrites stale or rotated content).
+install_coo_ssh_keys() {
+  local ssh_dir="${HOME}/.ssh"
+  mkdir -p "$ssh_dir"
+  chmod 700 "$ssh_dir"
+
+  if [ -f "$ssh_dir/vade-coo-auth" ] \
+     && [ -f "$ssh_dir/vade-coo-auth.pub" ] \
+     && [ -f "$ssh_dir/vade-coo-sign" ] \
+     && [ -f "$ssh_dir/vade-coo-sign.pub" ] \
+     && ensure_openssh_client; then
+    local _disk_fp_auth _disk_fp_sign
+    _disk_fp_auth="$(_fingerprint_of "$ssh_dir/vade-coo-auth.pub")"
+    _disk_fp_sign="$(_fingerprint_of "$ssh_dir/vade-coo-sign.pub")"
+    if [ "$_disk_fp_auth" = "$COO_AUTH_FP_EXPECTED" ] \
+       && [ "$_disk_fp_sign" = "$COO_SIGN_FP_EXPECTED" ]; then
+      log "COO SSH keys already installed at $ssh_dir (fingerprints match); skipping op-read"
+      _install_coo_ssh_keys_derived_state "$ssh_dir"
+      return 0
+    fi
+    log "COO SSH keys on disk but fingerprint mismatch (auth=${_disk_fp_auth:-empty} sign=${_disk_fp_sign:-empty}); refetching"
+  fi
+
+  log "Installing COO SSH keys into $ssh_dir"
+  _op_to_file "op://COO/vade-coo-ssh-auth/private key" "$ssh_dir/vade-coo-auth"     0600 || return 1
+  _op_to_file "op://COO/vade-coo-ssh-auth/public key"  "$ssh_dir/vade-coo-auth.pub" 0644 || return 1
+  _op_to_file "op://COO/vade-coo-ssh-sign/private key" "$ssh_dir/vade-coo-sign"     0600 || return 1
+  _op_to_file "op://COO/vade-coo-ssh-sign/public key"  "$ssh_dir/vade-coo-sign.pub" 0644 || return 1
+
+  if ensure_openssh_client; then
+    local fp_auth fp_sign
+    fp_auth="$(_fingerprint_of "$ssh_dir/vade-coo-auth.pub")"
+    fp_sign="$(_fingerprint_of "$ssh_dir/vade-coo-sign.pub")"
+    if [ "$fp_auth" != "$COO_AUTH_FP_EXPECTED" ]; then
+      log "FATAL: auth key fingerprint mismatch (got '${fp_auth:-empty}', expected $COO_AUTH_FP_EXPECTED)"
+      return 1
+    fi
+    if [ "$fp_sign" != "$COO_SIGN_FP_EXPECTED" ]; then
+      log "FATAL: signing key fingerprint mismatch (got '${fp_sign:-empty}', expected $COO_SIGN_FP_EXPECTED)"
+      return 1
+    fi
+    log "SSH key fingerprints validated"
+  else
+    log "WARNING: skipping SSH key fingerprint validation (ssh-keygen unavailable)"
+  fi
+
+  _install_coo_ssh_keys_derived_state "$ssh_dir"
 }
 
 # Record a per-call op-read observability event to


### PR DESCRIPTION
Closes #473.

## Why

`install_coo_ssh_keys` issues four 1Password reads every bootstrap. On a fresh boot that's load-bearing; on a marker-stale re-bootstrap it's pure waste — disk already holds the correct keys from the cold boot 30 s ago, and the four `op read`s just rewrite identical bytes. Each one is ~0.4 s wall time + one quota unit against the per-SA daily budget (1000 read+write/24h on Personal/Teams plans).

Our own session today shows the shape:
```
09:58:25Z START
09:58:55Z OK step=complete rc=0     (30s cold)
09:59:26Z START marker stale ...
09:59:35Z OK step=complete rc=0     (9s warm re-run — but four redundant op-reads inside)
```

Separate from [#451](https://github.com/coo-labs/coo-harness/issues/451) (fresh-boot first-attempt FAIL). #451 is about recovery from transients on a no-disk-state boot; #473 is about not paying for a fetch when disk is already authoritative. The two issues touch the same function for orthogonal reasons.

## What changed

**`scripts/lib/common.sh` `install_coo_ssh_keys`** — new skip-when-clean gate at the top:

```
if four-key-files-exist && ssh-keygen-available && both-fingerprints-match-expected; then
    log "COO SSH keys already installed at $ssh_dir (fingerprints match); skipping op-read"
    refresh allowed_signers + known_hosts
    return 0
fi
# else: fall through to the existing op-read + fingerprint-check + write path
```

Truth table:

| keys-on-disk | ssh-keygen | fp match | path           |
|---|---|---|---|
| any-missing  | -          | -        | full fetch     |
| all-present  | absent     | -        | full fetch (can't validate → safer to refetch) |
| all-present  | present    | mismatch | full fetch (logs `refetching` — stale or rotated key) |
| all-present  | present    | match    | **skip** (logs `skipping op-read`) |

The `allowed_signers` / `ssh-keyscan` derived-state section is extracted into `_install_coo_ssh_keys_derived_state` so both paths reach identical disk state without code duplication.

## Test

New `scripts/ci/test-install-coo-ssh-keys-idempotent.sh`, modeled on `test-op-retry-recovery.sh`. Generates fixture ed25519 keys, captures their fingerprints as `COO_*_FP_EXPECTED`, then asserts:

1. **Skip path** — disk pre-staged with matching fingerprints; `op` is never called (0 invocations); `rc=0`; skip-line logged; `allowed_signers` refreshed.
2. **Mismatch path** — flip the expected auth fingerprint; `op` IS called (4 invocations); `refetching` line logged; `rc=1` (post-fetch check rejects against the now-mismatched expected — confirming the AND-of-both gate, not OR).
3. **Missing-file path** — `rm` one key file before invocation; the gate drops to the fetch branch even though three files are present; `op` called ≥4 times; `rc=0` (mock writes content matching the reset expected fingerprints).

10 assertions, runs in <1 s (no retry sleeps). Wired into the `transcript-redaction` job in `.github/workflows/bootstrap-regression.yml`.

## Verification in-session

- `bash -n scripts/lib/common.sh` clean.
- New test: 10/10 passing.
- Adjacent suites unaffected: `test-op-retry-recovery.sh` 8/8, `test-op-coo-wrap.sh` 30/30.

Live container behavior requires a fresh boot. Handoff prompt posted as PR comment per CLAUDE.md "Handoff prompts for boot-impacting PRs".

## Linked work

- Issue: #473
- Sibling (orthogonal but adjacent): #451 / [#472](https://github.com/coo-labs/coo-harness/pull/472)

https://claude.ai/code/session_01RuoFyvVGb6dcqp7jJi3PMH