### PR TITLE
ci-strategy phase 3: publish-binary-vendor cleanup + registry-check reusable

### DIFF
--- a/.github/workflows/publish-binary-vendor.yml
+++ b/.github/workflows/publish-binary-vendor.yml
@@ -18,11 +18,13 @@ name: Publish binary vendor bundle
 # PAT-already-authenticated, snapshot-cache compatible) all hold for
 # release assets without the daemon dependency.
 #
-# The same Dockerfile install steps are replicated here (in an Ubuntu
-# container, no docker-in-docker required) with absolute target paths
-# matching production layout (/home/user/.local/...), so mem0-mcp-server's
-# uv-managed venv shebangs resolve unchanged when the bundle is untarred
-# at cloud-setup.sh time.
+# The install steps that previously lived in a Dockerfile run here in
+# an Ubuntu container (no docker-in-docker required) with absolute
+# target paths matching production layout (/home/user/.local/...), so
+# mem0-mcp-server's uv-managed venv shebangs resolve unchanged when the
+# bundle is untarred at cloud-setup.sh time. The Dockerfile was removed
+# (the snapshot build no longer goes through docker); this workflow now
+# owns the canonical install recipe.
 #
 # Tag scheme: binary-vendor-<short-sha> per-build + binary-vendor-latest
 # moving tag for cloud-setup.sh to fetch. SHA256 of the bundle is
@@ -33,7 +35,6 @@ on:
   push:
     branches: [main]
     paths:
-      - 'Dockerfile'
       - 'versions.lock'
       - '.github/workflows/publish-binary-vendor.yml'
   workflow_dispatch:

--- a/.github/workflows/registry-check-reusable.yml
+++ b/.github/workflows/registry-check-reusable.yml
@@ -1,0 +1,55 @@
+name: Registry drift-check (reusable)
+
+# Reusable workflow: asserts coo-labs/.github/repos.yaml matches the
+# live coo-labs org state — membership, visibility, status. Wraps
+# scripts/registry-check.sh, which lives next to this workflow in
+# coo-harness (kernel scope per F11; see MEMO-2026-05-25-txjg). The
+# script's prior split — workflow in coo-labs/.github, script here —
+# violated G5 substrate-self-describes ("one canonical path per concern")
+# and required a cross-repo checkout from the trigger side. This
+# reusable absorbs both.
+#
+# Canonical home: coo-labs/coo-harness/.github/workflows/registry-check-reusable.yml
+# Co-location source: coo-labs/coo-memory#1018 (G5 substrate-self-describes).
+# Script source: coo-memory#999 (F17b drift-check; load-bearing).
+#
+# Trigger contract for callers (see coo-labs/.github thin trigger):
+#   on:
+#     pull_request:
+#       paths: ['repos.yaml', '.github/workflows/registry-check.yml']
+#     push:
+#       branches: [main]
+#       paths: ['repos.yaml']
+#     schedule:
+#       - cron: '0 12 * * *'
+#     workflow_dispatch:
+#   permissions:
+#     contents: read
+#   jobs:
+#     drift-check:
+#       uses: coo-labs/coo-harness/.github/workflows/registry-check-reusable.yml@main
+#       secrets: inherit
+
+on:
+  workflow_call:
+    secrets:
+      VADE_FIELDS_ADMIN_PAT:
+        description: "Org-secret mirror of the COO PAT (visibility=all). Required to enumerate private repos that github.token cannot see."
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout coo-harness (script lives here per F11 kernel scope)
+        uses: actions/checkout@v4
+        with:
+          repository: coo-labs/coo-harness
+
+      - name: Run registry-check
+        env:
+          GH_TOKEN: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}
+        run: bash scripts/registry-check.sh


### PR DESCRIPTION
Phase 3 of the CI strategy ([`operations/ci-strategy.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/ci-strategy.md), epic coo-labs/coo-memory#933) — two small follow-ups here landing the strategy's G2 `drift-watch` recategorization for coo-labs/coo-memory#1014 and the G5 `substrate-self-describes` co-location for coo-labs/coo-memory#1018. One PR, two distinct commits so each finding is reviewable independently.

## Commit 1 — publish-binary-vendor: drop dead Dockerfile trigger; refresh header

Closes coo-labs/coo-memory#1014.

**Research outcome.** The workflow IS still consumed, contrary to the silent-dead suspicion in the audit. `ensure_binaries_from_vendor` lives in [`scripts/lib/common.sh:770`](https://github.com/coo-labs/coo-harness/blob/main/scripts/lib/common.sh#L770) and is called from [`scripts/boot/cloud-setup.sh:98`](https://github.com/coo-labs/coo-harness/blob/main/scripts/boot/cloud-setup.sh#L98) on every fresh-snapshot boot. `versions.lock` carries the SHA pin (`binary_vendor_bundle 47130b3a...`), the workflow is firing successfully (latest run 2026-06-05; releases through `binary-vendor-0be1f51` on 2026-05-27), and the bundle reaches `/home/user/.local/{bin,share}/...` on the consumer side. The structural concern in Ven's coo-labs/coo-memory#1009 review ("we got rid of the dockerfile. Is this action still used?") was real but the answer is yes — the Dockerfile removal eliminated the *image-based* distribution path, not the workflow that took over the install recipe.

**Recategorization.** From research-first → likely retire **to** G2 `drift-watch` (active vendored-binary-version surface). Loop position: at-event (push to `versions.lock` or workflow file). Retirement criterion: now (d) defense-in-depth-perpetual rather than (a) struct-fix-cite or W5 silent-dead — the workflow is the load-bearing path between `versions.lock` pins and the snapshot-time install.

**Code change.** Two small fixes that the recategorization implies:

- Trigger filter drops the `Dockerfile` path entry (dead — file no longer exists in the repo, so the trigger never fires from that hook).
- Header comment rephrased from "the same Dockerfile install steps are replicated here" to "the install steps that previously lived in a Dockerfile run here ... this workflow now owns the canonical install recipe" — the Dockerfile is gone, the workflow is the canonical recipe now.

Workflow behavior is unchanged. The change is purely substrate-self-describes (G5 catches the docstring; G2 keeps the workflow as the watcher).

## Commit 2 — registry-check: add reusable workflow alongside the script

Closes coo-labs/coo-memory#1018 *(in concert with the follow-on `.github` PR; see below).*

**Friction.** Today the registry-drift-check workflow lives in [`coo-labs/.github/.github/workflows/registry-check.yml`](https://github.com/coo-labs/.github/blob/main/.github/workflows/registry-check.yml) and checks out [the script](https://github.com/coo-labs/coo-harness/blob/main/scripts/registry-check.sh) at runtime to invoke it. Two repos, one diff surface forever broken: a script rename on this side silently breaks the workflow on the other. The split was justified by F11 / MEMO-2026-05-25-txjg's kernel-scope criterion (scripts the boot chain depends on live here), but the criterion never mandated splitting the *workflow* from its script.

**Fix.** Add `registry-check-reusable.yml` alongside its script. The workflow lives next to the only file it invokes; any rename, refactor, or signature change is one diff. F7 pattern — symmetric with `coo-on-assign-reusable.yml`, `issue-pr-hygiene-reusable.yml`, etc.

**Two-PR staging.** The thin-trigger replacement in `.github` needs the reusable to exist on `main` first before its `workflow_call` can resolve. After this merges, the follow-on PR in `coo-labs/.github` replaces `registry-check.yml` with a thin trigger pointing at the new reusable.

## Verification

Both changes are CI-config-level; the runtime behavior is exercised by the next workflow event:

- **First commit**: workflow is unchanged behaviorally; only its trigger filter and header comment change. The first push that touches `versions.lock` after merge will validate the new trigger filter fires; `workflow_dispatch` still works for manual operator runs.
- **Second commit**: the reusable workflow's first invocation comes via the follow-on `.github` thin-trigger PR. Local YAML validity verified by structure-matching against the four existing reusables (`issue-pr-hygiene-reusable`, `auto-tag-issues-reusable`, `auto-merge-sync-pr-reusable`, `coo-on-assign-reusable`).

Commits authored as `vade-coo-app[bot]` via App-token PUT contents (OAuth scope wall on workflow files).


https://claude.ai/code/session_0189tCpLT2DGvag6ZYtTBP9B