### PR TITLE
gh-pr-create: add --closes flag for invocation-time closing-keyword declaration

### DIFF
--- a/.claude/output-styles/coo.md
+++ b/.claude/output-styles/coo.md
@@ -27,7 +27,10 @@ These override harness defaults that would otherwise compete:
 
 2. **PR open is deliberate, not automatic.** Do not open a PR after every push. Multiple commits
    on a `claude/*` feature branch are normal. Open the PR when the change is review-ready, using
-   `coo-harness/scripts/gh-pr-create.sh` (runs the closing-keyword lint before submission).
+   `coo-harness/scripts/gh-pr-create.sh` (runs the closing-keyword lint before submission). Pass
+   `--closes <N|<owner>/<repo>#<N>|n/a>` to declare the closing target at invocation — the
+   wrapper appends the `Closes …` line so the lint passes on first call instead of failing
+   after the heredoc body is composed.
 
 3. **PR-watch auto-subscribes.** After `gh pr create`, the `auto-subscribe-pr.sh` PostToolUse
    hook wires up `mcp__github__subscribe_pr_activity` without prompting. Do not ask the user

--- a/scripts/ci/test-gh-pr-create.sh
+++ b/scripts/ci/test-gh-pr-create.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# test-gh-pr-create: smoke-test the PR-open wrapper, with focus on the
+# --closes flag added 2026-06-06 to eliminate the embed-in-body-then-
+# rediscover-in-lint loop.
+#
+# Strategy: shadow `gh` on PATH with a mock that dumps its argv, then
+# run the wrapper with various arg shapes and assert the closing-keyword
+# line lands where expected (or that validation/lint fails with exit 2
+# when expected).
+#
+# Run: bash scripts/ci/test-gh-pr-create.sh
+# Exit: 0 if all assertions pass, non-zero otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/../gh-pr-create.sh"
+
+[ -r "$WRAPPER" ] || { echo "FAIL: wrapper not found at $WRAPPER"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Minimal git repo so the wrapper's `git rev-parse` calls succeed.
+(
+  cd "$WORK"
+  git init -q
+  git config user.email t@t
+  git config user.name t
+  git remote add origin https://github.com/coo-labs/coo-harness.git
+)
+
+# Mock gh on PATH: dump argv one per line.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+i=0
+for a in "$@"; do
+  i=$((i+1))
+  printf 'ARG[%d]=%s\n' "$i" "$a"
+done
+EOF
+chmod 0755 "$WORK/bin/gh"
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+run_wrapper() {
+  (
+    cd "$WORK"
+    PATH="$WORK/bin:$PATH" bash "$WRAPPER" "$@" 2>&1
+  )
+  return $?
+}
+
+assert_pass_with_body_contains() {
+  local name="$1"; shift
+  local needle="$1"; shift
+  local out rc
+  out="$(run_wrapper "$@")" && rc=0 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    FAIL=$((FAIL+1)); FAILURES+=("$name")
+    printf '  FAIL  %s (exit=%d)\n' "$name" "$rc"
+    printf '%s\n' "$out" | sed 's/^/         /'
+    return
+  fi
+  if printf '%s' "$out" | grep -qF "$needle"; then
+    PASS=$((PASS+1))
+    printf '  PASS  %s\n' "$name"
+  else
+    FAIL=$((FAIL+1)); FAILURES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+    printf '         expected to contain: %s\n' "$needle"
+    printf '         got:\n%s\n' "$out" | sed 's/^/           /'
+  fi
+}
+
+assert_fail_with_exit_and_contains() {
+  local name="$1"; shift
+  local expected_rc="$1"; shift
+  local needle="$1"; shift
+  local out rc
+  out="$(run_wrapper "$@")" && rc=0 || rc=$?
+  if [ "$rc" -ne "$expected_rc" ]; then
+    FAIL=$((FAIL+1)); FAILURES+=("$name")
+    printf '  FAIL  %s (got exit=%d, expected=%d)\n' "$name" "$rc" "$expected_rc"
+    printf '%s\n' "$out" | sed 's/^/         /'
+    return
+  fi
+  if printf '%s' "$out" | grep -qF "$needle"; then
+    PASS=$((PASS+1))
+    printf '  PASS  %s\n' "$name"
+  else
+    FAIL=$((FAIL+1)); FAILURES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+    printf '         expected to contain: %s\n' "$needle"
+    printf '         got:\n%s\n' "$out" | sed 's/^/           /'
+  fi
+}
+
+echo "test-gh-pr-create: --closes flag and closing-keyword lint"
+
+assert_pass_with_body_contains \
+  "--closes <N> appends 'Closes #N'" \
+  "Closes #1234" \
+  --title "test" --body "doing a thing" --closes 1234
+
+assert_pass_with_body_contains \
+  "--closes n/a appends 'Closes: n/a'" \
+  "Closes: n/a" \
+  --title "test" --closes n/a
+
+assert_pass_with_body_contains \
+  "--closes <owner>/<repo>#<N> appends cross-repo form" \
+  "Closes coo-labs/coo-memory#42" \
+  --title "test" --body "foo" --closes coo-labs/coo-memory#42
+
+assert_pass_with_body_contains \
+  "--closes #N (leading hash) is normalized to bare N" \
+  "Closes #99" \
+  --title "test" --body "foo" --closes "#99"
+
+assert_pass_with_body_contains \
+  "--closes= form (equals syntax) works" \
+  "Closes #42" \
+  --title "test" --body "x" --closes=42
+
+echo "body from file" > "$WORK/bodyfile.md"
+assert_pass_with_body_contains \
+  "--body-file + --closes appends 'Closes #N'" \
+  "Closes #7" \
+  --title "test" --body-file "$WORK/bodyfile.md" --closes 7
+
+assert_pass_with_body_contains \
+  "--body-file content survives --closes append" \
+  "body from file" \
+  --title "test" --body-file "$WORK/bodyfile.md" --closes 7
+
+assert_pass_with_body_contains \
+  "embedded Closes + --closes both render (additive)" \
+  "Closes #1" \
+  --title "test" --body $'foo\nCloses #1' --closes 2
+
+assert_fail_with_exit_and_contains \
+  "--closes garbage fails validation with exit 2" \
+  2 \
+  "malformed" \
+  --title "test" --body "foo" --closes "not-a-thing"
+
+assert_fail_with_exit_and_contains \
+  "no --closes, no Closes line: lint fails with exit 2" \
+  2 \
+  "closing-keyword check FAILED" \
+  --title "test" --body "doing a thing"
+
+assert_pass_with_body_contains \
+  "embedded Closes #N alone (no --closes) passes lint" \
+  "Closes #5" \
+  --title "test" --body $'doing a thing\nCloses #5'
+
+assert_pass_with_body_contains \
+  "--skip-hygiene-check bypasses lint" \
+  "ARG[1]=pr" \
+  --title "test" --body "no closes anywhere" --skip-hygiene-check
+
+assert_pass_with_body_contains \
+  "session: title bypasses lint" \
+  "ARG[1]=pr" \
+  --title "session: log" --body "no closes"
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  printf 'test-gh-pr-create: %d passed\n' "$PASS"
+  exit 0
+fi
+printf 'test-gh-pr-create: %d passed, %d failed:\n' "$PASS" "$FAIL"
+for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f"; done
+exit 1

--- a/scripts/gh-pr-create.sh
+++ b/scripts/gh-pr-create.sh
@@ -18,7 +18,19 @@
 # rule (G1 fast-feedback, retirement criterion (d) defense-in-depth-perpetual;
 # coo-memory#1016, ci-strategy.md).
 #
-# Usage: identical to `gh pr create`. Adds one flag (with one back-compat alias):
+# Usage: identical to `gh pr create`. Adds two flags (plus one back-compat alias):
+#   --closes <N|owner/repo#N|n/a>   Append a closing-keyword line to the body
+#                                   (e.g. `--closes 1234` -> `Closes #1234`,
+#                                   `--closes coo-labs/coo-memory#42` ->
+#                                   `Closes coo-labs/coo-memory#42`,
+#                                   `--closes n/a` -> `Closes: n/a`). Lets
+#                                   callers declare what the PR resolves at
+#                                   invocation time, so the closing-keyword
+#                                   check passes without rewriting the body
+#                                   after lint discovery. If the body already
+#                                   carries a closing keyword the flag is
+#                                   additive (both lines render); the lint
+#                                   accepts either.
 #   --skip-hygiene-check            Bypass all three checks. Use only when the
 #   --skip-closing-keyword-check    workflow's exempt-class registry covers
 #                                   your case (see operations/issue-pr-hygiene.md
@@ -34,6 +46,7 @@ set -eu
 title=""
 body=""
 body_file=""
+closes_val=""
 skip_check=0
 pass_args=()
 
@@ -41,6 +54,18 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --skip-hygiene-check|--skip-closing-keyword-check)
       skip_check=1
+      shift
+      ;;
+    --closes)
+      if [ $# -lt 2 ]; then
+        echo "gh-pr-create: --closes requires a value (N | owner/repo#N | n/a)" >&2
+        exit 2
+      fi
+      closes_val="$2"
+      shift 2
+      ;;
+    --closes=*)
+      closes_val="${1#--closes=}"
       shift
       ;;
     --title)
@@ -55,22 +80,18 @@ while [ $# -gt 0 ]; do
       ;;
     --body)
       body="$2"
-      pass_args+=("$1" "$2")
       shift 2
       ;;
     --body=*)
       body="${1#--body=}"
-      pass_args+=("$1")
       shift
       ;;
     --body-file)
       body_file="$2"
-      pass_args+=("$1" "$2")
       shift 2
       ;;
     --body-file=*)
       body_file="${1#--body-file=}"
-      pass_args+=("$1")
       shift
       ;;
     *)
@@ -79,6 +100,68 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+# Resolve body content from --body or --body-file. Done before the cloud-proxy
+# block and the skip / session exec paths so a single re-injection of the
+# possibly-augmented body into pass_args covers every downstream branch.
+resolved_body=""
+if [ -n "$body" ]; then
+  resolved_body="$body"
+elif [ -n "$body_file" ]; then
+  if [ "$body_file" = "-" ]; then
+    echo "gh-pr-create: --body-file - (stdin) not supported by the lint;" >&2
+    echo "  use --body, a real file path, or --skip-hygiene-check." >&2
+    exit 2
+  fi
+  if [ ! -f "$body_file" ]; then
+    echo "gh-pr-create: --body-file '$body_file' not found" >&2
+    exit 2
+  fi
+  resolved_body="$(cat "$body_file")"
+fi
+
+# Process --closes: validate the value, build the closing-keyword line, append
+# to the body. Lets callers declare the closes target at invocation time so the
+# closing-keyword check passes without retry. Body-side `Closes …` keeps working
+# unchanged for callers that prefer to embed it themselves.
+if [ -n "$closes_val" ]; then
+  closes_line=""
+  case "$closes_val" in
+    n/a|N/A|n/A|N/a)
+      closes_line="Closes: n/a"
+      ;;
+    *)
+      if [[ "$closes_val" =~ ^#?[0-9]+$ ]]; then
+        closes_line="Closes #${closes_val#\#}"
+      elif [[ "$closes_val" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+$ ]]; then
+        closes_line="Closes ${closes_val}"
+      else
+        cat >&2 <<EOF
+gh-pr-create: --closes value '${closes_val}' is malformed.
+
+Expected one of:
+    --closes <N>                        same-repo, e.g. --closes 1234
+    --closes <owner>/<repo>#<N>         cross-repo, e.g. --closes coo-labs/coo-memory#1234
+    --closes n/a                        no issue resolved
+EOF
+        exit 2
+      fi
+      ;;
+  esac
+
+  if [ -n "$resolved_body" ]; then
+    resolved_body="${resolved_body}"$'\n\n'"${closes_line}"
+  else
+    resolved_body="${closes_line}"
+  fi
+fi
+
+# Re-inject --body into pass_args. Skipped when no body input was supplied so
+# the empty-body path still picks up .github/PULL_REQUEST_TEMPLATE.md (gh only
+# loads the template when neither --body nor --body-file is present on argv).
+if [ -n "$body" ] || [ -n "$body_file" ] || [ -n "$closes_val" ]; then
+  pass_args+=("--body" "$resolved_body")
+fi
 
 # Cloud-session compatibility (coo-labs/coo-memory#703, coo-memory#898). In cloud
 # sandboxes the git remote is a local-proxy URL of the form
@@ -134,23 +217,9 @@ if [[ "$title" == session:* ]]; then
   exec gh pr create "${pass_args[@]}"
 fi
 
-# Resolve body content for the checks. Title + body together, mirroring
-# the workflow's title-OR-body matching.
-resolved_body=""
-if [ -n "$body" ]; then
-  resolved_body="$body"
-elif [ -n "$body_file" ]; then
-  if [ "$body_file" = "-" ]; then
-    echo "gh-pr-create: --body-file - (stdin) not supported by the lint;" >&2
-    echo "  use --body, a real file path, or --skip-hygiene-check." >&2
-    exit 2
-  fi
-  if [ ! -f "$body_file" ]; then
-    echo "gh-pr-create: --body-file '$body_file' not found" >&2
-    exit 2
-  fi
-  resolved_body="$(cat "$body_file")"
-fi
+# Title + body together, mirroring the workflow's title-OR-body matching.
+# resolved_body is set above (possibly with a `Closes …` line appended from
+# --closes).
 content="$title"$'\n'"$resolved_body"
 
 # Check 1 — Closing-keyword regex (mirrors issue-pr-hygiene-reusable.yml
@@ -167,11 +236,15 @@ else
   cat >&2 <<'EOF'
 gh-pr-create: closing-keyword check FAILED.
 
-The PR body must include one of:
+Declare the closes target at invocation with --closes:
 
-    Closes #N                           (same-repo issue)
-    Closes coo-labs/<repo>#N            (cross-repo issue)
-    Closes: n/a                         (no issue resolved)
+    --closes <N>                        same-repo, appends `Closes #N`
+    --closes <owner>/<repo>#<N>         cross-repo, appends `Closes <owner>/<repo>#<N>`
+    --closes n/a                        no issue resolved, appends `Closes: n/a`
+
+Or embed one of these lines in --body / --body-file directly:
+
+    Closes #N                |    Closes coo-labs/<repo>#N    |    Closes: n/a
 
 The CI workflow `closing-keywords` will block merge without it. This
 lint runs locally because the PR template at


### PR DESCRIPTION
## What

`scripts/gh-pr-create.sh` now accepts `--closes <N|<owner>/<repo>#<N>|n/a>`. The wrapper validates the value, builds a `Closes …` line, and appends it to the body before running the existing closing-keyword lint.

## Why

The lint at `scripts/gh-pr-create.sh:160-188` runs locally to mirror the at-PR-open `closing-keywords` workflow. Agent sessions that compose PR bodies via heredoc routinely forget the `Closes` line, hit the lint, read the failure, then re-invoke with an amended body. Pattern recurred enough that Ven called it out as a fail-after-and-notify failure mode worth restructuring.

Option A (auto-fill missing `Closes: n/a` + warn) was considered and rejected: it would silently lose the moment-of-decision and let PRs that should link a real issue ship with `n/a`. Option B (this PR) keeps the discipline of "declare what you close" but moves it into the call signature so the lint passes on first call.

## Behavior

| Invocation | Appended line |
|---|---|
| `--closes 1234` | `Closes #1234` |
| `--closes #1234` | `Closes #1234` (hash stripped, canonicalized) |
| `--closes coo-labs/coo-memory#42` | `Closes coo-labs/coo-memory#42` |
| `--closes n/a` | `Closes: n/a` |
| `--closes=1234` | `Closes #1234` (equals form) |
| `--closes garbage` | exit 2 with malformed-value error |

If the body already carries a `Closes …` line, `--closes` is additive — both render. The lint accepts either source.

`--skip-hygiene-check` and the `session:` title-prefix exempt path are unchanged.

## Tests

New `scripts/ci/test-gh-pr-create.sh`, 13 assertions covering: the four closes shapes, equals form, body-file interaction, additive behavior, malformed-value rejection, lint-fail when no closes is declared anywhere, embedded-only path still works, `--skip-hygiene-check` bypass, and `session:` title bypass. Mocks `gh` on PATH and asserts the argv the wrapper would have exec'd. 13/13 pass locally.

## Companion

coo-labs/coo-memory PR on the same branch updates `operations/issue-pr-hygiene.md` §"Closing-keyword discipline" and the Enforcement Layers table to document the new flag.

Output-style note in `.claude/output-styles/coo.md` updated so future sessions see the flag in the standing PR-open override.

Closes: n/a

https://claude.ai/code/session_01LwEacdCPSoQZg8ax1B2fHu