### PR TITLE
integrity+hook: load non_secret_env_* from schema as canonical source

### DIFF
--- a/scripts/hooks/preuse-agent-env-scrub.sh
+++ b/scripts/hooks/preuse-agent-env-scrub.sh
@@ -59,56 +59,27 @@ schema_path = sys.argv[1]
 subagent_type = sys.argv[2]
 
 # ── Load schema ────────────────────────────────────────────────────────────────
+# PyYAML is the canonical reader for schema.yaml across the COO substrate
+# (coo-labs/coo-memory#1268). Fail-open on import error — the hook's posture
+# is fail-open on any missing dependency.
+try:
+    import yaml
+except ImportError as e:
+    print(f"FAIL_OPEN\tpyyaml-not-importable: {e}")
+    sys.exit(0)
+
 allowlist = []
 prefixes = []
 secret_vars = []
 
 try:
     with open(schema_path) as f:
-        content = f.read()
-
-    # Parse non_secret_env_allowlist
-    in_allowlist = False
-    for line in content.split('\n'):
-        stripped = line.lstrip()
-        if re.match(r'non_secret_env_allowlist\s*:', stripped):
-            in_allowlist = True
-            continue
-        if in_allowlist:
-            m = re.match(r'-\s+([A-Za-z_][A-Za-z0-9_]*)', stripped)
-            if m:
-                allowlist.append(m.group(1))
-            elif stripped and not stripped.startswith('#'):
-                in_allowlist = False
-
-    # Parse non_secret_env_prefixes
-    in_prefixes = False
-    for line in content.split('\n'):
-        stripped = line.lstrip()
-        if re.match(r'non_secret_env_prefixes\s*:', stripped):
-            in_prefixes = True
-            continue
-        if in_prefixes:
-            m = re.match(r'-\s+([A-Za-z_][A-Za-z0-9_]*)', stripped)
-            if m:
-                prefixes.append(m.group(1))
-            elif stripped and not stripped.startswith('#'):
-                in_prefixes = False
-
-    # Parse credentials[].env_aliases (secret vars — these must NOT cross)
-    in_env_aliases = False
-    for line in content.split('\n'):
-        stripped = line.lstrip()
-        if re.match(r'env_aliases\s*:', stripped):
-            in_env_aliases = True
-            continue
-        if in_env_aliases:
-            m = re.match(r'-\s+([A-Za-z_][A-Za-z0-9_]*)', stripped)
-            if m:
-                secret_vars.append(m.group(1))
-            elif stripped and not stripped.startswith('#'):
-                in_env_aliases = False
-
+        s = yaml.safe_load(f) or {}
+    allowlist = list(s.get('non_secret_env_allowlist', []) or [])
+    prefixes = list(s.get('non_secret_env_prefixes', []) or [])
+    for cred in s.get('credentials', []) or []:
+        for alias in cred.get('env_aliases', []) or []:
+            secret_vars.append(alias)
 except Exception as e:
     # Fail-open: no schema data loaded; allow spawn unmodified
     print(f"FAIL_OPEN\tschema-load-error: {e}")

--- a/scripts/lib/integrity-group-s.sh
+++ b/scripts/lib/integrity-group-s.sh
@@ -506,34 +506,28 @@ s_check_S5() {
   # Path is overridable via $VADE_S5_SETTINGS_JSON_OVERRIDE for test fixtures
   # (CI fake-env, integrity-group-s test harness); production uses the literal
   # /root path.
+  #
+  # The "what counts as non-secret" allowlist + prefix list are loaded from
+  # schema.yaml (canonical source per coo-labs/coo-memory#1268). No hardcoded
+  # copy lives here.
   local sj="${VADE_S5_SETTINGS_JSON_OVERRIDE:-/root/.claude/settings.json}"
+  local s5_allowlist_json s5_prefixes_json
+  s5_allowlist_json="$(yq -r '.non_secret_env_allowlist // [] | tojson' "$schema" 2>/dev/null)" || s5_allowlist_json='[]'
+  s5_prefixes_json="$(yq -r '.non_secret_env_prefixes // [] | tojson' "$schema" 2>/dev/null)" || s5_prefixes_json='[]'
   if [ -f "$sj" ] && command -v node >/dev/null 2>&1; then
     checks=$((checks + 1))
     local env_values
-    env_values="$(node -e '
+    env_values="$(VADE_S5_ALLOWLIST="$s5_allowlist_json" VADE_S5_PREFIXES="$s5_prefixes_json" node -e '
       const fs = require("fs");
       let c = {};
       try { c = JSON.parse(fs.readFileSync(process.argv[1], "utf8")) || {}; } catch { process.exit(0); }
       const env = c.env || {};
-      // Non-secret env vars per non_secret_env_allowlist: skip their values
-      // to avoid false positives (CLOUDFLARE_ACCOUNT_ID matches agentmail shape,
-      // PATH/NODE_PATH matches various patterns, etc.).
-      const nonSecretKeys = new Set([
-        "HOME","USER","PATH","LANG","LC_ALL","TERM","PWD",
-        "CLAUDE_PROJECT_DIR","VADE_CLOUD_STATE_DIR","VADE_RUNTIME_DIR","VADE_COO_MEMORY_DIR",
-        "GITHUB_APP_ID","VADE_COO_APP_ID","CLOUDFLARE_ACCOUNT_ID",
-        "GITHUB_APP_INSTALLATION_ID",
-        "NODE_PATH","PLAYWRIGHT_BROWSERS_PATH","UV_CACHE_DIR","PYTHONUSERBASE","VADE_BINDIR","VADE_BRAKE_ENFORCE","VADE_BRAKE_MANIFEST_SHA256",
-        "GIT_AUTHOR_NAME","GIT_AUTHOR_EMAIL","GIT_COMMITTER_NAME","GIT_COMMITTER_EMAIL",
-        "CLAUDE_STREAM_IDLE_TIMEOUT_MS","CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",
-        "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS","ENABLE_CLAUDEAI_MCP_SERVERS",
-      ]);
-      // Emit values of non-allowlist keys only
+      const allowlist = new Set(JSON.parse(process.env.VADE_S5_ALLOWLIST || "[]"));
+      const prefixes = JSON.parse(process.env.VADE_S5_PREFIXES || "[]");
       for (const [k, v] of Object.entries(env)) {
-        if (!nonSecretKeys.has(k) && !k.startsWith("CLAUDE_") && !k.startsWith("CLAUDE_CODE_")
-            && !k.startsWith("GIT_") && v && typeof v === "string") {
-          process.stdout.write(v + "\n");
-        }
+        if (allowlist.has(k)) continue;
+        if (prefixes.some(p => k.startsWith(p))) continue;
+        if (v && typeof v === "string") process.stdout.write(v + "\n");
       }
     ' "$sj" 2>/dev/null)"
     local found_in_settings=0


### PR DESCRIPTION
## Summary

Migrates two consumers of the "non-secret env vars" allowlist to read
from `coo-memory/operations/secrets/schema.yaml` as the canonical
source. Drops the last in-repo hardcoded copy.

## Changes

**S5 invariant** (`scripts/lib/integrity-group-s.sh`):

- Drops the hardcoded `nonSecretKeys = new Set([...])` JS Set
  (28 entries) and inline prefix guards
  (`!k.startsWith("CLAUDE_") && !k.startsWith("CLAUDE_CODE_") && !k.startsWith("GIT_")`).
- Loads `non_secret_env_allowlist` + `non_secret_env_prefixes` from
  schema.yaml via `yq -r '... | tojson'`. Passes both as JSON env vars
  into the node block, which builds a Set + prefix matcher at runtime.
- Same `yq`-based pattern as S2 / S3 in the same file.

**preuse-agent-env-scrub hook** (`scripts/hooks/preuse-agent-env-scrub.sh`):

- Replaces the ~60-line custom regex-based YAML parser with PyYAML
  (`yaml.safe_load`). Fail-open on `ImportError` matches the hook's
  existing fail-open posture on missing deps.
- S8 already uses PyYAML against the same schema, so the dependency is
  present in every COO container; no new runtime requirement.

## Why now

[MEMO-2026-06-06-bvqe](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-06-bvqe.md)
shipped `VADE_BRAKE_MANIFEST_SHA256` without registering it anywhere
— boot degraded because S5 + S8 disagreed. Fix in #526 +
coo-labs/coo-memory#1266 patched both sides. This PR (the consolidation
in coo-labs/coo-memory#1268) collapses the two sides into one source so
the next "register a new public-shape var" only needs a schema edit.

## Paired PR

- coo-labs/coo-memory: `secrets/schema: extend allowlist + prefixes for S5 consumer parity`

The schema-side PR adds the entries previously only in S5's hardcoded
copy (`GITHUB_APP_INSTALLATION_ID`, `PLAYWRIGHT_BROWSERS_PATH`,
`VADE_BINDIR`, `ENABLE_CLAUDEAI_MCP_SERVERS`, and the `GIT_` prefix).
With both PRs landed, S5 reads from schema with full parity to the
prior hardcoded behavior.

## Verification

```
VADE integrity: 34/34 OK
test-integrity-group-s.sh → 29 pass, 0 fail (S5 + S8 still green)
test-track2-env-scrub.sh   → 7 pass, 0 fail (warn / enforce / fail-open paths intact)
```

Closes coo-labs/coo-memory#1268 (paired with the coo-memory PR).

https://claude.ai/code/session_01KeGgm5kvvHfALen3D4gzm7