### PR TITLE
gh-coo-wrap+coo-session-url: document inlined session-URL duplication

### DIFF
--- a/scripts/coo-session-url.sh
+++ b/scripts/coo-session-url.sh
@@ -4,9 +4,15 @@
 # CLAUDE_CODE_SESSION_ID). Silent no-op outside Claude Code: empty
 # stdout, exit 0.
 #
-# Used by the coo-harness gh-coo-wrap wrapper as the URL source, and
-# by humans / scripts that need the URL ad-hoc — e.g. inside an
+# Used by humans / scripts that need the URL ad-hoc — e.g. inside an
 # editor body, a heredoc, or a manual MCP call.
+#
+# Canonical-call exception: gh-coo-wrap.sh inlines the same derivation
+# (search "session URL once" in that file) to avoid a fork+exec on
+# every attributable `gh` write. The two sites must stay in sync — any
+# change to the sid resolution / cse_ stripping / URL shape here must
+# also update gh-coo-wrap.sh, and vice versa. coo-labs/coo-harness#341
+# recorded this convention.
 #
 # Source: issue coo-labs/coo-memory#150; MEMO 2026-04-26-02.
 

--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -54,6 +54,12 @@ if [ -z "$REAL_GH" ] || [ ! -x "$REAL_GH" ]; then
 fi
 
 # Compute session URL once. Empty if outside Claude Code.
+#
+# This derivation is inlined from coo-harness/scripts/coo-session-url.sh
+# (the canonical single-shot script) rather than shelled out — every
+# attributable `gh` write would otherwise pay a fork+exec on the hot
+# path. Convention recorded in coo-labs/coo-harness#341: any change to
+# sid resolution / cse_ stripping / URL shape must update both sites.
 sid="${CLAUDE_CODE_REMOTE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
 SESSION_URL=""
 [ -n "$sid" ] && SESSION_URL="https://claude.ai/code/session_${sid#cse_}"


### PR DESCRIPTION
Per Ven's decision on #341 (option 2: `decision - inline`), keep both sites and record the convention.

## Change

- `scripts/gh-coo-wrap.sh` (lines 56-63): add a comment at the inlined session-URL derivation explaining that the duplication is deliberate — avoids a fork+exec on every attributable `gh` write — and pointing to #341 for the convention.
- `scripts/coo-session-url.sh` (header): reciprocal note flagging the inlined site in `gh-coo-wrap.sh` and the "keep them in sync" rule.

No logic change. `bash -n` clean on both files. The inlined `SESSION_URL="https://claude.ai/code/session_${sid#cse_}"` and the canonical script's `printf 'https://claude.ai/code/session_%s\n' "${sid#cse_}"` continue to produce equivalent URLs.

## Acceptance vs issue body

- [x] Comment in `gh-coo-wrap.sh` documents the deliberate duplication.
- [x] Comment in `coo-session-url.sh` flags the second location.
- [x] Convention recorded: any change to URL-derivation logic must update both sites.

## Verification

```
bash -n scripts/coo-session-url.sh   # OK
bash -n scripts/gh-coo-wrap.sh       # OK
bash scripts/coo-session-url.sh      # prints https://claude.ai/code/session_<id>
```

Bootstrap regression CI will exercise `gh-coo-wrap.sh` end-to-end via `session-start-sync.sh` once it runs against this PR.

Closes #341