### PR TITLE
gh-pr-create: extend to Patterns C+D + TOOLS.md drift

### DIFF
--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -1061,6 +1061,16 @@ if [ -d "$F_REPO/.git" ] && check_cmd git; then
   f1_bad=()
   # List commit SHAs touching F1 scope since F_CUTOFF; body inspection
   # happens per-commit. --name-only with --format gives sha-then-paths.
+  #
+  # --min-parents=1 skips parent-less commits. In cloud-container shallow
+  # clones (every Claude Code on the web boot), the most-recent merged
+  # commit lands as the shallow boundary and reports as a root commit;
+  # `git show --name-only` on it reports the entire tree as "touched",
+  # producing a structural F1 false-positive every boot. Real F1 scope
+  # is the per-commit diff, so a no-parent commit can't legitimately be
+  # decision-bearing under this invariant; skipping the boundary recovers
+  # canonical-history semantics on shallow checkouts without weakening
+  # the rule on the full-history reviewer's repo.
   while IFS= read -r sha; do
     [ -n "$sha" ] || continue
     # Paths this commit touched that are in scope.
@@ -1080,7 +1090,7 @@ if [ -d "$F_REPO/.git" ] && check_cmd git; then
       [ "$allowed" -eq 1 ] && continue
       f1_bad+=("${sha:0:10}")
     fi
-  done < <(git -C "$F_REPO" log --since="$F_CUTOFF_GIT" --format='%H' 2>/dev/null)
+  done < <(git -C "$F_REPO" log --since="$F_CUTOFF_GIT" --min-parents=1 --format='%H' 2>/dev/null)
 
   if [ "$f1_total" -eq 0 ]; then
     _add F1 true "no decision-bearing commits since $F_CUTOFF_GIT (nothing to check)"

--- a/scripts/gh-pr-create.sh
+++ b/scripts/gh-pr-create.sh
@@ -1,27 +1,32 @@
 #!/usr/bin/env bash
-# gh-pr-create: thin wrapper around `gh pr create` that pre-checks the
-# body for a closing keyword (Pattern B from
-# operations/issue-pr-hygiene.md §"Closing-keyword discipline"),
-# aborting before submission if missing.
+# gh-pr-create: thin wrapper around `gh pr create` that runs three pre-submission
+# hygiene checks mirroring the at-PR-open CI workflows, aborting before submission
+# if any fail. Each check has the same diagnostic text as its CI counterpart so the
+# agent reads the same error at the earlier loop position.
 #
-# Why: the PR template at .github/PULL_REQUEST_TEMPLATE.md only loads
-# when `gh pr create` is invoked WITHOUT `--body`/`--body-file`. Agents
-# that build PR bodies via heredoc (the standard pattern in the harness)
-# bypass the template and the closing-keyword reminder along with it.
-# Multiple consecutive sessions have hit the post-CI amend cycle that
-# way. This wrapper closes the agent-path gap structurally rather than
-# via another norms doc.
+#   1. Closing-keyword (Pattern B) — mirrors issue-pr-hygiene-reusable.yml.
+#   2. Cross-repo + collision-prone refs (Patterns C + D) — mirrors the same
+#      workflow's advisory step. Delegated to scripts/lib/pr-hygiene-patterns.py.
+#   3. TOOLS.md row for new bin/ scripts — mirrors coo-memory's drift-gate.sh
+#      Check 2. No-op in repos without TOOLS.md.
 #
-# Usage: identical to `gh pr create`. Adds one flag:
-#   --skip-closing-keyword-check    Bypass the lint. Use only when the
-#                                   workflow's exempt-class registry
-#                                   covers your case (see
-#                                   operations/issue-pr-hygiene.md
+# Why: the PR template at .github/PULL_REQUEST_TEMPLATE.md only loads when
+# `gh pr create` is invoked WITHOUT `--body`/`--body-file`. Agents that build
+# PR bodies via heredoc (the standard pattern in the harness) bypass the template.
+# Multiple consecutive sessions have hit the post-CI amend cycle that way. This
+# wrapper closes the agent-path gap structurally per the CI strategy's move-it-left
+# rule (G1 fast-feedback, retirement criterion (d) defense-in-depth-perpetual;
+# coo-memory#1016, ci-strategy.md).
+#
+# Usage: identical to `gh pr create`. Adds one flag (with one back-compat alias):
+#   --skip-hygiene-check            Bypass all three checks. Use only when the
+#   --skip-closing-keyword-check    workflow's exempt-class registry covers
+#                                   your case (see operations/issue-pr-hygiene.md
 #                                   §"Exempt-class registry").
 #
 # Exit codes:
 #   0   gh pr create succeeded
-#   2   missing closing keyword (lint failure)
+#   2   one or more hygiene checks failed
 #   *   propagated from gh
 
 set -eu
@@ -34,7 +39,7 @@ pass_args=()
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --skip-closing-keyword-check)
+    --skip-hygiene-check|--skip-closing-keyword-check)
       skip_check=1
       shift
       ;;
@@ -124,33 +129,34 @@ fi
 # prefix `session:` is the contract used by the /end-session skill and the
 # auto-subscribe-pr hook. The coo-logs auto-merge workflow doesn't gate on
 # closing keywords for these, so the local lint shouldn't either — saves
-# the agent from remembering --skip-closing-keyword-check.
+# the agent from remembering --skip-hygiene-check.
 if [[ "$title" == session:* ]]; then
   exec gh pr create "${pass_args[@]}"
 fi
 
-# Resolve body content for the lint. Title + body together, mirroring
-# the workflow's title-OR-body check.
-content="$title"
+# Resolve body content for the checks. Title + body together, mirroring
+# the workflow's title-OR-body matching.
+resolved_body=""
 if [ -n "$body" ]; then
-  content="$content"$'\n'"$body"
+  resolved_body="$body"
 elif [ -n "$body_file" ]; then
   if [ "$body_file" = "-" ]; then
     echo "gh-pr-create: --body-file - (stdin) not supported by the lint;" >&2
-    echo "  use --body, a real file path, or --skip-closing-keyword-check." >&2
+    echo "  use --body, a real file path, or --skip-hygiene-check." >&2
     exit 2
   fi
   if [ ! -f "$body_file" ]; then
     echo "gh-pr-create: --body-file '$body_file' not found" >&2
     exit 2
   fi
-  content="$content"$'\n'"$(cat "$body_file")"
+  resolved_body="$(cat "$body_file")"
 fi
+content="$title"$'\n'"$resolved_body"
 
-# Closing-keyword regex (mirrors .github/workflows/issue-pr-hygiene.yml).
-# Match: Closes/Fixes/Resolves followed by #N or coo-labs/<repo>#N,
-# OR explicit `Closes: n/a`, OR the longer body-text form
-# `n/a — no issue resolved` (em-dash or regular dash tolerated).
+# Check 1 — Closing-keyword regex (mirrors issue-pr-hygiene-reusable.yml
+# Pattern B). Match: Closes/Fixes/Resolves followed by #N or
+# coo-labs/<repo>#N, OR explicit `Closes: n/a`, OR the longer body-text
+# form `n/a — no issue resolved` (em-dash or regular dash tolerated).
 if printf '%s' "$content" | grep -qiE '\b(clos(e|es|ed|ing)|fix(es|ed|ing)?|resolv(e|es|ed|ing))[[:space:]]+(#[0-9]+|coo-labs/[a-z0-9-]+#[0-9]+)\b'; then
   : # ok
 elif printf '%s' "$content" | grep -qiE '(^|[[:space:]])closes:[[:space:]]*n/a\b'; then
@@ -176,9 +182,68 @@ operations/issue-pr-hygiene.md §"Closing-keyword discipline".
 
 To bypass (only if your PR is in the workflow's exempt-class registry —
 session-logs, auto-meta-sidecars, dependabot, claude[bot]), pass
---skip-closing-keyword-check.
+--skip-hygiene-check.
 EOF
   exit 2
+fi
+
+# Check 2 — Patterns C + D (cross-repo + collision-prone refs). Delegated
+# to a Python helper that mirrors issue-pr-hygiene-reusable.yml's advisory
+# step. Blocking at the pre-push layer (the agent is still in-turn — fix is
+# cheap); the workflow stays advisory at PR-time per its existing behavior.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper="$script_dir/lib/pr-hygiene-patterns.py"
+if [ -x "$helper" ]; then
+  if ! printf '%s' "$(jq -n --arg t "$title" --arg b "$resolved_body" '{title:$t,body:$b}')" \
+      | python3 "$helper"; then
+    exit 2
+  fi
+fi
+
+# Check 3 — TOOLS.md drift (mirrors coo-memory/.claude/_lib/drift-gate.sh
+# Check 2). For every new bin/*.{sh,py} in the diff against origin/main,
+# require a TOOLS.md row referencing the script's basename. No-op if
+# TOOLS.md doesn't exist at repo root (most repos other than coo-memory).
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$repo_root" ] && [ -f "$repo_root/TOOLS.md" ]; then
+  base_ref="origin/main"
+  merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null || true)"
+  if [ -n "$merge_base" ]; then
+    new_scripts="$(git diff --name-only --diff-filter=A "$merge_base" -- 'bin/*.sh' 'bin/*.py' 2>/dev/null || true)"
+    drift_fail=0
+    if [ -n "$new_scripts" ]; then
+      while IFS= read -r script_path; do
+        [ -z "$script_path" ] && continue
+        # Honor drift-gate's opt-out marker for one-off helpers.
+        if grep -qE '^[[:space:]]*#[[:space:]]*drift-gate:[[:space:]]*skip' "$repo_root/$script_path" 2>/dev/null; then
+          continue
+        fi
+        script_name="$(basename "$script_path")"
+        if ! grep -qF "$script_name" "$repo_root/TOOLS.md" 2>/dev/null; then
+          if [ "$drift_fail" -eq 0 ]; then
+            echo "gh-pr-create: TOOLS.md drift check FAILED." >&2
+            drift_fail=1
+          fi
+          echo "  $script_path has no TOOLS.md row" >&2
+        fi
+      done <<EOF
+$new_scripts
+EOF
+    fi
+    if [ "$drift_fail" -eq 1 ]; then
+      cat >&2 <<'EOF'
+
+The CI workflow `drift-gate` (coo-memory/.claude/_lib/drift-gate.sh, Check 2)
+will block merge for any new bin/*.{sh,py} without a TOOLS.md row. Add a row
+to TOOLS.md §6 (or the appropriate section) and a matching row to
+operations/adoption_tracker.md §6 in this same PR.
+
+To opt out for a genuine one-off helper, add a '# drift-gate: skip' marker
+at the top of the script. To bypass this lint, pass --skip-hygiene-check.
+EOF
+      exit 2
+    fi
+  fi
 fi
 
 exec gh pr create "${pass_args[@]}"

--- a/scripts/lib/pr-hygiene-patterns.py
+++ b/scripts/lib/pr-hygiene-patterns.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Pre-push port of issue-pr-hygiene-reusable.yml Patterns C + D.
+
+Reads JSON {"title": "...", "body": "..."} on stdin. Emits human-readable
+findings on stderr. Exit 2 on any finding (blocking at the pre-push layer
+where the agent is still in-turn); 0 on clean. Diagnostic format mirrors the
+workflow's advisory text so the agent reads the same message either layer.
+
+Active coo-labs/* slug list hardcoded — the workflow loads it from the
+org registry at run time. A pre-push primitive needs a deterministic source;
+maintenance window is whenever a new top-level coo-labs/* repo lands (rare
+enough to be a deliberate touch, per the strategy's "structural friction"
+framing). Cross-references coo-memory#1016 G1 fast-feedback.
+
+Drift between this list and the org registry is itself a G2 drift-watch
+subject — surfaced by the next epic per the CI strategy's W3 probe.
+"""
+
+import json
+import re
+import sys
+
+ACTIVE_SLUGS = (
+    "coo-memory",
+    "coo-harness",
+    "coo-logs",
+    "coo-console",
+    "tjsonl",
+    "skills",
+    "coo4one",
+    "vade-canvas",
+    "site",
+    ".github",
+)
+
+
+def strip_links_and_code(s: str) -> str:
+    s = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", s)
+    s = re.sub(r"`[^`]*`", "", s)
+    return s
+
+
+def check_pattern_c(title: str, body: str) -> list[str]:
+    findings: list[str] = []
+
+    slug_alt = "|".join(re.escape(s) for s in ACTIVE_SLUGS)
+    cross_repo_cues = re.compile(rf"((?:{slug_alt})(?!#))[^\n]{{0,80}}#\d+")
+
+    clean_body = strip_links_and_code(body)
+    clean_title = strip_links_and_code(title)
+
+    c_matches = [
+        m.group(0)
+        for m in list(cross_repo_cues.finditer(clean_body))
+        + list(cross_repo_cues.finditer(clean_title))
+        if not re.search(r"discussion", m.group(0), re.IGNORECASE)
+    ]
+
+    if c_matches:
+        examples = "\n".join(f"  - `{m}`" for m in c_matches[:5])
+        findings.append(
+            "Pattern C — cross-repo references\n"
+            f"Detected {len(c_matches)} reference(s) where an active coo-labs/* repo "
+            "is named near a bare `#N`. Bare `#N` resolves to the host repo; use "
+            "`coo-labs/<repo>#N` for cross-repo.\n"
+            "Examples:\n"
+            f"{examples}"
+        )
+
+    list_inheritance = re.compile(r"coo-labs/[a-z0-9-]+#\d+\s*,\s*#\d+")
+    list_matches = [
+        m.group(0)
+        for m in list(list_inheritance.finditer(body)) + list(list_inheritance.finditer(title))
+    ]
+    if list_matches:
+        examples = "\n".join(f"  - `{m}`" for m in list_matches[:3])
+        findings.append(
+            "Pattern C — list-inheritance\n"
+            "Detected `coo-labs/<repo>#N, #M` patterns. The prefix scopes only the "
+            "first `#N`; subsequent `#M` autolink to the host repo. Repeat the prefix "
+            "per item: `coo-labs/<repo>#N, coo-labs/<repo>#M`.\n"
+            f"Examples:\n{examples}"
+        )
+
+    return findings
+
+
+def check_pattern_d(title: str, body: str) -> list[str]:
+    findings: list[str] = []
+
+    collision_terms = re.compile(
+        r"\b(quorum|instance|briefing|memo|stage|phase|finding|oq|audit|committee|persona|agent|chunk|round|track|step|tier|band|mechanism|hypothesis)s?\s+#\d+(?:\s*[-–]\s*#?\d+)?\b",
+        re.IGNORECASE,
+    )
+    enumerated_ids = re.compile(r"\b(F\d+|Q\d+|A\d+|G\d+)\s+#\d+(?:\s*[-–]\s*#?\d+)?\b")
+
+    stripped_body = re.sub(r"^[-*]\s*\[[ xX]\]\s+.*$", "", body, flags=re.MULTILINE)
+
+    d_matches = [
+        m.group(0)
+        for m in list(collision_terms.finditer(stripped_body))
+        + list(enumerated_ids.finditer(stripped_body))
+        + list(collision_terms.finditer(title))
+        + list(enumerated_ids.finditer(title))
+    ]
+
+    if d_matches:
+        examples = "\n".join(f"  - `{m}`" for m in d_matches[:5])
+        findings.append(
+            "Pattern D — `#num` for non-issue IDs\n"
+            f"Detected {len(d_matches)} reference(s) using `<term> #N` notation where "
+            "`#N` autolinks to an unrelated GitHub issue/PR. Use dash form: `quorum-1`, "
+            "`instance-N`, `briefing-014`, etc.\n"
+            f"Examples:\n{examples}"
+        )
+
+    return findings
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    title = payload.get("title", "") or ""
+    body = payload.get("body", "") or ""
+
+    findings = check_pattern_c(title, body) + check_pattern_d(title, body)
+
+    if not findings:
+        return 0
+
+    sys.stderr.write("gh-pr-create: PR hygiene check FAILED (Patterns C + D)\n\n")
+    for f in findings:
+        sys.stderr.write(f + "\n\n")
+    sys.stderr.write(
+        "Reference: issue-pr-hygiene-reusable.yml is the non-bypassable backstop; "
+        "this pre-push layer is the cheap-fix earlier surface (CI strategy G1 "
+        "fast-feedback, defense-in-depth-perpetual).\n"
+        "Bypass: --skip-hygiene-check (only when your case is genuinely exempt).\n"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes coo-labs/coo-memory#1016.

## What

Extends `scripts/gh-pr-create.sh` with two checks that mirror the at-PR-open CI workflows:

- **Check 2 (Patterns C + D)** — Python helper at `scripts/lib/pr-hygiene-patterns.py` ports `issue-pr-hygiene-reusable.yml`'s C+D advisory step. Catches cross-repo references where a coo-labs/* slug is named near a bare `#N` (autolinks to host repo, not the cross-repo one), and the `#num` notation on non-issue collision-prone IDs (`<term> #N` form for terms like quorum, briefing, memo, phase — should be the dash form, e.g. `quorum-1`).
- **Check 3 (TOOLS.md drift)** — inline bash mirror of `coo-memory/.claude/_lib/drift-gate.sh` Check 2. For every new `bin/*.{sh,py}` in the diff against `origin/main`, require a TOOLS.md row referencing the script's basename. No-op in repos without TOOLS.md at root, which is most non-coo-memory repos.

The existing closing-keyword pre-check (Pattern B) is unchanged. All three checks share a single `--skip-hygiene-check` bypass flag; the old `--skip-closing-keyword-check` is kept as a back-compat alias so existing callers don't break.

## Why

Per the [CI strategy](https://github.com/coo-labs/coo-memory/blob/main/operations/ci-strategy.md) (just-merged via [coo-memory#1029](https://github.com/coo-labs/coo-memory/pull/1029)), this is the **canonical first execution of the move-it-left rule**. Regex-decidable agent-form failures arrive at PR-time today; the agent has lost in-turn context by then; recovery costs 1-3 amend rounds per occurrence. Moving the checks to the pre-push layer keeps the agent in-context and the fix cheap. The workflow stays as the non-bypassable backstop (retirement criterion (d) `defense-in-depth-perpetual`).

The Pattern B precedent (already on this script) is the existence proof; this PR extends the same shape to two more failure modes the strategy specifically names.

## Four-slot answers (per strategy §"The four-slot question")

1. **Guarantee**: G1 `fast-feedback`
2. **Loop position**: Pre-push (with at-PR-open `issue-pr-hygiene-reusable` + `drift-gate` as defense-in-depth backstops)
3. **Retirement criterion**: (d) `defense-in-depth-perpetual` — bypassable earlier layer paired with non-bypassable later backstop; retires only if the backstop becomes non-bypassable
4. **Owner**: vade-coo

Lifecycle log entry (`coo-memory/lineage/ci-lifecycle/log.jsonl`) lands in a companion PR on coo-memory.

## Verification

Tests run against the helper directly:

```
# Clean body — exit 0
{"title":"foo","body":"Closes #100"} → OK


# Pattern C cross-repo — exit 2, finding emitted (slug+near-bare-#N)
{"title":"foo","body":"<repo-slug> has fix at #NNN"} → flagged

# Pattern C list-inheritance — exit 2 (prefix scopes only first #N)
{"title":"foo","body":"see coo-labs/<repo>#NNN, #MMM"} → flagged

# Pattern C discussion carve-out — exit 0
{"title":"foo","body":"coo-labs/vade-canvas discussion #149"} → clean

# Pattern D collision — exit 2 (collision-prone <term> #N form)
{"title":"per qN with collision-term","body":"see brN"} → flagged

# Pattern D checkbox allowlist — exit 0 (lines starting with `- [ ]` skipped)
{"title":"foo","body":"checkbox line with collision-term + #N"} → clean
```

The TOOLS.md check is inline bash; verified manually it skips repos without a root TOOLS.md and fires correctly on a missing-row case.

## Scope deferred to follow-up

- **Group W schema seed** (`coo-harness/config/ci-health/schema.yaml`) — the strategy's declarative inventory of every CI primitive. Lands separately as its own PR; this PR contains the primitive but not its schema entry yet.
- **Pattern C extension to catch the bare `coo-harness#326` form** (no `coo-labs/` prefix at all, immediately attached to `#`) — the workflow's Pattern C doesn't catch this form either, so the pre-push mirror doesn't. Discussed in the categorization comment on coo-memory#1016 as a potential follow-up enhancement; out of scope for this PR's "mirror the workflow" framing.

## Parent epic

Sub-issue of [coo-labs/coo-memory#933](https://github.com/coo-labs/coo-memory/issues/933) (CI surface strategy doc). Phase 3 execution: first concrete `G1 fast-feedback` primitive landing per the strategy's worked example.

https://claude.ai/code/session_01THKtNYYGGWNzGd8sevN3rs