### PR TITLE
lifecycle hooks: repoint deleted operations/memo-access.md refs

### DIFF
--- a/scripts/hooks/read-boot-inlined-guard.sh
+++ b/scripts/hooks/read-boot-inlined-guard.sh
@@ -32,7 +32,7 @@
 #   - */memos/memo_index.json
 #     Flat JSON, ≳25K tokens, regenerated each container epoch from
 #     memos/*.md by the `memo-index` SessionStart hook. 10-most-recent
-#     in digest; deeper slices via `jq` per operations/memo-access.md.
+#     in digest; deeper slices via `jq` per .claude/skills/memo-search/references/retrieval-policy.md.
 #   - */identity/identity_layer.md
 #     Fully inlined in the digest's "Identity layer (CB-*/OG-*)" block.
 #     If genuinely truncated, force-read via `cat` from Bash.
@@ -66,7 +66,7 @@ case "$file_path" in
     reason="[read-boot-inlined-guard] memos/memo_index.json is regenerated each container epoch from memos/*.md and the 10-most-recent slice is already in the boot digest's \"Latest memos\" block. The full file is ≳25K tokens — Read would dump it into context unnecessarily.
 
 Use one of:
-  - \`jq '...' memos/memo_index.json\` from a Bash call for deeper slices (schema: operations/memo-access.md).
+  - \`jq '...' memos/memo_index.json\` from a Bash call for deeper slices (schema: .claude/skills/memo-search/references/retrieval-policy.md).
   - \`/memo-query <term>\` for literal keyword lookup.
   - \`/memo-query --semantic \"<query>\"\` for concept search.
 

--- a/scripts/lifecycle/coo-identity-digest.sh
+++ b/scripts/lifecycle/coo-identity-digest.sh
@@ -276,7 +276,7 @@ else
   # memo lands closest to the user prompt.
   #
   # Prints only id + status + title. Full schema is documented in
-  # operations/memo-access.md. The index uses ~19K tokens at ~95
+  # .claude/skills/memo-search/references/retrieval-policy.md. The index uses ~19K tokens at ~95
   # memos post-coo-memory#351 — agents needing other slices
   # should jq the file rather than Read it.
   if digest_out=$(jq -r '
@@ -290,7 +290,7 @@ else
     echo "  (memo_index.json present but unparseable; skipping digest)"
   fi
   echo ""
-  echo "Deeper slices: jq '...' memos/memo_index.json (flat array — schema in operations/memo-access.md)"
+  echo "Deeper slices: jq '...' memos/memo_index.json (flat array — schema in .claude/skills/memo-search/references/retrieval-policy.md)"
 fi
 
 echo "───────────────────────────────────────────────────────────────"


### PR DESCRIPTION
Continuation of the operations/-audit triage from [coo-memory#1239](https://github.com/coo-labs/coo-memory/pull/1239). Both lifecycle hooks emitted `operations/memo-access.md` into either the boot output (`coo-identity-digest.sh`'s "Deeper slices" echo) or the read-blocking guard's reason text. That path was deleted in the `#759` memo-ops consolidation; the schema for `memo_index.json` now lives in the memo-search skill bundle.

| Referrer | Locations | Old path | New path |
|---|---|---|---|
| `scripts/lifecycle/coo-identity-digest.sh` | line 279 (comment), 293 (echo) | `operations/memo-access.md` | `.claude/skills/memo-search/references/retrieval-policy.md` |
| `scripts/hooks/read-boot-inlined-guard.sh` | line 35 (comment), 69 (heredoc reason) | `operations/memo-access.md` | `.claude/skills/memo-search/references/retrieval-policy.md` |

The new path matches the canonical citation in `coo-memory/CLAUDE.md §7`. Boot output and guard-rejection messages will now point readers at a real file.

## Boot-impact note

Per `operations/handoff-prompts.md`, hook-output changes are visible in any subsequent session's boot context. Verification is mechanical: open a fresh session and confirm the "Deeper slices: …" line in the boot digest now cites `.claude/skills/memo-search/references/retrieval-policy.md`. No bootstrap regression expected — this is text-content only.

## Closing

Closes: n/a — follow-up cleanup to coo-memory#759 (memo-ops consolidation), coo-memory#1225 (filing-issues skill consolidation), and the operations/-audit triage continued from coo-memory#1239. No standalone tracker issue.

https://claude.ai/code/session_012k8sVZ2ixyv97uqw6zJonP