### PR TITLE
lib/transcripts: jsonl parsing + classification primitives

### DIFF
--- a/lib/transcripts/__init__.py
+++ b/lib/transcripts/__init__.py
@@ -11,6 +11,14 @@ to the module and may change without notice.
 
 from __future__ import annotations
 
+from transcripts.jsonl import (
+    AUTO_NOTIFICATION_RES,
+    SYSTEM_REMINDER_RE,
+    classify,
+    is_auto_notification_user_entry,
+    read_entries,
+    strip_auto_notifications,
+)
 from transcripts.provenance import (
     AUTHORITATIVE_URL_SOURCES,
     RECONCILE_ELIGIBLE_URL_SOURCES,
@@ -35,18 +43,24 @@ from transcripts.schema import (
 
 __all__ = [
     "AUTHORITATIVE_URL_SOURCES",
+    "AUTO_NOTIFICATION_RES",
     "PARSER_VERSION",
     "RECONCILE_ELIGIBLE_URL_SOURCES",
+    "SYSTEM_REMINDER_RE",
     "VALID_URL_SOURCES",
     "R2Coordinates",
     "R2Error",
     "Sidecar",
     "UrlSource",
+    "classify",
     "dominant_scan_source",
     "is_authoritative",
+    "is_auto_notification_user_entry",
     "list_keys",
     "r2_client",
     "r2_coordinates",
+    "read_entries",
     "read_sidecar",
+    "strip_auto_notifications",
     "write_sidecar",
 ]

--- a/lib/transcripts/jsonl.py
+++ b/lib/transcripts/jsonl.py
@@ -1,0 +1,133 @@
+"""Local JSONL parsing + classification primitives.
+
+Consolidates the JSONL reader, auto-notification stripping, and entry
+classification that the renderer and the session-end export hook both
+inline. Pure-Python — no boto3, no R2, no filesystem coupling beyond
+reading the path passed in.
+
+The Claude Code transcript format is documented in `coo-labs/tjsonl` —
+this module covers the slice of the format the COO's renderer and
+session-end hook need to make rendering decisions. Anything beyond
+classification + auto-notification filtering belongs in `tjsonl` or
+in `render.py`, not here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SYSTEM_REMINDER_RE: re.Pattern[str] = re.compile(
+    r"<system-reminder>(.*?)</system-reminder>", re.DOTALL
+)
+
+AUTO_NOTIFICATION_RES: list[re.Pattern[str]] = [
+    re.compile(r"<github-webhook-activity>.*?</github-webhook-activity>", re.DOTALL),
+    re.compile(r"<task-notification>.*?</task-notification>", re.DOTALL),
+]
+
+
+def read_entries(jsonl_path: Path) -> list[dict[str, Any]]:
+    """Parse a Claude Code transcript JSONL file into a list of entries.
+
+    Lenient on the line-decode side: skips malformed lines with a stderr
+    warning rather than aborting. This matches the renderer's behavior —
+    partial reads are preferred to total failure, since the renderer can
+    still emit a meaningful HTML page from an incomplete jsonl.
+    """
+    entries: list[dict[str, Any]] = []
+    with open(jsonl_path) as f:
+        for lineno, line in enumerate(f, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                entries.append(json.loads(stripped))
+            except json.JSONDecodeError as e:
+                sys.stderr.write(f"[transcripts.jsonl] skipping malformed line {lineno}: {e}\n")
+    return entries
+
+
+def strip_auto_notifications(text: str) -> str:
+    """Strip system-reminders and known auto-notification envelopes.
+
+    Returns the residue — what the user actually typed, if anything.
+    Empty string means the message slot carried only auto-injected
+    content (webhook activity, task completion, system reminders).
+    """
+    out = SYSTEM_REMINDER_RE.sub("", text)
+    for r in AUTO_NOTIFICATION_RES:
+        out = r.sub("", out)
+    return out
+
+
+def is_auto_notification_user_entry(entry: dict[str, Any]) -> bool:
+    """True iff a user-typed message slot carries only auto-notifications.
+
+    Discriminates between operator-typed turns and webhook /
+    task-completion notifications injected into the user role. Returns
+    False on entries whose content list contains no text blocks (tool_result
+    messages — classified separately by callers).
+    """
+    msg = entry.get("message", {}) or {}
+    content = msg.get("content")
+    if isinstance(content, str):
+        return not strip_auto_notifications(content).strip()
+    if isinstance(content, list):
+        any_text = False
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                any_text = True
+                if strip_auto_notifications(block.get("text", "")).strip():
+                    return False
+        return any_text
+    return False
+
+
+def classify(entry: dict[str, Any]) -> str:
+    """Bucket a raw jsonl entry into a rendering kind.
+
+    Kinds: "user", "assistant", "thinking", "tool_use", "tool_result",
+    "attachment", "meta", "other". The renderer dispatches on this;
+    consumers that count turn types (cohort report, future indexer) also
+    dispatch on it.
+
+    Caller responsibility: filter via is_auto_notification_user_entry()
+    before counting a "user" kind as a real operator turn — this function
+    classifies by content shape only, not by author intent.
+    """
+    t = entry.get("type")
+    if t == "attachment":
+        return "attachment"
+    if t in ("queue-operation", "last-prompt", "mode", "summary"):
+        return "meta"
+    if t == "user":
+        return _classify_user(entry)
+    if t == "assistant":
+        return _classify_assistant(entry)
+    return "other"
+
+
+def _classify_user(entry: dict[str, Any]) -> str:
+    msg = entry.get("message", {}) or {}
+    content = msg.get("content")
+    if isinstance(content, list) and any(
+        isinstance(b, dict) and b.get("type") == "tool_result" for b in content
+    ):
+        return "tool_result"
+    return "user"
+
+
+def _classify_assistant(entry: dict[str, Any]) -> str:
+    msg = entry.get("message", {}) or {}
+    content = msg.get("content")
+    if isinstance(content, list):
+        kinds = [b.get("type") for b in content if isinstance(b, dict)]
+        if kinds and all(k == "thinking" for k in kinds):
+            return "thinking"
+        if kinds and all(k == "tool_use" for k in kinds):
+            return "tool_use"
+    return "assistant"

--- a/lib/transcripts/tests/test_jsonl.py
+++ b/lib/transcripts/tests/test_jsonl.py
@@ -1,0 +1,262 @@
+"""Tests for lib/transcripts/jsonl.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from transcripts.jsonl import (
+    AUTO_NOTIFICATION_RES,
+    SYSTEM_REMINDER_RE,
+    classify,
+    is_auto_notification_user_entry,
+    read_entries,
+    strip_auto_notifications,
+)
+
+# ---------------------------------------------------------------------------
+# read_entries
+# ---------------------------------------------------------------------------
+
+
+def test_read_entries_empty(tmp_path: Path) -> None:
+    p = tmp_path / "empty.jsonl"
+    p.write_text("")
+    assert read_entries(p) == []
+
+
+def test_read_entries_basic(tmp_path: Path) -> None:
+    p = tmp_path / "basic.jsonl"
+    p.write_text('{"type":"user","seq":1}\n{"type":"assistant","seq":2}\n')
+    assert read_entries(p) == [
+        {"type": "user", "seq": 1},
+        {"type": "assistant", "seq": 2},
+    ]
+
+
+def test_read_entries_skips_blank_lines(tmp_path: Path) -> None:
+    p = tmp_path / "blanks.jsonl"
+    p.write_text('\n\n{"a":1}\n   \n{"b":2}\n\n')
+    assert read_entries(p) == [{"a": 1}, {"b": 2}]
+
+
+def test_read_entries_skips_malformed_lines(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "mixed.jsonl"
+    p.write_text('{"ok":1}\n{not-json}\n{"ok":2}\n')
+    assert read_entries(p) == [{"ok": 1}, {"ok": 2}]
+    err = capsys.readouterr().err
+    assert "skipping malformed line 2" in err
+
+
+def test_read_entries_no_trailing_newline(tmp_path: Path) -> None:
+    p = tmp_path / "no-trail.jsonl"
+    p.write_text('{"a":1}\n{"b":2}')
+    assert read_entries(p) == [{"a": 1}, {"b": 2}]
+
+
+# ---------------------------------------------------------------------------
+# strip_auto_notifications
+# ---------------------------------------------------------------------------
+
+
+def test_strip_passthrough() -> None:
+    assert strip_auto_notifications("plain text") == "plain text"
+
+
+def test_strip_empty() -> None:
+    assert strip_auto_notifications("") == ""
+
+
+def test_strip_system_reminder() -> None:
+    assert (
+        strip_auto_notifications("before <system-reminder>foo</system-reminder> after")
+        == "before  after"
+    )
+
+
+def test_strip_multiline_system_reminder() -> None:
+    text = "x <system-reminder>line1\nline2</system-reminder> y"
+    assert strip_auto_notifications(text) == "x  y"
+
+
+def test_strip_webhook() -> None:
+    assert strip_auto_notifications("<github-webhook-activity>foo</github-webhook-activity>") == ""
+
+
+def test_strip_task_notification() -> None:
+    assert strip_auto_notifications("<task-notification>foo</task-notification>") == ""
+
+
+def test_strip_all_envelopes() -> None:
+    text = (
+        "<system-reminder>x</system-reminder>"
+        "<github-webhook-activity>y</github-webhook-activity>"
+        "<task-notification>z</task-notification>"
+    )
+    assert strip_auto_notifications(text) == ""
+
+
+def test_strip_preserves_residue_between_envelopes() -> None:
+    text = (
+        "<system-reminder>x</system-reminder>"
+        "real text"
+        "<github-webhook-activity>y</github-webhook-activity>"
+    )
+    assert strip_auto_notifications(text) == "real text"
+
+
+def test_regex_exports_compile() -> None:
+    # Smoke-check that the public regex exports are usable patterns.
+    assert SYSTEM_REMINDER_RE.search("<system-reminder>x</system-reminder>") is not None
+    assert (
+        AUTO_NOTIFICATION_RES[0].search("<github-webhook-activity>x</github-webhook-activity>")
+        is not None
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_auto_notification_user_entry
+# ---------------------------------------------------------------------------
+
+
+def test_auto_notif_string_content_empty() -> None:
+    entry = {"message": {"content": "<system-reminder>x</system-reminder>"}}
+    assert is_auto_notification_user_entry(entry) is True
+
+
+def test_auto_notif_string_content_real_text() -> None:
+    assert is_auto_notification_user_entry({"message": {"content": "hello"}}) is False
+
+
+def test_auto_notif_string_content_whitespace_only() -> None:
+    assert is_auto_notification_user_entry({"message": {"content": "   \n  "}}) is True
+
+
+def test_auto_notif_list_only_webhook_text() -> None:
+    entry = {
+        "message": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "<github-webhook-activity>x</github-webhook-activity>",
+                }
+            ]
+        }
+    }
+    assert is_auto_notification_user_entry(entry) is True
+
+
+def test_auto_notif_list_has_real_text() -> None:
+    entry = {
+        "message": {
+            "content": [
+                {"type": "text", "text": "real content"},
+                {"type": "text", "text": "<system-reminder>x</system-reminder>"},
+            ]
+        }
+    }
+    assert is_auto_notification_user_entry(entry) is False
+
+
+def test_auto_notif_list_no_text_blocks() -> None:
+    # tool_result-only content → not auto, but also not a typed user turn.
+    # Callers route these via classify() == "tool_result", not via this fn.
+    entry = {"message": {"content": [{"type": "tool_result", "content": "..."}]}}
+    assert is_auto_notification_user_entry(entry) is False
+
+
+def test_auto_notif_missing_content() -> None:
+    assert is_auto_notification_user_entry({}) is False
+    assert is_auto_notification_user_entry({"message": {}}) is False
+
+
+def test_auto_notif_none_message() -> None:
+    assert is_auto_notification_user_entry({"message": None}) is False
+
+
+# ---------------------------------------------------------------------------
+# classify
+# ---------------------------------------------------------------------------
+
+
+def test_classify_attachment() -> None:
+    assert classify({"type": "attachment"}) == "attachment"
+
+
+def test_classify_meta_kinds() -> None:
+    for t in ("queue-operation", "last-prompt", "mode", "summary"):
+        assert classify({"type": t}) == "meta"
+
+
+def test_classify_user_string() -> None:
+    assert classify({"type": "user", "message": {"content": "hi"}}) == "user"
+
+
+def test_classify_user_list_text() -> None:
+    entry = {"type": "user", "message": {"content": [{"type": "text", "text": "hi"}]}}
+    assert classify(entry) == "user"
+
+
+def test_classify_user_tool_result() -> None:
+    entry = {
+        "type": "user",
+        "message": {"content": [{"type": "tool_result", "tool_use_id": "x", "content": "..."}]},
+    }
+    assert classify(entry) == "tool_result"
+
+
+def test_classify_user_no_message() -> None:
+    assert classify({"type": "user"}) == "user"
+
+
+def test_classify_assistant_text() -> None:
+    entry = {
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": "x"}]},
+    }
+    assert classify(entry) == "assistant"
+
+
+def test_classify_assistant_thinking_only() -> None:
+    entry = {
+        "type": "assistant",
+        "message": {"content": [{"type": "thinking", "thinking": "x"}]},
+    }
+    assert classify(entry) == "thinking"
+
+
+def test_classify_assistant_tool_use_only() -> None:
+    entry = {
+        "type": "assistant",
+        "message": {"content": [{"type": "tool_use", "id": "x", "name": "y", "input": {}}]},
+    }
+    assert classify(entry) == "tool_use"
+
+
+def test_classify_assistant_mixed() -> None:
+    # Mixed text + tool_use → "assistant" (the generic dispatch).
+    entry = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "text", "text": "ok"},
+                {"type": "tool_use", "id": "x", "name": "y", "input": {}},
+            ]
+        },
+    }
+    assert classify(entry) == "assistant"
+
+
+def test_classify_assistant_empty_content_list() -> None:
+    # Empty list — the "all kinds are X" predicates require non-empty, so
+    # falls through to generic "assistant".
+    entry = {"type": "assistant", "message": {"content": []}}
+    assert classify(entry) == "assistant"
+
+
+def test_classify_other() -> None:
+    assert classify({"type": "system"}) == "other"
+    assert classify({}) == "other"

--- a/scripts/ci/test-lib-transcripts-parity.py
+++ b/scripts/ci/test-lib-transcripts-parity.py
@@ -13,6 +13,10 @@ Checks:
      scripts/lifecycle/session-end-transcript-render.py uses.
   3. dominant_scan_source picks the same canonical scan-* tag as
      scripts/transcript-url-backfill.py's _dominant_scan_source function.
+  4. jsonl.py primitives (read_entries, strip_auto_notifications,
+     is_auto_notification_user_entry, classify) match the renderer's
+     inlined _read_entries / _strip_auto_notifications /
+     _is_auto_notification_user_entry / _classify across a fixture set.
 
 Exits 0 on full parity, 1 on any divergence.
 """
@@ -43,6 +47,12 @@ def _load_module(name: str, path: Path):
 def main() -> int:
     failures: list[str] = []
 
+    from transcripts.jsonl import (
+        classify as lib_classify,
+        is_auto_notification_user_entry as lib_is_auto,
+        read_entries as lib_read_entries,
+        strip_auto_notifications as lib_strip,
+    )
     from transcripts.provenance import (
         AUTHORITATIVE_URL_SOURCES as LIB_AUTH,
         RECONCILE_ELIGIBLE_URL_SOURCES as LIB_RECON,
@@ -91,13 +101,152 @@ def main() -> int:
             f"PARSER_VERSION drift — script={renderer.PARSER_VERSION} lib={LIB_PV}"
         )
 
+    # jsonl primitives: regex pattern equivalence first (catches a drift the
+    # downstream behavioral fixtures might miss if their inputs don't exercise
+    # the changed branch).
+    if renderer.SYSTEM_REMINDER_RE.pattern != "<system-reminder>(.*?)</system-reminder>":
+        failures.append(
+            f"SYSTEM_REMINDER_RE drift — script={renderer.SYSTEM_REMINDER_RE.pattern!r}"
+        )
+    script_auto_patterns = [r.pattern for r in renderer.AUTO_NOTIFICATION_RES]
+    expected_auto_patterns = [
+        r"<github-webhook-activity>.*?</github-webhook-activity>",
+        r"<task-notification>.*?</task-notification>",
+    ]
+    if script_auto_patterns != expected_auto_patterns:
+        failures.append(
+            f"AUTO_NOTIFICATION_RES drift — script={script_auto_patterns}"
+        )
+
+    # strip_auto_notifications + is_auto_notification_user_entry: behavioral parity
+    # across the cases the renderer's classifier touches.
+    strip_cases = [
+        "plain text",
+        "",
+        "before <system-reminder>x</system-reminder> after",
+        "<github-webhook-activity>x</github-webhook-activity>",
+        "<task-notification>x</task-notification>",
+        "<system-reminder>x</system-reminder>text<github-webhook-activity>y</github-webhook-activity>",
+    ]
+    for case in strip_cases:
+        s_val = renderer._strip_auto_notifications(case)
+        l_val = lib_strip(case)
+        if s_val != l_val:
+            failures.append(
+                f"strip_auto_notifications({case!r}) — script={s_val!r} lib={l_val!r}"
+            )
+
+    is_auto_cases = [
+        {"message": {"content": "hello"}},
+        {"message": {"content": "<system-reminder>x</system-reminder>"}},
+        {"message": {"content": "   "}},
+        {
+            "message": {
+                "content": [{"type": "text", "text": "real"}],
+            }
+        },
+        {
+            "message": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "<github-webhook-activity>x</github-webhook-activity>",
+                    }
+                ],
+            }
+        },
+        {"message": {"content": [{"type": "tool_result", "content": "..."}]}},
+        {},
+    ]
+    for case in is_auto_cases:
+        s_val = renderer._is_auto_notification_user_entry(case)
+        l_val = lib_is_auto(case)
+        if s_val != l_val:
+            failures.append(
+                f"is_auto_notification_user_entry({case!r}) — script={s_val} lib={l_val}"
+            )
+
+    # classify: cover each branch of the renderer's _classify.
+    classify_cases = [
+        {"type": "attachment"},
+        {"type": "queue-operation"},
+        {"type": "last-prompt"},
+        {"type": "mode"},
+        {"type": "summary"},
+        {"type": "user", "message": {"content": "hi"}},
+        {"type": "user", "message": {"content": [{"type": "text", "text": "x"}]}},
+        {
+            "type": "user",
+            "message": {"content": [{"type": "tool_result", "content": "..."}]},
+        },
+        {"type": "user"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "x"}]}},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "thinking", "thinking": "x"}]},
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "a", "name": "b", "input": {}}
+                ]
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "x"},
+                    {"type": "tool_use", "id": "a", "name": "b", "input": {}},
+                ]
+            },
+        },
+        {"type": "assistant", "message": {"content": []}},
+        {"type": "system"},
+        {},
+    ]
+    for case in classify_cases:
+        s_val = renderer._classify(case)
+        l_val = lib_classify(case)
+        if s_val != l_val:
+            failures.append(f"classify({case!r}) — script={s_val!r} lib={l_val!r}")
+
+    # read_entries: behavioral parity on a synthetic fixture.
+    import tempfile
+
+    fixture = (
+        '{"type":"user","message":{"content":"hi"}}\n'
+        "\n"
+        '{"type":"assistant","message":{"content":[]}}\n'
+        "{not-json}\n"
+        '{"type":"summary","seq":42}\n'
+    )
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".jsonl", delete=False
+    ) as f:
+        f.write(fixture)
+        fixture_path = Path(f.name)
+    try:
+        s_entries = renderer._read_entries(fixture_path)
+        l_entries = lib_read_entries(fixture_path)
+        if s_entries != l_entries:
+            failures.append(
+                f"read_entries fixture parity — script={s_entries} lib={l_entries}"
+            )
+    finally:
+        fixture_path.unlink(missing_ok=True)
+
     if failures:
         sys.stderr.write("PARITY FAILURES:\n")
         for f in failures:
             sys.stderr.write(f"  - {f}\n")
         return 1
 
-    print(f"parity OK — {len(LIB_AUTH)} auth, {len(LIB_RECON)} reconcile, PARSER_VERSION={LIB_PV}")
+    print(
+        f"parity OK — {len(LIB_AUTH)} auth, {len(LIB_RECON)} reconcile, "
+        f"PARSER_VERSION={LIB_PV}, jsonl primitives match"
+    )
     return 0
 
 


### PR DESCRIPTION
## What

Extends `lib/transcripts/` with JSONL parsing + classification
primitives — the second slice of Phase 1 PR-1 scope (the first slice
shipped as #413).

| Primitive | Replaces (in `scripts/lifecycle/session-end-transcript-render.py`) |
|---|---|
| `read_entries(path)` | `_read_entries` |
| `strip_auto_notifications(text)` | `_strip_auto_notifications` |
| `is_auto_notification_user_entry(entry)` | `_is_auto_notification_user_entry` |
| `classify(entry)` | `_classify` |
| `SYSTEM_REMINDER_RE`, `AUTO_NOTIFICATION_RES` | inlined regex constants |

Plus the parity check at `scripts/ci/test-lib-transcripts-parity.py`
now exercises behavioral equivalence between lib and renderer across
each branch (strip / is_auto / classify / read_entries) on synthetic
fixtures. A script-port PR that drifts the renderer's `_classify`
from `transcripts.classify` fails the check at PR-open time, not at
runtime against R2.

## What stays out by design

- **No consumer port in this PR.** The renderer continues to use its
  inlined definitions; the port lands in a follow-up once the lib
  API is stable. This matches the slicing discipline used in #413
  (scaffold first, ports separately under parity coverage).
- **No `render.py`, no `state.py`.** Those primitives are still
  outstanding in the Phase 1 scope; deferring to keep this PR
  reviewable. `render.py` extraction is the bigger lift (renderer is
  ~1200 LOC, many `_render_*` helpers).
- **`classify` split into helpers** (`_classify_user`,
  `_classify_assistant`) — needed to satisfy the `PLR0911`
  too-many-returns lint cap. Same semantics as the renderer's
  monolithic `_classify`; parity check covers each branch.

## Quality bar (all green locally)

| Tool | Result |
|---|---|
| `ruff check lib/transcripts` | All checks passed |
| `ruff format --check lib/transcripts` | 10 files already formatted |
| `mypy lib/transcripts` (strict) | Success: no issues found in 10 source files |
| `pytest` | 92/92 passed, 96.81% coverage (fail-under=80) |
| `python3 scripts/ci/test-lib-transcripts-parity.py` | OK — 5 auth, 4 reconcile, PARSER_VERSION=3, jsonl primitives match |

`jsonl.py` itself: 66 stmts, 100% coverage.

## Epic context

Part of #1145 — the transcripts substrate epic. Phase 1 sub-issue
[#1147](https://github.com/coo-labs/coo-memory/issues/1147) tracks:
- PR-1: scaffold + ports + parity (this PR is the second of N
  slices; closes when ports land).
- PR-2: R2-inventory cron in coo-console (separate PR, not started).

Closes: n/a — partial progress on Phase 1 sub-issue
coo-labs/coo-memory#1147 (script ports + R2-inventory cron remain).
Refs: coo-labs/coo-memory#1147, coo-labs/coo-memory#1145.

https://claude.ai/code/session_013ZTGZKRCZXLPxbYi57c99p