### PR TITLE
scripts/transcript-render-backfill: port to lib/transcripts primitives

### DIFF
--- a/.github/workflows/lib-transcripts.yml
+++ b/.github/workflows/lib-transcripts.yml
@@ -4,12 +4,18 @@ on:
   pull_request:
     paths:
       - "lib/transcripts/**"
+      - "scripts/transcript-render-backfill.py"
+      - "scripts/ci/test-transcript-render-backfill.py"
+      - "scripts/ci/test-lib-transcripts-parity.py"
       - "pyproject.toml"
       - ".github/workflows/lib-transcripts.yml"
   push:
     branches: [main]
     paths:
       - "lib/transcripts/**"
+      - "scripts/transcript-render-backfill.py"
+      - "scripts/ci/test-transcript-render-backfill.py"
+      - "scripts/ci/test-lib-transcripts-parity.py"
       - "pyproject.toml"
       - ".github/workflows/lib-transcripts.yml"
 
@@ -44,3 +50,6 @@ jobs:
 
       - name: parity check (lib vs scripts)
         run: python3 scripts/ci/test-lib-transcripts-parity.py
+
+      - name: ported-script smoke (transcript-render-backfill)
+        run: python3 scripts/ci/test-transcript-render-backfill.py

--- a/scripts/ci/test-transcript-render-backfill.py
+++ b/scripts/ci/test-transcript-render-backfill.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Smoke test for the lib-ported transcript-render-backfill.py.
+
+The script ports its R2 plumbing to `from transcripts import ...` per
+coo-labs/coo-memory#1147; this test exercises the surviving inlined
+helper (`_list_sessions`) against a boto3-shaped fake to confirm the
+regex filtering + SESSION_ID_RE validation still picks the expected
+sids — the anti-regression layer for the per-port parity discipline.
+
+No live R2. No `op` calls. Loads the script as a module, monkey-patches
+the transcripts package's bucket resolver to a fixed value, runs
+`_list_sessions` against a FakeS3Client, asserts the result set.
+
+Exits 0 on full parity, 1 on any divergence.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = REPO_ROOT / "lib"
+SCRIPT = REPO_ROOT / "scripts" / "transcript-render-backfill.py"
+
+sys.path.insert(0, str(LIB_DIR))
+
+
+def _load_module(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakeS3:
+    """boto3-S3-shaped fake — only the `get_paginator` + `paginate` surface
+    that lib's list_keys exercises.
+    """
+
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self.objects = objects
+
+    def get_paginator(self, op: str) -> FakePaginator:
+        return FakePaginator(self)
+
+
+class FakePaginator:
+    def __init__(self, client: FakeS3) -> None:
+        self.client = client
+
+    def paginate(self, *, Bucket: str, Prefix: str) -> list[dict[str, Any]]:
+        class _Dt:
+            def isoformat(self) -> str:
+                return "2026-06-06T00:00:00Z"
+
+        contents = [
+            {"Key": k, "Size": len(v), "LastModified": _Dt()}
+            for k, v in self.client.objects.items()
+            if k.startswith(Prefix)
+        ]
+        return [{"Contents": contents}] if contents else [{}]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    mod = _load_module("transcript_render_backfill", SCRIPT)
+
+    valid_sid = "01234567-89ab-cdef-0123-456789abcdef"
+    other_sid = "fedcba98-7654-3210-fedc-ba9876543210"
+    not_a_sid_format = "01234567-89ab-cdef-0123-456789abcdez"  # 'z' at end
+    objects = {
+        f"transcripts/2026/06/06/{valid_sid}.jsonl.gz.age": b"x",
+        f"transcripts/2026/06/06/{other_sid}.jsonl.gz.age": b"x",
+        f"transcripts/2026/06/06/{not_a_sid_format}.jsonl.gz.age": b"x",
+        "transcripts/2026/06/06/not-a-uuid.jsonl.gz.age": b"x",
+        f"rendered/{valid_sid}.html": b"x",
+        f"rendered/{other_sid}.meta.json": b"x",  # wrong suffix
+        "other-prefix/x.jsonl.gz.age": b"x",
+    }
+
+    with patch("transcripts.r2._bucket_from_env_or_op", return_value="bkt"):
+        cipher = mod._list_sessions("transcripts/", mod.CIPHERTEXT_KEY_RE, FakeS3(objects))
+        rendered = mod._list_sessions(
+            "rendered/", mod.RENDERED_KEY_RE, FakeS3(objects)
+        )
+
+    if cipher != {valid_sid, other_sid}:
+        failures.append(
+            f"ciphertext set drift — got={sorted(cipher)} "
+            f"expected={sorted([valid_sid, other_sid])}"
+        )
+    if rendered != {valid_sid}:
+        failures.append(
+            f"rendered set drift — got={sorted(rendered)} expected=[{valid_sid}]"
+        )
+
+    if failures:
+        sys.stderr.write("RENDER-BACKFILL PARITY FAILURES:\n")
+        for f in failures:
+            sys.stderr.write(f"  - {f}\n")
+        return 1
+
+    print(f"render-backfill OK — cipher={len(cipher)} rendered={len(rendered)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/transcript-render-backfill.py
+++ b/scripts/transcript-render-backfill.py
@@ -38,9 +38,7 @@ and continue — backfill is intentionally best-effort, fail-soft.
 from __future__ import annotations
 
 import argparse
-import os
 import re
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -49,6 +47,14 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 RUNTIME_ROOT = SCRIPT_DIR.parent
 FETCH_SH = RUNTIME_ROOT / "scripts" / "lib" / "transcript-fetch.sh"
 RENDER_PY = RUNTIME_ROOT / "scripts" / "lifecycle" / "session-end-transcript-render.py"
+
+# Locate coo-harness/lib/ on sys.path so `from transcripts import ...` resolves
+# under the uv-run venv this script spawns into. See lib/transcripts/README.md
+# §"Importing" for the parents[N] table; this script lives at scripts/<top>.py
+# so parents[1] is the repo root.
+sys.path.insert(0, str(SCRIPT_DIR.parent / "lib"))
+
+from transcripts import R2Error, list_keys, r2_client, r2_coordinates  # noqa: E402
 
 SESSION_ID_RE = re.compile(
     r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
@@ -63,57 +69,12 @@ def _stderr(msg: str) -> None:
     sys.stderr.write(f"[transcript-render-backfill] {msg}\n")
 
 
-def _op_read(ref: str) -> str:
-    if not shutil.which("op"):
-        return ""
-    try:
-        out = subprocess.run(
-            ["op", "read", ref],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        return out.stdout.strip()
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return ""
-
-
-def _r2_client():
-    access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
-    secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
-    if not access_key or not secret_key:
-        raise RuntimeError(
-            "R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY missing"
-        )
-    endpoint = _op_read("op://COO/r2-transcripts/endpoint")
-    bucket = _op_read("op://COO/r2-transcripts/bucket")
-    if not endpoint or not bucket:
-        raise RuntimeError(
-            "R2 endpoint or bucket not readable from op://COO/r2-transcripts/{endpoint,bucket}"
-        )
-    import boto3
-    from botocore.config import Config
-
-    s3 = boto3.client(
-        "s3",
-        endpoint_url=endpoint,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        region_name="auto",
-        config=Config(signature_version="s3v4", retries={"max_attempts": 3, "mode": "standard"}),
-    )
-    return s3, bucket
-
-
-def _list_sessions(s3, bucket: str, prefix: str, key_re: re.Pattern[str]) -> set[str]:
+def _list_sessions(prefix: str, key_re: re.Pattern[str], s3) -> set[str]:
     sids: set[str] = set()
-    paginator = s3.get_paginator("list_objects_v2")
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-        for obj in page.get("Contents", []) or []:
-            m = key_re.search(obj["Key"])
-            if m and SESSION_ID_RE.match(m.group(1)):
-                sids.add(m.group(1))
+    for obj in list_keys(prefix, s3=s3):
+        m = key_re.search(obj["key"])
+        if m and SESSION_ID_RE.match(m.group(1)):
+            sids.add(m.group(1))
     return sids
 
 
@@ -199,17 +160,19 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     try:
-        s3, bucket = _r2_client()
-    except RuntimeError as e:
+        coords = r2_coordinates()
+        s3 = r2_client(coords)
+    except R2Error as e:
         _stderr(str(e))
         return 1
+    bucket = coords.bucket
 
     _stderr(f"scanning r2://{bucket}/transcripts/ for ciphertext keys…")
-    exported = _list_sessions(s3, bucket, "transcripts/", CIPHERTEXT_KEY_RE)
+    exported = _list_sessions("transcripts/", CIPHERTEXT_KEY_RE, s3)
     _stderr(f"  {len(exported)} session(s) in archive")
 
     _stderr(f"scanning r2://{bucket}/{args.key_prefix}/ for existing renders…")
-    already_rendered = _list_sessions(s3, bucket, f"{args.key_prefix}/", RENDERED_KEY_RE)
+    already_rendered = _list_sessions(f"{args.key_prefix}/", RENDERED_KEY_RE, s3)
     _stderr(f"  {len(already_rendered)} already rendered")
 
     if args.include_existing:


### PR DESCRIPTION
Third slice on coo-labs/coo-memory#1147: port `transcript-render-backfill.py` (247 LOC standalone orchestrator) to the lib/transcripts primitive layer.

Closes: n/a

(coo-labs/coo-memory#1147 has multiple sub-PRs left and is not closed by this slice; see "Remaining" below.)

## What ships

**`scripts/transcript-render-backfill.py`** — inlined R2 plumbing is replaced with lib calls:

- `_op_read` / `_r2_client` → `r2_coordinates()` + `r2_client(coords)` from `transcripts.r2`.
- The paginated list loop in `_list_sessions` → `list_keys(prefix, s3=s3)`. The regex filtering + `SESSION_ID_RE` validation stay local (script-shape narrower than the lib's snapshot regex; see "Out of scope" below).

Orchestration — the subprocess fetch + render dispatch in `_render_one` — stays inlined per the principal-engineer + SRE review cited in the lib README: hooks/CLIs hold orchestration, lib holds primitives.

**`scripts/ci/test-transcript-render-backfill.py`** — the per-script parity smoke required by the issue body's "Parity test per ported script" line. Loads the ported script as a module, feeds `_list_sessions` a boto3-shaped fake against a fixture, asserts the regex filter + `SESSION_ID_RE` validation pick the expected sids. The anti-regression layer now that the inlined `_op_read` / `_r2_client` versions are gone — a future drift in either the regex shape or `list_keys`' return contract would surface here.

**`.github/workflows/lib-transcripts.yml`** — adds the script + its smoke test to the trigger paths so the workflow runs on changes to the ported script, and wires the smoke test as a new step.

## Smoke + parity verification (local)

- `python3 scripts/transcript-render-backfill.py --help` — clean exit, args parse correctly.
- `python3 scripts/ci/test-transcript-render-backfill.py` — `render-backfill OK — cipher=2 rendered=1`.
- `python3 scripts/ci/test-lib-transcripts-parity.py` — `parity OK — 5 auth, 4 reconcile, PARSER_VERSION=3, jsonl primitives match` (unchanged; render-backfill didn't carry constants that lib mirrors).
- `pytest` — 234 passes, 98% coverage (unchanged).
- `ruff check lib/transcripts` + `ruff format --check lib/transcripts` clean.

## Out of scope

- `SESSION_ID_RE`, `CIPHERTEXT_KEY_RE`, `RENDERED_KEY_RE` stay inlined in the script. Render-backfill wants UUID-only sids because it subprocess-spawns the renderer with `--session-id` argv; `state.py`'s snapshot regex is wider (matches `cse_…` remote-session ids too). Consolidating would need a wider-or-narrower call I don't want to make in this slice; leaving each consumer to express its own shape until a second pairing rationalises a shared narrower pattern.
- The remaining 4 script ports (rerender, url-backfill, export Stop-hook, render Stop-hook) — each gets its own slice per the issue body's smallest-first ordering.

## Remaining on coo-labs/coo-memory#1147 after this PR

- ☐ `lib/transcripts/render.py` (extracted from the ~1200-LOC `_render_*` family in `session-end-transcript-render.py`).
- ☐ 4 remaining script ports + parity smokes (rerender → url-backfill → export → render). With `state.py` and now render-backfill landed, the lib-vs-script parity floor is established and the pattern is stable for the rest.
- ☐ PR-2: the R2-inventory cron in coo-console — now has both `state.py` math (Python reference; the Worker will port the shape to TS) and a worked example of the lib-port pattern to follow.

## Risk

- Behavior change risk: low. The inlined `_r2_client` + `_op_read` were byte-equivalent to the lib's `r2_coordinates` / `r2_client` (verified via the parity check pre-port). The `_list_sessions` loop change is mechanical — same regex, same SESSION_ID_RE gate, same paginate semantics.
- Subprocess dispatch and per-session retry logic in `_render_one` are unchanged.
- Workflow trigger-path addition is additive; no existing trigger is removed.

https://claude.ai/code/session_01TVP2gk9X4bvo1bV5yzVx8j