### PR TITLE
fix(mcp): use absolute path for op in mem0+agentmail spawn

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mem0": {
       "type": "stdio",
-      "command": "op",
+      "command": "/home/user/.local/bin/op",
       "args": [
         "run",
         "--env-file",
@@ -15,7 +15,7 @@
       }
     },
     "agentmail": {
-      "command": "op",
+      "command": "/home/user/.local/bin/op",
       "args": [
         "run",
         "--env-file",


### PR DESCRIPTION
Closes #511

## What

`coo-harness/.mcp.json`: changed bare `"command": "op"` -> `"command": "/home/user/.local/bin/op"` for the `mem0` and `agentmail` stdio MCP servers.

## Why

The bare-op-not-on-PATH-at-MCP-spawn-time bug has been silently breaking interactive Claude Code sessions since #435 merged (2026-06-04). Three operator sessions have reported "mem0 is working again" because the E5 integrity probe gives a false positive — it sidesteps the launcher path and invokes the binary directly.

This session's evidence: `/root/.cache/claude-cli-nodejs/-home-user/mcp-logs-mem0/2026-06-06T11-17-20-081Z.jsonl` contains:

```
Connection failed: Executable not found in $PATH: "op"
```

The `mcp__mem0__*` tool namespace is completely absent from the session's deferred-tools list. The fallback for end-of-session episodic write had to go through a direct `curl` to `api.mem0.ai` instead of the canonical `mcp__mem0__add_memory` path.

Why 1password worked but mem0/agentmail didn't: 1password uses bare `npx` (already on system PATH at MCP-spawn time); mem0 and agentmail use bare `op` (lives at `/home/user/.local/bin/op`, not on the launcher's PATH).

Regression root: #435 (2026-06-04) introduced the op-run wrapping. #437 (same day) then changed the env-file path to a pre-resolved tmpfs file — so the wrapper is now functionally vestigial for credential resolution (the file contains the plaintext key), but the spawn still requires the wrapper binary to be resolvable.

## What this PR does NOT fix (follow-up)

- **E5 false positive.** The probe runs the binary directly (`integrity-check.sh:551`), not the launcher's actual command path. Filed as a separate issue so this PR stays minimal.
- **The wrapper is vestigial.** The env file at `/dev/shm/coo-mcp-env/mem0.env` is plaintext post-#437. The wrap is now spawn overhead with no purpose. Worth revisiting whether the command should just be the mem0 binary directly with env loaded inside — refactor, not bug fix.

## Verification

Cannot verify in this session — `.mcp.json` is read at Claude Code session boot. A fresh-container session is required. Handoff prompt posted as a PR comment.

## References

- #435 (Phase 2, regression source)
- #437 (tmpfs env-file pre-materialization, made the wrapper vestigial)
- This session's MCP log file: `/root/.cache/claude-cli-nodejs/-home-user/mcp-logs-mem0/2026-06-06T11-17-20-081Z.jsonl`

https://claude.ai/code/session_01WCP8LHrqFoiaK5gWsAdzpX