### PR TITLE
scripts/billing: add cloudflare-scope-probe.sh (refs coo-labs/coo-memory#1025)

### DIFF
--- a/scripts/billing/cloudflare-scope-probe.sh
+++ b/scripts/billing/cloudflare-scope-probe.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# cloudflare-scope-probe.sh — verify the six account-level read scopes
+# added to CLOUDFLARE_API_TOKEN per MEMO-2026-06-05-vegp actually work
+# against the live Cloudflare API.
+#
+# Read-only; emits a markdown probe report to stdout. No side effects.
+# Sister script (full usage digest) is the deferred follow-on tracked
+# against coo-labs/coo-memory#1025.
+
+set -euo pipefail
+
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN not set}"
+: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID not set}"
+
+CF_BASE="https://api.cloudflare.com/client/v4"
+H_AUTH=(-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
+H_CT=(-H "Content-Type: application/json")
+
+probe() {
+  local label="$1" method="$2" path="$3"
+  local resp http body success
+  resp=$(curl -s -w '\n%{http_code}' -X "$method" "${H_AUTH[@]}" "${H_CT[@]}" "$CF_BASE$path")
+  http="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  success=$(printf '%s' "$body" | jq -r '.success // empty' 2>/dev/null || echo "")
+  if [[ "$http" == "200" && "$success" == "true" ]]; then
+    printf -- "- **%s** — \`%s %s\` — OK\n" "$label" "$method" "$path"
+  else
+    local err
+    err=$(printf '%s' "$body" | jq -r '.errors[0].message // empty' 2>/dev/null || echo "")
+    printf -- "- **%s** — \`%s %s\` — FAIL (http=%s%s)\n" "$label" "$method" "$path" "$http" "${err:+, $err}"
+  fi
+}
+
+printf "# Cloudflare scope probe (account_id=%s)\n\n" "$CLOUDFLARE_ACCOUNT_ID"
+printf "Generated: %s\n\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf "## New account-level read scopes (MEMO-2026-06-05-vegp)\n\n"
+probe "Account Settings"  GET "/accounts/$CLOUDFLARE_ACCOUNT_ID"
+probe "Billing profile"   GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/billing/profile"
+probe "Billing history"   GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/billing/history"
+probe "Workers scripts"   GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts"
+probe "R2 buckets"        GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/r2/buckets"
+probe "Pages projects"    GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects"
+printf "\n## Pre-existing scopes (sanity)\n\n"
+probe "Zone list"         GET "/zones"


### PR DESCRIPTION
Adds `scripts/billing/cloudflare-scope-probe.sh` — a read-only verification script for the six Account-level read scopes added to `CLOUDFLARE_API_TOKEN` per [coo-labs/coo-memory MEMO-2026-06-05-vegp](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-05-vegp.md).

## What it does

Hits each scope's canonical Cloudflare API endpoint, reports success/failure per endpoint as a markdown report on stdout. No side effects, no PII or billing values leaked (just success/failure per endpoint).

| Scope | Endpoint |
|---|---|
| Account Settings | `GET /accounts/{id}` |
| Billing | `GET /accounts/{id}/billing/profile` + `/billing/history` |
| Workers Scripts | `GET /accounts/{id}/workers/scripts` |
| Workers R2 Storage | `GET /accounts/{id}/r2/buckets` |
| Pages | `GET /accounts/{id}/pages/projects` |
| (sanity) Zone list | `GET /zones` |

## Verified live

Ran end-to-end against the Cloudflare API after the scope edit. All six new scope endpoints returned `success=true`; pre-existing zone scope still works.

## Invocation

```sh
CLOUDFLARE_API_TOKEN=$(op read 'op://COO/cloudflare-api-vade-coo/credential') \
CLOUDFLARE_ACCOUNT_ID=$(op read 'op://COO/cloudflare-api-vade-coo/account_id') \
bash scripts/billing/cloudflare-scope-probe.sh
```

## What's next

The full Cloudflare usage / cost digest script that consumes these endpoints is the deferred follow-on — tracked against [coo-labs/coo-memory#1025](https://github.com/coo-labs/coo-memory/issues/1025) (services + subscriptions tracking epic). This PR is the verification half; the digest builds on the verified endpoint set.

Companion memo + schema update in [coo-labs/coo-memory#1224](https://github.com/coo-labs/coo-memory/pull/1224).

Closes: n/a

https://claude.ai/code/session_01PJdsm8uEWfJgX1xSdZAKyQ