### PR TITLE
integrity-check D7: distinguish retry-recovered from actually-degraded

### DIFF
--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -380,11 +380,17 @@ fi
 # Probe is `true` when:
 #   - no events in window (clean), or
 #   - events present but rc=0 across the board (slow but recoverable);
-#     surfaced as a non-blocking detail so operators can see the cost.
-# Probe is `false` when any event has rc!=0 — that's an
-# install_coo_ssh_keys-class FAIL that wasted bootstrap wall time and
-# may have triggered a retry-bootstrap cycle.
+#     surfaced as a non-blocking detail so operators can see the cost, or
+#   - events with rc!=0 present BUT the last recorded bootstrap line
+#     in ~/.vade/coo-bootstrap.log is `OK step=complete` — the retry
+#     path absorbed the failure and bootstrap completed cleanly. That
+#     is recoverable noise, not a degraded boot. Surfaced as detail so
+#     operators can still see the cost.
+# Probe is `false` when rc!=0 events are present AND the last bootstrap
+# line is not `OK step=complete` — that's an install_coo_ssh_keys-class
+# FAIL that wasn't (yet) recovered, and the boot is actually degraded.
 D7_log="${HOME}/.vade/op-read-failures.jsonl"
+D7_boot_log="${HOME}/.vade/coo-bootstrap.log"
 D7_window_h="${VADE_D7_WINDOW_H:-24}"
 if [ -f "$D7_log" ] && check_cmd python3; then
   D7_summary="$(python3 -c "
@@ -405,18 +411,32 @@ try:
             try: total_ms += int(ev.get('elapsed_ms',0) or 0)
             except Exception: pass
 except Exception: pass
-print(f'{total}|{fails}|{total_ms}')
-" 2>/dev/null || echo "0|0|0")"
+recovered = 0
+try:
+    last = ''
+    with open('$D7_boot_log') as f:
+        for line in f:
+            if line.strip():
+                last = line.strip()
+    if 'OK step=complete' in last:
+        recovered = 1
+except Exception: pass
+print(f'{total}|{fails}|{total_ms}|{recovered}')
+" 2>/dev/null || echo "0|0|0|0")"
   D7_total="${D7_summary%%|*}"
   _D7_rest="${D7_summary#*|}"
   D7_fails="${_D7_rest%%|*}"
-  D7_ms="${_D7_rest#*|}"
+  _D7_rest="${_D7_rest#*|}"
+  D7_ms="${_D7_rest%%|*}"
+  D7_recovered="${_D7_rest#*|}"
   if [ "$D7_total" = "0" ]; then
     _add D7 true "no op-read events in last ${D7_window_h}h"
   elif [ "$D7_fails" = "0" ]; then
     _add D7 true "${D7_total} slow op-read event(s) in last ${D7_window_h}h, 0 failed (${D7_ms}ms cumulative); see $D7_log"
+  elif [ "$D7_recovered" = "1" ]; then
+    _add D7 true "${D7_fails}/${D7_total} op-read event(s) failed in last ${D7_window_h}h but bootstrap recovered (${D7_ms}ms cumulative wall-time cost); see $D7_log"
   else
-    _add D7 false "${D7_fails}/${D7_total} op-read event(s) failed in last ${D7_window_h}h (${D7_ms}ms cumulative wall-time cost); see $D7_log"
+    _add D7 false "${D7_fails}/${D7_total} op-read event(s) failed in last ${D7_window_h}h, bootstrap did not recover (${D7_ms}ms cumulative wall-time cost); see $D7_log"
   fi
 else
   _add D7 true "no op-read-failures.jsonl (clean steady state)"

--- a/scripts/coo-session-url.sh
+++ b/scripts/coo-session-url.sh
@@ -4,9 +4,15 @@
 # CLAUDE_CODE_SESSION_ID). Silent no-op outside Claude Code: empty
 # stdout, exit 0.
 #
-# Used by the coo-harness gh-coo-wrap wrapper as the URL source, and
-# by humans / scripts that need the URL ad-hoc — e.g. inside an
+# Used by humans / scripts that need the URL ad-hoc — e.g. inside an
 # editor body, a heredoc, or a manual MCP call.
+#
+# Canonical-call exception: gh-coo-wrap.sh inlines the same derivation
+# (search "session URL once" in that file) to avoid a fork+exec on
+# every attributable `gh` write. The two sites must stay in sync — any
+# change to the sid resolution / cse_ stripping / URL shape here must
+# also update gh-coo-wrap.sh, and vice versa. coo-labs/coo-harness#341
+# recorded this convention.
 #
 # Source: issue coo-labs/coo-memory#150; MEMO 2026-04-26-02.
 

--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -54,6 +54,12 @@ if [ -z "$REAL_GH" ] || [ ! -x "$REAL_GH" ]; then
 fi
 
 # Compute session URL once. Empty if outside Claude Code.
+#
+# This derivation is inlined from coo-harness/scripts/coo-session-url.sh
+# (the canonical single-shot script) rather than shelled out — every
+# attributable `gh` write would otherwise pay a fork+exec on the hot
+# path. Convention recorded in coo-labs/coo-harness#341: any change to
+# sid resolution / cse_ stripping / URL shape must update both sites.
 sid="${CLAUDE_CODE_REMOTE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
 SESSION_URL=""
 [ -n "$sid" ] && SESSION_URL="https://claude.ai/code/session_${sid#cse_}"


### PR DESCRIPTION
D7 currently flips `false` on any `rc!=0` event in `~/.vade/op-read-failures.jsonl` over its 24h rolling window. That conflates two cases:

1. **Recoverable retry pressure** — the op-read retry chain burned wall time but bootstrap completed cleanly. The boot is fine.
2. **Actually-degraded bootstrap** — install_coo_ssh_keys (or peer) never recovered, identity isn't installed.

Under the new block-on-FAIL boot brake (MEMO-2026-06-04-nzxf), case 1 is now load-bearing: a single recovered rate-limit hit derails *every* same-day session even though the boot succeeded.

## Today's evidence

This session booted on a degraded D7 from a real `rc=1` event at 2026-06-05T11:35:14Z (`op://COO/vade-coo-ssh-auth/private key` rate-limited; retry-bootstrap recovered; `coo-bootstrap.log` ends `OK step=complete rc=0`). The first real failure trace [#451](https://github.com/coo-labs/coo-harness/issues/451) was waiting on, captured.

## Change

D7 now reads the last non-blank line of `~/.vade/coo-bootstrap.log`. When `OK step=complete` is present in that line AND the failures-jsonl has `rc!=0` events in the window, D7 reports `ok: true` with a *"but bootstrap recovered"* detail string instead of flipping false. Operators still see the cost (rc!=0 count, total wall-time ms).

When `rc!=0` events are present AND the last bootstrap line is *not* `OK step=complete`, D7 still reports `false` — that's the actually-degraded case it's meant to surface.

## Verification

Against today's archived event (`/root/.vade/op-read-failures.archive-2026-06-05T11-35.jsonl`):

```
D7: { ok: true,
      detail: '1/3 op-read event(s) failed in last 24h but bootstrap recovered (18772ms cumulative wall-time cost); see /root/.vade/op-read-failures.jsonl' }
```

Against a clean failures-jsonl:

```
D7: { ok: true, detail: 'no op-read events in last 24h' }
```

The actually-degraded path (rc!=0 events AND bootstrap.log ends `FAIL step=...`) preserves the original `false` behavior with an enriched detail.

`bash -n` clean. The existing `scripts/ci/test-op-retry-recovery.sh` exercises `_op_to_file` (in common.sh, unchanged) — no overlap, no regression risk there.

## Refs

- #451 — closed observability issue; D7 was its surface
- #492 — substrate-fix follow-up for the deeper "both SA tokens rate-limited simultaneously" failure mode that today's event surfaced; this PR is symptom-absorption, #492 is cause-fix
- MEMO-2026-06-04-nzxf — block-on-FAIL boot brake (why this matters now)

Closes: n/a

https://claude.ai/code/session_01Mshk8vQUNUa7TnNkKCVNCD