### PR TITLE
scripts/lifecycle/session-end-transcript-export: port to lib/transcripts primitives

### DIFF
--- a/.github/workflows/lib-transcripts.yml
+++ b/.github/workflows/lib-transcripts.yml
@@ -7,9 +7,11 @@ on:
       - "scripts/transcript-render-backfill.py"
       - "scripts/transcript-url-backfill.py"
       - "scripts/transcript-rerender-v3-backfill.py"
+      - "scripts/lifecycle/session-end-transcript-export.py"
       - "scripts/ci/test-transcript-render-backfill.py"
       - "scripts/ci/test-transcript-url-backfill.py"
       - "scripts/ci/test-transcript-rerender-v3-backfill.py"
+      - "scripts/ci/test-session-end-transcript-export.py"
       - "scripts/ci/test-lib-transcripts-parity.py"
       - "pyproject.toml"
       - ".github/workflows/lib-transcripts.yml"
@@ -20,9 +22,11 @@ on:
       - "scripts/transcript-render-backfill.py"
       - "scripts/transcript-url-backfill.py"
       - "scripts/transcript-rerender-v3-backfill.py"
+      - "scripts/lifecycle/session-end-transcript-export.py"
       - "scripts/ci/test-transcript-render-backfill.py"
       - "scripts/ci/test-transcript-url-backfill.py"
       - "scripts/ci/test-transcript-rerender-v3-backfill.py"
+      - "scripts/ci/test-session-end-transcript-export.py"
       - "scripts/ci/test-lib-transcripts-parity.py"
       - "pyproject.toml"
       - ".github/workflows/lib-transcripts.yml"
@@ -67,3 +71,6 @@ jobs:
 
       - name: ported-script smoke (transcript-rerender-v3-backfill)
         run: python3 scripts/ci/test-transcript-rerender-v3-backfill.py
+
+      - name: ported-script smoke (session-end-transcript-export)
+        run: python3 scripts/ci/test-session-end-transcript-export.py

--- a/lib/transcripts/__init__.py
+++ b/lib/transcripts/__init__.py
@@ -7,9 +7,17 @@ orchestration (the SessionEnd hook, mass-mutation drivers) stays in scripts/.
 
 Public surface is what's re-exported below. Anything not in __all__ is private
 to the module and may change without notice.
+
+Schema imports are lazy (PEP 562 __getattr__): the export Stop-hook runs under
+`uv run --script` with PEP 723 inline deps that include only boto3, not
+pydantic. An eager `from transcripts.schema import ...` here would force every
+consumer to ship pydantic in its inline deps, which breaks the Stop-hook's cold
+boot. Schema symbols load on first attribute access instead.
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from transcripts.jsonl import (
     AUTO_NOTIFICATION_RES,
@@ -36,11 +44,6 @@ from transcripts.r2 import (
     write_html_object,
     write_sidecar,
 )
-from transcripts.schema import (
-    PARSER_VERSION,
-    Sidecar,
-    UrlSource,
-)
 from transcripts.state import (
     COHORT_LABELS,
     Artifact,
@@ -53,6 +56,32 @@ from transcripts.state import (
     sid_from_rendered_key,
     take_snapshot,
 )
+
+if TYPE_CHECKING:
+    # Re-export for static type-checkers; runtime resolution happens via
+    # __getattr__ below.
+    from transcripts.schema import PARSER_VERSION, Sidecar, UrlSource
+
+
+_LAZY_SCHEMA_NAMES = frozenset({"PARSER_VERSION", "Sidecar", "UrlSource"})
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy-load schema symbols so consumers without pydantic still import.
+
+    Called by Python whenever a name isn't found in the module's normal
+    attribute lookup. Touching `transcripts.Sidecar` (or PARSER_VERSION /
+    UrlSource) triggers the pydantic import on first use; the export
+    Stop-hook never touches them and so never pays for pydantic.
+    """
+    if name in _LAZY_SCHEMA_NAMES:
+        from transcripts import schema as _schema  # noqa: PLC0415 — lazy by design
+
+        value = getattr(_schema, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module 'transcripts' has no attribute {name!r}")
+
 
 __all__ = [
     "AUTHORITATIVE_URL_SOURCES",

--- a/scripts/ci/test-session-end-transcript-export.py
+++ b/scripts/ci/test-session-end-transcript-export.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Smoke test for the lib-ported session-end-transcript-export.py.
+
+The Stop-hook script ports its R2 credential plumbing to
+`from transcripts import r2_coordinates, r2_client` per
+coo-labs/coo-memory#1147. This test exercises the surviving inlined
+helpers against boto3-shaped fakes:
+
+  - `_encode_meta_for_object_metadata` — pure: covers the full-encode,
+    drop-redaction-hits truncation, and None-on-overflow branches.
+  - `_r2_upload` — verifies the IfNoneMatch="*" + Metadata=... PUT shape,
+    the ceded=True return on PreconditionFailed, the ceded=False on
+    success, and that the file is read from the passed Path.
+  - `_r2_head_object_metadata` — returns dict on success, None on
+    head_object failure (the cede-branch recovery path).
+
+No live R2. No `op` calls. Stop-hook semantics (gzip/age/sha256/redaction)
+are out of scope — those are tested separately by the redact engine
+suite. This is the lib-port parity layer.
+
+Exits 0 on full parity, 1 on any divergence.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = REPO_ROOT / "lib"
+SCRIPT = REPO_ROOT / "scripts" / "lifecycle" / "session-end-transcript-export.py"
+
+sys.path.insert(0, str(LIB_DIR))
+
+
+def _load_module(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakeClientError(Exception):
+    def __init__(self, code: str, status: int) -> None:
+        super().__init__(code)
+        self.response = {
+            "Error": {"Code": code},
+            "ResponseMetadata": {"HTTPStatusCode": status},
+        }
+
+
+class FakeS3:
+    """Records put_object calls; can be primed to raise on a specific key."""
+
+    def __init__(self, raise_on_keys: dict[str, FakeClientError] | None = None,
+                 head_metadata: dict[str, dict[str, str]] | None = None) -> None:
+        self.puts: list[dict[str, Any]] = []
+        self.raise_on_keys = raise_on_keys or {}
+        self.head_metadata = head_metadata or {}
+
+    def put_object(self, *, Bucket: str, Key: str, Body: Any, **kw: Any) -> dict[str, Any]:
+        if Key in self.raise_on_keys:
+            raise self.raise_on_keys[Key]
+        self.puts.append(
+            {
+                "Bucket": Bucket,
+                "Key": Key,
+                "Body": Body.read() if hasattr(Body, "read") else Body,
+                **kw,
+            }
+        )
+        return {}
+
+    def head_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:
+        if Key not in self.head_metadata:
+            raise RuntimeError(f"NoSuchKey: {Key}")
+        return {"Metadata": self.head_metadata[Key]}
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    mod = _load_module("session_end_transcript_export", SCRIPT)
+
+    # --- Patch botocore.exceptions.ClientError so _r2_upload catches our fake.
+    # _r2_upload imports ClientError from botocore.exceptions lazily; we need
+    # the same class for isinstance to work. The clean way: monkey-patch
+    # botocore.exceptions.ClientError to FakeClientError for the duration of
+    # the test, so the try/except in _r2_upload catches the fake.
+    import botocore.exceptions
+
+    saved_client_error = botocore.exceptions.ClientError
+    botocore.exceptions.ClientError = FakeClientError  # type: ignore[misc]
+
+    try:
+        # --- _encode_meta_for_object_metadata: full encode happy path.
+        small_sidecar = {
+            "schema_version": 3,
+            "session_id": "01234567-89ab-cdef-0123-456789abcdef",
+            "events_processed": 5,
+            "ciphertext_sha256": "a" * 64,
+        }
+        enc = mod._encode_meta_for_object_metadata(small_sidecar)
+        if not isinstance(enc, dict) or "vade-meta-json" not in enc:
+            failures.append(f"_encode_meta full-encode dropped keys: {enc!r}")
+        else:
+            if enc.get("vade-meta-schema") != "3":
+                failures.append(f"_encode_meta schema marker drift: {enc!r}")
+            if "vade-meta-truncated" in enc:
+                failures.append(f"_encode_meta should not truncate small sidecar: {enc!r}")
+            if json.loads(enc["vade-meta-json"]) != small_sidecar:
+                failures.append("_encode_meta json round-trip diverged")
+
+        # _encode_meta with redaction_hits big enough to require truncation
+        # but the truncated version fits. Build a sidecar whose redaction_hits
+        # alone push past LIMIT (1900B) but the rest stays under.
+        big_hits = {f"pattern_{i}": i for i in range(400)}  # ~6KB JSON
+        big_sidecar = dict(small_sidecar)
+        big_sidecar["redaction_hits"] = big_hits
+        enc_trunc = mod._encode_meta_for_object_metadata(big_sidecar)
+        if not isinstance(enc_trunc, dict):
+            failures.append("_encode_meta should truncate but returned None")
+        elif enc_trunc.get("vade-meta-truncated") != "redaction_hits":
+            failures.append(
+                f"_encode_meta truncation marker missing/wrong: {enc_trunc!r}"
+            )
+        else:
+            recovered = json.loads(enc_trunc["vade-meta-json"])
+            if "redaction_hits" in recovered:
+                failures.append("_encode_meta truncation should drop redaction_hits")
+            if recovered.get("session_id") != small_sidecar["session_id"]:
+                failures.append("_encode_meta truncation lost session_id")
+
+        # _encode_meta where even the truncated version overflows: load every
+        # field with bulk data so dropping redaction_hits doesn't fix it.
+        bulk = {f"f{i}": "x" * 100 for i in range(50)}  # ~5KB just in extra fields
+        overflow_sidecar = {**small_sidecar, **bulk, "redaction_hits": big_hits}
+        enc_over = mod._encode_meta_for_object_metadata(overflow_sidecar)
+        if enc_over is not None:
+            failures.append(
+                f"_encode_meta should return None on overflow: got {enc_over!r}"
+            )
+
+        # --- _r2_upload happy path
+        with tempfile.NamedTemporaryFile("wb", delete=False) as f:
+            f.write(b"ciphertext-bytes")
+            local = Path(f.name)
+        try:
+            s3 = FakeS3()
+            result = mod._r2_upload(
+                local, "transcripts/2026/06/06/sid.jsonl.gz.age",
+                metadata={"vade-meta-json": '{"k":1}', "vade-meta-schema": "3"},
+                s3=s3, bucket="bkt", endpoint="https://r2.example",
+            )
+            if result.get("ceded"):
+                failures.append(f"_r2_upload happy path returned ceded=True: {result!r}")
+            if result.get("bucket") != "bkt" or result.get("key") != "transcripts/2026/06/06/sid.jsonl.gz.age":
+                failures.append(f"_r2_upload result drift: {result!r}")
+            if len(s3.puts) != 1:
+                failures.append(f"_r2_upload put-count drift: {len(s3.puts)}")
+            elif s3.puts[0].get("IfNoneMatch") != "*":
+                failures.append(f"_r2_upload missing IfNoneMatch=*: {s3.puts[0]!r}")
+            elif s3.puts[0].get("Metadata") != {"vade-meta-json": '{"k":1}', "vade-meta-schema": "3"}:
+                failures.append(f"_r2_upload metadata drift: {s3.puts[0]!r}")
+            elif s3.puts[0].get("Body") != b"ciphertext-bytes":
+                failures.append(f"_r2_upload body drift: {s3.puts[0]!r}")
+
+            # _r2_upload cede branch — PreconditionFailed → ceded=True
+            s3_cede = FakeS3(raise_on_keys={
+                "transcripts/2026/06/06/sid.jsonl.gz.age": FakeClientError(
+                    "PreconditionFailed", 412
+                )
+            })
+            result_cede = mod._r2_upload(
+                local, "transcripts/2026/06/06/sid.jsonl.gz.age",
+                metadata=None,
+                s3=s3_cede, bucket="bkt", endpoint="https://r2.example",
+            )
+            if not result_cede.get("ceded"):
+                failures.append(
+                    f"_r2_upload should return ceded=True on 412: {result_cede!r}"
+                )
+
+            # _r2_upload non-precondition error — re-raises
+            s3_err = FakeS3(raise_on_keys={
+                "transcripts/2026/06/06/sid.jsonl.gz.age": FakeClientError("InternalError", 500)
+            })
+            raised = False
+            try:
+                mod._r2_upload(
+                    local, "transcripts/2026/06/06/sid.jsonl.gz.age",
+                    metadata=None,
+                    s3=s3_err, bucket="bkt", endpoint="https://r2.example",
+                )
+            except FakeClientError:
+                raised = True
+            if not raised:
+                failures.append("_r2_upload should re-raise non-precondition errors")
+        finally:
+            local.unlink(missing_ok=True)
+
+        # --- _r2_head_object_metadata: returns dict on success.
+        s3h = FakeS3(head_metadata={
+            "transcripts/2026/06/06/sid.jsonl.gz.age": {
+                "vade-meta-json": '{"session_id":"x"}',
+                "vade-meta-schema": "3",
+            }
+        })
+        md = mod._r2_head_object_metadata(
+            "transcripts/2026/06/06/sid.jsonl.gz.age",
+            s3=s3h, bucket="bkt",
+        )
+        if md != {"vade-meta-json": '{"session_id":"x"}', "vade-meta-schema": "3"}:
+            failures.append(f"_r2_head_object_metadata happy path drift: {md!r}")
+
+        # _r2_head_object_metadata: returns None on head_object failure
+        s3h_miss = FakeS3()
+        md_miss = mod._r2_head_object_metadata(
+            "transcripts/missing-key.jsonl.gz.age",
+            s3=s3h_miss, bucket="bkt",
+        )
+        if md_miss is not None:
+            failures.append(f"_r2_head_object_metadata should return None on failure: {md_miss!r}")
+    finally:
+        botocore.exceptions.ClientError = saved_client_error  # type: ignore[misc]
+
+    if failures:
+        sys.stderr.write("EXPORT PARITY FAILURES:\n")
+        for f in failures:
+            sys.stderr.write(f"  - {f}\n")
+        return 1
+
+    print(
+        "export OK — _encode_meta(full+truncate+overflow) + _r2_upload(happy+cede+raise) "
+        "+ _r2_head_object_metadata(hit+miss) parity"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lifecycle/session-end-transcript-export.py
+++ b/scripts/lifecycle/session-end-transcript-export.py
@@ -95,6 +95,13 @@ REDACT_PY = RUNTIME_ROOT / "scripts" / "lib" / "transcript-redact.py"
 RECIPIENT_FILE = RUNTIME_ROOT / "scripts" / "lib" / "transcripts-recipient.age"
 REDACTION_CONFIG = RUNTIME_ROOT / "scripts" / "lib" / "transcript-redaction.json"
 
+# Locate coo-harness/lib/ on sys.path so `from transcripts import ...` resolves
+# under the uv-run venv this script spawns into. lifecycle/ is two parents up
+# from the repo root.
+sys.path.insert(0, str(RUNTIME_ROOT / "lib"))
+
+from transcripts import R2Error, r2_client, r2_coordinates  # noqa: E402
+
 
 def _stderr(msg: str) -> None:
     sys.stderr.write(f"[session-end-transcript-export] {msg}\n")
@@ -258,48 +265,14 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
-def _op_read(ref: str) -> str:
-    """Read a 1Password reference via the op CLI. Returns empty string
-    on any failure (caller decides whether to abort or skip)."""
-    if not shutil.which("op"):
-        return ""
-    try:
-        out = subprocess.run(
-            ["op", "read", ref],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        return out.stdout.strip()
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return ""
-
-
-def _r2_endpoint_bucket() -> tuple[str, str]:
-    """Resolve R2 endpoint + bucket via `op` once.
-
-    Callers that PUT twice (ciphertext + flat-key meta) should resolve
-    once here and pass the values into `_r2_upload` to avoid duplicate
-    `op` invocations. Raises if either slot is empty.
-    """
-    endpoint = _op_read("op://COO/r2-transcripts/endpoint")
-    bucket = _op_read("op://COO/r2-transcripts/bucket")
-    if not endpoint or not bucket:
-        raise RuntimeError(
-            "R2 endpoint or bucket not readable from "
-            "op://COO/r2-transcripts/{endpoint,bucket}"
-        )
-    return endpoint, bucket
-
-
 def _r2_upload(
     local: Path,
     key: str,
     *,
     metadata: dict[str, str] | None = None,
-    endpoint: str | None = None,
-    bucket: str | None = None,
+    s3,
+    bucket: str,
+    endpoint: str,
 ) -> dict:
     """Upload a local file to R2 at the given key with first-write-wins
     semantics. Returns a dict with bucket+key+endpoint for the sidecar
@@ -328,15 +301,6 @@ def _r2_upload(
     server-side before commit, so a 412 cede leaves no metadata
     behind either.
     """
-    access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
-    secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
-    if not access_key or not secret_key:
-        raise RuntimeError(
-            "R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY "
-            "missing — fetch_coo_secrets did not populate them"
-        )
-    if endpoint is None or bucket is None:
-        endpoint, bucket = _r2_endpoint_bucket()
     if metadata is not None:
         # R2 user-metadata is ISO-8859-1 string-only; ascii-encoded JSON
         # caller-side keeps that constraint trivially.
@@ -344,21 +308,7 @@ def _r2_upload(
             "R2 user-metadata values must be strings"
         )
 
-    import boto3  # imported lazily — uv resolves on first run
-    from botocore.config import Config
     from botocore.exceptions import ClientError
-
-    s3 = boto3.client(
-        "s3",
-        endpoint_url=endpoint,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        region_name="auto",
-        config=Config(
-            signature_version="s3v4",
-            retries={"max_attempts": 3, "mode": "standard"},
-        ),
-    )
 
     put_kwargs = {
         "Bucket": bucket,
@@ -384,7 +334,7 @@ def _r2_upload(
 def _r2_head_object_metadata(
     key: str,
     *,
-    endpoint: str,
+    s3,
     bucket: str,
 ) -> dict[str, str] | None:
     """Fetch R2 user-metadata for an existing key via head_object.
@@ -399,26 +349,7 @@ def _r2_head_object_metadata(
     Returns the lowercased Metadata dict on success, None on any failure
     (caller falls back to breadcrumb-only behavior).
     """
-    access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
-    secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
-    if not access_key or not secret_key:
-        return None
-
     try:
-        import boto3
-        from botocore.config import Config
-
-        s3 = boto3.client(
-            "s3",
-            endpoint_url=endpoint,
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            region_name="auto",
-            config=Config(
-                signature_version="s3v4",
-                retries={"max_attempts": 3, "mode": "standard"},
-            ),
-        )
         resp = s3.head_object(Bucket=bucket, Key=key)
         return resp.get("Metadata") or {}
     except BaseException:
@@ -783,6 +714,7 @@ def main() -> int:
             if dry_run:
                 r2_endpoint = "<dry-run>"
                 r2_bucket = "<dry-run>"
+                s3 = None
                 r2_target = {
                     "bucket": r2_bucket,
                     "key": r2_key,
@@ -791,7 +723,10 @@ def main() -> int:
                     "meta_key": meta_r2_key,
                 }
             else:
-                r2_endpoint, r2_bucket = _r2_endpoint_bucket()
+                coords = r2_coordinates()
+                r2_endpoint = coords.endpoint
+                r2_bucket = coords.bucket
+                s3 = r2_client(coords)
                 r2_target = {
                     "bucket": r2_bucket,
                     "key": r2_key,
@@ -842,7 +777,7 @@ def main() -> int:
                 upload = _r2_upload(
                     ciphertext, r2_key,
                     metadata=embed_metadata,
-                    endpoint=r2_endpoint, bucket=r2_bucket,
+                    s3=s3, bucket=r2_bucket, endpoint=r2_endpoint,
                 )
                 # First-write-wins cede (coo-harness#204): another writer
                 # already holds this R2 key. Our ciphertext_sha256 does NOT
@@ -854,7 +789,7 @@ def main() -> int:
                 # discoverable through every navigation path (coo-harness#416).
                 if upload.get("ceded"):
                     md = _r2_head_object_metadata(
-                        r2_key, endpoint=r2_endpoint, bucket=r2_bucket,
+                        r2_key, s3=s3, bucket=r2_bucket,
                     )
                     embed = (md or {}).get("vade-meta-json", "")
                     recovered: dict | None = None
@@ -896,7 +831,7 @@ def main() -> int:
                 try:
                     meta_upload = _r2_upload(
                         meta_temp, meta_r2_key,
-                        endpoint=r2_endpoint, bucket=r2_bucket,
+                        s3=s3, bucket=r2_bucket, endpoint=r2_endpoint,
                     )
                     if meta_upload.get("ceded"):
                         _stderr(


### PR DESCRIPTION
Fifth slice on coo-labs/coo-memory#1147: port `scripts/lifecycle/session-end-transcript-export.py` (954 LOC, Stop-hook) to the `lib/transcripts/` primitive layer.

Closes: n/a (coo-labs/coo-memory#1147 has 1 script port + render.py + the R2-inventory cron remaining; see "Remaining" below).

## What ships

**`scripts/lifecycle/session-end-transcript-export.py`** — the Stop-hook that runs after every Claude Code session ends.

- `_op_read` and `_r2_endpoint_bucket` → removed. `r2_coordinates()` from `transcripts.r2` resolves credentials + endpoint + bucket in one call via the lib's private `_op_read`.
- `_r2_upload` → refactored to take a pre-built `s3` client + `bucket` + `endpoint` instead of constructing its own boto3 client per call. The `IfNoneMatch='*'` + `Metadata={vade-meta-*}` + ceded-on-412 return-dict shape is preserved verbatim — this is the script-specific atomic-PUT-with-embedded-metadata flow ([coo-harness#204](https://github.com/coo-labs/coo-harness/issues/204), [#416](https://github.com/coo-labs/coo-harness/issues/416)), not generalizable to the lib's `write_html_object` / `write_sidecar` primitives which serialize fixed shapes under the `rendered/` prefix.
- `_r2_head_object_metadata` → same refactor (takes `s3` + `bucket`). Used by the cede-recovery branch.
- `_encode_meta_for_object_metadata` (full-encode → drop-redaction-hits → None-on-overflow degradation ladder), `_resolve_session_id_and_jsonl`, `_first_event_date`, `_run_redact`, `_gzip_file`, `_age_encrypt`, `_sha256`, `_open_meta_pr`, `_emit_export_error`, `_emit_meta_pr_error` → unchanged. Orchestration; stays in `scripts/` per the lib README's primitive/orchestration split.

In `main()`: one `r2_coordinates()` + `r2_client(coords)` call replaces the prior per-PUT credential resolution. The dry-run branch sets `s3=None` and skips the resolution entirely (parity with prior behavior).

**`scripts/ci/test-session-end-transcript-export.py`** — new per-port smoke. Exercises `_encode_meta_for_object_metadata` (full-encode, drop-redaction-hits truncation, None-on-overflow), `_r2_upload` (happy path; ceded=True on `PreconditionFailed` / 412; re-raise on `InternalError` / 500), and `_r2_head_object_metadata` (hit + miss) against boto3-shaped fakes. Patches `botocore.exceptions.ClientError` for the duration of the test so the script's lazy import catches the fake.

**`.github/workflows/lib-transcripts.yml`** — adds the script + its smoke to the trigger paths and wires the new smoke step after the existing url-backfill + rerender-v3 smokes.

## Smoke + parity verification (local)

- `python3 scripts/ci/test-session-end-transcript-export.py` — `export OK — _encode_meta(full+truncate+overflow) + _r2_upload(happy+cede+raise) + _r2_head_object_metadata(hit+miss) parity`.
- `python3 scripts/ci/test-transcript-render-backfill.py` — `render-backfill OK — cipher=2 rendered=1`.
- `python3 scripts/ci/test-transcript-url-backfill.py` — `url-backfill OK — missing=3 all=4 sid_map=1 patch-rules=3`.
- `python3 scripts/ci/test-transcript-rerender-v3-backfill.py` — `rerender-v3 OK — all=3 filter-rv3=2 skipped-noUrl=1/1 skipped-filter=1`.
- `python3 scripts/ci/test-lib-transcripts-parity.py` — `parity OK — 5 auth, 4 reconcile, PARSER_VERSION=3, jsonl primitives match`.
- `pytest` — 234 passes, 97.80% coverage.
- `ruff check lib/transcripts` clean. `mypy lib/transcripts` clean.

## Out of scope

- `_open_meta_pr` (the gh-based auto-PR opener), `_encode_meta_for_object_metadata` (the R2 user-metadata encoder with size-limited degradation ladder), the redact/gzip/age subprocess chain — all stay inlined. Script-specific shapes that no other consumer needs.
- The Stop-hook integration (data plane: redact engine, gzip, age encrypt, sidecar write, auto-PR open) is unchanged. The CI smoke covers only the lib-port surface; integration coverage stays in the existing test infrastructure (redaction-engine drift tests, etc).
- `session-end-transcript-render.py` (1211 LOC, the other Stop-hook) — next slice. Will benefit from the new `lib/transcripts/render.py` extraction.

## Remaining on coo-labs/coo-memory#1147 after this PR

- ☐ `lib/transcripts/render.py` (extracted from the ~1200-LOC `_render_*` family in `session-end-transcript-render.py`).
- ☐ 1 remaining script port + parity smoke (the render Stop-hook).
- ☐ PR-2: the R2-inventory cron in coo-console.

## Risk

- Data-plane behavior change: low. The two refactored helpers (`_r2_upload`, `_r2_head_object_metadata`) are pure plumbing — `s3` is now constructed once via `r2_client(coords)` instead of per-PUT via inline `boto3.client()`, and credentials come from `r2_coordinates()` (same env vars + same op references). PUT semantics (`IfNoneMatch`, `Metadata`, ceded-on-412) and `head_object` semantics are byte-equivalent.
- Stop-hook resilience: unchanged. The script still wraps `main()` in `except BaseException` and always exits 0, so any new exception shape from the lib (`R2Error` inherits from `RuntimeError`) lands in the existing export-error breadcrumb path. No new failure mode.
- Workflow trigger-path additions are additive; no existing trigger is removed.

https://claude.ai/code/session_01HqaFJxXTYs67BDHZnucsky