### PR TITLE
events-api: translator + backfill driver + CLI (coo-memory#1148 Phase 2 PR-3)

### DIFF
--- a/bin/events-backfill.py
+++ b/bin/events-backfill.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "boto3>=1.34,<2",
+#   "pydantic>=2.6,<3",
+# ]
+# ///
+"""events-backfill — translate an events-API dump and write HTML + sidecar to R2.
+
+Operator runs `snippets/events-dump.js` in claude.ai DevTools, scp's the
+resulting JSON to the container, then invokes this CLI:
+
+  events-backfill --dump path/to/dump.json              # dry-run by default
+  events-backfill --dump path/to/dump.json --apply      # write to R2
+  events-backfill --dump dump.json --only-session-ids session_01ab,session_02cd
+
+Per-session result is printed as JSONL on stdout (one line per session); the
+operator pipes this to `coo-harness/state/events-backfill/manifest.jsonl`
+and commits the append. Exit 0 iff every session landed in a non-error
+status (`applied`, `dry_run`, `ceded_authoritative`, `skipped_*`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _setup_path() -> None:
+    """Insert coo-harness/lib on sys.path so `from transcripts import …` works.
+
+    Two parents up from `bin/events-backfill.py` is the repo root; `lib` lives
+    there. This is the same dance documented in `lib/transcripts/README.md`,
+    repeated here because PEP 723 venvs don't see editable installs.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+
+
+_setup_path()
+
+from transcripts.backfill import backfill_dump  # noqa: E402
+
+
+def _parse_only_session_ids(raw: str | None) -> set[str] | None:
+    if not raw:
+        return None
+    return {sid.strip() for sid in raw.split(",") if sid.strip()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1] if __doc__ else "")
+    parser.add_argument(
+        "--dump",
+        type=Path,
+        required=True,
+        help="path to the JSON (or .json.gz) dump produced by snippets/events-dump.js",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="write to R2 (default: dry-run; translate + render but no upload)",
+    )
+    parser.add_argument(
+        "--only-session-ids",
+        help="comma-separated session ids; restricts the run to a subset",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress the human-readable footer summary; JSONL on stdout still emits",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.dump.is_file():
+        sys.stderr.write(f"[events-backfill] --dump {args.dump} not found\n")
+        return 2
+
+    report = backfill_dump(
+        dump_path=args.dump,
+        apply=args.apply,
+        only_session_ids=_parse_only_session_ids(args.only_session_ids),
+    )
+
+    error_count = 0
+    for result in report.results:
+        sys.stdout.write(result.to_jsonl())
+        sys.stdout.write("\n")
+        if result.status.value == "error":
+            error_count += 1
+
+    if not args.quiet:
+        counts = report.counts_by_status()
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+        sys.stderr.write(
+            f"[events-backfill] {report.dump_path}: {len(report.results)} sessions"
+            f" — {summary}{' (DRY RUN)' if not args.apply else ''}\n"
+        )
+
+    return 1 if error_count else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/transcripts/__init__.py
+++ b/lib/transcripts/__init__.py
@@ -33,6 +33,7 @@ from transcripts.r2 import (
     r2_client,
     r2_coordinates,
     read_sidecar,
+    write_html_object,
     write_sidecar,
 )
 from transcripts.schema import (
@@ -62,5 +63,6 @@ __all__ = [
     "read_entries",
     "read_sidecar",
     "strip_auto_notifications",
+    "write_html_object",
     "write_sidecar",
 ]

--- a/lib/transcripts/backfill/__init__.py
+++ b/lib/transcripts/backfill/__init__.py
@@ -1,0 +1,24 @@
+"""Mass-mutation drivers — orchestrators that batch primitive operations.
+
+Each module here owns one driver:
+  - `events` — events-API dump → translated entries → render → R2 write.
+
+Public surface is intentionally narrow: the driver entry points + their
+result types. Implementation helpers stay module-private.
+"""
+
+from __future__ import annotations
+
+from transcripts.backfill.events import (
+    BackfillReport,
+    BackfillResult,
+    BackfillStatus,
+    backfill_dump,
+)
+
+__all__ = [
+    "BackfillReport",
+    "BackfillResult",
+    "BackfillStatus",
+    "backfill_dump",
+]

--- a/lib/transcripts/backfill/events.py
+++ b/lib/transcripts/backfill/events.py
@@ -1,0 +1,347 @@
+"""Events-API → R2 backfill driver.
+
+Per session in a dump file:
+
+  1. Translate events to renderer-compatible jsonl entries
+     (`transcripts.events.translator.events_to_entries`).
+  2. Extract v3 sidecar metadata directly from events
+     (`transcripts.events.translator.extract_metadata`); stamp
+     `url_source="claudeai-events-uuid"` + `session_url`.
+  3. Hand the translated entries to the existing renderer
+     (`scripts/lifecycle/session-end-transcript-render.py` via subprocess
+     with `--no-upload --output`) to produce HTML.
+  4. Upload HTML + sidecar to R2 with first-write-wins semantics, respecting
+     `provenance.is_authoritative` on the existing sidecar (no overwrite of
+     authoritative tags).
+
+Default is `--dry-run`: translate + render but don't upload. Apply with
+`apply=True`. The driver returns a structured `BackfillReport` the CLI prints
+and the operator commits to `coo-harness/state/events-backfill/manifest.jsonl`.
+
+Renderer invocation is subprocess (not import) for the same reason
+`transcript-render-backfill.py` does it: the renderer's argparse main is the
+authoritative interface and stays so until the Phase 1 port lands a callable
+`render_html` re-export under the lib.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from transcripts.events.intake import SessionPayload, load_dump
+from transcripts.events.translator import events_to_entries, extract_metadata
+from transcripts.provenance import is_authoritative
+from transcripts.r2 import (
+    R2Error,
+    r2_client,
+    read_sidecar,
+    write_html_object,
+    write_sidecar,
+)
+from transcripts.schema import PARSER_VERSION as RENDERER_VERSION
+
+EVENTS_URL_SOURCE = "claudeai-events-uuid"
+
+
+class BackfillStatus(str, Enum):
+    """Per-session outcome bucket.
+
+    `applied` — translated, rendered, both keys written to R2.
+    `dry_run` — translated + rendered; no R2 writes attempted.
+    `ceded_authoritative` — existing sidecar carries an authoritative tag from
+        a different source (e.g., env-recovery from a live session); the driver
+        refuses to overwrite. The HTML write was skipped for consistency.
+    `skipped_no_entries` — no user/assistant/init events survived translation
+        (typical for control-plane-only sessions).
+    `skipped_fetch_error` — the dump envelope flagged fetch errors against this
+        session id (cookie expired mid-page); operator re-runs after refreshing.
+    `error` — translation or render subprocess failed; details in `error_detail`.
+    """
+
+    APPLIED = "applied"
+    DRY_RUN = "dry_run"
+    CEDED_AUTHORITATIVE = "ceded_authoritative"
+    SKIPPED_NO_ENTRIES = "skipped_no_entries"
+    SKIPPED_FETCH_ERROR = "skipped_fetch_error"
+    ERROR = "error"
+
+
+@dataclass
+class BackfillResult:
+    """Per-session record written to the backfill manifest."""
+
+    session_id: str
+    status: BackfillStatus
+    entry_count: int = 0
+    user_turn_count: int = 0
+    assistant_turn_count: int = 0
+    html_bytes: int = 0
+    error_detail: str = ""
+
+    def to_jsonl(self) -> str:
+        """One-line JSON serialization for the append-only manifest."""
+        payload = {
+            "session_id": self.session_id,
+            "status": self.status.value,
+            "entry_count": self.entry_count,
+            "user_turn_count": self.user_turn_count,
+            "assistant_turn_count": self.assistant_turn_count,
+            "html_bytes": self.html_bytes,
+        }
+        if self.error_detail:
+            payload["error_detail"] = self.error_detail
+        return json.dumps(payload, separators=(",", ":"))
+
+
+@dataclass
+class BackfillReport:
+    """Aggregate result of one driver invocation."""
+
+    started_at: str
+    finished_at: str
+    dump_path: str
+    org_uuid: str
+    apply: bool
+    results: list[BackfillResult] = field(default_factory=list)
+
+    def counts_by_status(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for r in self.results:
+            counts[r.status.value] = counts.get(r.status.value, 0) + 1
+        return counts
+
+
+def backfill_dump(
+    dump_path: Path,
+    *,
+    apply: bool = False,
+    renderer_script: Path | None = None,
+    s3: Any = None,
+    only_session_ids: set[str] | None = None,
+) -> BackfillReport:
+    """Process every session in a dump file.
+
+    `apply=False` (default) translates and renders but writes nothing to R2.
+    `only_session_ids`, if set, filters the dump to a subset — useful for
+    iterating on a single problem session without re-processing 80.
+
+    `renderer_script` overrides the default path lookup; tests pass a fake.
+    Passing `s3=` injects a pre-built boto3 client (tests use a mock).
+    """
+    started = _iso_now()
+    payloads, envelope = load_dump(dump_path)
+
+    if apply and s3 is None:
+        s3 = r2_client()
+
+    report = BackfillReport(
+        started_at=started,
+        finished_at="",
+        dump_path=str(dump_path),
+        org_uuid=envelope.get("org_uuid", ""),
+        apply=apply,
+    )
+
+    renderer = renderer_script or _default_renderer_script()
+
+    for payload in payloads:
+        if only_session_ids is not None and payload.session_id not in only_session_ids:
+            continue
+        result = _process_session(payload, renderer=renderer, apply=apply, s3=s3)
+        report.results.append(result)
+
+    report.finished_at = _iso_now()
+    return report
+
+
+def _process_session(  # noqa: PLR0911 — one return per outcome bucket; refactoring obscures the gate sequence
+    payload: SessionPayload,
+    *,
+    renderer: Path,
+    apply: bool,
+    s3: Any,
+) -> BackfillResult:
+    sid = payload.session_id
+
+    if payload.fetch_errors:
+        return BackfillResult(
+            session_id=sid,
+            status=BackfillStatus.SKIPPED_FETCH_ERROR,
+            error_detail=_summarize_fetch_errors(payload.fetch_errors),
+        )
+
+    entries = events_to_entries(payload.events, sid)
+    if not entries:
+        return BackfillResult(
+            session_id=sid,
+            status=BackfillStatus.SKIPPED_NO_ENTRIES,
+        )
+
+    meta = extract_metadata(payload.events, sid)
+
+    try:
+        html_bytes = _render_via_subprocess(renderer, sid, entries)
+    except _RenderError as e:
+        return BackfillResult(
+            session_id=sid,
+            status=BackfillStatus.ERROR,
+            entry_count=meta.entry_count,
+            user_turn_count=meta.user_turn_count,
+            assistant_turn_count=meta.assistant_turn_count,
+            error_detail=f"render: {e}",
+        )
+
+    if not apply:
+        return BackfillResult(
+            session_id=sid,
+            status=BackfillStatus.DRY_RUN,
+            entry_count=meta.entry_count,
+            user_turn_count=meta.user_turn_count,
+            assistant_turn_count=meta.assistant_turn_count,
+            html_bytes=len(html_bytes),
+        )
+
+    try:
+        existing = read_sidecar(sid, s3=s3)
+    except R2Error as e:
+        return BackfillResult(
+            session_id=sid,
+            status=BackfillStatus.ERROR,
+            entry_count=meta.entry_count,
+            error_detail=f"read existing sidecar: {e}",
+        )
+
+    if existing is not None:
+        existing_source = existing.get("url_source")
+        if (
+            isinstance(existing_source, str)
+            and is_authoritative(existing_source)
+            and existing_source != EVENTS_URL_SOURCE
+        ):
+            return BackfillResult(
+                session_id=sid,
+                status=BackfillStatus.CEDED_AUTHORITATIVE,
+                entry_count=meta.entry_count,
+                user_turn_count=meta.user_turn_count,
+                assistant_turn_count=meta.assistant_turn_count,
+                error_detail=f"existing url_source={existing_source!r}",
+            )
+
+    overwrite = existing is not None
+    write_html_object(sid, html_bytes, overwrite=overwrite, s3=s3)
+    sidecar = _build_sidecar(meta)
+    write_sidecar(sid, sidecar, overwrite=overwrite, s3=s3)
+
+    return BackfillResult(
+        session_id=sid,
+        status=BackfillStatus.APPLIED,
+        entry_count=meta.entry_count,
+        user_turn_count=meta.user_turn_count,
+        assistant_turn_count=meta.assistant_turn_count,
+        html_bytes=len(html_bytes),
+    )
+
+
+def _build_sidecar(meta: Any) -> dict[str, Any]:
+    """Render the v3 sidecar dict, with events-API provenance stamped on."""
+    return {
+        "session_id": meta.session_id,
+        "started_at": meta.started_at or None,
+        "ended_at": meta.ended_at or None,
+        "duration_seconds": meta.duration_seconds,
+        "entry_count": meta.entry_count,
+        "user_turn_count": meta.user_turn_count,
+        "assistant_turn_count": meta.assistant_turn_count,
+        "tool_call_count": meta.tool_call_count,
+        "error_count": meta.error_count,
+        "first_user_preview": meta.first_user_preview,
+        "first_user_uuid": meta.first_user_uuid,
+        "models": meta.models,
+        "cwds": meta.cwds,
+        "cc_version": meta.cc_version,
+        "session_url": f"https://claude.ai/code/{meta.session_id}",
+        "url_source": EVENTS_URL_SOURCE,
+        "renderer_version": RENDERER_VERSION,
+    }
+
+
+class _RenderError(RuntimeError):
+    """Raised when the renderer subprocess fails."""
+
+
+def _render_via_subprocess(renderer: Path, sid: str, entries: list[dict[str, Any]]) -> bytes:
+    """Write entries to a tmp jsonl, invoke the renderer, capture HTML output.
+
+    Returns the rendered HTML bytes. Raises `_RenderError` on subprocess
+    failure or empty output. Temp files are cleaned up on every path.
+    """
+    with tempfile.TemporaryDirectory(prefix="events-backfill-") as td:
+        td_path = Path(td)
+        jsonl_path = td_path / f"{sid}.jsonl"
+        html_path = td_path / f"{sid}.html"
+
+        with open(jsonl_path, "w", encoding="utf-8") as f:
+            for entry in entries:
+                f.write(json.dumps(entry, separators=(",", ":")))
+                f.write("\n")
+
+        cmd = [
+            sys.executable,
+            str(renderer),
+            "--input",
+            str(jsonl_path),
+            "--session-id",
+            sid,
+            "--no-upload",
+            "--output",
+            str(html_path),
+        ]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise _RenderError(f"renderer rc={result.returncode}: {result.stderr.strip()[:240]}")
+        if not html_path.exists():
+            raise _RenderError("renderer wrote no output file")
+        return html_path.read_bytes()
+
+
+def _default_renderer_script() -> Path:
+    """Path to scripts/lifecycle/session-end-transcript-render.py from this file.
+
+    Three layers up from lib/transcripts/backfill/events.py reaches the repo root.
+    """
+    return (
+        Path(__file__).resolve().parents[3]
+        / "scripts"
+        / "lifecycle"
+        / "session-end-transcript-render.py"
+    )
+
+
+_FETCH_ERROR_SAMPLE_SIZE = 2
+
+
+def _summarize_fetch_errors(errors: list[dict[str, Any]]) -> str:
+    head = errors[:_FETCH_ERROR_SAMPLE_SIZE]
+    rendered = "; ".join(f"page={e.get('page')} err={e.get('error', '')[:80]}" for e in head)
+    extra = len(errors) - _FETCH_ERROR_SAMPLE_SIZE
+    if extra > 0:
+        rendered += f" (+{extra} more)"
+    return rendered
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/lib/transcripts/events/__init__.py
+++ b/lib/transcripts/events/__init__.py
@@ -1,0 +1,52 @@
+"""Events-API recovery primitives.
+
+The claude.ai server-side events stream is the canonical source for any session
+whose local jsonl is unrecoverable (cohort B/C with broken ciphertext, dark-mass
+sessions never exported). Operator runs `snippets/events-dump.js` from claude.ai
+DevTools, scp's the resulting JSON to the container, then `bin/events-backfill`
+ingests it: per session, translate events → renderer-compatible jsonl entries,
+hand to the existing renderer, write sidecar to R2.
+
+Public surface:
+  - `PARSER_VERSION` — must match `snippets/events-dump.js _PARSER_VERSION`.
+  - `CCR_HEADERS` — beta-header gate; MEMO-2026-06-05-dyb0.
+  - `events_to_entries(events, sid)` — jsonl-shaped entries for the renderer.
+  - `extract_metadata(events, sid)` — v3 sidecar fields direct from events.
+  - `load_dump(path)` — parse a dump file into per-session payloads.
+  - `probe.compare_to_schema(events)` — schema-drift diff vs the pinned fixture.
+
+The parallel package `transcripts.backfill` orchestrates the per-session
+translation → render → R2 write loop; everything here is pure data.
+"""
+
+from __future__ import annotations
+
+from transcripts.events.client import (
+    CCR_HEADERS,
+    EVENTS_ENDPOINT_TEMPLATE,
+    PARSER_VERSION,
+    REQUIRED_RESPONSE_KEYS,
+)
+from transcripts.events.intake import (
+    DumpEnvelopeError,
+    SessionPayload,
+    load_dump,
+)
+from transcripts.events.translator import (
+    EventsMetadata,
+    events_to_entries,
+    extract_metadata,
+)
+
+__all__ = [
+    "CCR_HEADERS",
+    "EVENTS_ENDPOINT_TEMPLATE",
+    "PARSER_VERSION",
+    "REQUIRED_RESPONSE_KEYS",
+    "DumpEnvelopeError",
+    "EventsMetadata",
+    "SessionPayload",
+    "events_to_entries",
+    "extract_metadata",
+    "load_dump",
+]

--- a/lib/transcripts/events/client.py
+++ b/lib/transcripts/events/client.py
@@ -1,0 +1,41 @@
+"""Transport constants and shape contracts for the events-API.
+
+The operator-facing fetch happens in `snippets/events-dump.js` (browser-paste
+under the operator's session cookie). This module mirrors the constants the
+snippet enforces so that `probe.py` and any future Python-side fetcher (a
+short-lived debug probe carrying the operator's cookie via env) speak the same
+gate.
+
+`PARSER_VERSION` is the single coordinating number across the JS snippet, the
+Python translator, and the on-disk dump envelope. Any change here must move in
+lockstep with `snippets/events-dump.js _PARSER_VERSION` (asserted at startup
+when the snippet's output is loaded — see intake.py).
+
+`CCR_HEADERS` + `x-organization-uuid` are the load-bearing authentication gate
+per [MEMO-2026-06-05-dyb0](../../../../coo-memory/memos/2026-06-05-dyb0.md).
+Cookie auth alone returns 404; the gateway routes the un-CCR-gated request to a
+generic list-handler that 400s with a misleading "Unknown query parameter"
+referencing an unrelated param taxonomy.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+PARSER_VERSION: Final[int] = 2
+
+CCR_HEADERS: Final[dict[str, str]] = {
+    "anthropic-beta": "ccr-byoc-2025-07-29",
+    "anthropic-client-feature": "ccr",
+    "anthropic-client-platform": "web_claude_ai",
+    "anthropic-version": "2023-06-01",
+}
+
+EVENTS_ENDPOINT_TEMPLATE: Final[str] = "https://claude.ai/v1/sessions/{sid}/events"
+
+REQUIRED_RESPONSE_KEYS: Final[frozenset[str]] = frozenset({"data", "has_more"})
+"""Keys the events-API response envelope must carry.
+
+`last_id` is checked separately — it's only required when `has_more` is true, so
+treating it as universally required would false-positive on the final page.
+"""

--- a/lib/transcripts/events/intake.py
+++ b/lib/transcripts/events/intake.py
@@ -1,0 +1,155 @@
+"""Dump-file parsing for `snippets/events-dump.js` output.
+
+The operator runs `events-dump.js` in claude.ai DevTools, scp's the resulting
+JSON file to the container, and the backfill driver consumes it through this
+module. The snippet's output shape:
+
+```json
+{
+  "parser_version": 2,
+  "dumped_at": "ISO-8601 UTC",
+  "org_uuid": "<operator org uuid>",
+  "sessions": {"session_01abc...": [<events>], ...},
+  "errors": [{"sid": "...", "page": N, "error": "..."}]
+}
+```
+
+The pinned probe fixture under `fixtures/events-api/` carries a single-session
+shape (one `sid` + `events[]` at the top level) — useful for probe/round-trip
+tests, kept supported here so a future single-session debug dump round-trips
+through the same loader.
+
+Both shapes normalize to `list[SessionPayload]`. Per-session errors recorded by
+the snippet during fetch are surfaced on the matching payload so the driver
+can flag partial dumps without re-parsing the envelope.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from transcripts.events.client import PARSER_VERSION
+
+
+class DumpEnvelopeError(ValueError):
+    """Raised when a dump file fails envelope validation.
+
+    Validation is intentionally strict — a malformed dump is operator-fixable
+    (rerun the snippet) and we'd rather refuse cleanly than corrupt the
+    backfill manifest with half-translated junk.
+    """
+
+
+@dataclass
+class SessionPayload:
+    """One session's worth of events from a dump file.
+
+    `events` is the raw list — translation happens later. `fetch_errors` is the
+    subset of dump-envelope `errors[]` whose `sid` matches this session;
+    typically empty on a clean dump, populated when the cookie expired mid-fetch
+    or the gateway returned an HTTP error on a specific page.
+    """
+
+    session_id: str
+    events: list[dict[str, Any]]
+    fetch_errors: list[dict[str, Any]] = field(default_factory=list)
+
+
+def load_dump(path: Path) -> tuple[list[SessionPayload], dict[str, Any]]:
+    """Parse a dump file into per-session payloads + envelope metadata.
+
+    `path` may be plain JSON or gzipped JSON (`.json.gz`); the format is
+    detected by extension. Returns `(payloads, envelope_meta)` where
+    `envelope_meta` carries the dump-level fields the caller may want to
+    log or store on the backfill manifest (`parser_version`, `dumped_at`,
+    `org_uuid`).
+
+    Raises `DumpEnvelopeError` on:
+      - parser_version mismatch (loud failure — translator's contract is
+        version-pinned; silent acceptance would risk schema-drift corruption)
+      - missing required envelope fields
+      - non-dict session payloads in the multi-session shape
+    """
+    raw = _read_json(path)
+    if not isinstance(raw, dict):
+        raise DumpEnvelopeError(f"dump {path} is not a JSON object")
+
+    version = raw.get("parser_version")
+    if version != PARSER_VERSION:
+        raise DumpEnvelopeError(
+            f"dump {path} parser_version={version!r} but loader expects "
+            f"{PARSER_VERSION} — re-run the snippet from "
+            "snippets/events-dump.js or update the loader in lockstep"
+        )
+
+    envelope: dict[str, Any] = {
+        "parser_version": version,
+        "dumped_at": raw.get("dumped_at", ""),
+        "org_uuid": raw.get("org_uuid", ""),
+        "source_path": str(path),
+    }
+
+    sessions = raw.get("sessions")
+    if isinstance(sessions, dict):
+        payloads = _from_multi_session(sessions, raw.get("errors") or [])
+    elif "sid" in raw and "events" in raw:
+        payloads = _from_single_session(raw)
+    else:
+        raise DumpEnvelopeError(
+            f"dump {path} has neither 'sessions' (multi) nor 'sid'+'events' "
+            "(single) shape — re-run the snippet"
+        )
+
+    return payloads, envelope
+
+
+def _read_json(path: Path) -> Any:
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            return json.load(f)
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _from_multi_session(
+    sessions: dict[str, Any], errors: list[dict[str, Any]]
+) -> list[SessionPayload]:
+    by_sid: dict[str, list[dict[str, Any]]] = {}
+    for err in errors:
+        if not isinstance(err, dict):
+            continue
+        sid = err.get("sid")
+        if not isinstance(sid, str):
+            continue
+        by_sid.setdefault(sid, []).append(err)
+
+    payloads: list[SessionPayload] = []
+    for sid, events in sessions.items():
+        if not isinstance(events, list):
+            raise DumpEnvelopeError(
+                f"session {sid}: events is not a list (got {type(events).__name__})"
+            )
+        payloads.append(
+            SessionPayload(
+                session_id=sid,
+                events=events,
+                fetch_errors=by_sid.get(sid, []),
+            )
+        )
+    return payloads
+
+
+def _from_single_session(raw: dict[str, Any]) -> list[SessionPayload]:
+    sid = raw["sid"]
+    events = raw["events"]
+    if not isinstance(sid, str):
+        raise DumpEnvelopeError(f"single-session dump: sid is {type(sid).__name__}, expected str")
+    if not isinstance(events, list):
+        raise DumpEnvelopeError(
+            f"single-session dump: events is {type(events).__name__}, expected list"
+        )
+    return [SessionPayload(session_id=sid, events=events)]

--- a/lib/transcripts/events/probe.py
+++ b/lib/transcripts/events/probe.py
@@ -1,0 +1,139 @@
+"""Schema-drift probe — compares observed events against the pinned reference.
+
+The probe runs in two contexts:
+
+1. **CI parity** — load the pinned fixture under `fixtures/events-api/` and
+   verify that the canonical event-type taxonomy + per-type field union still
+   round-trips through the translator. The reference schema lives at
+   `fixtures/events-api/schema.json` and is the source of truth for what the
+   translator is built against.
+
+2. **Live drift** — operator runs the events snippet with logging, captures
+   the live response shape, feeds it through `compare_to_schema`. Surfaces
+   any new event type, missing field, or shape change before the next
+   ~80-session backfill batch runs against stale assumptions.
+
+The live form requires the operator's cookie + the CCR header gate; it is not
+called from any automated path. Phase 3 will add a Cloudflare-Worker-side
+canary that pins one session and re-fetches nightly.
+
+Reference-schema location is the published bundle; consumers pin against it
+to avoid silent drift when the schema file evolves on `main` ahead of a
+translator update.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from transcripts.events.client import REQUIRED_RESPONSE_KEYS
+
+_DEFAULT_SCHEMA_RELPATH = "fixtures/events-api/schema.json"
+
+
+def default_reference_schema_path() -> Path:
+    """Locate `fixtures/events-api/schema.json` relative to the repo root.
+
+    Walk up from this file's location (`lib/transcripts/events/probe.py`) to the
+    repo root, then descend into fixtures. Two layers up from `events/` gets to
+    `lib/`; three gets to the repo root.
+    """
+    return Path(__file__).resolve().parents[3] / _DEFAULT_SCHEMA_RELPATH
+
+
+def load_reference_schema(path: Path | None = None) -> dict[str, Any]:
+    """Read the schema reference JSON. Caller passes path for non-default repos."""
+    target = path or default_reference_schema_path()
+    with open(target, encoding="utf-8") as f:
+        loaded = json.load(f)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"reference schema at {target} is not a JSON object")
+    return loaded
+
+
+@dataclass
+class SchemaDiff:
+    """Drift report: zero-length on a clean match, populated when fields shifted.
+
+    `unknown_types` — event types observed in input not present in the reference.
+      A non-empty list signals that the API surfaced a new event family; the
+      translator either ignores it (no harm; loses fidelity) or surfaces it
+      (refactor required).
+    `missing_required_types` — types declared in the reference's
+      `translator_targets.renderer_compatible` not present in input. Typically
+      benign on short sessions (e.g. system events absent on a 1-turn session).
+    `unexpected_fields_by_type` — observed fields not in the reference's
+      `event_types_observed.<type>.fields` list. Same disposition as
+      unknown_types — the translator passes through `message.content` verbatim,
+      so unknown sibling fields rarely matter.
+    """
+
+    unknown_types: list[str] = field(default_factory=list)
+    missing_required_types: list[str] = field(default_factory=list)
+    unexpected_fields_by_type: dict[str, list[str]] = field(default_factory=dict)
+
+    def is_clean(self) -> bool:
+        return (
+            not self.unknown_types
+            and not self.missing_required_types
+            and not self.unexpected_fields_by_type
+        )
+
+
+def compare_to_schema(
+    events: list[dict[str, Any]],
+    schema: dict[str, Any] | None = None,
+) -> SchemaDiff:
+    """Diff observed events vs the reference schema."""
+    schema = schema or load_reference_schema()
+    declared = schema.get("event_types_observed") or {}
+    targets = schema.get("translator_targets") or {}
+
+    observed_types: dict[str, set[str]] = {}
+    for ev in events:
+        kind = ev.get("type")
+        if not isinstance(kind, str):
+            continue
+        observed_types.setdefault(kind, set()).update(ev.keys())
+
+    diff = SchemaDiff()
+
+    for kind in observed_types:
+        if kind not in declared:
+            diff.unknown_types.append(kind)
+
+    required = targets.get("renderer_compatible") or []
+    for req in required:
+        if isinstance(req, str) and req not in observed_types:
+            diff.missing_required_types.append(req)
+
+    for kind, fields in observed_types.items():
+        if kind not in declared:
+            continue
+        declared_fields = set(declared[kind].get("fields", []))
+        unexpected = sorted(fields - declared_fields)
+        if unexpected:
+            diff.unexpected_fields_by_type[kind] = unexpected
+
+    return diff
+
+
+def validate_response_envelope(body: dict[str, Any]) -> list[str]:
+    """Check a paginated response envelope for the keys the snippet depends on.
+
+    Returns a list of human-readable drift messages; empty on a clean envelope.
+    Used by the snippet's Python-side counterpart (probe.py) and by intake.py
+    if a future caller hands intake() raw page bodies instead of a dump file.
+    """
+    issues: list[str] = []
+    missing = REQUIRED_RESPONSE_KEYS - body.keys()
+    if missing:
+        issues.append(f"missing required envelope keys: {sorted(missing)}")
+    if "data" in body and not isinstance(body["data"], list):
+        issues.append(f"data is {type(body['data']).__name__}, expected list")
+    if body.get("has_more") and "last_id" not in body:
+        issues.append("has_more=true but no last_id for next-page cursor")
+    return issues

--- a/lib/transcripts/events/translator.py
+++ b/lib/transcripts/events/translator.py
@@ -1,0 +1,337 @@
+"""Server-side events → renderer-compatible jsonl entries + sidecar metadata.
+
+The renderer at `scripts/lifecycle/session-end-transcript-render.py` expects
+jsonl entries shaped like the local Claude Code transcript: top-level `type`,
+`timestamp`, `uuid`, plus `message.content` carrying the per-role payload. The
+events stream uses `created_at` instead of `timestamp` and emits a wider type
+taxonomy (system / env_manager_log / result / tool_progress / ...). This module
+maps one to the other.
+
+## Translation rules (v1)
+
+| Event type                | Becomes              | Why                                       |
+|---------------------------|----------------------|-------------------------------------------|
+| `user`                    | type=`user`          | content already renderer-shaped           |
+| `assistant`               | type=`assistant`     | content already renderer-shaped           |
+| `system` subtype=`init`   | type=`summary` meta  | source of cwd + claude_code_version       |
+| `system` (other subtypes) | dropped              | telemetry — future v2 if value emerges    |
+| `result`                  | dropped              | metadata-only via `extract_metadata`      |
+| `env_manager_log`         | dropped              | container telemetry, not renderer-fidelity|
+| `tool_progress`           | dropped              | streaming partials; archival via result   |
+| `control_request|response`| dropped              | session-control plane                     |
+| `rate_limit_event`        | dropped              | telemetry                                 |
+
+`extract_metadata` is the canonical v3 sidecar source for events-recovered
+sessions — the renderer's `compute_metadata` operates on entries and would
+miss the richer model variants surfaced by `result.modelUsage` keys (the local
+`message.model` lacks the `[1m]` suffix on the 1M-context Opus variant).
+
+## Stability
+
+- `events_to_entries` is pure: same input always produces the same output.
+- Field renames are documented inline. If the events-API drifts, the probe
+  (`transcripts.events.probe`) surfaces it before the next backfill.
+- Per Decision: synthetic init entries carry only the subset the renderer reads
+  (`cwd`, `version`, `uuid`, `timestamp`, `type`) — not the full init payload.
+  Full init payload retention is a follow-up if the v3 sidecar gains fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+_PREVIEW_MAX_LEN = 140
+
+
+@dataclass(frozen=True)
+class EventsMetadata:
+    """v3 sidecar fields extracted directly from the events stream.
+
+    Mirrors the renderer-computed metadata block but sourced from the raw events
+    (richer than the renderer's per-entry walk because `result.modelUsage` keys
+    carry the `[1m]` variant the assistant message-level `model` field omits).
+
+    `started_at` / `ended_at` are ISO-8601 strings or empty when no timestamped
+    event was present. `duration_seconds` is 0 in that case.
+    """
+
+    session_id: str
+    started_at: str
+    ended_at: str
+    duration_seconds: int
+    entry_count: int
+    user_turn_count: int
+    assistant_turn_count: int
+    tool_call_count: int
+    error_count: int
+    first_user_preview: str
+    first_user_uuid: str
+    models: list[str] = field(default_factory=list)
+    cwds: list[str] = field(default_factory=list)
+    cc_version: str = ""
+
+
+_RENDERER_PASS_THROUGH: frozenset[str] = frozenset({"user", "assistant"})
+
+
+def events_to_entries(events: list[dict[str, Any]], session_id: str) -> list[dict[str, Any]]:
+    """Map events stream → renderer-compatible jsonl entries.
+
+    `session_id` is the canonical session id — used to fill the `sessionId`
+    field on entries whose event payload had an empty `session_id` (the leading
+    bootstrap events on a freshly-created session can carry `""`).
+
+    Output ordering follows event ordering (events are server-ordered by
+    `created_at`); the renderer's elapsed-time computation depends on this.
+    """
+    entries: list[dict[str, Any]] = []
+    for ev in events:
+        kind = ev.get("type")
+        if kind in _RENDERER_PASS_THROUGH:
+            entries.append(_pass_through(ev, session_id))
+        elif kind == "system" and ev.get("subtype") == "init":
+            entries.append(_init_meta(ev, session_id))
+    return entries
+
+
+def _pass_through(ev: dict[str, Any], session_id: str) -> dict[str, Any]:
+    """Rename event fields onto a jsonl-shaped entry without semantic change.
+
+    `created_at` → `timestamp` is the only structural rename; everything else
+    is preserved verbatim so the renderer's classifier and per-role formatters
+    see exactly what they would on a local jsonl.
+    """
+    entry: dict[str, Any] = {
+        "type": ev["type"],
+        "timestamp": ev.get("created_at", ""),
+        "uuid": ev.get("uuid", ""),
+        "sessionId": ev.get("session_id") or session_id,
+    }
+    if "message" in ev:
+        entry["message"] = ev["message"]
+    if ev.get("parent_tool_use_id"):
+        entry["parentUuid"] = ev["parent_tool_use_id"]
+    if ev.get("request_id"):
+        entry["requestId"] = ev["request_id"]
+    if "isSynthetic" in ev:
+        entry["isSynthetic"] = ev["isSynthetic"]
+    if "client_platform" in ev:
+        entry["client_platform"] = ev["client_platform"]
+    return entry
+
+
+def _init_meta(ev: dict[str, Any], session_id: str) -> dict[str, Any]:
+    """Synthetic meta entry from a `system` `subtype=init` event.
+
+    `type=summary` is the renderer's existing meta classification (one of the
+    four bucketed under `_classify` → "meta"). Carries `cwd` + `version` at
+    the top level so the renderer's `compute_metadata` populates the v3
+    `cwds` / `cc_version` fields without bespoke logic.
+    """
+    return {
+        "type": "summary",
+        "timestamp": ev.get("created_at", ""),
+        "uuid": ev.get("uuid", ""),
+        "sessionId": session_id,
+        "cwd": ev.get("cwd", ""),
+        "version": ev.get("claude_code_version", ""),
+        "summary": _init_summary(ev),
+    }
+
+
+def _init_summary(ev: dict[str, Any]) -> str:
+    """Short human-readable label for an init meta entry.
+
+    Surfaces in the renderer's `_render_meta` summary slot; keeps the rendered
+    HTML scannable without bloating the entry payload.
+    """
+    cwd = ev.get("cwd", "")
+    ver = ev.get("claude_code_version", "")
+    perm = ev.get("permissionMode", "")
+    bits = []
+    if cwd:
+        bits.append(f"cwd={cwd}")
+    if ver:
+        bits.append(f"cc={ver}")
+    if perm:
+        bits.append(f"perm={perm}")
+    return "init: " + ", ".join(bits) if bits else "init"
+
+
+@dataclass
+class _MetadataAccumulator:
+    """Mutable scratch state for one `extract_metadata` pass.
+
+    Split out so per-type handlers stay small enough to read; lives entirely
+    inside the module — not part of the public surface.
+    """
+
+    first_ts: str = ""
+    last_ts: str = ""
+    user_count: int = 0
+    assistant_count: int = 0
+    tool_call_count: int = 0
+    error_count: int = 0
+    entry_count: int = 0
+    first_user_uuid: str = ""
+    first_user_preview: str = ""
+    models: list[str] = field(default_factory=list)
+    cwds: list[str] = field(default_factory=list)
+    cc_version: str = ""
+
+
+def _add_unique(lst: list[str], val: str) -> None:
+    if val and val not in lst:
+        lst.append(val)
+
+
+def _update_user(acc: _MetadataAccumulator, ev: dict[str, Any]) -> None:
+    acc.entry_count += 1
+    if ev.get("isSynthetic"):
+        return
+    acc.user_count += 1
+    if not acc.first_user_uuid:
+        acc.first_user_uuid = ev.get("uuid", "")
+    if not acc.first_user_preview:
+        acc.first_user_preview = _user_preview(ev)
+    acc.error_count += _count_tool_result_errors(ev)
+
+
+def _update_assistant(acc: _MetadataAccumulator, ev: dict[str, Any]) -> None:
+    acc.entry_count += 1
+    acc.assistant_count += 1
+    msg = ev.get("message", {}) or {}
+    model = msg.get("model")
+    if isinstance(model, str):
+        _add_unique(acc.models, model)
+    acc.tool_call_count += _count_tool_uses(ev)
+
+
+def _update_system(acc: _MetadataAccumulator, ev: dict[str, Any]) -> None:
+    if ev.get("subtype") != "init":
+        return
+    acc.entry_count += 1
+    ver = ev.get("claude_code_version", "")
+    if isinstance(ver, str) and ver:
+        acc.cc_version = ver
+    cwd = ev.get("cwd", "")
+    if isinstance(cwd, str):
+        _add_unique(acc.cwds, cwd)
+
+
+def _update_result(acc: _MetadataAccumulator, ev: dict[str, Any]) -> None:
+    """result events surface the [1m] model variants the assistant key omits."""
+    mu = ev.get("modelUsage") or {}
+    for model_key in mu:
+        if isinstance(model_key, str):
+            _add_unique(acc.models, model_key)
+
+
+_KIND_HANDLERS: dict[str, Any] = {
+    "user": _update_user,
+    "assistant": _update_assistant,
+    "system": _update_system,
+}
+
+
+def extract_metadata(events: list[dict[str, Any]], session_id: str) -> EventsMetadata:
+    """Compute v3 sidecar fields directly from the events stream.
+
+    Authoritative for events-recovered sessions. The renderer's
+    `compute_metadata` can be run on the translated entries as a parity check,
+    but the canonical sidecar comes from here because `result.modelUsage` keys
+    carry the `[1m]` variant the per-entry walk misses.
+    """
+    acc = _MetadataAccumulator()
+
+    for ev in events:
+        ts = ev.get("created_at", "")
+        if ts:
+            if not acc.first_ts:
+                acc.first_ts = ts
+            acc.last_ts = ts
+
+        kind = ev.get("type")
+        handler = _KIND_HANDLERS.get(kind) if isinstance(kind, str) else None
+        if handler is None:
+            if kind == "result":
+                _update_result(acc, ev)
+            continue
+        handler(acc, ev)
+
+    duration = _compute_duration_seconds(acc.first_ts, acc.last_ts)
+
+    return EventsMetadata(
+        session_id=session_id,
+        started_at=acc.first_ts,
+        ended_at=acc.last_ts,
+        duration_seconds=duration,
+        entry_count=acc.entry_count,
+        user_turn_count=acc.user_count,
+        assistant_turn_count=acc.assistant_count,
+        tool_call_count=acc.tool_call_count,
+        error_count=acc.error_count,
+        first_user_preview=acc.first_user_preview,
+        first_user_uuid=acc.first_user_uuid,
+        models=acc.models,
+        cwds=acc.cwds,
+        cc_version=acc.cc_version,
+    )
+
+
+def _user_preview(ev: dict[str, Any]) -> str:
+    """First-line preview of a user event's content, truncated to 140 chars.
+
+    Mirrors the renderer's `_first_line(text, 140)` convention so events-recovered
+    sidecars don't visibly differ from locally-rendered sidecars on the list page.
+    """
+    msg = ev.get("message", {}) or {}
+    content = msg.get("content")
+    text = ""
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "")
+                break
+    text = text.strip()
+    if not text:
+        return ""
+    first_line = text.split("\n", 1)[0]
+    if len(first_line) > _PREVIEW_MAX_LEN:
+        return first_line[: _PREVIEW_MAX_LEN - 3] + "..."
+    return first_line
+
+
+def _count_tool_uses(ev: dict[str, Any]) -> int:
+    msg = ev.get("message", {}) or {}
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return 0
+    return sum(1 for b in content if isinstance(b, dict) and b.get("type") == "tool_use")
+
+
+def _count_tool_result_errors(ev: dict[str, Any]) -> int:
+    msg = ev.get("message", {}) or {}
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return 0
+    return sum(
+        1
+        for b in content
+        if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("is_error")
+    )
+
+
+def _compute_duration_seconds(first_ts: str, last_ts: str) -> int:
+    if not first_ts or not last_ts:
+        return 0
+    try:
+        start = datetime.fromisoformat(first_ts.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(last_ts.replace("Z", "+00:00"))
+    except ValueError:
+        return 0
+    return max(0, int((end - start).total_seconds()))

--- a/lib/transcripts/r2.py
+++ b/lib/transcripts/r2.py
@@ -204,6 +204,44 @@ def _is_no_such_key(e: BaseException) -> bool:
 
 SIDECAR_CACHE_CONTROL = "private, max-age=0, must-revalidate"
 SIDECAR_CONTENT_TYPE = "application/json; charset=utf-8"
+HTML_CONTENT_TYPE = "text/html; charset=utf-8"
+
+
+def write_html_object(
+    session_id: str,
+    html_bytes: bytes,
+    *,
+    key_prefix: str = "rendered",
+    overwrite: bool = False,
+    s3: S3Client | None = None,
+) -> bool:
+    """Upload rendered HTML to R2 at <key_prefix>/<sid>.html.
+
+    Sibling of write_sidecar — same cede semantics, same atomic-create
+    discipline (IfNoneMatch="*" when overwrite=False), same cache-control
+    headers. Used by the events-API backfill driver and (Phase 1 port) by
+    the existing render-backfill script.
+    """
+    if s3 is None:
+        s3 = r2_client()
+    bucket = _bucket_from_env_or_op()
+    key = f"{key_prefix}/{session_id}.html"
+    put_kwargs: dict[str, Any] = {
+        "Bucket": bucket,
+        "Key": key,
+        "Body": html_bytes,
+        "ContentType": HTML_CONTENT_TYPE,
+        "CacheControl": SIDECAR_CACHE_CONTROL,
+    }
+    if not overwrite:
+        put_kwargs["IfNoneMatch"] = "*"
+    try:
+        s3.put_object(**put_kwargs)
+    except Exception as e:
+        if not overwrite and _is_precondition_failed(e):
+            return False
+        raise
+    return True
 
 
 def write_sidecar(

--- a/lib/transcripts/tests/test_backfill_events.py
+++ b/lib/transcripts/tests/test_backfill_events.py
@@ -1,0 +1,427 @@
+"""Backfill driver tests — dry-run + apply paths against an in-memory dump.
+
+The renderer subprocess is stubbed with a tiny shell-like script that writes
+known bytes to `--output`. R2 is mocked at the boto3 client level via a fake.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from transcripts.backfill.events import (
+    EVENTS_URL_SOURCE,
+    BackfillResult,
+    BackfillStatus,
+    backfill_dump,
+)
+from transcripts.events.client import PARSER_VERSION
+
+
+def _write_dump(tmp_path: Path, sessions: dict[str, list[dict[str, Any]]]) -> Path:
+    """Build a multi-session dump file from sessions dict."""
+    dump = {
+        "parser_version": PARSER_VERSION,
+        "dumped_at": "2026-06-06T00:00:00Z",
+        "org_uuid": "org-test",
+        "sessions": sessions,
+        "errors": [],
+    }
+    path = tmp_path / "dump.json"
+    path.write_text(json.dumps(dump), encoding="utf-8")
+    return path
+
+
+def _write_fake_renderer(tmp_path: Path, *, html_body: str = "<html>OK</html>") -> Path:
+    """Create a Python stub that mimics the renderer's --input/--output contract."""
+    script = tmp_path / "fake_renderer.py"
+    script.write_text(
+        "import argparse, sys\n"
+        "from pathlib import Path\n"
+        "p = argparse.ArgumentParser()\n"
+        "p.add_argument('--input', type=Path, required=True)\n"
+        "p.add_argument('--session-id', required=True)\n"
+        "p.add_argument('--output', type=Path, required=True)\n"
+        "p.add_argument('--no-upload', action='store_true')\n"
+        "args, _ = p.parse_known_args()\n"
+        "lines = [l for l in args.input.read_text().splitlines() if l.strip()]\n"
+        f"args.output.write_text({html_body!r} + f'<!-- entries={{len(lines)}} -->')\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    return script
+
+
+def _write_failing_renderer(tmp_path: Path) -> Path:
+    script = tmp_path / "failing_renderer.py"
+    script.write_text(
+        "import sys\nsys.stderr.write('renderer exploded\\n')\nsys.exit(7)\n",
+        encoding="utf-8",
+    )
+    return script
+
+
+_SAMPLE_EVENTS: list[dict[str, Any]] = [
+    {
+        "type": "system",
+        "subtype": "init",
+        "created_at": "2026-05-31T01:00:00Z",
+        "uuid": "i1",
+        "cwd": "/home/user",
+        "claude_code_version": "2.1.158",
+    },
+    {
+        "type": "user",
+        "created_at": "2026-05-31T01:00:05Z",
+        "uuid": "u1",
+        "session_id": "",
+        "message": {"content": "hi coo, boot up please"},
+    },
+    {
+        "type": "assistant",
+        "created_at": "2026-05-31T01:00:10Z",
+        "uuid": "a1",
+        "message": {
+            "model": "claude-opus-4-7",
+            "content": [{"type": "text", "text": "Boot starting"}],
+        },
+    },
+]
+
+
+@dataclass
+class _FakeS3:
+    """Minimal in-memory S3 stand-in: tracks PUT/GET calls + canned NoSuchKey.
+
+    Mirrors the shape of `_is_no_such_key` / `_is_precondition_failed` so the
+    lib's r2.py recognizes the synthesized exceptions correctly.
+    """
+
+    objects: dict[str, bytes] = field(default_factory=dict)
+    puts: list[dict[str, Any]] = field(default_factory=list)
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:
+        if Key not in self.objects:
+            raise _NoSuchKeyError()
+        body = self.objects[Key]
+
+        class _Body:
+            def read(self) -> bytes:
+                return body
+
+        return {"Body": _Body()}
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        key = kwargs["Key"]
+        self.puts.append(kwargs)
+        if kwargs.get("IfNoneMatch") == "*" and key in self.objects:
+            raise _PreconditionFailedError()
+        self.objects[key] = kwargs["Body"]
+        return {}
+
+
+class _NoSuchKeyError(Exception):
+    """Mock botocore's NoSuchKey shape — duck-typed on `.response`."""
+
+    def __init__(self) -> None:
+        super().__init__("NoSuchKey")
+        self.response = {"Error": {"Code": "NoSuchKey"}}
+
+
+class _PreconditionFailedError(Exception):
+    def __init__(self) -> None:
+        super().__init__("PreconditionFailed")
+        self.response = {"Error": {"Code": "PreconditionFailed"}}
+
+
+@pytest.fixture
+def fake_s3() -> _FakeS3:
+    return _FakeS3()
+
+
+@pytest.fixture
+def _patch_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the op-bucket resolution; tests never reach 1Password."""
+    monkeypatch.setattr(
+        "transcripts.r2._bucket_from_env_or_op",
+        lambda: "test-bucket",
+    )
+
+
+class TestDryRunPath:
+    def test_dry_run_translates_and_renders_no_writes(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        dump_path = _write_dump(tmp_path, {"session_dry": _SAMPLE_EVENTS})
+        renderer = _write_fake_renderer(tmp_path)
+
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=False,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+
+        assert len(report.results) == 1
+        result = report.results[0]
+        assert result.status == BackfillStatus.DRY_RUN
+        assert result.session_id == "session_dry"
+        assert result.html_bytes > 0
+        assert result.user_turn_count == 1
+        assert result.assistant_turn_count == 1
+        assert fake_s3.puts == []  # no R2 writes
+
+
+class TestApplyPath:
+    def test_apply_writes_html_then_sidecar(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        dump_path = _write_dump(tmp_path, {"session_apply": _SAMPLE_EVENTS})
+        renderer = _write_fake_renderer(tmp_path)
+
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=True,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+
+        result = report.results[0]
+        assert result.status == BackfillStatus.APPLIED
+        # Two PUTs: html + sidecar.
+        keys = [p["Key"] for p in fake_s3.puts]
+        assert "rendered/session_apply.html" in keys
+        assert "rendered/session_apply.meta.json" in keys
+
+    def test_sidecar_carries_events_url_source(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        dump_path = _write_dump(tmp_path, {"session_url": _SAMPLE_EVENTS})
+        renderer = _write_fake_renderer(tmp_path)
+
+        backfill_dump(
+            dump_path=dump_path,
+            apply=True,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+
+        meta_put = next(p for p in fake_s3.puts if p["Key"].endswith(".meta.json"))
+        body = json.loads(meta_put["Body"])
+        assert body["url_source"] == EVENTS_URL_SOURCE
+        assert body["session_url"] == "https://claude.ai/code/session_url"
+        assert body["cc_version"] == "2.1.158"
+        assert body["cwds"] == ["/home/user"]
+
+    def test_first_write_uses_if_none_match(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        dump_path = _write_dump(tmp_path, {"session_first": _SAMPLE_EVENTS})
+        renderer = _write_fake_renderer(tmp_path)
+
+        backfill_dump(
+            dump_path=dump_path,
+            apply=True,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+
+        for put in fake_s3.puts:
+            assert put.get("IfNoneMatch") == "*", f"{put['Key']} missing atomic-create"
+
+
+class TestProvenanceGate:
+    def test_authoritative_existing_sidecar_cedes(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        sid = "session_existing"
+        existing = json.dumps({"session_id": sid, "url_source": "env-recovery"}).encode()
+        fake_s3.objects[f"rendered/{sid}.meta.json"] = existing
+
+        dump_path = _write_dump(tmp_path, {sid: _SAMPLE_EVENTS})
+        renderer = _write_fake_renderer(tmp_path)
+
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=True,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+
+        result = report.results[0]
+        assert result.status == BackfillStatus.CEDED_AUTHORITATIVE
+        # No additional PUTs after the ceded decision.
+        keys_after_cede = [p["Key"] for p in fake_s3.puts if p["Key"].startswith("rendered/")]
+        assert f"rendered/{sid}.html" not in keys_after_cede
+
+    def test_existing_events_uuid_can_overwrite(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        """A re-run against the same source should overwrite, not cede."""
+        sid = "session_rerun"
+        existing = json.dumps({"session_id": sid, "url_source": EVENTS_URL_SOURCE}).encode()
+        fake_s3.objects[f"rendered/{sid}.meta.json"] = existing
+        fake_s3.objects[f"rendered/{sid}.html"] = b"<old html>"
+
+        dump_path = _write_dump(tmp_path, {sid: _SAMPLE_EVENTS})
+        renderer = _write_fake_renderer(tmp_path)
+
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=True,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+
+        assert report.results[0].status == BackfillStatus.APPLIED
+        # PUTs went through (overwrite path; no IfNoneMatch).
+        rewrite_puts = [p for p in fake_s3.puts if p["Key"].startswith(f"rendered/{sid}.")]
+        for put in rewrite_puts:
+            assert "IfNoneMatch" not in put
+
+
+class TestSkipPaths:
+    def test_empty_translation_skipped(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        # Only control-plane events; translator produces zero entries.
+        events = [{"type": "control_request", "created_at": "ts", "uuid": "c"}]
+        dump_path = _write_dump(tmp_path, {"session_empty": events})
+        renderer = _write_fake_renderer(tmp_path)
+
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=True,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+        assert report.results[0].status == BackfillStatus.SKIPPED_NO_ENTRIES
+        assert fake_s3.puts == []
+
+    def test_fetch_errors_skipped_with_detail(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        sid = "session_bad_fetch"
+        dump_path = tmp_path / "dump.json"
+        dump_path.write_text(
+            json.dumps(
+                {
+                    "parser_version": PARSER_VERSION,
+                    "dumped_at": "ts",
+                    "org_uuid": "x",
+                    "sessions": {sid: _SAMPLE_EVENTS},
+                    "errors": [{"sid": sid, "page": 1, "error": "HTTP 401"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        renderer = _write_fake_renderer(tmp_path)
+
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=True,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+        result = report.results[0]
+        assert result.status == BackfillStatus.SKIPPED_FETCH_ERROR
+        assert "HTTP 401" in result.error_detail
+
+
+class TestErrorPropagation:
+    def test_renderer_failure_marked_as_error(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        dump_path = _write_dump(tmp_path, {"session_render_fail": _SAMPLE_EVENTS})
+        renderer = _write_failing_renderer(tmp_path)
+
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=True,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+        result = report.results[0]
+        assert result.status == BackfillStatus.ERROR
+        assert "rc=7" in result.error_detail
+
+
+class TestSubsetFiltering:
+    def test_only_session_ids_filters_dump(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        sessions = {
+            "session_in": _SAMPLE_EVENTS,
+            "session_out": _SAMPLE_EVENTS,
+        }
+        dump_path = _write_dump(tmp_path, sessions)
+        renderer = _write_fake_renderer(tmp_path)
+
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=False,
+            renderer_script=renderer,
+            s3=fake_s3,
+            only_session_ids={"session_in"},
+        )
+        assert {r.session_id for r in report.results} == {"session_in"}
+
+
+class TestReportShape:
+    def test_counts_by_status_aggregates(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        sessions = {
+            "session_a": _SAMPLE_EVENTS,
+            "session_b": [{"type": "control_request", "created_at": "t", "uuid": "c"}],
+        }
+        dump_path = _write_dump(tmp_path, sessions)
+        renderer = _write_fake_renderer(tmp_path)
+
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=False,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+        counts = report.counts_by_status()
+        assert counts.get("dry_run") == 1
+        assert counts.get("skipped_no_entries") == 1
+
+    def test_result_to_jsonl_omits_empty_error_detail(self) -> None:
+        r = BackfillResult(
+            session_id="x",
+            status=BackfillStatus.DRY_RUN,
+            entry_count=3,
+            html_bytes=42,
+        )
+        parsed = json.loads(r.to_jsonl())
+        assert "error_detail" not in parsed
+        assert parsed["status"] == "dry_run"
+
+    def test_report_dump_path_recorded(
+        self, tmp_path: Path, fake_s3: _FakeS3, _patch_bucket: None
+    ) -> None:
+        dump_path = _write_dump(tmp_path, {"session_x": _SAMPLE_EVENTS})
+        renderer = _write_fake_renderer(tmp_path)
+        report = backfill_dump(
+            dump_path=dump_path,
+            apply=False,
+            renderer_script=renderer,
+            s3=fake_s3,
+        )
+        assert report.dump_path == str(dump_path)
+        assert report.org_uuid == "org-test"
+
+
+def test_subprocess_runs_against_real_python() -> None:
+    """Sanity: the fake renderer pattern actually works under the lib's subprocess.
+
+    Ensures `sys.executable` is a sensible default; matches the driver path.
+    """
+    assert Path(sys.executable).exists()

--- a/lib/transcripts/tests/test_events_client.py
+++ b/lib/transcripts/tests/test_events_client.py
@@ -1,0 +1,73 @@
+"""Client constants tests — the lockstep contract with the JS snippet.
+
+PARSER_VERSION here MUST match snippets/events-dump.js. This test reads the
+snippet directly and asserts equality so a future bump in only one place fires
+loudly at PR-open time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from transcripts.events.client import (
+    CCR_HEADERS,
+    EVENTS_ENDPOINT_TEMPLATE,
+    PARSER_VERSION,
+    REQUIRED_RESPONSE_KEYS,
+)
+
+_SNIPPET_PATH = Path(__file__).resolve().parents[3] / "snippets" / "events-dump.js"
+
+
+class TestParserVersionLockstep:
+    """If this fails, the JS snippet and the Python loader disagree.
+
+    Bump both in the same PR or the dump file the operator generates will
+    fail intake validation with `parser_version` mismatch.
+    """
+
+    def test_python_constant_matches_snippet(self) -> None:
+        snippet = _SNIPPET_PATH.read_text(encoding="utf-8")
+        match = re.search(r"_PARSER_VERSION\s*=\s*(\d+)", snippet)
+        assert match is not None, "could not find _PARSER_VERSION in snippets/events-dump.js"
+        assert int(match.group(1)) == PARSER_VERSION
+
+
+class TestCcrHeaders:
+    def test_beta_flag_present(self) -> None:
+        assert CCR_HEADERS["anthropic-beta"] == "ccr-byoc-2025-07-29"
+
+    def test_client_feature_ccr(self) -> None:
+        assert CCR_HEADERS["anthropic-client-feature"] == "ccr"
+
+    def test_platform_web_claude_ai(self) -> None:
+        assert CCR_HEADERS["anthropic-client-platform"] == "web_claude_ai"
+
+    def test_version_2023_06_01(self) -> None:
+        assert CCR_HEADERS["anthropic-version"] == "2023-06-01"
+
+    def test_no_organization_uuid_in_static_dict(self) -> None:
+        # x-organization-uuid is per-operator; must NOT be a constant.
+        assert "x-organization-uuid" not in CCR_HEADERS
+
+
+class TestEndpointTemplate:
+    def test_template_takes_sid(self) -> None:
+        url = EVENTS_ENDPOINT_TEMPLATE.format(sid="session_01abc")
+        assert url == "https://claude.ai/v1/sessions/session_01abc/events"
+
+    def test_template_uses_claude_ai_host(self) -> None:
+        assert EVENTS_ENDPOINT_TEMPLATE.startswith("https://claude.ai/")
+
+
+class TestRequiredResponseKeys:
+    def test_contains_data(self) -> None:
+        assert "data" in REQUIRED_RESPONSE_KEYS
+
+    def test_contains_has_more(self) -> None:
+        assert "has_more" in REQUIRED_RESPONSE_KEYS
+
+    def test_does_not_contain_last_id(self) -> None:
+        # last_id is conditionally required — only when has_more=True.
+        assert "last_id" not in REQUIRED_RESPONSE_KEYS

--- a/lib/transcripts/tests/test_events_init.py
+++ b/lib/transcripts/tests/test_events_init.py
@@ -1,0 +1,39 @@
+"""Smoke tests for the transcripts.events public surface."""
+
+from __future__ import annotations
+
+import transcripts.events as events_pkg
+from transcripts import write_html_object, write_sidecar
+
+_EXPECTED_PUBLIC = {
+    "CCR_HEADERS",
+    "EVENTS_ENDPOINT_TEMPLATE",
+    "PARSER_VERSION",
+    "REQUIRED_RESPONSE_KEYS",
+    "DumpEnvelopeError",
+    "EventsMetadata",
+    "SessionPayload",
+    "events_to_entries",
+    "extract_metadata",
+    "load_dump",
+}
+
+
+class TestEventsPackageSurface:
+    def test_all_lists_the_public_surface(self) -> None:
+        assert set(events_pkg.__all__) == _EXPECTED_PUBLIC
+
+    def test_each_member_resolvable(self) -> None:
+        for name in events_pkg.__all__:
+            assert hasattr(events_pkg, name), f"missing public export: {name}"
+
+
+class TestTopLevelLibReExports:
+    """The events module is reachable as `transcripts.events`; primitives
+    used by hooks (e.g., write_html_object) re-export from the package root."""
+
+    def test_write_html_object_reachable_from_lib_root(self) -> None:
+        assert callable(write_html_object)
+
+    def test_write_sidecar_still_reachable(self) -> None:
+        assert callable(write_sidecar)

--- a/lib/transcripts/tests/test_events_intake.py
+++ b/lib/transcripts/tests/test_events_intake.py
@@ -1,0 +1,210 @@
+"""Intake tests — both dump shapes + envelope validation."""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from transcripts.events.client import PARSER_VERSION
+from transcripts.events.intake import DumpEnvelopeError, load_dump
+
+
+def _write(tmp_path: Path, name: str, payload: dict[str, Any]) -> Path:
+    target = tmp_path / name
+    if name.endswith(".gz"):
+        with gzip.open(target, "wt", encoding="utf-8") as f:
+            json.dump(payload, f)
+    else:
+        target.write_text(json.dumps(payload), encoding="utf-8")
+    return target
+
+
+class TestMultiSessionShape:
+    def test_two_sessions_parse_in_declared_order(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "2026-06-06T00:00:00Z",
+                "org_uuid": "org-abc",
+                "sessions": {
+                    "session_01abc": [{"type": "user", "uuid": "u1"}],
+                    "session_02def": [{"type": "assistant", "uuid": "a1"}],
+                },
+                "errors": [],
+            },
+        )
+        payloads, envelope = load_dump(path)
+        assert [p.session_id for p in payloads] == ["session_01abc", "session_02def"]
+        assert envelope["org_uuid"] == "org-abc"
+        assert envelope["dumped_at"] == "2026-06-06T00:00:00Z"
+        assert envelope["parser_version"] == PARSER_VERSION
+
+    def test_errors_routed_to_matching_session(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "sessions": {"session_01": [], "session_02": []},
+                "errors": [
+                    {"sid": "session_01", "page": 0, "error": "HTTP 429"},
+                    {"sid": "session_02", "page": 2, "error": "cookie expired"},
+                ],
+            },
+        )
+        payloads, _ = load_dump(path)
+        by_sid = {p.session_id: p for p in payloads}
+        assert by_sid["session_01"].fetch_errors[0]["error"] == "HTTP 429"
+        assert by_sid["session_02"].fetch_errors[0]["error"] == "cookie expired"
+
+    def test_orphan_errors_no_match_silently_dropped(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "sessions": {"session_01": []},
+                "errors": [{"sid": "session_other", "page": 0, "error": "x"}],
+            },
+        )
+        payloads, _ = load_dump(path)
+        assert payloads[0].fetch_errors == []
+
+    def test_malformed_error_entry_skipped(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "sessions": {"session_01": []},
+                "errors": ["not a dict", {"no_sid_key": "x"}],
+            },
+        )
+        payloads, _ = load_dump(path)
+        assert payloads[0].fetch_errors == []
+
+    def test_non_list_events_raises(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "sessions": {"session_01": "not a list"},
+            },
+        )
+        with pytest.raises(DumpEnvelopeError, match="events is not a list"):
+            load_dump(path)
+
+
+class TestSingleSessionShape:
+    def test_parses_single_session_dump(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "sid": "session_solo",
+                "events": [{"type": "user", "uuid": "u1"}],
+                "event_count": 1,
+            },
+        )
+        payloads, envelope = load_dump(path)
+        assert len(payloads) == 1
+        assert payloads[0].session_id == "session_solo"
+        assert envelope["parser_version"] == PARSER_VERSION
+
+    def test_non_string_sid_raises(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "sid": 123,
+                "events": [],
+            },
+        )
+        with pytest.raises(DumpEnvelopeError, match="sid is"):
+            load_dump(path)
+
+    def test_non_list_events_raises(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "sid": "session_x",
+                "events": {"not": "a list"},
+            },
+        )
+        with pytest.raises(DumpEnvelopeError, match="events is"):
+            load_dump(path)
+
+
+class TestEnvelopeValidation:
+    def test_wrong_parser_version_raises(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION + 99,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "sessions": {},
+            },
+        )
+        with pytest.raises(DumpEnvelopeError, match="parser_version"):
+            load_dump(path)
+
+    def test_unrecognized_shape_raises(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "events": [],  # no sid → not single-session; no sessions → not multi
+            },
+        )
+        with pytest.raises(DumpEnvelopeError, match=r"multi.*single"):
+            load_dump(path)
+
+    def test_top_level_non_dict_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "dump.json"
+        path.write_text(json.dumps([]), encoding="utf-8")
+        with pytest.raises(DumpEnvelopeError, match="not a JSON object"):
+            load_dump(path)
+
+    def test_gzip_dump_supported(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            "dump.json.gz",
+            {
+                "parser_version": PARSER_VERSION,
+                "dumped_at": "ts",
+                "org_uuid": "x",
+                "sessions": {"session_gz": []},
+            },
+        )
+        payloads, _ = load_dump(path)
+        assert payloads[0].session_id == "session_gz"

--- a/lib/transcripts/tests/test_events_probe.py
+++ b/lib/transcripts/tests/test_events_probe.py
@@ -1,0 +1,136 @@
+"""Schema-drift probe tests — fixture vs reference + envelope validation."""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+from typing import Any
+
+from transcripts.events.probe import (
+    SchemaDiff,
+    compare_to_schema,
+    default_reference_schema_path,
+    load_reference_schema,
+    validate_response_envelope,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "fixtures"
+    / "events-api"
+    / "session_0146dWU8wPHNwLyNLLJLuTYL.events.json.gz"
+)
+
+
+def _fixture_events() -> list[dict[str, Any]]:
+    with gzip.open(_FIXTURE_PATH, "rt", encoding="utf-8") as f:
+        raw = json.load(f)
+    events: list[dict[str, Any]] = raw["events"]
+    return events
+
+
+class TestReferenceSchema:
+    def test_default_path_resolves_to_existing_file(self) -> None:
+        assert default_reference_schema_path().is_file()
+
+    def test_load_returns_dict(self) -> None:
+        schema = load_reference_schema()
+        assert isinstance(schema, dict)
+        assert "event_types_observed" in schema
+        assert "translator_targets" in schema
+
+
+class TestCompareToSchemaFixture:
+    """The fixture is what the reference was derived from — diff must be clean."""
+
+    def test_fixture_round_trip_is_clean(self) -> None:
+        diff = compare_to_schema(_fixture_events())
+        assert diff.is_clean(), (
+            f"fixture-vs-reference drift detected:\n"
+            f"  unknown: {diff.unknown_types}\n"
+            f"  missing: {diff.missing_required_types}\n"
+            f"  fields: {diff.unexpected_fields_by_type}"
+        )
+
+
+class TestCompareToSchemaSynthetic:
+    def test_unknown_type_surfaces(self) -> None:
+        events = [{"type": "novel_event_type", "uuid": "n1"}]
+        diff = compare_to_schema(events)
+        assert "novel_event_type" in diff.unknown_types
+
+    def test_unexpected_field_surfaces(self) -> None:
+        events = [
+            {
+                "type": "user",
+                "uuid": "u1",
+                "created_at": "ts",
+                "message": {"content": "x"},
+                "novel_field": "x",
+            }
+        ]
+        diff = compare_to_schema(events)
+        assert "user" in diff.unexpected_fields_by_type
+        assert "novel_field" in diff.unexpected_fields_by_type["user"]
+
+    def test_missing_required_type_surfaces(self) -> None:
+        # Only user/system, no assistant → "assistant" missing per renderer_compatible.
+        events: list[dict[str, Any]] = [
+            {"type": "user", "uuid": "u1", "created_at": "ts", "message": {}},
+            {"type": "system", "uuid": "s1", "subtype": "init"},
+        ]
+        diff = compare_to_schema(events)
+        assert "assistant" in diff.missing_required_types
+
+    def test_empty_events_misses_all_required_types(self) -> None:
+        diff = compare_to_schema([])
+        assert "user" in diff.missing_required_types
+        assert "assistant" in diff.missing_required_types
+        assert "system" in diff.missing_required_types
+
+    def test_non_string_type_skipped(self) -> None:
+        events = [{"type": 123, "uuid": "x"}]
+        diff = compare_to_schema(events)
+        # The malformed event doesn't count as an observed type.
+        assert all(not isinstance(t, int) for t in diff.unknown_types)
+
+
+class TestSchemaDiffIsClean:
+    def test_all_empty_is_clean(self) -> None:
+        diff = SchemaDiff()
+        assert diff.is_clean() is True
+
+    def test_unknown_dirty(self) -> None:
+        diff = SchemaDiff(unknown_types=["x"])
+        assert diff.is_clean() is False
+
+    def test_missing_dirty(self) -> None:
+        diff = SchemaDiff(missing_required_types=["x"])
+        assert diff.is_clean() is False
+
+    def test_fields_dirty(self) -> None:
+        diff = SchemaDiff(unexpected_fields_by_type={"user": ["x"]})
+        assert diff.is_clean() is False
+
+
+class TestValidateResponseEnvelope:
+    def test_clean_envelope_no_issues(self) -> None:
+        issues = validate_response_envelope({"data": [{}], "has_more": False})
+        assert issues == []
+
+    def test_missing_data_flagged(self) -> None:
+        issues = validate_response_envelope({"has_more": False})
+        assert any("missing required envelope keys" in i for i in issues)
+
+    def test_data_not_list_flagged(self) -> None:
+        issues = validate_response_envelope({"data": "string", "has_more": False})
+        assert any("data is str" in i for i in issues)
+
+    def test_has_more_without_last_id_flagged(self) -> None:
+        issues = validate_response_envelope({"data": [], "has_more": True})
+        assert any("no last_id" in i for i in issues)
+
+    def test_has_more_false_no_last_id_ok(self) -> None:
+        issues = validate_response_envelope({"data": [], "has_more": False})
+        assert issues == []

--- a/lib/transcripts/tests/test_events_translator.py
+++ b/lib/transcripts/tests/test_events_translator.py
@@ -1,0 +1,401 @@
+"""Translator tests — synthetic shapes + round-trip against the pinned fixture.
+
+The fixture lives at `fixtures/events-api/session_0146...events.json.gz` and
+carries the 3438-event, 9-distinct-type ground truth from the 2026-06-05 probe.
+The fixture-round-trip test is the load-bearing one: it catches any change to
+the translator that would silently break the events-API recovery driver.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from transcripts.events.translator import (
+    EventsMetadata,
+    events_to_entries,
+    extract_metadata,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "fixtures"
+    / "events-api"
+    / "session_0146dWU8wPHNwLyNLLJLuTYL.events.json.gz"
+)
+
+
+def _load_fixture() -> tuple[str, list[dict[str, Any]]]:
+    with gzip.open(_FIXTURE_PATH, "rt", encoding="utf-8") as f:
+        raw = json.load(f)
+    return raw["sid"], raw["events"]
+
+
+@pytest.fixture(scope="module")
+def fixture_events() -> tuple[str, list[dict[str, Any]]]:
+    return _load_fixture()
+
+
+class TestEventsToEntriesShape:
+    def test_user_event_becomes_user_entry(self) -> None:
+        events = [
+            {
+                "type": "user",
+                "created_at": "2026-05-31T01:24:57.825423Z",
+                "uuid": "u1",
+                "session_id": "sid",
+                "message": {"content": "hello", "role": "user"},
+                "client_platform": "web_claude_ai",
+            }
+        ]
+        entries = events_to_entries(events, "sid")
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["type"] == "user"
+        assert entry["timestamp"] == "2026-05-31T01:24:57.825423Z"
+        assert entry["uuid"] == "u1"
+        assert entry["message"] == {"content": "hello", "role": "user"}
+        assert entry["client_platform"] == "web_claude_ai"
+        assert entry["sessionId"] == "sid"
+
+    def test_empty_session_id_falls_back_to_arg(self) -> None:
+        events = [{"type": "user", "created_at": "ts", "uuid": "u", "session_id": ""}]
+        entries = events_to_entries(events, "canonical-sid")
+        assert entries[0]["sessionId"] == "canonical-sid"
+
+    def test_assistant_event_passes_through_message(self) -> None:
+        msg = {
+            "content": [{"type": "text", "text": "hi"}],
+            "model": "claude-opus-4-7",
+            "role": "assistant",
+        }
+        events = [
+            {
+                "type": "assistant",
+                "created_at": "ts",
+                "uuid": "a1",
+                "session_id": "sid",
+                "message": msg,
+                "request_id": "req_x",
+            }
+        ]
+        entries = events_to_entries(events, "sid")
+        assert entries[0]["message"] == msg
+        assert entries[0]["requestId"] == "req_x"
+
+    def test_system_init_becomes_summary_meta(self) -> None:
+        events = [
+            {
+                "type": "system",
+                "subtype": "init",
+                "created_at": "ts",
+                "uuid": "i1",
+                "cwd": "/home/user",
+                "claude_code_version": "2.1.158",
+                "permissionMode": "default",
+            }
+        ]
+        entries = events_to_entries(events, "sid")
+        assert entries[0]["type"] == "summary"
+        assert entries[0]["cwd"] == "/home/user"
+        assert entries[0]["version"] == "2.1.158"
+        assert "perm=default" in entries[0]["summary"]
+
+    def test_system_non_init_dropped(self) -> None:
+        events = [
+            {
+                "type": "system",
+                "subtype": "hook_started",
+                "created_at": "ts",
+                "uuid": "h1",
+            }
+        ]
+        entries = events_to_entries(events, "sid")
+        assert entries == []
+
+    def test_telemetry_event_types_dropped(self) -> None:
+        events = [
+            {"type": "result", "created_at": "ts", "uuid": "r1"},
+            {"type": "env_manager_log", "created_at": "ts", "uuid": "e1"},
+            {"type": "tool_progress", "created_at": "ts", "uuid": "p1"},
+            {"type": "control_request", "created_at": "ts", "uuid": "c1"},
+            {"type": "rate_limit_event", "created_at": "ts", "uuid": "rl1"},
+        ]
+        entries = events_to_entries(events, "sid")
+        assert entries == []
+
+    def test_ordering_preserved(self) -> None:
+        events = [
+            {"type": "user", "created_at": "1", "uuid": "u1"},
+            {"type": "assistant", "created_at": "2", "uuid": "a1"},
+            {"type": "user", "created_at": "3", "uuid": "u2"},
+        ]
+        entries = events_to_entries(events, "sid")
+        assert [e["uuid"] for e in entries] == ["u1", "a1", "u2"]
+
+    def test_optional_fields_omitted_when_absent(self) -> None:
+        events = [{"type": "user", "created_at": "ts", "uuid": "u1"}]
+        entry = events_to_entries(events, "sid")[0]
+        assert "parentUuid" not in entry
+        assert "requestId" not in entry
+        assert "isSynthetic" not in entry
+
+    def test_synthetic_user_marked(self) -> None:
+        events = [{"type": "user", "created_at": "ts", "uuid": "u1", "isSynthetic": True}]
+        entry = events_to_entries(events, "sid")[0]
+        assert entry["isSynthetic"] is True
+
+
+class TestExtractMetadataShape:
+    def test_empty_events_returns_zeros(self) -> None:
+        meta = extract_metadata([], "sid")
+        assert meta.session_id == "sid"
+        assert meta.entry_count == 0
+        assert meta.duration_seconds == 0
+        assert meta.first_user_preview == ""
+        assert meta.models == []
+
+    def test_first_user_uuid_skips_synthetic(self) -> None:
+        events: list[dict[str, Any]] = [
+            {
+                "type": "user",
+                "created_at": "ts",
+                "uuid": "synth",
+                "isSynthetic": True,
+            },
+            {"type": "user", "created_at": "ts", "uuid": "real"},
+        ]
+        meta = extract_metadata(events, "sid")
+        assert meta.first_user_uuid == "real"
+        assert meta.user_turn_count == 1
+
+    def test_models_union_from_assistant_and_result(self) -> None:
+        events = [
+            {
+                "type": "assistant",
+                "created_at": "ts",
+                "uuid": "a1",
+                "message": {"model": "claude-opus-4-7", "content": []},
+            },
+            {
+                "type": "result",
+                "created_at": "ts",
+                "uuid": "r1",
+                "modelUsage": {"claude-opus-4-7[1m]": {"costUSD": 0.1}},
+            },
+        ]
+        meta = extract_metadata(events, "sid")
+        assert set(meta.models) == {"claude-opus-4-7", "claude-opus-4-7[1m]"}
+
+    def test_cwds_from_init_events(self) -> None:
+        events = [
+            {
+                "type": "system",
+                "subtype": "init",
+                "created_at": "ts",
+                "uuid": "i1",
+                "cwd": "/home/user",
+                "claude_code_version": "2.1.158",
+            },
+            {
+                "type": "system",
+                "subtype": "init",
+                "created_at": "ts",
+                "uuid": "i2",
+                "cwd": "/home/user",
+                "claude_code_version": "2.1.158",
+            },
+            {
+                "type": "system",
+                "subtype": "init",
+                "created_at": "ts",
+                "uuid": "i3",
+                "cwd": "/tmp",
+                "claude_code_version": "2.1.159",
+            },
+        ]
+        meta = extract_metadata(events, "sid")
+        assert meta.cwds == ["/home/user", "/tmp"]
+        assert meta.cc_version == "2.1.159"
+
+    def test_tool_call_count_from_assistant_blocks(self) -> None:
+        events = [
+            {
+                "type": "assistant",
+                "created_at": "ts",
+                "uuid": "a1",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "name": "Bash"},
+                        {"type": "tool_use", "name": "Read"},
+                        {"type": "text", "text": "x"},
+                    ]
+                },
+            }
+        ]
+        meta = extract_metadata(events, "sid")
+        assert meta.tool_call_count == 2
+
+    def test_error_count_from_tool_results(self) -> None:
+        events = [
+            {
+                "type": "user",
+                "created_at": "ts",
+                "uuid": "u1",
+                "message": {
+                    "content": [
+                        {"type": "tool_result", "content": "ok", "is_error": False},
+                        {"type": "tool_result", "content": "bad", "is_error": True},
+                    ]
+                },
+            }
+        ]
+        meta = extract_metadata(events, "sid")
+        assert meta.error_count == 1
+
+    def test_first_user_preview_truncates_long_text(self) -> None:
+        long_text = "x" * 200
+        events = [
+            {
+                "type": "user",
+                "created_at": "ts",
+                "uuid": "u1",
+                "message": {"content": long_text},
+            }
+        ]
+        meta = extract_metadata(events, "sid")
+        assert len(meta.first_user_preview) == 140
+        assert meta.first_user_preview.endswith("...")
+
+    def test_first_user_preview_first_line_only(self) -> None:
+        events = [
+            {
+                "type": "user",
+                "created_at": "ts",
+                "uuid": "u1",
+                "message": {"content": "line1\nline2\nline3"},
+            }
+        ]
+        meta = extract_metadata(events, "sid")
+        assert meta.first_user_preview == "line1"
+
+    def test_duration_seconds_from_ISO_timestamps(self) -> None:
+        events = [
+            {"type": "user", "created_at": "2026-05-31T01:00:00Z", "uuid": "u1"},
+            {"type": "assistant", "created_at": "2026-05-31T01:00:30Z", "uuid": "a1"},
+        ]
+        meta = extract_metadata(events, "sid")
+        assert meta.duration_seconds == 30
+
+    def test_duration_zero_on_unparseable_timestamp(self) -> None:
+        events = [{"type": "user", "created_at": "not-iso", "uuid": "u1"}]
+        meta = extract_metadata(events, "sid")
+        assert meta.duration_seconds == 0
+
+
+class TestFixtureRoundTrip:
+    """The load-bearing test: a real 3438-event session translates cleanly.
+
+    These assertions match the schema.json reference and the manual probe
+    output. Any divergence is either a schema-drift signal (in which case the
+    probe.py module's compare_to_schema should also fail) or a translator
+    regression (in which case this test is the falsifier).
+    """
+
+    def test_session_id_present(self, fixture_events: tuple[str, list[dict[str, Any]]]) -> None:
+        sid, _ = fixture_events
+        assert sid.startswith("session_")
+
+    def test_translation_yields_renderer_compatible_entries(
+        self, fixture_events: tuple[str, list[dict[str, Any]]]
+    ) -> None:
+        sid, events = fixture_events
+        entries = events_to_entries(events, sid)
+        # user + assistant + system:init counts per schema.json
+        assert len(entries) > 0
+        types = {e["type"] for e in entries}
+        assert types <= {"user", "assistant", "summary"}
+
+    def test_every_entry_has_renderer_required_fields(
+        self, fixture_events: tuple[str, list[dict[str, Any]]]
+    ) -> None:
+        sid, events = fixture_events
+        entries = events_to_entries(events, sid)
+        for entry in entries:
+            assert isinstance(entry["type"], str)
+            assert isinstance(entry["timestamp"], str)
+            assert isinstance(entry["uuid"], str)
+            assert isinstance(entry["sessionId"], str)
+
+    def test_metadata_matches_known_counts(
+        self, fixture_events: tuple[str, list[dict[str, Any]]]
+    ) -> None:
+        sid, events = fixture_events
+        meta = extract_metadata(events, sid)
+        # Per schema.json: 249 user events; some may be synthetic.
+        assert meta.user_turn_count > 0
+        assert meta.user_turn_count <= 249
+        # 494 assistant events per schema.json.
+        assert meta.assistant_turn_count == 494
+        assert meta.first_user_uuid != ""
+        assert meta.first_user_preview != ""
+
+    def test_metadata_models_includes_opus_variant(
+        self, fixture_events: tuple[str, list[dict[str, Any]]]
+    ) -> None:
+        sid, events = fixture_events
+        meta = extract_metadata(events, sid)
+        # The fixture's modelUsage carries the [1m] suffix variant.
+        assert any("[1m]" in m for m in meta.models)
+
+    def test_metadata_cc_version_recovered(
+        self, fixture_events: tuple[str, list[dict[str, Any]]]
+    ) -> None:
+        sid, events = fixture_events
+        meta = extract_metadata(events, sid)
+        assert meta.cc_version != ""
+
+    def test_metadata_cwds_recovered(
+        self, fixture_events: tuple[str, list[dict[str, Any]]]
+    ) -> None:
+        sid, events = fixture_events
+        meta = extract_metadata(events, sid)
+        assert len(meta.cwds) > 0
+        for cwd in meta.cwds:
+            assert cwd.startswith("/")
+
+
+class TestEventsMetadataDataclass:
+    def test_default_lists_are_independent_instances(self) -> None:
+        a = EventsMetadata(
+            session_id="a",
+            started_at="",
+            ended_at="",
+            duration_seconds=0,
+            entry_count=0,
+            user_turn_count=0,
+            assistant_turn_count=0,
+            tool_call_count=0,
+            error_count=0,
+            first_user_preview="",
+            first_user_uuid="",
+        )
+        b = EventsMetadata(
+            session_id="b",
+            started_at="",
+            ended_at="",
+            duration_seconds=0,
+            entry_count=0,
+            user_turn_count=0,
+            assistant_turn_count=0,
+            tool_call_count=0,
+            error_count=0,
+            first_user_preview="",
+            first_user_uuid="",
+        )
+        a.models.append("x")
+        assert b.models == []


### PR DESCRIPTION
## Summary

Phase 2 PR-3 from [coo-labs/coo-memory#1148](https://github.com/coo-labs/coo-memory/issues/1148): code for the events-API recovery path. Translates an operator-mediated `events-dump.js` dump → renderer-compatible jsonl entries, extracts v3 sidecar metadata directly from the events stream, invokes the existing renderer for HTML, and writes HTML + sidecar to R2 with provenance-aware first-write-wins.

## What lands

- `lib/transcripts/events/`
  - `client.py` — `PARSER_VERSION` lockstep with `snippets/events-dump.js`, `CCR_HEADERS` (MEMO-2026-06-05-dyb0 gate), `EVENTS_ENDPOINT_TEMPLATE`, `REQUIRED_RESPONSE_KEYS`.
  - `translator.py` — `events_to_entries()` (user/assistant/system:init pass-through with `created_at` → `timestamp` rename) + `extract_metadata()` (authoritative for events-recovered sidecars; surfaces the `[1m]` model variant the per-entry walk misses).
  - `intake.py` — `load_dump()` accepts both the multi-session snippet shape and the single-session fixture/probe shape; strict parser_version pinning rejects drift.
  - `probe.py` — `compare_to_schema()` diffs observed events vs the pinned reference at `fixtures/events-api/schema.json`; `validate_response_envelope()` reusable by future Python-side probes.
- `lib/transcripts/backfill/events.py` — `backfill_dump()` driver, dry-run by default. Six per-session outcome buckets (`applied`, `dry_run`, `ceded_authoritative`, `skipped_no_entries`, `skipped_fetch_error`, `error`). Respects `is_authoritative()` on existing sidecars — refuses to overwrite non-events authoritative tags.
- `lib/transcripts/r2.py` — adds `write_html_object()` sibling of `write_sidecar()`, reused now by the events backfill and (Phase 1 PR-1) by the existing render-backfill port.
- `bin/events-backfill.py` — uv-shebanged CLI: `--dump` `--apply` `--only-session-ids` `--quiet`. Per-session JSONL to stdout for `>> manifest.jsonl` piping.
- 6 new test modules (91 new tests, 177 total). Coverage 97.55%.

The runbook lands separately in `coo-labs/coo-memory` on the matching branch.

## Verification

- `pytest` — 177 passed, 97.55% coverage (lib floor: 80%).
- `ruff check lib/transcripts` — clean.
- `ruff format --check lib/transcripts` — clean.
- `mypy lib/transcripts` (strict) — clean.
- `python3 scripts/ci/test-lib-transcripts-parity.py` — parity OK, 5 auth / 4 reconcile, PARSER_VERSION=3, jsonl primitives match.
- End-to-end smoke against the pinned fixture: `PYTHONPATH=lib python3 bin/events-backfill.py --dump fixtures/events-api/session_0146dWU8wPHNwLyNLLJLuTYL.events.json.gz` → 1 session translated, 794 entries, 248 user turns, 494 assistant turns, 6.1 MB HTML, dry_run.

## Notes

- Renderer invocation is subprocess (not import) — same pattern as `transcript-render-backfill.py`; deferred to the Phase 1 port that lands `render.py` under the lib.
- AUTHORITATIVE binding (`claudeai-events-uuid`) shipped earlier in `coo-labs/coo-harness#414` + [MEMO-2026-06-01-903b](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-01-903b.md). This PR consumes it.
- CCR header gate per [MEMO-2026-06-05-dyb0](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-05-dyb0.md) — load-bearing authentication; cookie alone 404s.

Closes: n/a (parent epic coo-labs/coo-memory#1148 remains open through the operator-mediated backfill run that this code unblocks).

https://claude.ai/code/session_019m9sgs5s5pcFqWgvGoFJWJ