### PR TITLE
agent-model-guard: auto-inject sonnet instead of refusing

### DIFF
--- a/scripts/ci/test-agent-model-guard.sh
+++ b/scripts/ci/test-agent-model-guard.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# test-agent-model-guard: smoke-test scripts/hooks/agent-model-guard.sh.
+#
+# Verifies the auto-inject behavior introduced in coo-harness#501:
+# Explore and claude-code-guide subagent calls without an explicit
+# `model:` get `sonnet` auto-injected via updatedInput. Calls that
+# already have model set, or that target other subagent types, pass
+# through unchanged.
+#
+# Run: bash scripts/ci/test-agent-model-guard.sh
+# Exit: 0 if all assertions pass, 1 otherwise.
+#
+# Reference: coo-harness#501.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/agent-model-guard.sh"
+
+[ -x "$HOOK" ] || { echo "FAIL: hook not executable at $HOOK"; exit 1; }
+command -v jq >/dev/null || { echo "FAIL: jq required"; exit 1; }
+
+PASS=0
+FAIL=0
+
+run_hook() {
+  local input="$1"
+  printf '%s' "$input" | "$HOOK" 2>/dev/null
+}
+
+expect_inject() {
+  local name="$1" input="$2"
+  local out injected decision
+  out="$(run_hook "$input")"
+  injected="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.updatedInput.model // ""' 2>/dev/null)"
+  decision="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null)"
+  if [ "$injected" = "sonnet" ] && [ "$decision" = "allow" ]; then
+    PASS=$((PASS+1))
+    printf '  PASS  INJECT: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf '  FAIL  INJECT: %s\n' "$name"
+    printf '         input: %s\n' "$input"
+    printf '         output: %s\n' "$out"
+  fi
+}
+
+expect_allow() {
+  local name="$1" input="$2"
+  local out
+  out="$(run_hook "$input")"
+  if [ -z "$out" ]; then
+    PASS=$((PASS+1))
+    printf '  PASS  ALLOW: %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    printf '  FAIL  ALLOW: %s\n' "$name"
+    printf '         input: %s\n' "$input"
+    printf '         output: %s\n' "$out"
+  fi
+}
+
+printf 'INJECT fixtures (must auto-inject sonnet):\n'
+expect_inject "Explore, no model" \
+  '{"tool_input": {"subagent_type": "Explore", "prompt": "find X"}}'
+expect_inject "claude-code-guide, no model" \
+  '{"tool_input": {"subagent_type": "claude-code-guide", "prompt": "lookup Y"}}'
+expect_inject "Explore, model empty string" \
+  '{"tool_input": {"subagent_type": "Explore", "model": "", "prompt": "find X"}}'
+
+printf '\nALLOW fixtures (must pass through unchanged):\n'
+expect_allow "Explore + model=sonnet (caller-set)" \
+  '{"tool_input": {"subagent_type": "Explore", "model": "sonnet", "prompt": "find X"}}'
+expect_allow "Explore + model=haiku (caller-chosen)" \
+  '{"tool_input": {"subagent_type": "Explore", "model": "haiku", "prompt": "find X"}}'
+expect_allow "Plan, no model (not in inject list)" \
+  '{"tool_input": {"subagent_type": "Plan", "prompt": "design X"}}'
+expect_allow "general-purpose, no model (not in inject list)" \
+  '{"tool_input": {"subagent_type": "general-purpose", "prompt": "research X"}}'
+expect_allow "empty subagent_type" \
+  '{"tool_input": {"prompt": "do X"}}'
+
+printf '\nPRESERVE fixture (other tool_input fields kept intact on inject):\n'
+out="$(run_hook '{"tool_input": {"subagent_type": "Explore", "prompt": "find X", "description": "search task"}}')"
+preserved_prompt="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.updatedInput.prompt')"
+preserved_desc="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.updatedInput.description')"
+if [ "$preserved_prompt" = "find X" ] && [ "$preserved_desc" = "search task" ]; then
+  PASS=$((PASS+1))
+  printf '  PASS  PRESERVE: prompt + description intact\n'
+else
+  FAIL=$((FAIL+1))
+  printf '  FAIL  PRESERVE: prompt=%s description=%s\n' "$preserved_prompt" "$preserved_desc"
+fi
+
+printf '\nResults: %d pass, %d fail\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/hooks/agent-model-guard.sh
+++ b/scripts/hooks/agent-model-guard.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# PreToolUse Agent hook: refuse dispatch of built-in subagents that
-# default to Haiku unless the caller passes an explicit `model:`
-# argument. Forces the dispatcher to make a calibrated model choice
-# rather than silently inheriting Haiku.
+# PreToolUse Agent hook: auto-inject `model: "sonnet"` for built-in
+# subagents that default to Haiku ({Explore, claude-code-guide}) when
+# the caller omits the model parameter. Preserves cost-safety from the
+# silent-Haiku failure mode without forcing a refuse-and-retry round-
+# trip on every honest forgetting.
 #
 # Why: Per https://code.claude.com/docs/en/sub-agents.md the built-in
 # `Explore` and `claude-code-guide` subagents are pinned to Haiku. The
@@ -12,29 +13,30 @@
 # the failure profile this produces: high-confidence shallow
 # heuristics, uncalibrated assertions, plausible hallucinations that
 # fail under verification. The motivating audit is
-# coo-labs/coo-logs#347 (Phase-1 orientation pass: two Explore
-# sub-agents made confident attribution errors based on branch-name
-# heuristics; both required active disambiguation in parent context).
+# coo-labs/coo-logs#347.
 #
-# Block rule:
+# The pre-coo-harness#501 version REFUSED these calls and demanded a
+# retry. That forced a round-trip on every honest omission. This
+# version preserves the safety property — Haiku is never silently used
+# — by injecting `model: "sonnet"` via `updatedInput`. The caller can
+# still pass `model: "haiku"` explicitly for narrow lookups; the
+# discipline shifts from "must type to choose" to "safe default with
+# documented override."
+#
+# Auto-inject rule:
 #   tool_input.subagent_type ∈ {"Explore", "claude-code-guide"}
 #   AND (tool_input.model is missing OR empty string)
+#   → emit updatedInput with .model = "sonnet" + additionalContext
 #
 # Allow rules:
-#   - tool_input.model is any non-empty string. Even `"haiku"` is
-#     allowed — the act of typing it IS the calibrated choice. Silent
-#     omission is what we refuse.
+#   - tool_input.model is any non-empty string. The act of typing it
+#     IS the calibrated choice; the hook does not override.
 #   - subagent_type is any other value (Plan and general-purpose
 #     inherit the parent's model; statusline-setup is Sonnet by
 #     default; all custom `.claude/agents/*.md` agents in this
 #     substrate pin `model:` in frontmatter).
 #
-# Bypass: none. The intervention is exactly to force the choice. If
-# you genuinely want silent-Haiku behavior on a per-call basis, pass
-# `model: "haiku"` — that satisfies the rule and documents your intent
-# in the call site.
-#
-# Reference: MEMO-2026-05-25-<suffix>; coo-memory#781;
+# Reference: coo-harness#501; coo-memory#781;
 # operations/parallel_instance_protocol.md §8.6.
 
 set -uo pipefail
@@ -55,10 +57,17 @@ if [ -n "$model" ]; then
   exit 0
 fi
 
-reason="[agent-model-guard] Built-in subagent '${subagent_type}' defaults to Haiku per code.claude.com/docs/en/sub-agents.md. Pass an explicit \`model:\` argument so the choice is calibrated: \`\"sonnet\"\` (or higher) for any result the parent will act on; \`\"haiku\"\` only when the result will be independently verified by the caller (e.g. a narrow file-existence check, a one-line lookup). Silent omission is refused because the failure profile of Haiku on load-bearing work — high-confidence shallow heuristics, uncalibrated assertions, plausible hallucinations — propagates errors that the parent then has to disambiguate. See operations/parallel_instance_protocol.md §8.6 and MEMO references in coo-memory#781."
+context="[agent-model-guard] Auto-injected model=\"sonnet\" for built-in subagent '${subagent_type}' (omitted on the call). Override with \`model: \"haiku\"\` only when the result is independently verifiable (narrow file-existence check, one-line lookup). See operations/parallel_instance_protocol.md §8.6."
 
-jq -n --arg reason "$reason" '{
-  decision: "block",
-  reason: $reason
-}'
+printf '%s' "$input" | jq --arg ctx "$context" '
+  .tool_input.model = "sonnet" |
+  {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+      updatedInput: .tool_input,
+      additionalContext: $ctx
+    }
+  }
+'
 exit 0


### PR DESCRIPTION
Resolves [#501](https://github.com/coo-labs/coo-harness/issues/501).

`scripts/hooks/agent-model-guard.sh` previously refused any `Agent` dispatch of `Explore` or `claude-code-guide` that omitted `model:`, forcing a round-trip on every honest forgetting. The friction pattern that motivated #501 was caught during the operations/-audit session ([coo-memory#1239](https://github.com/coo-labs/coo-memory/pull/1239)): one Agent call refused, retry with `model: "sonnet"` added, work resumed.

## Change

Auto-inject `model: "sonnet"` for `Explore` and `claude-code-guide` calls that omit the parameter, via `hookSpecificOutput.updatedInput`. Preserves the safety property the original hook existed to enforce — Haiku is never silently used — without the refuse-and-retry cost. Callers who set `model:` explicitly pass through unchanged; the act of typing is still respected as the calibrated choice.

An `additionalContext` system reminder explains the auto-inject and how to override with `model: "haiku"` for narrow lookups where the result is independently verifiable.

## Test

New `scripts/ci/test-agent-model-guard.sh` — 9 fixtures, all passing locally:
- 3 INJECT cases (Explore/claude-code-guide without model; empty-string model)
- 5 ALLOW cases (caller-set sonnet/haiku, Plan, general-purpose, empty subagent_type)
- 1 PRESERVE case (other tool_input fields survive the inject)

```
Results: 9 pass, 0 fail
```

## Boot-impact note

This hook fires on every `Agent` tool call. Behavior shift is visible immediately on next session: callers that previously hit the refuse-and-retry now silently auto-inject sonnet with a system-reminder explaining what happened. No bootstrap-regression impact expected (the hook is not exercised by bootstrap-regression CI).

## Closing

Closes coo-labs/coo-harness#501.

https://claude.ai/code/session_012k8sVZ2ixyv97uqw6zJonP