### PR TITLE
integrity-check: skip shallow-clone boundary in F1 rev-list

### DIFF
--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -1061,6 +1061,16 @@ if [ -d "$F_REPO/.git" ] && check_cmd git; then
   f1_bad=()
   # List commit SHAs touching F1 scope since F_CUTOFF; body inspection
   # happens per-commit. --name-only with --format gives sha-then-paths.
+  #
+  # --min-parents=1 skips parent-less commits. In cloud-container shallow
+  # clones (every Claude Code on the web boot), the most-recent merged
+  # commit lands as the shallow boundary and reports as a root commit;
+  # `git show --name-only` on it reports the entire tree as "touched",
+  # producing a structural F1 false-positive every boot. Real F1 scope
+  # is the per-commit diff, so a no-parent commit can't legitimately be
+  # decision-bearing under this invariant; skipping the boundary recovers
+  # canonical-history semantics on shallow checkouts without weakening
+  # the rule on the full-history reviewer's repo.
   while IFS= read -r sha; do
     [ -n "$sha" ] || continue
     # Paths this commit touched that are in scope.
@@ -1080,7 +1090,7 @@ if [ -d "$F_REPO/.git" ] && check_cmd git; then
       [ "$allowed" -eq 1 ] && continue
       f1_bad+=("${sha:0:10}")
     fi
-  done < <(git -C "$F_REPO" log --since="$F_CUTOFF_GIT" --format='%H' 2>/dev/null)
+  done < <(git -C "$F_REPO" log --since="$F_CUTOFF_GIT" --min-parents=1 --format='%H' 2>/dev/null)
 
   if [ "$f1_total" -eq 0 ]; then
     _add F1 true "no decision-bearing commits since $F_CUTOFF_GIT (nothing to check)"


### PR DESCRIPTION
Closes #497.

## What

Adds `--min-parents=1` to the F1 invariant's `git log --since` rev-list in `scripts/boot/integrity-check.sh`, plus an explanatory comment block recording the shallow-clone reasoning.

## Why

Every cloud-container boot reports `F1: 1/N commits missing memo-or-issue citation: <boundary-sha>` against the shallow-clone boundary, producing a structural false-positive that gates substantive work via the boot brake / CLAUDE.md banner discipline.

Diagnosis (full write-up on the issue):
- Cloud sessions clone `coo-memory` shallow; the most-recent merged commit lands as the shallow boundary.
- `git show --name-only` on a parent-less commit reports the entire HEAD tree as "touched", so the F1 path-filter matches every in-scope directory at once.
- The message-citation regex then runs against whatever message that commit happens to carry on main.
- The boundary commit's real per-commit diff is typically out of F1 scope. The present boundary `d3479467e8`'s real diff is entirely under `.claude/skills/end-session/*` (not F1-scope) — F1 would correctly skip it on a canonical full-history reviewer's repo.

`--min-parents=1` recovers canonical-history semantics on shallow checkouts. A parent-less commit can't legitimately be decision-bearing under this invariant — the per-commit diff that determines F1 scope is structurally unknowable without a parent — so skipping the boundary is principled, not a workaround.

## Out of scope

- **F4 (attribution)**: `d3479467e8` is already in `F4_ALLOWLIST_SHA` (lines 1196-1207) for an unrelated reason — an Anthropic credential-override author-leak. F4 catches the boundary correctly via author-email check on shallow clones too; no change needed.
- **F2, F3**: don't walk commit history, not affected.

## Verification

Before (boot-time digest):
```
F1: 1/42 commits missing memo-or-issue citation (MEMO-YYYY-MM-DD-suffix or #NNN): d3479467e8
```

After (re-run after fix):
```
$ bash coo-harness/scripts/boot/integrity-check.sh
VADE integrity: 33/34 DEGRADED — degraded (D4) — ...
```

F1 cleared. The remaining D4 (`MCP materialized files missing at /dev/shm/coo-mcp-env`) is a separate transient — not caused by this PR.

## Bootstrap CI

This PR touches `scripts/boot/integrity-check.sh`, which triggers `bootstrap-regression.yml`. F1 skips cleanly in CI per the existing arrangement (the staged `coo-memory` is a stub without `.git`), so the bootstrap-regression suite isn't a verification surface here. The change is still inside the suite's blast radius — script-level regression coverage is preserved.

## Parent epic

Sub-issue of [coo-labs/coo-memory#933](https://github.com/coo-labs/coo-memory/issues/933) (CI surface: write principled strategy doc) — falls under the substrate-hygiene / boot-integrity strategy that #933 frames.

https://claude.ai/code/session_01THKtNYYGGWNzGd8sevN3rs