### PR TITLE
scripts/billing: add github-scope-probe.sh (refs coo-labs/coo-memory#1025)

### DIFF
--- a/scripts/billing/cloudflare-scope-probe.sh
+++ b/scripts/billing/cloudflare-scope-probe.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# cloudflare-scope-probe.sh — verify the six account-level read scopes
+# added to CLOUDFLARE_API_TOKEN per MEMO-2026-06-05-vegp actually work
+# against the live Cloudflare API.
+#
+# Read-only; emits a markdown probe report to stdout. No side effects.
+# Sister script (full usage digest) is the deferred follow-on tracked
+# against coo-labs/coo-memory#1025.
+
+set -euo pipefail
+
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN not set}"
+: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID not set}"
+
+CF_BASE="https://api.cloudflare.com/client/v4"
+H_AUTH=(-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
+H_CT=(-H "Content-Type: application/json")
+
+probe() {
+  local label="$1" method="$2" path="$3"
+  local resp http body success
+  resp=$(curl -s -w '\n%{http_code}' -X "$method" "${H_AUTH[@]}" "${H_CT[@]}" "$CF_BASE$path")
+  http="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  success=$(printf '%s' "$body" | jq -r '.success // empty' 2>/dev/null || echo "")
+  if [[ "$http" == "200" && "$success" == "true" ]]; then
+    printf -- "- **%s** — \`%s %s\` — OK\n" "$label" "$method" "$path"
+  else
+    local err
+    err=$(printf '%s' "$body" | jq -r '.errors[0].message // empty' 2>/dev/null || echo "")
+    printf -- "- **%s** — \`%s %s\` — FAIL (http=%s%s)\n" "$label" "$method" "$path" "$http" "${err:+, $err}"
+  fi
+}
+
+printf "# Cloudflare scope probe (account_id=%s)\n\n" "$CLOUDFLARE_ACCOUNT_ID"
+printf "Generated: %s\n\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf "## New account-level read scopes (MEMO-2026-06-05-vegp)\n\n"
+probe "Account Settings"  GET "/accounts/$CLOUDFLARE_ACCOUNT_ID"
+probe "Billing profile"   GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/billing/profile"
+probe "Billing history"   GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/billing/history"
+probe "Workers scripts"   GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts"
+probe "R2 buckets"        GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/r2/buckets"
+probe "Pages projects"    GET "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects"
+printf "\n## Pre-existing scopes (sanity)\n\n"
+probe "Zone list"         GET "/zones"

--- a/scripts/billing/github-scope-probe.sh
+++ b/scripts/billing/github-scope-probe.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# github-scope-probe.sh — verify the Organization administration:Read
+# permission added to vade-coo-app per coo-labs/coo-memory MEMO-2026-06-05-nubs
+# actually reaches the GitHub billing endpoints. Runs the App-install-token
+# path (via gh-coo-wrap.sh's GH_USE_APP_TOKEN=1 mode), not the PAT path
+# (vade-coo is non-org-admin per MEMO-2026-05-21-w6qz; PAT is structurally
+# blocked regardless of declared scope).
+#
+# Read-only; emits a markdown probe report to stdout. No side effects.
+# Sister script (full usage / cost digest) is the deferred follow-on
+# tracked against coo-labs/coo-memory#1025.
+
+set -euo pipefail
+
+ORG="${ORG:-coo-labs}"
+
+probe() {
+  local label="$1" method="$2" path="$3"
+  local resp http body
+  resp=$(GH_USE_APP_TOKEN=1 gh api -i -X "$method" "$path" 2>&1) || true
+  http=$(printf '%s' "$resp" | awk '/^HTTP\// {print $2; exit}')
+  body=$(printf '%s' "$resp" | awk '/^$/{found=1; next} found' | head -c 400)
+  case "$http" in
+    200|204)
+      printf -- "- **%s** — \`%s %s\` — OK (%s)\n" "$label" "$method" "$path" "$http"
+      ;;
+    410)
+      msg=$(printf '%s' "$body" | jq -r '.message // empty' 2>/dev/null | head -c 100)
+      printf -- "- **%s** — \`%s %s\` — DEPRECATED (410, %s)\n" "$label" "$method" "$path" "$msg"
+      ;;
+    422)
+      msg=$(printf '%s' "$body" | jq -r '.message // empty' 2>/dev/null | head -c 100)
+      printf -- "- **%s** — \`%s %s\` — OK-shape (422 needs param: %s)\n" "$label" "$method" "$path" "$msg"
+      ;;
+    *)
+      msg=$(printf '%s' "$body" | jq -r '.message // empty' 2>/dev/null | head -c 100)
+      printf -- "- **%s** — \`%s %s\` — FAIL (http=%s%s)\n" "$label" "$method" "$path" "$http" "${msg:+, $msg}"
+      ;;
+  esac
+}
+
+printf "# GitHub scope probe (org=%s, App install token route)\n\n" "$ORG"
+printf "Generated: %s\n\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf "## Org plan visibility (Organization administration:Read)\n\n"
+probe "Org metadata"           GET "orgs/$ORG"
+printf "\n## Enhanced billing (canonical surface — MEMO-2026-06-05-nubs)\n\n"
+probe "Usage report"           GET "organizations/$ORG/settings/billing/usage"
+probe "Budgets"                GET "organizations/$ORG/settings/billing/budgets"
+printf "\n## Legacy billing (deprecated; expect 410 redirects to enhanced)\n\n"
+probe "Actions billing"        GET "orgs/$ORG/settings/billing/actions"
+probe "Packages billing"       GET "orgs/$ORG/settings/billing/packages"
+probe "Shared-storage billing" GET "orgs/$ORG/settings/billing/shared-storage"
+probe "Adv-Security billing"   GET "orgs/$ORG/settings/billing/advanced-security"


### PR DESCRIPTION
Adds `scripts/billing/github-scope-probe.sh` — read-only verification that the `Organization administration: Read` permission added to `vade-coo-app` per [coo-labs/coo-memory MEMO-2026-06-05-nubs](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-05-nubs.md) actually reaches GitHub billing endpoints.

Runs the App-install-token path (`GH_USE_APP_TOKEN=1`) only — the PAT path is structurally blocked because `vade-coo` is non-org-admin per [MEMO-2026-05-21-w6qz](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-05-21-w6qz.md).

## What it does

Hits the canonical billing endpoint + legacy endpoints + org metadata; reports per-endpoint status as a markdown report on stdout. No side effects.

| Endpoint | Status (verified live 2026-06-05) |
|---|---|
| `GET orgs/coo-labs` (org metadata + plan) | OK |
| `GET organizations/coo-labs/settings/billing/usage` (canonical) | OK |
| `GET organizations/coo-labs/settings/billing/budgets` | OK |
| Legacy `/orgs/{org}/settings/billing/{actions,packages,shared-storage}` | 410 (deprecated, migration signal) |
| Legacy `/orgs/{org}/settings/billing/advanced-security` | 422 (needs `advanced_security_product` param) |

Sister to [`scripts/billing/cloudflare-scope-probe.sh`](https://github.com/coo-labs/coo-harness/blob/main/scripts/billing/cloudflare-scope-probe.sh) shipped in [#476](https://github.com/coo-labs/coo-harness/pull/476).

## Invocation

```sh
ORG=coo-labs bash scripts/billing/github-scope-probe.sh
```

The wrapper script auto-routes through `gh-coo-wrap.sh`'s App-token mode; no env var setup needed.

## What's next

The full GitHub usage / cost digest that consumes the enhanced billing endpoint is the deferred follow-on, tracked against [coo-labs/coo-memory#1025](https://github.com/coo-labs/coo-memory/issues/1025) (services + subscriptions tracking epic). This PR is the verification half.

Companion memo + schema update in [coo-labs/coo-memory#1228](https://github.com/coo-labs/coo-memory/pull/1228).

Closes: n/a

https://claude.ai/code/session_01PJdsm8uEWfJgX1xSdZAKyQ