### PR TITLE
transcript-redaction: fix agentmail + R2-pair patterns; add schema_shape cross-ref + drift lint

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -230,6 +230,17 @@ jobs:
       - name: Transcript redaction engine — corpus + thinking + negative tests
         run: python3 "$GITHUB_WORKSPACE/scripts/ci/test-transcript-redaction.py"
 
+      - name: Redaction-schema drift — transcript-redaction.json vs coo-memory secret_shapes
+        # Cross-references each JSON pattern's `schema_shape` annotation
+        # against schema.yaml::secret_shapes. The primary catch is the
+        # interactive session where coo-memory is symlinked at /home/user;
+        # CI runs --allow-skip because the bootstrap-regression runner has
+        # no cross-org checkout of coo-memory. The check still runs
+        # locally as a hard gate before PR open. Closes coo-labs/coo-harness#361.
+        run: |
+          pip install --quiet pyyaml
+          python3 "$GITHUB_WORKSPACE/scripts/ci/check-redaction-schema-drift.py" --allow-skip
+
       - name: Install age (apt)
         run: sudo apt-get install -y --no-install-recommends age
 

--- a/scripts/ci/check-redaction-schema-drift.py
+++ b/scripts/ci/check-redaction-schema-drift.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Drift check between coo-harness's transcript-redaction.json and coo-memory's
+operations/secrets/schema.yaml::secret_shapes registry.
+
+Asserts the two registries cross-reference cleanly:
+
+  - For every active (match_required != false) secret_shape declared in
+    schema.yaml, at least one transcript-redaction.json pattern must
+    declare `schema_shape: <name>` referencing it. (A defense-only shape
+    with match_required=false is OK uncovered; coverage is reported
+    informationally.)
+
+  - For every transcript-redaction.json pattern that declares a
+    `schema_shape` value, the named shape must exist in schema.yaml.
+
+  - Patterns without a `schema_shape` are treated as defensive-only
+    (stripe / slack / hf / npm / pypi / gcp-refresh / jwt / etc.) and
+    are not required to map.
+
+Closes the meta-bug originally documented in coo-labs/coo-harness#361.
+The runtime "registered-but-non-matching" failure surfaces in
+test-transcript-redaction.py via synthetic positive cases; this script
+covers the orthogonal "registries diverged silently" failure mode.
+
+Schema path defaults to $VADE_COO_MEMORY_DIR/operations/secrets/schema.yaml
+(or /home/user/coo-memory/... if the env var is unset). In CI environments
+without a coo-memory checkout, pass --allow-skip to exit 0 with a warning
+instead of failing.
+
+Exit codes:
+  0  no drift (or skipped per --allow-skip)
+  1  drift detected
+  2  invocation error (missing files, unparseable, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+DEFAULT_JSON = os.path.join(REPO_ROOT, "scripts", "lib", "transcript-redaction.json")
+DEFAULT_SCHEMA = os.path.join(
+    os.environ.get("VADE_COO_MEMORY_DIR", "/home/user/coo-memory"),
+    "operations",
+    "secrets",
+    "schema.yaml",
+)
+
+
+def load_schema_shapes(path: str) -> list[dict]:
+    try:
+        import yaml
+    except ImportError:
+        print(
+            f"ERROR: PyYAML required to parse {path} (pip install pyyaml)",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        print(f"ERROR: {path} did not parse as a dict", file=sys.stderr)
+        sys.exit(2)
+    return data.get("secret_shapes", []) or []
+
+
+def load_json_patterns(path: str) -> list[dict]:
+    with open(path) as f:
+        cfg = json.load(f)
+    return cfg.get("patterns", []) or []
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Drift check: transcript-redaction.json <-> schema.yaml::secret_shapes",
+    )
+    ap.add_argument(
+        "--schema",
+        default=DEFAULT_SCHEMA,
+        help=f"path to schema.yaml (default: {DEFAULT_SCHEMA})",
+    )
+    ap.add_argument(
+        "--json",
+        default=DEFAULT_JSON,
+        help=f"path to transcript-redaction.json (default: {DEFAULT_JSON})",
+    )
+    ap.add_argument(
+        "--allow-skip",
+        action="store_true",
+        help="If schema.yaml is unreachable, exit 0 with a warning instead of failing.",
+    )
+    args = ap.parse_args()
+
+    if not os.path.exists(args.schema):
+        msg = f"schema.yaml not found at {args.schema}"
+        if args.allow_skip:
+            print(f"[check-redaction-schema-drift] {msg} — skipping (--allow-skip)")
+            return 0
+        print(f"ERROR: {msg}", file=sys.stderr)
+        return 2
+
+    if not os.path.exists(args.json):
+        print(f"ERROR: transcript-redaction.json not found at {args.json}", file=sys.stderr)
+        return 2
+
+    schema_shapes = load_schema_shapes(args.schema)
+    json_patterns = load_json_patterns(args.json)
+
+    schema_by_name: dict[str, dict] = {s["name"]: s for s in schema_shapes if "name" in s}
+
+    json_by_schema_shape: dict[str, list[str]] = {}
+    for p in json_patterns:
+        s = p.get("schema_shape")
+        if s:
+            json_by_schema_shape.setdefault(s, []).append(p["id"])
+
+    failures: list[str] = []
+
+    print(f"Schema:  {args.schema}")
+    print(f"JSON:    {args.json}")
+    print(f"Shapes:  {len(schema_shapes)} declared in schema; "
+          f"{len(json_by_schema_shape)} cross-referenced from JSON patterns")
+    print("")
+    print("Coverage:")
+
+    for shape in schema_shapes:
+        name = shape.get("name")
+        if not name:
+            continue
+        required = shape.get("match_required", True) is not False
+        covered_by = json_by_schema_shape.get(name, [])
+        if required and not covered_by:
+            failures.append(
+                f"schema secret_shape '{name}' is active (match_required=true) but no "
+                f"transcript-redaction.json pattern declares `schema_shape: {name}`"
+            )
+            print(f"  X {name:<35} MISSING JSON coverage (active shape)")
+        elif covered_by:
+            tag = "(active)" if required else "(defense-only)"
+            print(f"  + {name:<35} {tag} -> {', '.join(covered_by)}")
+        else:
+            print(f"  - {name:<35} (defense-only, uncovered — OK)")
+
+    for shape_name, json_ids in json_by_schema_shape.items():
+        if shape_name not in schema_by_name:
+            for jid in json_ids:
+                failures.append(
+                    f"transcript-redaction.json pattern '{jid}' declares "
+                    f"`schema_shape: {shape_name}` but no such shape exists in "
+                    f"schema.yaml::secret_shapes"
+                )
+
+    print("")
+    if failures:
+        print(f"FAIL ({len(failures)} drift issue(s)):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print("no drift detected")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test-transcript-redaction.py
+++ b/scripts/ci/test-transcript-redaction.py
@@ -73,7 +73,33 @@ def _mem0_key() -> str:
 
 
 def _agentmail_key() -> str:
-    return "agentmail" + "-" + _A(76)
+    # Real AgentMail shape: `am_` prefix + body (~73 chars in practice).
+    # The previous `"agentmail" + "-" + ...` shape was wrong — the
+    # corresponding regex never matched live keys; three secrets leaked
+    # into capture archives 2026-05-30 (coo-labs/coo-harness#361).
+    return "am" + "_" + _A(73)
+
+
+def _r2_access_key_id_env() -> str:
+    # env-assignment form: NAME=val
+    return "R2_TRANSCRIPTS_ACCESS_KEY_ID" + "=" + ("a" * 32)
+
+
+def _r2_access_key_id_json() -> str:
+    # JSON form: "NAME": "val" — the form that bypassed redaction in #361.
+    return '"R2_TRANSCRIPTS_ACCESS_KEY_ID"' + ": " + '"' + ("a" * 32) + '"'
+
+
+def _r2_secret_access_key_env() -> str:
+    return "R2_TRANSCRIPTS_SECRET_ACCESS_KEY" + "=" + ("a" * 64)
+
+
+def _r2_secret_access_key_json() -> str:
+    return '"R2_TRANSCRIPTS_SECRET_ACCESS_KEY"' + ": " + '"' + ("a" * 64) + '"'
+
+
+def _cloudflare_tunnel_token() -> str:
+    return "cfut" + "_" + _A(48)
 
 
 def _op_token() -> str:
@@ -159,6 +185,11 @@ POSITIVE_CASES: list[tuple[str, callable, str]] = [
     ("openai-key", _openai_key, "leaked into Bash output"),
     ("mem0-key", _mem0_key, "in env-snapshot"),
     ("agentmail-key", _agentmail_key, "agentmail key dump"),
+    ("r2-access-key-id", _r2_access_key_id_env, "R2 access key id env-assignment form"),
+    ("r2-access-key-id", _r2_access_key_id_json, "R2 access key id JSON form (settings.json case)"),
+    ("r2-secret-access-key", _r2_secret_access_key_env, "R2 secret access key env-assignment form"),
+    ("r2-secret-access-key", _r2_secret_access_key_json, "R2 secret access key JSON form"),
+    ("cloudflare-tunnel-token", _cloudflare_tunnel_token, "Cloudflare Tunnel token"),
     ("op-token", _op_token, "1Password service token"),
     ("jwt", _generic_jwt, "a JWT in a tool result"),
     ("aws-akid", _aws_akid, "AWS access key in stdout"),

--- a/scripts/lib/transcript-redaction.json
+++ b/scripts/lib/transcript-redaction.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Redaction patterns applied to Claude Code session transcripts before commit/upload. Order matters — longer/more-structured shapes first, prefixed shapes next, generic JWT, then entropy fallback. See coo-labs/coo-logs#64 design comment + security review.",
+  "_comment": "Redaction patterns applied to Claude Code session transcripts before commit/upload. Order matters — longer/more-structured shapes first, prefixed shapes next, generic JWT, then entropy fallback. Each pattern with a corresponding entry in coo-memory/operations/secrets/schema.yaml::secret_shapes carries a `schema_shape` cross-reference for drift detection (coo-labs/coo-harness#361). Defensive-only patterns (stripe / slack / hf / npm / pypi / gcp-refresh / generic auth-header / jwt) have no schema_shape because there's no corresponding VADE-vault credential. See coo-labs/coo-logs#64 design comment + security review.",
   "version": 1,
   "patterns": [
     {
@@ -21,6 +21,7 @@
       "regex": "\\bops_eyJ[A-Za-z0-9_-]+(?:\\.[A-Za-z0-9_-]+){0,3}\\b",
       "replacement": "[REDACTED:op-token]",
       "secret_var": null,
+      "schema_shape": "op-service-account-token",
       "notes": "1Password service-account token. Defensive: the harness env carries OP_SERVICE_ACCOUNT_TOKEN at boot but fetch_coo_secrets does not re-export it (the harness owns it directly). Apply before generic JWT — ops_ prefix carries an embedded JWT-shaped payload that would otherwise match the JWT pattern."
     },
     {
@@ -28,6 +29,7 @@
       "regex": "\\bsk-ant-(?:api|admin|sid)\\d{2}-[A-Za-z0-9_-]{86,}\\b",
       "replacement": "[REDACTED:anthropic-key]",
       "secret_var": null,
+      "schema_shape": "anthropic-api-key",
       "notes": "Anthropic API keys. Critical class for a Claude-running shop. Pattern covers api/admin/sid variants with 2-digit version. Defensive: not currently in fetch_coo_secrets, but lands in transcripts via stray Bash output / WebFetch / colleague-paste paths."
     },
     {
@@ -35,6 +37,7 @@
       "regex": "\\bsk-(?:proj-)?[A-Za-z0-9_-]{40,}\\b",
       "replacement": "[REDACTED:openai-key]",
       "secret_var": null,
+      "schema_shape": "openai-api-key",
       "notes": "OpenAI API keys, current and project-scoped formats."
     },
     {
@@ -42,6 +45,7 @@
       "regex": "\\bgithub_pat_[A-Za-z0-9_]{82,}\\b",
       "replacement": "[REDACTED:gh-fine-pat]",
       "secret_var": ["GITHUB_MCP_PAT", "GITHUB_TOKEN"],
+      "schema_shape": "github-fine-grained-pat",
       "notes": "GitHub fine-grained PAT. 11-char prefix + 82 chars (verified against live PAT length 93). Spec is exact 82, but using {82,} so over-long anomalous strings (e.g. corpus typos, future format extensions) still redact rather than slip through into commit."
     },
     {
@@ -49,6 +53,7 @@
       "regex": "\\bghp_[A-Za-z0-9]{36}\\b",
       "replacement": "[REDACTED:gh-classic-pat]",
       "secret_var": "GITHUB_PUBLIC_PAT",
+      "schema_shape": "github-classic-pat",
       "notes": "GitHub classic PAT, 40 chars total. GITHUB_PUBLIC_PAT (MEMO-2026-05-11-6xv2) is exported under this shape; gh-coo-wrap routes cross-org public-repo writes through it."
     },
     {
@@ -56,6 +61,7 @@
       "regex": "\\bghu_[A-Za-z0-9]{36}\\b",
       "replacement": "[REDACTED:gh-oauth-u2s]",
       "secret_var": null,
+      "schema_shape": "github-app-user-token",
       "notes": "GitHub OAuth user-to-server token."
     },
     {
@@ -63,6 +69,7 @@
       "regex": "\\bghs_[A-Za-z0-9]{36}\\b",
       "replacement": "[REDACTED:gh-oauth-s2s]",
       "secret_var": null,
+      "schema_shape": "github-app-installation-token",
       "notes": "GitHub OAuth server-to-server token."
     },
     {
@@ -70,6 +77,7 @@
       "regex": "\\bghr_[A-Za-z0-9]{36}\\b",
       "replacement": "[REDACTED:gh-oauth-refresh]",
       "secret_var": null,
+      "schema_shape": "github-app-refresh-token",
       "notes": "GitHub OAuth refresh token."
     },
     {
@@ -77,21 +85,32 @@
       "regex": "\\bm0-[A-Za-z0-9]{40,}\\b",
       "replacement": "[REDACTED:mem0-key]",
       "secret_var": "MEM0_API_KEY",
+      "schema_shape": "mem0-api-key",
       "notes": "Mem0 API key. Live key length observed at 43 chars."
     },
     {
       "id": "agentmail-key",
-      "regex": "\\bagentmail[_-]?[A-Za-z0-9_-]{60,}\\b",
+      "regex": "\\bam_[A-Za-z0-9_]{20,}\\b",
       "replacement": "[REDACTED:agentmail-key]",
       "secret_var": "AGENTMAIL_API_KEY",
-      "notes": "AgentMail API key (length 76 per coo-bootstrap.sh). Prefix unverified — refine when shape known."
+      "schema_shape": "agentmail-api-key",
+      "notes": "AgentMail API key. Prefix `am_` verified against live key shape during coo-labs/coo-harness#361 audit (the previous `agentmail`-literal-prefix assumption never matched and silently leaked into 10 capture archives 2026-05-30). Length 76 per coo-bootstrap.sh; body `[A-Za-z0-9_]{20,}` is permissive to tolerate future format changes."
     },
     {
       "id": "cloudflare-api-token",
       "regex": "\\bcfat_[A-Za-z0-9_-]{40,}\\b",
       "replacement": "[REDACTED:cloudflare-api-token]",
       "secret_var": "CLOUDFLARE_API_TOKEN",
+      "schema_shape": "cloudflare-api-token",
       "notes": "Cloudflare Account-owned API token (cfat_ prefix; introduced ~2024). Live token observed at length 53 (cfat_ + 48 chars). MEMO-2026-05-09-vwk2."
+    },
+    {
+      "id": "cloudflare-tunnel-token",
+      "regex": "\\bcfut_[A-Za-z0-9]{40,}\\b",
+      "replacement": "[REDACTED:cloudflare-tunnel-token]",
+      "secret_var": null,
+      "schema_shape": "cloudflare-tunnel-token",
+      "notes": "Cloudflare Tunnel token (cfut_ prefix). Defensive — no current VADE consumer is of this shape; mirrors schema.yaml::secret_shapes for symmetry per coo-labs/coo-harness#361."
     },
     {
       "id": "cloudflare-account-id",
@@ -175,6 +194,7 @@
       "regex": "AGE-SECRET-KEY-1[A-Z0-9]{50,80}",
       "replacement": "[REDACTED:age-identity]",
       "secret_var": "TRANSCRIPTS_AGE_IDENTITY",
+      "schema_shape": "age-secret-key",
       "notes": "age X25519 private identity (Bech32-encoded, uppercase). Prefix is the literal `AGE-SECRET-KEY-1`, body is 58-char Bech32 in practice; range 50–80 tolerates format extension. High false-positive resistance — the prefix is unique. Used by the Stage-1 transcript-analyzer (Batch 3 of coo-labs/coo-logs#64) to decrypt R2-stored transcripts."
     },
     {
@@ -182,6 +202,7 @@
       "regex": "\\bAKIA[A-Z0-9]{16}\\b",
       "replacement": "[REDACTED:aws-akid]",
       "secret_var": null,
+      "schema_shape": "aws-access-key-id",
       "notes": "AWS access-key id, 20 chars. Defensive — does NOT cover Cloudflare R2 access key IDs (R2 uses 32-char hex, not AKIA-prefix); see r2-access-key-id."
     },
     {
@@ -193,17 +214,17 @@
     },
     {
       "id": "r2-access-key-id",
-      "regex": "(?i)((?:R2_TRANSCRIPTS_ACCESS_KEY_ID|AWS_ACCESS_KEY_ID)\\s*[=:]\\s*['\"]?)[a-fA-F0-9]{32}",
-      "replacement": "\\g<1>[REDACTED:r2-access-key]",
+      "regex": "(?i)((?:R2_TRANSCRIPTS_ACCESS_KEY_ID|AWS_ACCESS_KEY_ID)(?:\\\\?[\"'])?\\s*[=:]\\s*(?:\\\\?['\"])?)[a-fA-F0-9]{32}",
+      "replacement": "\\g<1>[REDACTED:r2-access-key-id]",
       "secret_var": "R2_TRANSCRIPTS_ACCESS_KEY_ID",
-      "notes": "Cloudflare R2 access key ID — 32-char hex (no AKIA prefix despite S3 compatibility). Shapeless in isolation (matches every git SHA / MD5), so kv-anchored to its env-var name. R2_TRANSCRIPTS_ACCESS_KEY_ID is the canonical export from fetch_coo_secrets; AWS_ACCESS_KEY_ID alias because the export hook re-maps R2_TRANSCRIPTS_* into AWS_* for boto3 at run time."
+      "notes": "Cloudflare R2 access key ID — 32-char hex (no AKIA prefix despite S3 compatibility). Shapeless in isolation (matches every git SHA / MD5), so kv-anchored to its env-var name. The `(?:\\\\?[\"'])?` groups around the var name let the pattern match the JSON form `\"NAME\": \"val\"` as well as the env-assignment form `NAME=val` / `NAME: val`; the `\\\\?` tolerates the JSON-escaped form `\\\"NAME\\\": \\\"val\\\"` produced when settings.json content is captured into a tool_response field and re-serialized via json.dumps (coo-labs/coo-harness#361 found settings.json captures with both forms bypassing the original name-anchor). R2_TRANSCRIPTS_ACCESS_KEY_ID is the canonical export from fetch_coo_secrets; AWS_ACCESS_KEY_ID alias because the export hook re-maps R2_TRANSCRIPTS_* into AWS_* for boto3 at run time. No schema_shape — the 32-char hex form is not in schema.yaml::secret_shapes (the related aws-access-key-id entry covers only AKIA shape); the structural follow-up to extend S7 invariant probing to op_alt_fields is tracked at coo-labs/coo-memory#1198."
     },
     {
       "id": "r2-secret-access-key",
-      "regex": "(?i)((?:R2_TRANSCRIPTS_SECRET_ACCESS_KEY|AWS_SECRET_ACCESS_KEY)\\s*[=:]\\s*['\"]?)[a-fA-F0-9]{64}",
-      "replacement": "\\g<1>[REDACTED:r2-secret-key]",
+      "regex": "(?i)((?:R2_TRANSCRIPTS_SECRET_ACCESS_KEY|AWS_SECRET_ACCESS_KEY)(?:\\\\?[\"'])?\\s*[=:]\\s*(?:\\\\?['\"])?)[a-fA-F0-9]{64}",
+      "replacement": "\\g<1>[REDACTED:r2-secret-access-key]",
       "secret_var": "R2_TRANSCRIPTS_SECRET_ACCESS_KEY",
-      "notes": "Cloudflare R2 secret access key — 64-char hex (SHA-256-derived). Same kv-anchoring rationale as r2-access-key-id; the existing aws-secret pattern (40-char base64) does not cover R2."
+      "notes": "Cloudflare R2 secret access key — 64-char hex (SHA-256-derived). Same kv-anchoring rationale as r2-access-key-id; the existing aws-secret pattern (40-char base64) does not cover R2. JSON-form alternation added 2026-06-06 per coo-labs/coo-harness#361. No schema_shape — schema.yaml::secret_shapes has no 64-char-hex entry."
     },
     {
       "id": "vade-auth-token",


### PR DESCRIPTION
Closes #361.

## Status of the original issue

Issue #361 (2026-05-30) reported three patterns in `transcript-redaction.json` registered but failing to match real values: `agentmail-key`, `r2-access-key-id`, `r2-secret-access-key`. It also reported the meta-bug that `check-secret-registration.sh` checked registration existence not regex efficacy.

Between then and now, the secrets-management epic ([coo-labs/coo-memory#871](https://github.com/coo-labs/coo-memory/issues/871), closed 2026-06-04) substantially superseded the original framing:

- **Original blast-radius path closed.** Track 4 Phase 2 ([coo-labs/coo-memory#873](https://github.com/coo-labs/coo-memory/issues/873)) stripped plaintext secrets from `settings.json::env`. The exact leak vector the issue documented can't recur the same way.
- **Meta-bug surface retired.** `check-secret-registration.sh` was deleted in #441. The "registration ≠ efficacy" critique no longer applies because that script is gone.
- **Replacement covers efficacy differently.** The schema-driven `secret_shapes:` registry in `coo-memory/operations/secrets/schema.yaml` + `postuse-bash-redactor.sh` + the S7 integrity invariant. S7 reads each credential's live value from `op://` and asserts ≥1 registered shape matches it — a stronger efficacy check than the synthetic-fixture one #361 proposed.

What survives: `transcript-redaction.json` itself still had the three broken patterns verbatim, and there was no mechanism preventing the two registries (JSON + `secret_shapes`) from silently diverging. This PR closes that residual.

## Patches

### Pattern reconciliation

| pattern | old regex (broken) | new regex |
|---|---|---|
| `agentmail-key` | `\bagentmail[_-]?[A-Za-z0-9_-]{60,}\b` | `\bam_[A-Za-z0-9_]{20,}\b` |
| `r2-access-key-id` | name-anchored to `NAME=val` / `NAME:val` only | also matches `"NAME": "val"` and `\"NAME\": \"val\"` |
| `r2-secret-access-key` | same name-anchor only | same JSON-form + JSON-escaped extension |

The R2-pair regexes keep the name-anchor (a bare 32/64-char hex pattern would flood false positives across every git SHA / content hash in transcripts). The new groups `(?:\\?["'])?` around the var name and value let the pattern also match the JSON form (`"NAME": "val"`) and its escaped sibling (`\"NAME\": \"val\"`, produced when settings.json content lands in a `tool_response` string and re-serializes via `json.dumps`).

R2-pair replacement labels aligned to their ids (`[REDACTED:r2-access-key-id]`, `[REDACTED:r2-secret-access-key]`) so the existing test contract `[REDACTED:<id>]` holds uniformly.

Defensive `cloudflare-tunnel-token` pattern added for symmetry with schema's `secret_shapes` (no current VADE consumer but mirrors the schema entry).

### Cross-reference + drift lint

Each JSON pattern now carries an optional `schema_shape` field referencing the corresponding `coo-memory/operations/secrets/schema.yaml::secret_shapes` entry. 14 schema entries are covered; defensive patterns (stripe / slack / hf / npm / pypi / gcp-refresh / jwt) carry no `schema_shape` because there's no corresponding VADE-vault credential.

`scripts/ci/check-redaction-schema-drift.py` walks both registries:
- For every active (`match_required != false`) `secret_shape`: assert ≥1 JSON pattern declares `schema_shape: <name>` referencing it.
- For every JSON `schema_shape`: assert the named shape exists in schema.yaml.
- Defense-only shapes are reported informationally; uncovered is OK.

Local invocation hard-fails on drift (the interactive COO has coo-memory symlinked at `/home/user/coo-memory`); CI runs `--allow-skip` because the bootstrap-regression runner has no cross-org checkout of coo-memory. The interactive-session gate is the primary catch; CI is best-effort defense-in-depth. Hard CI enforcement is the structural follow-up if it ever becomes worth the cross-org checkout cost.

### Test updates

`test-transcript-redaction.py`:
- `_agentmail_key()` builder produces the real `am_` shape (was building `agentmail-` shape that matched the broken regex but no real key).
- New positive cases for R2 access-key-id and r2-secret-access-key in both env-assignment form and JSON form (the latter is the form that originally bypassed redaction).
- New positive case for cloudflare-tunnel-token.

### Workflow

`bootstrap-regression.yml`: one new step under `hook-and-wrapper-tests` running the drift check with `--allow-skip`.

## Verification

```
$ python3 scripts/ci/test-transcript-redaction.py
[1/3] Positive corpus: every shape must redact with its expected label
[2/3] Negative corpus: strings must pass through unchanged
[3/3] Thinking blocks: text replaced + signature preserved + embedded secrets gone

all transcript-redaction tests passed

$ python3 scripts/ci/check-redaction-schema-drift.py
Schema:  /home/user/coo-memory/operations/secrets/schema.yaml
JSON:    /home/user/coo-harness/scripts/lib/transcript-redaction.json
Shapes:  14 declared in schema; 14 cross-referenced from JSON patterns

Coverage:
  + github-classic-pat                  (active) -> gh-classic-pat
  + github-fine-grained-pat             (active) -> gh-fine-pat
  + github-app-installation-token       (defense-only) -> gh-oauth-s2s
  + github-app-user-token               (defense-only) -> gh-oauth-u2s
  + github-app-refresh-token            (defense-only) -> gh-oauth-refresh
  + anthropic-api-key                   (active) -> anthropic-key
  + openai-api-key                      (defense-only) -> openai-key
  + cloudflare-api-token                (active) -> cloudflare-api-token
  + cloudflare-tunnel-token             (defense-only) -> cloudflare-tunnel-token
  + mem0-api-key                        (active) -> mem0-key
  + op-service-account-token            (defense-only) -> op-token
  + age-secret-key                      (active) -> age-secret-key
  + aws-access-key-id                   (defense-only) -> aws-akid
  + agentmail-api-key                   (active) -> agentmail-key

no drift detected
```

Drift-detection paths also verified by hand against synthetic schema fixtures (active-shape missing from JSON, and JSON `schema_shape` not resolving in schema).

https://claude.ai/code/session_01Xkf1rivNht8ACngFTMcuvR