### PR TITLE
lib/transcripts: render.py + port session-end-transcript-render Stop-hook

### DIFF
--- a/.github/workflows/lib-transcripts.yml
+++ b/.github/workflows/lib-transcripts.yml
@@ -8,10 +8,12 @@ on:
       - "scripts/transcript-url-backfill.py"
       - "scripts/transcript-rerender-v3-backfill.py"
       - "scripts/lifecycle/session-end-transcript-export.py"
+      - "scripts/lifecycle/session-end-transcript-render.py"
       - "scripts/ci/test-transcript-render-backfill.py"
       - "scripts/ci/test-transcript-url-backfill.py"
       - "scripts/ci/test-transcript-rerender-v3-backfill.py"
       - "scripts/ci/test-session-end-transcript-export.py"
+      - "scripts/ci/test-session-end-transcript-render.py"
       - "scripts/ci/test-lib-transcripts-parity.py"
       - "pyproject.toml"
       - ".github/workflows/lib-transcripts.yml"
@@ -23,10 +25,12 @@ on:
       - "scripts/transcript-url-backfill.py"
       - "scripts/transcript-rerender-v3-backfill.py"
       - "scripts/lifecycle/session-end-transcript-export.py"
+      - "scripts/lifecycle/session-end-transcript-render.py"
       - "scripts/ci/test-transcript-render-backfill.py"
       - "scripts/ci/test-transcript-url-backfill.py"
       - "scripts/ci/test-transcript-rerender-v3-backfill.py"
       - "scripts/ci/test-session-end-transcript-export.py"
+      - "scripts/ci/test-session-end-transcript-render.py"
       - "scripts/ci/test-lib-transcripts-parity.py"
       - "pyproject.toml"
       - ".github/workflows/lib-transcripts.yml"
@@ -74,3 +78,6 @@ jobs:
 
       - name: ported-script smoke (session-end-transcript-export)
         run: python3 scripts/ci/test-session-end-transcript-export.py
+
+      - name: ported-script smoke (session-end-transcript-render)
+        run: python3 scripts/ci/test-session-end-transcript-render.py

--- a/lib/transcripts/render.py
+++ b/lib/transcripts/render.py
@@ -1,0 +1,896 @@
+"""HTML rendering primitives for Claude Code transcripts.
+
+Pure-Python rendering core extracted from
+scripts/lifecycle/session-end-transcript-render.py per
+coo-labs/coo-memory#1147. Takes a list of jsonl entries → returns either
+the per-entry HTML strings or a full self-contained HTML document.
+
+No boto3, no R2, no filesystem coupling beyond the inputs. The orchestration
+(R2 PUT of html + sidecar, session-URL resolution from env/R2) stays in the
+Stop-hook script. compute_metadata and render_html accept session_url +
+url_source as inputs rather than resolving them internally — that's the
+primitive/orchestration split per the lib README.
+
+RENDERER_VERSION is the canonical version constant for the rendered sidecar
+shape (renderer_version field). Bump it when the rendered HTML or the
+compute_metadata output diverges in a way reconcile needs to detect.
+"""
+
+from __future__ import annotations
+
+import datetime
+import html
+import json
+from typing import Any
+
+from transcripts.jsonl import (
+    AUTO_NOTIFICATION_RES,
+    SYSTEM_REMINDER_RE,
+    classify,
+    is_auto_notification_user_entry,
+    strip_auto_notifications,
+)
+
+RENDERER_VERSION: int = 3
+
+# Re-export the regex constants so consumers don't have to reach into jsonl.
+__all__ = [
+    "AUTO_NOTIFICATION_RES",
+    "CSS",
+    "JS",
+    "RENDERER_VERSION",
+    "SYSTEM_REMINDER_RE",
+    "build_toc",
+    "compute_metadata",
+    "esc",
+    "first_line",
+    "format_elapsed",
+    "format_session_url",
+    "format_ts",
+    "json_pretty",
+    "render_assistant",
+    "render_attachment",
+    "render_html",
+    "render_meta",
+    "render_other",
+    "render_raw",
+    "render_text_with_reminders",
+    "render_thinking_entry",
+    "render_tool_result",
+    "render_user",
+    "tool_args_summary",
+    "tool_result_text",
+    "truncate",
+    "ts_to_dt",
+]
+
+
+# ---------------------------------------------------------------------------
+# Time + string formatting
+# ---------------------------------------------------------------------------
+
+
+def format_ts(ts: str | None) -> str:
+    if not ts:
+        return ""
+    try:
+        dt = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+    except (ValueError, TypeError):
+        return ts or ""
+
+
+def ts_to_dt(ts: str | None) -> datetime.datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def format_elapsed(prev: datetime.datetime | None, now: datetime.datetime | None) -> str:
+    _S_PER_MIN = 60
+    _S_PER_HOUR = 3600
+    if prev is None or now is None:
+        return ""
+    delta = (now - prev).total_seconds()
+    if delta < 0:
+        return ""
+    if delta < 1:
+        return "<1s"
+    if delta < _S_PER_MIN:
+        return f"{int(delta)}s"
+    if delta < _S_PER_HOUR:
+        return f"{int(delta // _S_PER_MIN)}m{int(delta % _S_PER_MIN):02d}s"
+    return f"{int(delta // _S_PER_HOUR)}h{int((delta % _S_PER_HOUR) // _S_PER_MIN):02d}m"
+
+
+def truncate(s: str, n: int) -> tuple[str, bool]:
+    """Return (head, was_truncated). Head has no trailing whitespace."""
+    if len(s) <= n:
+        return s, False
+    return s[:n].rstrip(), True
+
+
+def first_line(s: Any, max_len: int = 80) -> str:
+    if not isinstance(s, str):
+        s = "" if s is None else json_pretty(s)
+    first = s.lstrip().splitlines()[0] if s.strip() else ""
+    head, _ = truncate(first, max_len)
+    return head
+
+
+def esc(s: Any) -> str:
+    if s is None:
+        return ""
+    if not isinstance(s, str):
+        s = str(s)
+    return str(html.escape(s, quote=True))
+
+
+def json_pretty(obj: Any) -> str:
+    try:
+        return json.dumps(obj, indent=2, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return repr(obj)
+
+
+def format_session_url(remote_sid: str) -> str:
+    remote_sid = remote_sid.strip()
+    if not remote_sid:
+        return ""
+    if remote_sid.startswith("cse_"):
+        remote_sid = remote_sid[4:]
+    return f"https://claude.ai/code/session_{remote_sid}"
+
+
+# ---------------------------------------------------------------------------
+# Tool args / result helpers
+# ---------------------------------------------------------------------------
+
+
+def tool_args_summary(input_obj: dict[str, Any] | None) -> str:
+    if not isinstance(input_obj, dict) or not input_obj:
+        return ""
+    parts = []
+    for k, v in input_obj.items():
+        if isinstance(v, str):
+            head, trunc = truncate(v.replace("\n", " "), 60)
+            parts.append(f"{k}={head}" + ("…" if trunc else ""))
+        elif isinstance(v, (int, float, bool)) or v is None:
+            parts.append(f"{k}={v}")
+        else:
+            parts.append(f"{k}=…")
+    out, _ = truncate(" ".join(parts), 160)
+    return out
+
+
+def tool_result_text(content: Any) -> str:
+    """Tool result content can be a string, list of content blocks, or dict."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        chunks = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    chunks.append(block.get("text", ""))
+                elif block.get("type") == "image":
+                    chunks.append("[image]")
+                else:
+                    chunks.append(json_pretty(block))
+            else:
+                chunks.append(str(block))
+        return "\n".join(chunks)
+    return json_pretty(content)
+
+
+# ---------------------------------------------------------------------------
+# Per-entry rendering
+# ---------------------------------------------------------------------------
+
+
+def render_raw(entry: dict[str, Any]) -> str:
+    raw = esc(json_pretty(entry))
+    return (
+        '<details class="raw"><summary>Show raw JSON</summary>'
+        f'<pre class="raw-json">{raw}</pre></details>'
+    )
+
+
+def render_text_with_reminders(text: str) -> str:
+    """Split text into normal segments and folded system-reminder blocks."""
+    parts: list[str] = []
+    cursor = 0
+    for m in SYSTEM_REMINDER_RE.finditer(text):
+        prefix = text[cursor : m.start()]
+        if prefix.strip():
+            parts.append(f'<div class="text">{esc(prefix)}</div>')
+        body = m.group(1).strip()
+        head = first_line(body, 80)
+        parts.append(
+            '<details class="sysrem">'
+            f'<summary><span class="badge">system-reminder</span> '
+            f'<span class="preview">{esc(head)}</span></summary>'
+            f'<pre class="content">{esc(body)}</pre>'
+            "</details>"
+        )
+        cursor = m.end()
+    tail = text[cursor:]
+    if tail.strip():
+        parts.append(f'<div class="text">{esc(tail)}</div>')
+    if not parts:
+        return ""
+    return "\n".join(parts)
+
+
+def render_user(idx: int, entry: dict[str, Any], elapsed: str) -> str:
+    msg = entry.get("message", {}) or {}
+    content = msg.get("content")
+    if isinstance(content, list):
+        body_parts = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text":
+                body_parts.append(render_text_with_reminders(block.get("text", "")))
+            else:
+                body_parts.append(f'<pre class="content">{esc(json_pretty(block))}</pre>')
+        body = "\n".join(p for p in body_parts if p)
+    elif isinstance(content, str):
+        body = render_text_with_reminders(content)
+    else:
+        body = f'<pre class="content">{esc(json_pretty(content))}</pre>'
+
+    ts = format_ts(entry.get("timestamp"))
+    return (
+        f'<article class="entry user" id="entry-{idx}" data-role="user">'
+        f'<header><a class="anchor" href="#entry-{idx}">#{idx}</a>'
+        f'<span class="role-badge">user</span>'
+        f'<span class="ts">{esc(ts)}</span>'
+        f'<span class="elapsed">{esc(elapsed)}</span></header>'
+        f'<div class="body">{body}</div>'
+        f"{render_raw(entry)}"
+        "</article>"
+    )
+
+
+def render_assistant(idx: int, entry: dict[str, Any], elapsed: str) -> str:
+    msg = entry.get("message", {}) or {}
+    content = msg.get("content")
+    usage = msg.get("usage") or {}
+    parts: list[str] = []
+    has_error = False
+
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                parts.append(f'<div class="text">{esc(block.get("text", ""))}</div>')
+            elif btype == "thinking":
+                thinking = block.get("thinking", "") or ""
+                head = first_line(thinking, 80)
+                parts.append(
+                    '<details class="thinking">'
+                    f'<summary><span class="badge">thinking</span> '
+                    f'<span class="preview">{esc(head)}</span></summary>'
+                    f'<pre class="content">{esc(thinking)}</pre>'
+                    "</details>"
+                )
+            elif btype == "tool_use":
+                name = block.get("name", "?")
+                input_obj = block.get("input", {})
+                summary = tool_args_summary(input_obj)
+                args_pretty = json_pretty(input_obj)
+                parts.append(
+                    '<div class="tool-use">'
+                    f'<span class="badge tool">⚒ {esc(name)}</span>'
+                    f'<span class="tool-summary">{esc(summary)}</span>'
+                    '<details class="tool-args">'
+                    "<summary>args</summary>"
+                    f'<pre class="content">{esc(args_pretty)}</pre>'
+                    "</details>"
+                    "</div>"
+                )
+            else:
+                parts.append(f'<pre class="content">{esc(json_pretty(block))}</pre>')
+    elif isinstance(content, str):
+        parts.append(f'<div class="text">{esc(content)}</div>')
+
+    in_tok = usage.get("input_tokens")
+    out_tok = usage.get("output_tokens")
+    cache_read = usage.get("cache_read_input_tokens")
+    token_bits = []
+    if in_tok is not None:
+        token_bits.append(f"in {in_tok}")
+    if out_tok is not None:
+        token_bits.append(f"out {out_tok}")
+    if cache_read:
+        token_bits.append(f"cache {cache_read}")
+    token_badge = " · ".join(token_bits)
+
+    ts = format_ts(entry.get("timestamp"))
+    role_cls = "assistant"
+    return (
+        f'<article class="entry {role_cls}{" error" if has_error else ""}" '
+        f'id="entry-{idx}" data-role="assistant">'
+        f'<header><a class="anchor" href="#entry-{idx}">#{idx}</a>'
+        f'<span class="role-badge">assistant</span>'
+        f'<span class="ts">{esc(ts)}</span>'
+        f'<span class="elapsed">{esc(elapsed)}</span>'
+        f'<span class="tokens">{esc(token_badge)}</span></header>'
+        f'<div class="body">{"".join(parts)}</div>'
+        f"{render_raw(entry)}"
+        "</article>"
+    )
+
+
+def render_tool_result(idx: int, entry: dict[str, Any], elapsed: str) -> str:
+    msg = entry.get("message", {}) or {}
+    content = msg.get("content")
+    if not isinstance(content, list):
+        content = []
+
+    body_parts = []
+    has_error = False
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_result":
+            continue
+        is_err = bool(block.get("is_error"))
+        has_error = has_error or is_err
+        text = tool_result_text(block.get("content"))
+        line_count = text.count("\n") + 1 if text else 0
+        first = first_line(text, 80)
+        tool_use_id = block.get("tool_use_id", "")
+        body_parts.append(
+            '<div class="tool-result-block">'
+            f'<span class="badge result{" err" if is_err else ""}">'
+            f"{'ERROR' if is_err else 'result'}</span>"
+            f'<span class="preview">{esc(first)}</span>'
+            f'<span class="lines">{line_count} line{"s" if line_count != 1 else ""}</span>'
+            f'<span class="tuid">{esc(tool_use_id[:8])}</span>'
+            '<details class="tool-result-full">'
+            "<summary>full</summary>"
+            f'<pre class="content">{esc(text)}</pre>'
+            "</details>"
+            "</div>"
+        )
+
+    ts = format_ts(entry.get("timestamp"))
+    return (
+        f'<article class="entry tool-result{" error" if has_error else ""}" '
+        f'id="entry-{idx}" data-role="tool_result">'
+        f'<header><a class="anchor" href="#entry-{idx}">#{idx}</a>'
+        f'<span class="role-badge">tool result</span>'
+        f'<span class="ts">{esc(ts)}</span>'
+        f'<span class="elapsed">{esc(elapsed)}</span></header>'
+        f'<div class="body">{"".join(body_parts)}</div>'
+        f"{render_raw(entry)}"
+        "</article>"
+    )
+
+
+def render_attachment(idx: int, entry: dict[str, Any], elapsed: str) -> str:
+    att = entry.get("attachment", {}) or {}
+    hook_name = att.get("hookName") or att.get("hookEvent") or att.get("type") or "attachment"
+    raw_stdout = att.get("stdout")
+    stdout: str = raw_stdout if isinstance(raw_stdout, str) else ""
+    raw_stderr = att.get("stderr")
+    stderr: str = raw_stderr if isinstance(raw_stderr, str) else ""
+    content = att.get("content")
+    content_str = content if isinstance(content, str) else (json_pretty(content) if content else "")
+    exit_code = att.get("exitCode")
+    has_error = isinstance(exit_code, int) and exit_code != 0
+
+    preview = first_line(stdout or content_str or stderr, 80)
+    body = stdout + (("\nSTDERR:\n" + stderr) if stderr else "")
+    if content_str and content_str != stdout:
+        body = body + (("\n---\n" + content_str) if body else content_str)
+
+    ts = format_ts(entry.get("timestamp"))
+    return (
+        '<details class="entry attachment'
+        f'{" error" if has_error else ""}" id="entry-{idx}" data-role="attachment">'
+        '<summary><a class="anchor" href="#entry-{idx}">'.format(idx=idx)
+        + f"#{idx}</a>"
+        f'<span class="role-badge">attachment</span>'
+        f'<span class="hook-name">{esc(hook_name)}</span>'
+        f'<span class="preview">{esc(preview)}</span>'
+        f'<span class="ts">{esc(ts)}</span>'
+        f'<span class="elapsed">{esc(elapsed)}</span></summary>'
+        f'<pre class="content">{esc(body)}</pre>'
+        f"{render_raw(entry)}"
+        "</details>"
+    )
+
+
+def render_thinking_entry(idx: int, entry: dict[str, Any], elapsed: str) -> str:
+    """Assistant entry whose only content is thinking — render compact."""
+    return render_assistant(idx, entry, elapsed)
+
+
+def render_meta(idx: int, entry: dict[str, Any], elapsed: str) -> str:
+    t = entry.get("type") or "meta"
+    body = json_pretty(entry)
+    ts = format_ts(entry.get("timestamp"))
+    return (
+        f'<details class="entry meta" id="entry-{idx}" data-role="meta">'
+        f'<summary><a class="anchor" href="#entry-{idx}">#{idx}</a>'
+        f'<span class="role-badge">{esc(t)}</span>'
+        f'<span class="ts">{esc(ts)}</span>'
+        f'<span class="elapsed">{esc(elapsed)}</span></summary>'
+        f'<pre class="content">{esc(body)}</pre>'
+        "</details>"
+    )
+
+
+def render_other(idx: int, entry: dict[str, Any], elapsed: str) -> str:
+    return render_meta(idx, entry, elapsed)
+
+
+def build_toc(rendered_entries: list[tuple[int, str, str]]) -> str:
+    """Build the table-of-contents nav.
+
+    Each tuple is (idx, kind, preview). Only user turns get numbered list
+    entries; assistant turns appear underneath their preceding user turn
+    as sub-entries (visual hierarchy is the user-turn anchor).
+    """
+    items = []
+    user_n = 0
+    for idx, kind, preview in rendered_entries:
+        if kind == "user":
+            user_n += 1
+            label = f"{user_n}. {preview or '(empty)'}"
+            label_short, _ = truncate(label, 60)
+            items.append(f'<li><a href="#entry-{idx}">{esc(label_short)}</a></li>')
+    if not items:
+        items.append('<li><em class="muted">no user turns</em></li>')
+    return f'<nav class="toc"><h2>User turns</h2><ol>{"".join(items)}</ol></nav>'
+
+
+# ---------------------------------------------------------------------------
+# Metadata (sidecar) computation
+# ---------------------------------------------------------------------------
+
+
+def compute_metadata(
+    session_id: str,
+    entries: list[dict[str, Any]],
+    *,
+    session_url: str = "",
+    url_source: str = "",
+) -> dict[str, Any]:
+    """Walk entries once; return the metadata blob for the list-page sidecar.
+
+    Schema (renderer_version=RENDERER_VERSION):
+      session_id, started_at, ended_at, duration_seconds,
+      entry_count, user_turn_count, assistant_turn_count,
+      tool_call_count, error_count, first_user_preview,
+      first_user_uuid, session_url, renderer_version,
+      models (list of distinct model strings from assistant messages),
+      cwds (list of distinct cwd strings),
+      cc_version (last seen Claude Code client version),
+      url_source (omitted when empty — matches the renderer's prior
+      omit-when-falsy pattern).
+
+    `session_url` + `url_source` are inputs — resolution from env / R2
+    is orchestration and stays in the calling script.
+    """
+    first_ts: datetime.datetime | None = None
+    last_ts: datetime.datetime | None = None
+    user_count = 0
+    assistant_count = 0
+    tool_call_count = 0
+    error_count = 0
+    first_user_preview = ""
+    first_user_uuid = ""
+    models: list[str] = []
+    cwds: list[str] = []
+    cc_version = ""
+
+    def _add_unique(lst: list[str], val: str) -> None:
+        if val and val not in lst:
+            lst.append(val)
+
+    for entry in entries:
+        kind = classify(entry)
+        ts = ts_to_dt(entry.get("timestamp"))
+        if ts is not None:
+            if first_ts is None:
+                first_ts = ts
+            last_ts = ts
+        v = entry.get("version")
+        if isinstance(v, str) and v:
+            cc_version = v
+        cwd = entry.get("cwd")
+        if isinstance(cwd, str):
+            _add_unique(cwds, cwd)
+
+        if kind == "user":
+            if is_auto_notification_user_entry(entry):
+                # Webhook events / task notifications injected into the user
+                # slot aren't operator turns; don't count them.
+                pass
+            else:
+                user_count += 1
+                if not first_user_uuid:
+                    uuid = entry.get("uuid")
+                    if isinstance(uuid, str) and uuid:
+                        first_user_uuid = uuid
+                if not first_user_preview:
+                    msg = entry.get("message", {}) or {}
+                    content = msg.get("content")
+                    text = ""
+                    if isinstance(content, str):
+                        text = content
+                    elif isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, dict) and block.get("type") == "text":
+                                text = block.get("text", "")
+                                break
+                    text = strip_auto_notifications(text).strip()
+                    if text:
+                        first_user_preview = first_line(text, 140)
+        elif kind in ("assistant", "tool_use", "thinking"):
+            assistant_count += 1
+            msg = entry.get("message", {}) or {}
+            model = msg.get("model")
+            if isinstance(model, str):
+                _add_unique(models, model)
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        tool_call_count += 1
+        elif kind == "tool_result":
+            msg = entry.get("message", {}) or {}
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if (
+                        isinstance(block, dict)
+                        and block.get("type") == "tool_result"
+                        and block.get("is_error")
+                    ):
+                        error_count += 1
+        elif kind == "attachment":
+            att = entry.get("attachment", {}) or {}
+            exit_code = att.get("exitCode")
+            if isinstance(exit_code, int) and exit_code != 0:
+                error_count += 1
+
+    duration_seconds = 0
+    if first_ts is not None and last_ts is not None:
+        duration_seconds = max(0, int((last_ts - first_ts).total_seconds()))
+
+    metadata: dict[str, Any] = {
+        "session_id": session_id,
+        "started_at": first_ts.isoformat() if first_ts else None,
+        "ended_at": last_ts.isoformat() if last_ts else None,
+        "duration_seconds": duration_seconds,
+        "entry_count": len(entries),
+        "user_turn_count": user_count,
+        "assistant_turn_count": assistant_count,
+        "tool_call_count": tool_call_count,
+        "error_count": error_count,
+        "first_user_preview": first_user_preview,
+        "first_user_uuid": first_user_uuid,
+        "models": models,
+        "cwds": cwds,
+        "cc_version": cc_version,
+        "session_url": session_url,
+        "renderer_version": RENDERER_VERSION,
+    }
+    if url_source:
+        metadata["url_source"] = url_source
+    return metadata
+
+
+# ---------------------------------------------------------------------------
+# Document assembly
+# ---------------------------------------------------------------------------
+
+
+CSS = """
+:root {
+  --bg: #0d1117; --panel: #161b22; --border: #30363d; --fg: #e6edf3;
+  --muted: #8b949e; --accent: #58a6ff; --user: #79c0ff; --assistant: #d2a8ff;
+  --tool: #7ee787; --system: #8b949e; --error: #ff7b72;
+  --warning: #d29922;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #ffffff; --panel: #f6f8fa; --border: #d0d7de; --fg: #1f2328;
+    --muted: #656d76; --accent: #0969da; --user: #0969da; --assistant: #8250df;
+    --tool: #1a7f37; --system: #656d76; --error: #cf222e;
+  }
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui,
+    sans-serif; font-size: 14px; line-height: 1.5; }
+body { display: grid; grid-template-columns: minmax(220px, 280px) 1fr;
+  min-height: 100vh; }
+nav.toc { position: sticky; top: 0; align-self: start; max-height: 100vh;
+  overflow-y: auto; padding: 16px; border-right: 1px solid var(--border);
+  background: var(--panel); font-size: 12px; }
+nav.toc h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em;
+  margin: 0 0 12px 0; color: var(--muted); }
+nav.toc ol { list-style: none; margin: 0; padding: 0; }
+nav.toc li { margin: 0 0 6px 0; }
+nav.toc a { color: var(--fg); text-decoration: none; display: block;
+  padding: 4px 6px; border-radius: 4px; }
+nav.toc a:hover { background: var(--bg); }
+main { padding: 16px 24px; min-width: 0; max-width: 100%; }
+p.back { margin: 0 0 8px 0; font-size: 12px; }
+p.back a { color: var(--muted); text-decoration: none; }
+p.back a:hover { color: var(--accent); }
+header.session { padding-bottom: 16px; border-bottom: 1px solid var(--border);
+  margin-bottom: 16px; }
+header.session h1 { margin: 0 0 4px 0; font-size: 18px; font-family: ui-monospace,
+  SFMono-Regular, Menlo, monospace; }
+header.session .meta { color: var(--muted); font-size: 12px; }
+.controls { display: flex; flex-wrap: wrap; gap: 8px; margin: 12px 0 24px;
+  align-items: center; }
+.controls input[type=search] { flex: 1 1 200px; background: var(--panel);
+  border: 1px solid var(--border); color: var(--fg); padding: 6px 10px;
+  border-radius: 6px; font: inherit; }
+.controls button { background: var(--panel); border: 1px solid var(--border);
+  color: var(--fg); padding: 6px 10px; border-radius: 6px; font: inherit;
+  cursor: pointer; }
+.controls button.active { background: var(--accent); color: var(--bg);
+  border-color: var(--accent); }
+.entry { margin: 0 0 14px 0; padding: 10px 12px; border: 1px solid var(--border);
+  border-left: 3px solid var(--system); border-radius: 6px; background: var(--panel); }
+.entry.user { border-left-color: var(--user); }
+.entry.assistant { border-left-color: var(--assistant); }
+.entry.tool-result { border-left-color: var(--tool); }
+.entry.attachment { border-left-color: var(--system); }
+.entry.meta { border-left-color: var(--system); opacity: 0.85; }
+.entry.error { border-left-color: var(--error); }
+.entry > header, .entry > summary { display: flex; flex-wrap: wrap; gap: 10px;
+  align-items: center; font-size: 12px; color: var(--muted); cursor: default; }
+.entry > summary { cursor: pointer; list-style: none; }
+.entry > summary::-webkit-details-marker { display: none; }
+.entry > summary::before { content: "▸"; color: var(--muted); width: 8px;
+  display: inline-block; transition: transform 0.1s; }
+.entry[open] > summary::before { transform: rotate(90deg); }
+.anchor { color: var(--muted); text-decoration: none; font-family: ui-monospace,
+  monospace; min-width: 32px; }
+.anchor:hover { color: var(--accent); }
+.role-badge { background: var(--bg); padding: 2px 6px; border-radius: 3px;
+  font-weight: 600; font-size: 11px; text-transform: uppercase;
+  letter-spacing: 0.03em; }
+.ts, .elapsed, .tokens, .hook-name, .tuid, .lines { font-family: ui-monospace,
+  monospace; font-size: 11px; color: var(--muted); }
+.elapsed::before { content: "+"; }
+.body { margin-top: 8px; }
+.text { white-space: pre-wrap; word-wrap: break-word; margin: 6px 0; }
+.entry pre.content, pre.raw-json { background: var(--bg); border: 1px solid var(--border);
+  border-radius: 4px; padding: 8px 10px; overflow-x: auto; font-family: ui-monospace,
+  monospace; font-size: 12px; white-space: pre-wrap; word-wrap: break-word;
+  max-width: 100%; margin: 6px 0; }
+details.sysrem, details.thinking, details.tool-args, details.tool-result-full,
+details.raw { margin: 6px 0; }
+details.sysrem > summary, details.thinking > summary, details.tool-args > summary,
+details.tool-result-full > summary, details.raw > summary {
+  cursor: pointer; color: var(--muted); font-size: 12px; list-style: none;
+  display: flex; gap: 8px; align-items: center; }
+details > summary::-webkit-details-marker { display: none; }
+details > summary::before { content: "▸"; width: 8px; display: inline-block;
+  color: var(--muted); transition: transform 0.1s; }
+details[open] > summary::before { transform: rotate(90deg); }
+.badge { background: var(--bg); padding: 2px 6px; border-radius: 3px;
+  font-size: 11px; font-weight: 600; }
+.badge.tool { color: var(--tool); }
+.badge.result { color: var(--tool); }
+.badge.result.err { color: var(--error); }
+.preview { color: var(--muted); font-family: ui-monospace, monospace;
+  font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  max-width: 60ch; }
+.tool-use { display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline;
+  margin: 4px 0; }
+.tool-summary { color: var(--fg); font-family: ui-monospace, monospace;
+  font-size: 12px; overflow-wrap: anywhere; }
+.tool-result-block { margin: 6px 0; padding: 6px 8px; background: var(--bg);
+  border-radius: 4px; }
+.tool-result-block > * { display: inline-block; vertical-align: middle;
+  margin-right: 8px; }
+.hide-attachment .entry.attachment { display: none; }
+.hide-tool-result .entry.tool-result { display: none; }
+.hide-meta .entry.meta { display: none; }
+.only-conversation .entry:not(.user):not(.assistant) { display: none; }
+mark.search-hit { background: var(--warning); color: var(--bg); }
+@media (max-width: 768px) {
+  body { grid-template-columns: 1fr; }
+  nav.toc { position: static; max-height: 280px; border-right: none;
+    border-bottom: 1px solid var(--border); }
+}
+"""
+
+JS = """
+(function(){
+  const main = document.querySelector('main');
+  const search = document.getElementById('search-box');
+  const buttons = document.querySelectorAll('.controls button[data-toggle]');
+  buttons.forEach(b => b.addEventListener('click', () => {
+    b.classList.toggle('active');
+    document.body.classList.toggle(b.dataset.toggle, b.classList.contains('active'));
+  }));
+  let timer;
+  search.addEventListener('input', () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => runSearch(search.value.trim()), 150);
+  });
+  function runSearch(q) {
+    // Clear previous highlights.
+    document.querySelectorAll('mark.search-hit').forEach(m => {
+      const t = document.createTextNode(m.textContent);
+      m.parentNode.replaceChild(t, m);
+    });
+    document.querySelectorAll('.entry').forEach(e => e.style.display = '');
+    if (!q) return;
+    const ql = q.toLowerCase();
+    const entries = document.querySelectorAll('.entry');
+    entries.forEach(e => {
+      const text = e.textContent.toLowerCase();
+      if (text.indexOf(ql) === -1) {
+        e.style.display = 'none';
+      } else {
+        // expand any closed <details> inside so the match is visible
+        e.querySelectorAll('details').forEach(d => d.open = true);
+        if (e.tagName === 'DETAILS') e.open = true;
+        highlight(e, q);
+      }
+    });
+  }
+  function highlight(root, q) {
+    const ql = q.toLowerCase();
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: n => n.parentElement.closest('script,style,mark') ? NodeFilter.FILTER_REJECT
+        : n.nodeValue.toLowerCase().indexOf(ql) !== -1 ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_SKIP
+    });
+    const nodes = [];
+    while (walker.nextNode()) nodes.push(walker.currentNode);
+    nodes.forEach(n => {
+      const v = n.nodeValue, lv = v.toLowerCase();
+      const frag = document.createDocumentFragment();
+      let i = 0;
+      while (i < v.length) {
+        const j = lv.indexOf(ql, i);
+        if (j === -1) { frag.appendChild(document.createTextNode(v.slice(i))); break; }
+        if (j > i) frag.appendChild(document.createTextNode(v.slice(i, j)));
+        const mark = document.createElement('mark');
+        mark.className = 'search-hit';
+        mark.textContent = v.slice(j, j + q.length);
+        frag.appendChild(mark);
+        i = j + q.length;
+      }
+      n.parentNode.replaceChild(frag, n);
+    });
+  }
+  const jumpErr = document.getElementById('jump-error');
+  if (jumpErr) jumpErr.addEventListener('click', () => {
+    const e = document.querySelector('.entry.error');
+    if (e) { e.scrollIntoView({block:'start'}); if (e.tagName==='DETAILS') e.open = true; }
+  });
+})();
+"""
+
+
+def render_html(
+    session_id: str,
+    entries: list[dict[str, Any]],
+    *,
+    session_url: str = "",
+) -> str:
+    """Render entries into a self-contained HTML document.
+
+    `session_url` is an input; resolution from env / R2 is orchestration and
+    stays in the calling script.
+    """
+    rendered: list[str] = []
+    toc_entries: list[tuple[int, str, str]] = []
+    prev_ts: datetime.datetime | None = None
+    first_ts: datetime.datetime | None = None
+    last_ts: datetime.datetime | None = None
+    error_count = 0
+
+    for i, entry in enumerate(entries):
+        kind = classify(entry)
+        now_ts = ts_to_dt(entry.get("timestamp"))
+        if now_ts is not None:
+            if first_ts is None:
+                first_ts = now_ts
+            last_ts = now_ts
+        elapsed = format_elapsed(prev_ts, now_ts)
+        if now_ts is not None:
+            prev_ts = now_ts
+
+        preview = ""
+        is_auto_user = kind == "user" and is_auto_notification_user_entry(entry)
+        if kind == "user" and not is_auto_user:
+            msg = entry.get("message", {}) or {}
+            content = msg.get("content")
+            if isinstance(content, str):
+                preview = first_line(strip_auto_notifications(content), 60)
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        preview = first_line(strip_auto_notifications(block.get("text", "")), 60)
+                        break
+
+        if kind == "user":
+            html_chunk = render_user(i, entry, elapsed)
+        elif kind == "assistant":
+            html_chunk = render_assistant(i, entry, elapsed)
+        elif kind == "thinking":
+            html_chunk = render_thinking_entry(i, entry, elapsed)
+        elif kind == "tool_use":
+            html_chunk = render_assistant(i, entry, elapsed)
+        elif kind == "tool_result":
+            html_chunk = render_tool_result(i, entry, elapsed)
+        elif kind == "attachment":
+            html_chunk = render_attachment(i, entry, elapsed)
+        elif kind == "meta":
+            html_chunk = render_meta(i, entry, elapsed)
+        else:
+            html_chunk = render_other(i, entry, elapsed)
+
+        if 'class="entry' in html_chunk and " error" in html_chunk.split(">", 1)[0]:
+            error_count += 1
+
+        rendered.append(html_chunk)
+        # Auto-notification user entries don't get a TOC slot — but they
+        # still render as entries (raw form remains scrollable / Find-able).
+        toc_entries.append((i, "auto_user" if is_auto_user else kind, preview))
+
+    toc = build_toc(toc_entries)
+    duration = format_elapsed(first_ts, last_ts) or "—"
+    started = format_ts(first_ts.isoformat() if first_ts else None) or "—"
+    entry_count = len(entries)
+    user_count = sum(1 for _, k, _ in toc_entries if k == "user")
+    assistant_count = sum(1 for _, k, _ in toc_entries if k == "assistant")
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Transcript {esc(session_id)}</title>
+<style>{CSS}</style>
+</head>
+<body>
+{toc}
+<main>
+  <p class="back"><a href="/transcripts/">← All transcripts</a>{(' &nbsp;·&nbsp; <a href="' + esc(session_url) + '" target="_blank" rel="noopener">Open in Claude Code ↗</a> &nbsp;·&nbsp; <a href="/sessions/' + esc(session_url.rsplit("/session_", 1)[-1]) + '">GitHub artifacts ↗</a>') if session_url else ""}</p>
+  <header class="session">
+    <h1>{esc(session_id)}</h1>
+    <div class="meta">
+      started {esc(started)} · duration {esc(duration)} ·
+      {entry_count} entries ({user_count} user, {assistant_count} assistant) ·
+      {error_count} error{"" if error_count == 1 else "s"}
+    </div>
+  </header>
+  <div class="controls">
+    <input type="search" id="search-box" placeholder="Search transcript..." autocomplete="off">
+    <button data-toggle="hide-attachment">Hide attachments</button>
+    <button data-toggle="hide-tool-result">Hide tool results</button>
+    <button data-toggle="hide-meta">Hide meta</button>
+    <button data-toggle="only-conversation">Only user + assistant</button>
+    <button id="jump-error">Jump to first error</button>
+  </div>
+  <div class="entries">
+    {"".join(rendered)}
+  </div>
+</main>
+<script>{JS}</script>
+</body>
+</html>
+"""

--- a/lib/transcripts/tests/test_render.py
+++ b/lib/transcripts/tests/test_render.py
@@ -1,0 +1,560 @@
+"""Tests for lib/transcripts/render.py."""
+
+from __future__ import annotations
+
+import datetime
+
+from transcripts.render import (
+    CSS,
+    JS,
+    RENDERER_VERSION,
+    build_toc,
+    compute_metadata,
+    esc,
+    first_line,
+    format_elapsed,
+    format_session_url,
+    format_ts,
+    json_pretty,
+    render_assistant,
+    render_attachment,
+    render_html,
+    render_meta,
+    render_text_with_reminders,
+    render_tool_result,
+    render_user,
+    tool_args_summary,
+    tool_result_text,
+    truncate,
+    ts_to_dt,
+)
+
+# ---------------------------------------------------------------------------
+# Time + string formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_ts_iso() -> None:
+    assert format_ts("2026-06-06T12:34:56Z") == "2026-06-06 12:34:56 UTC"
+
+
+def test_format_ts_empty() -> None:
+    assert format_ts(None) == ""
+    assert format_ts("") == ""
+
+
+def test_format_ts_malformed() -> None:
+    assert format_ts("not-a-timestamp") == "not-a-timestamp"
+
+
+def test_ts_to_dt_iso() -> None:
+    dt = ts_to_dt("2026-06-06T12:34:56Z")
+    assert dt is not None
+    assert dt.year == 2026 and dt.month == 6 and dt.day == 6
+
+
+def test_ts_to_dt_empty() -> None:
+    assert ts_to_dt(None) is None
+    assert ts_to_dt("") is None
+
+
+def test_format_elapsed_seconds() -> None:
+    t0 = datetime.datetime(2026, 6, 6, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    t1 = datetime.datetime(2026, 6, 6, 0, 0, 5, tzinfo=datetime.timezone.utc)
+    assert format_elapsed(t0, t1) == "5s"
+
+
+def test_format_elapsed_minutes() -> None:
+    t0 = datetime.datetime(2026, 6, 6, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    t1 = datetime.datetime(2026, 6, 6, 0, 5, 30, tzinfo=datetime.timezone.utc)
+    assert format_elapsed(t0, t1) == "5m30s"
+
+
+def test_format_elapsed_hours() -> None:
+    t0 = datetime.datetime(2026, 6, 6, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    t1 = datetime.datetime(2026, 6, 6, 2, 15, 0, tzinfo=datetime.timezone.utc)
+    assert format_elapsed(t0, t1) == "2h15m"
+
+
+def test_format_elapsed_sub_second() -> None:
+    t0 = datetime.datetime(2026, 6, 6, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    t1 = datetime.datetime(2026, 6, 6, 0, 0, 0, 500000, tzinfo=datetime.timezone.utc)
+    assert format_elapsed(t0, t1) == "<1s"
+
+
+def test_format_elapsed_none() -> None:
+    assert format_elapsed(None, None) == ""
+    t = datetime.datetime(2026, 6, 6, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    assert format_elapsed(None, t) == ""
+    assert format_elapsed(t, None) == ""
+
+
+def test_format_elapsed_negative() -> None:
+    t0 = datetime.datetime(2026, 6, 6, 0, 0, 10, tzinfo=datetime.timezone.utc)
+    t1 = datetime.datetime(2026, 6, 6, 0, 0, 5, tzinfo=datetime.timezone.utc)
+    assert format_elapsed(t0, t1) == ""
+
+
+def test_truncate_short() -> None:
+    assert truncate("hello", 10) == ("hello", False)
+
+
+def test_truncate_long() -> None:
+    assert truncate("hello world", 5) == ("hello", True)
+
+
+def test_truncate_trims_trailing_whitespace() -> None:
+    assert truncate("hi   ", 4) == ("hi", True)
+
+
+def test_first_line_short() -> None:
+    assert first_line("hello world") == "hello world"
+
+
+def test_first_line_multiline() -> None:
+    assert first_line("line one\nline two") == "line one"
+
+
+def test_first_line_non_str() -> None:
+    assert first_line(None) == ""
+    assert first_line({"a": 1}) in ("{", '{"a": 1}')
+
+
+def test_first_line_truncates() -> None:
+    assert first_line("x" * 200, max_len=10) == "xxxxxxxxxx"
+
+
+def test_esc_html() -> None:
+    assert esc("<b>x</b>") == "&lt;b&gt;x&lt;/b&gt;"
+
+
+def test_esc_none() -> None:
+    assert esc(None) == ""
+
+
+def test_esc_non_str() -> None:
+    assert esc(42) == "42"
+
+
+def test_json_pretty_dict() -> None:
+    out = json_pretty({"a": 1})
+    assert '"a"' in out and "1" in out
+
+
+def test_json_pretty_unencodable() -> None:
+    # Unencodable inputs (non-JSON-serializable) fall back to repr.
+    class Weird:
+        def __repr__(self) -> str:
+            return "<weird>"
+
+    assert json_pretty(Weird()) == "<weird>"
+
+
+def test_format_session_url_plain() -> None:
+    assert format_session_url("abc") == "https://claude.ai/code/session_abc"
+
+
+def test_format_session_url_cse_prefix() -> None:
+    assert format_session_url("cse_xyz") == "https://claude.ai/code/session_xyz"
+
+
+def test_format_session_url_empty() -> None:
+    assert format_session_url("") == ""
+    assert format_session_url("   ") == ""
+
+
+# ---------------------------------------------------------------------------
+# Tool args / result
+# ---------------------------------------------------------------------------
+
+
+def test_tool_args_summary_empty() -> None:
+    assert tool_args_summary(None) == ""
+    assert tool_args_summary({}) == ""
+
+
+def test_tool_args_summary_basic() -> None:
+    out = tool_args_summary({"a": "hello", "b": 1, "c": True, "d": [1, 2]})
+    assert "a=hello" in out
+    assert "b=1" in out
+    assert "c=True" in out
+    assert "d=…" in out
+
+
+def test_tool_args_summary_truncates_long_string() -> None:
+    out = tool_args_summary({"k": "x" * 200})
+    assert "…" in out
+
+
+def test_tool_result_text_string() -> None:
+    assert tool_result_text("hi") == "hi"
+
+
+def test_tool_result_text_blocks() -> None:
+    blocks = [
+        {"type": "text", "text": "alpha"},
+        {"type": "image"},
+        {"type": "weird", "k": 1},
+    ]
+    out = tool_result_text(blocks)
+    assert "alpha" in out and "[image]" in out and "weird" in out
+
+
+def test_tool_result_text_dict() -> None:
+    out = tool_result_text({"k": 1})
+    assert '"k"' in out
+
+
+# ---------------------------------------------------------------------------
+# Per-entry rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_user_string_content() -> None:
+    out = render_user(
+        0,
+        {"message": {"content": "hello"}, "timestamp": "2026-06-06T00:00:00Z"},
+        elapsed="",
+    )
+    assert "entry-0" in out
+    assert "user" in out
+    assert "hello" in out
+
+
+def test_render_user_list_content_with_text_block() -> None:
+    out = render_user(
+        1,
+        {
+            "message": {
+                "content": [{"type": "text", "text": "<b>x</b>"}],
+            },
+            "timestamp": "2026-06-06T00:00:00Z",
+        },
+        elapsed="2s",
+    )
+    assert "&lt;b&gt;" in out
+    assert "+" not in out or "2s" in out  # elapsed badge is decorated
+
+
+def test_render_user_with_system_reminder() -> None:
+    out = render_user(
+        2,
+        {"message": {"content": "<system-reminder>secret</system-reminder>after"}},
+        elapsed="",
+    )
+    assert "system-reminder" in out
+    assert "secret" in out
+    assert "after" in out
+
+
+def test_render_assistant_text() -> None:
+    out = render_assistant(
+        3,
+        {
+            "message": {
+                "content": [{"type": "text", "text": "hi"}],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+            "timestamp": "2026-06-06T00:00:00Z",
+        },
+        elapsed="",
+    )
+    assert "assistant" in out
+    assert "in 10" in out and "out 5" in out
+    assert "hi" in out
+
+
+def test_render_assistant_thinking() -> None:
+    out = render_assistant(
+        4,
+        {
+            "message": {
+                "content": [{"type": "thinking", "thinking": "reasoning"}],
+            }
+        },
+        elapsed="",
+    )
+    assert "thinking" in out
+    assert "reasoning" in out
+
+
+def test_render_assistant_tool_use() -> None:
+    out = render_assistant(
+        5,
+        {
+            "message": {
+                "content": [{"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}]
+            }
+        },
+        elapsed="",
+    )
+    assert "Bash" in out
+    assert "command=ls" in out
+
+
+def test_render_tool_result_basic() -> None:
+    out = render_tool_result(
+        6,
+        {
+            "message": {
+                "content": [{"type": "tool_result", "content": "output", "tool_use_id": "abcd1234"}]
+            }
+        },
+        elapsed="",
+    )
+    assert "tool_result" in out or "tool-result" in out
+    assert "output" in out
+    assert "abcd1234" in out or "abcd1234"[:8] in out
+
+
+def test_render_tool_result_error() -> None:
+    out = render_tool_result(
+        7,
+        {
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "content": "boom",
+                        "is_error": True,
+                        "tool_use_id": "x",
+                    }
+                ]
+            }
+        },
+        elapsed="",
+    )
+    assert "ERROR" in out
+    assert "error" in out
+
+
+def test_render_attachment_with_exit_code() -> None:
+    out = render_attachment(
+        8,
+        {
+            "attachment": {
+                "hookName": "pre-tool",
+                "stdout": "ok",
+                "stderr": "warn",
+                "exitCode": 1,
+            }
+        },
+        elapsed="",
+    )
+    assert "pre-tool" in out
+    assert " error" in out
+    assert "ok" in out
+    assert "STDERR" in out
+
+
+def test_render_meta_summary() -> None:
+    out = render_meta(9, {"type": "summary", "seq": 1}, "")
+    assert "summary" in out
+    assert "seq" in out
+
+
+def test_render_text_with_reminders_no_reminder() -> None:
+    out = render_text_with_reminders("plain text")
+    assert "plain text" in out
+
+
+def test_render_text_with_reminders_only_whitespace() -> None:
+    assert render_text_with_reminders("") == ""
+    assert render_text_with_reminders("   ") == ""
+
+
+# ---------------------------------------------------------------------------
+# TOC
+# ---------------------------------------------------------------------------
+
+
+def test_build_toc_no_users() -> None:
+    out = build_toc([(0, "assistant", "")])
+    assert "no user turns" in out
+
+
+def test_build_toc_user_turns() -> None:
+    out = build_toc([(0, "user", "first"), (1, "assistant", ""), (2, "user", "second")])
+    assert "1. first" in out
+    assert "2. second" in out
+    assert "entry-0" in out
+    assert "entry-2" in out
+
+
+# ---------------------------------------------------------------------------
+# compute_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_compute_metadata_empty_entries() -> None:
+    md = compute_metadata("sid", [])
+    assert md["session_id"] == "sid"
+    assert md["entry_count"] == 0
+    assert md["user_turn_count"] == 0
+    assert md["assistant_turn_count"] == 0
+    assert md["renderer_version"] == RENDERER_VERSION
+    assert md["session_url"] == ""
+    assert "url_source" not in md
+
+
+def test_compute_metadata_basic_counts() -> None:
+    entries = [
+        {
+            "type": "user",
+            "uuid": "u1",
+            "message": {"content": "hello"},
+            "timestamp": "2026-06-06T00:00:00Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "hi"},
+                    {"type": "tool_use", "name": "Bash", "input": {}},
+                ],
+                "model": "claude-opus-4-7",
+            },
+            "timestamp": "2026-06-06T00:00:10Z",
+        },
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "content": "ok",
+                        "is_error": False,
+                    }
+                ]
+            },
+            "timestamp": "2026-06-06T00:00:20Z",
+        },
+    ]
+    md = compute_metadata(
+        "sid", entries, session_url="https://claude.ai/code/session_x", url_source="env-recovery"
+    )
+    assert md["user_turn_count"] == 1
+    assert md["assistant_turn_count"] == 1
+    assert md["tool_call_count"] == 1
+    assert md["error_count"] == 0
+    assert md["first_user_preview"] == "hello"
+    assert md["first_user_uuid"] == "u1"
+    assert md["models"] == ["claude-opus-4-7"]
+    assert md["session_url"] == "https://claude.ai/code/session_x"
+    assert md["url_source"] == "env-recovery"
+    assert md["duration_seconds"] == 20
+
+
+def test_compute_metadata_skips_auto_notification_user_entries() -> None:
+    entries = [
+        {
+            "type": "user",
+            "message": {"content": "<github-webhook-activity>x</github-webhook-activity>"},
+        },
+        {
+            "type": "user",
+            "message": {"content": "real user message"},
+        },
+    ]
+    md = compute_metadata("sid", entries)
+    assert md["user_turn_count"] == 1
+    assert md["first_user_preview"] == "real user message"
+
+
+def test_compute_metadata_error_count_from_tool_result() -> None:
+    entries = [
+        {
+            "type": "user",
+            "message": {"content": [{"type": "tool_result", "content": "x", "is_error": True}]},
+        }
+    ]
+    md = compute_metadata("sid", entries)
+    assert md["error_count"] == 1
+
+
+def test_compute_metadata_error_count_from_attachment_exit_code() -> None:
+    entries = [
+        {
+            "type": "attachment",
+            "attachment": {"exitCode": 1},
+        }
+    ]
+    md = compute_metadata("sid", entries)
+    assert md["error_count"] == 1
+
+
+def test_compute_metadata_collects_cc_version_and_cwds() -> None:
+    entries = [
+        {
+            "type": "user",
+            "version": "1.2.3",
+            "cwd": "/home/user/a",
+            "message": {"content": "hi"},
+        },
+        {
+            "type": "user",
+            "version": "1.2.4",
+            "cwd": "/home/user/b",
+            "message": {"content": "hi2"},
+        },
+        {
+            "type": "user",
+            "cwd": "/home/user/a",  # duplicate; should dedupe
+            "message": {"content": "hi3"},
+        },
+    ]
+    md = compute_metadata("sid", entries)
+    assert md["cc_version"] == "1.2.4"
+    assert md["cwds"] == ["/home/user/a", "/home/user/b"]
+
+
+# ---------------------------------------------------------------------------
+# render_html
+# ---------------------------------------------------------------------------
+
+
+def test_render_html_smoke() -> None:
+    entries = [
+        {"type": "user", "message": {"content": "hi"}, "timestamp": "2026-06-06T00:00:00Z"},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "hello"}]},
+            "timestamp": "2026-06-06T00:00:01Z",
+        },
+    ]
+    doc = render_html("sid", entries)
+    assert doc.startswith("<!DOCTYPE html>")
+    assert "Transcript sid" in doc
+    assert CSS.split("\n")[1] in doc
+    assert "1 entries" not in doc  # plural check
+    assert "2 entries" in doc
+
+
+def test_render_html_session_url_chrome() -> None:
+    entries = [{"type": "user", "message": {"content": "hi"}}]
+    doc = render_html("sid", entries, session_url="https://claude.ai/code/session_01ABC")
+    assert "Open in Claude Code" in doc
+    assert "/sessions/01ABC" in doc
+
+
+def test_render_html_no_session_url() -> None:
+    entries = [{"type": "user", "message": {"content": "hi"}}]
+    doc = render_html("sid", entries, session_url="")
+    assert "Open in Claude Code" not in doc
+
+
+def test_render_html_includes_css_js() -> None:
+    doc = render_html("sid", [])
+    assert "<style>" in doc and "</style>" in doc
+    assert "<script>" in doc and "</script>" in doc
+    assert "search-box" in doc
+
+
+def test_renderer_version_constant() -> None:
+    """Guard against accidental version bumps without paired memo + parity update."""
+    assert RENDERER_VERSION == 3
+
+
+def test_js_constant_not_empty() -> None:
+    assert JS.strip()
+    assert "search-box" in JS or "runSearch" in JS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,13 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "lib/transcripts/tests/*" = ["PLR2004"]  # magic-value checks fire constantly in tests
+"lib/transcripts/render.py" = [
+    "PLR0912",  # render_html + compute_metadata branch on every entry-kind by design
+    "PLR0915",  # same: rendering pipelines are inherently statement-heavy
+    "E501",    # session_url chrome line in render_html is long because the f-string
+               # builds two anchor tags inline; split would obscure parity vs the
+               # script's original shape (coo-memory#1147)
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/scripts/ci/test-lib-transcripts-parity.py
+++ b/scripts/ci/test-lib-transcripts-parity.py
@@ -1,26 +1,20 @@
 #!/usr/bin/env python3
-"""Parity check: lib/transcripts/ matches the inlined definitions in scripts/.
+"""Structural parity check: every ported script imports its primitives from lib.
 
-Confirms that the consolidated primitives in lib/transcripts/ match the values
-the existing scripts hardcode. Run before any script-port PR ships — if this
-fails, the port would silently change behavior.
+Originally a value-equality check between the renderer's inlined definitions
+and the lib copies — but every script that touched the lib has now been
+ported (coo-memory#1147 series), so the parity check pivots to a structural
+shape: confirm the script attributes still resolve, and the values they
+expose match what lib provides.
 
-Checks (post-coo-memory#1147 url-backfill port — the script now imports the
-url_source taxonomy and dominant_scan_source from lib; what remains here is
-the renderer-side parity, which still inlines):
-
-  1. PARSER_VERSION in lib/transcripts/schema.py matches the integer
-     scripts/lifecycle/session-end-transcript-render.py uses.
-  2. jsonl.py primitives (read_entries, strip_auto_notifications,
-     is_auto_notification_user_entry, classify) match the renderer's
-     inlined _read_entries / _strip_auto_notifications /
-     _is_auto_notification_user_entry / _classify across a fixture set.
-  3. SYSTEM_REMINDER_RE and AUTO_NOTIFICATION_RES regex patterns in the
-     renderer match the lib values.
-
-The url-backfill checks (AUTHORITATIVE_URL_SOURCES drift,
-_dominant_scan_source) are removed — the script now imports those names
-directly from lib, so the parity is structural rather than value-equality.
+Checks:
+  1. The renderer's PARSER_VERSION (kept as a backward-compat alias) matches
+     transcripts.render.RENDERER_VERSION.
+  2. The renderer's compute_metadata + render_html are the same callables
+     lib publishes (not script-local re-implementations).
+  3. The lib's RENDERER_VERSION matches the (re-exported) PARSER_VERSION in
+     schema — guards against the renderer-version constant drifting between
+     render.py and schema.py.
 
 Exits 0 on full parity, 1 on any divergence.
 """
@@ -50,159 +44,32 @@ def _load_module(name: str, path: Path):
 def main() -> int:
     failures: list[str] = []
 
-    from transcripts.jsonl import (
-        classify as lib_classify,
-        is_auto_notification_user_entry as lib_is_auto,
-        read_entries as lib_read_entries,
-        strip_auto_notifications as lib_strip,
+    from transcripts.render import (
+        RENDERER_VERSION as LIB_RV,
+        compute_metadata as lib_compute_metadata,
+        render_html as lib_render_html,
     )
-    from transcripts.provenance import (
-        AUTHORITATIVE_URL_SOURCES as LIB_AUTH,
-        RECONCILE_ELIGIBLE_URL_SOURCES as LIB_RECON,
-    )
-    from transcripts.schema import PARSER_VERSION as LIB_PV
+    from transcripts.schema import PARSER_VERSION as SCHEMA_PV
 
     renderer = _load_module("session_end_transcript_render", RENDERER)
-    if renderer.PARSER_VERSION != LIB_PV:
+    if renderer.PARSER_VERSION != LIB_RV:
         failures.append(
-            f"PARSER_VERSION drift — script={renderer.PARSER_VERSION} lib={LIB_PV}"
+            f"renderer.PARSER_VERSION (back-compat alias) drift — "
+            f"script={renderer.PARSER_VERSION} lib={LIB_RV}"
         )
-
-    # jsonl primitives: regex pattern equivalence first (catches a drift the
-    # downstream behavioral fixtures might miss if their inputs don't exercise
-    # the changed branch).
-    if renderer.SYSTEM_REMINDER_RE.pattern != "<system-reminder>(.*?)</system-reminder>":
+    if renderer.compute_metadata is not lib_compute_metadata:
         failures.append(
-            f"SYSTEM_REMINDER_RE drift — script={renderer.SYSTEM_REMINDER_RE.pattern!r}"
+            "renderer.compute_metadata is not transcripts.render.compute_metadata"
         )
-    script_auto_patterns = [r.pattern for r in renderer.AUTO_NOTIFICATION_RES]
-    expected_auto_patterns = [
-        r"<github-webhook-activity>.*?</github-webhook-activity>",
-        r"<task-notification>.*?</task-notification>",
-    ]
-    if script_auto_patterns != expected_auto_patterns:
+    if renderer.render_html is not lib_render_html:
         failures.append(
-            f"AUTO_NOTIFICATION_RES drift — script={script_auto_patterns}"
+            "renderer.render_html is not transcripts.render.render_html"
         )
-
-    # strip_auto_notifications + is_auto_notification_user_entry: behavioral parity
-    # across the cases the renderer's classifier touches.
-    strip_cases = [
-        "plain text",
-        "",
-        "before <system-reminder>x</system-reminder> after",
-        "<github-webhook-activity>x</github-webhook-activity>",
-        "<task-notification>x</task-notification>",
-        "<system-reminder>x</system-reminder>text<github-webhook-activity>y</github-webhook-activity>",
-    ]
-    for case in strip_cases:
-        s_val = renderer._strip_auto_notifications(case)
-        l_val = lib_strip(case)
-        if s_val != l_val:
-            failures.append(
-                f"strip_auto_notifications({case!r}) — script={s_val!r} lib={l_val!r}"
-            )
-
-    is_auto_cases = [
-        {"message": {"content": "hello"}},
-        {"message": {"content": "<system-reminder>x</system-reminder>"}},
-        {"message": {"content": "   "}},
-        {
-            "message": {
-                "content": [{"type": "text", "text": "real"}],
-            }
-        },
-        {
-            "message": {
-                "content": [
-                    {
-                        "type": "text",
-                        "text": "<github-webhook-activity>x</github-webhook-activity>",
-                    }
-                ],
-            }
-        },
-        {"message": {"content": [{"type": "tool_result", "content": "..."}]}},
-        {},
-    ]
-    for case in is_auto_cases:
-        s_val = renderer._is_auto_notification_user_entry(case)
-        l_val = lib_is_auto(case)
-        if s_val != l_val:
-            failures.append(
-                f"is_auto_notification_user_entry({case!r}) — script={s_val} lib={l_val}"
-            )
-
-    # classify: cover each branch of the renderer's _classify.
-    classify_cases = [
-        {"type": "attachment"},
-        {"type": "queue-operation"},
-        {"type": "last-prompt"},
-        {"type": "mode"},
-        {"type": "summary"},
-        {"type": "user", "message": {"content": "hi"}},
-        {"type": "user", "message": {"content": [{"type": "text", "text": "x"}]}},
-        {
-            "type": "user",
-            "message": {"content": [{"type": "tool_result", "content": "..."}]},
-        },
-        {"type": "user"},
-        {"type": "assistant", "message": {"content": [{"type": "text", "text": "x"}]}},
-        {
-            "type": "assistant",
-            "message": {"content": [{"type": "thinking", "thinking": "x"}]},
-        },
-        {
-            "type": "assistant",
-            "message": {
-                "content": [
-                    {"type": "tool_use", "id": "a", "name": "b", "input": {}}
-                ]
-            },
-        },
-        {
-            "type": "assistant",
-            "message": {
-                "content": [
-                    {"type": "text", "text": "x"},
-                    {"type": "tool_use", "id": "a", "name": "b", "input": {}},
-                ]
-            },
-        },
-        {"type": "assistant", "message": {"content": []}},
-        {"type": "system"},
-        {},
-    ]
-    for case in classify_cases:
-        s_val = renderer._classify(case)
-        l_val = lib_classify(case)
-        if s_val != l_val:
-            failures.append(f"classify({case!r}) — script={s_val!r} lib={l_val!r}")
-
-    # read_entries: behavioral parity on a synthetic fixture.
-    import tempfile
-
-    fixture = (
-        '{"type":"user","message":{"content":"hi"}}\n'
-        "\n"
-        '{"type":"assistant","message":{"content":[]}}\n'
-        "{not-json}\n"
-        '{"type":"summary","seq":42}\n'
-    )
-    with tempfile.NamedTemporaryFile(
-        "w", suffix=".jsonl", delete=False
-    ) as f:
-        f.write(fixture)
-        fixture_path = Path(f.name)
-    try:
-        s_entries = renderer._read_entries(fixture_path)
-        l_entries = lib_read_entries(fixture_path)
-        if s_entries != l_entries:
-            failures.append(
-                f"read_entries fixture parity — script={s_entries} lib={l_entries}"
-            )
-    finally:
-        fixture_path.unlink(missing_ok=True)
+    if SCHEMA_PV != LIB_RV:
+        failures.append(
+            f"schema.PARSER_VERSION drift vs render.RENDERER_VERSION — "
+            f"schema={SCHEMA_PV} render={LIB_RV}"
+        )
 
     if failures:
         sys.stderr.write("PARITY FAILURES:\n")
@@ -210,10 +77,7 @@ def main() -> int:
             sys.stderr.write(f"  - {f}\n")
         return 1
 
-    print(
-        f"parity OK — {len(LIB_AUTH)} auth, {len(LIB_RECON)} reconcile, "
-        f"PARSER_VERSION={LIB_PV}, jsonl primitives match"
-    )
+    print(f"parity OK — renderer ports → lib; RENDERER_VERSION={LIB_RV}")
     return 0
 
 

--- a/scripts/ci/test-session-end-transcript-render.py
+++ b/scripts/ci/test-session-end-transcript-render.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Smoke test for the lib-ported session-end-transcript-render.py.
+
+The Stop-hook ports its rendering helpers + R2 plumbing to
+`from transcripts.render import ...` and `from transcripts import ...`
+per coo-labs/coo-memory#1147. This test confirms:
+
+  - The script loads cleanly with the lib-import surface (no stale
+    references to deleted helpers like `_render_user`, `CSS`, `JS`,
+    `_op_read`, `_r2_endpoint_bucket`, `_r2_put_bytes`).
+  - The lib-exported `compute_metadata` + `render_html` produce the
+    expected output shape against a synthetic jsonl fixture (smoke,
+    not exhaustive — lib's own test suite covers the rendering core).
+  - The backward-compat alias `script.PARSER_VERSION` still resolves
+    to the lib `RENDERER_VERSION`.
+
+No live R2. No `op` calls. The Stop-hook integration tests
+(`test-transcript-export.py` etc.) cover the live invocation path —
+this test exists to catch port-time regressions before the live
+chain runs.
+
+Exits 0 on pass, 1 on any divergence.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = REPO_ROOT / "lib"
+SCRIPT = REPO_ROOT / "scripts" / "lifecycle" / "session-end-transcript-render.py"
+
+sys.path.insert(0, str(LIB_DIR))
+
+
+def _load_module(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    mod = _load_module("session_end_transcript_render", SCRIPT)
+    from transcripts.render import (
+        RENDERER_VERSION as LIB_RV,
+        compute_metadata as lib_compute_metadata,
+        render_html as lib_render_html,
+    )
+
+    # 1. Backward-compat alias.
+    if mod.PARSER_VERSION != LIB_RV:
+        failures.append(
+            f"PARSER_VERSION alias drift — script={mod.PARSER_VERSION} lib={LIB_RV}"
+        )
+
+    # 2. The script re-exports the lib symbols (used by other code that loads
+    # the script as a module to access compute_metadata + render_html).
+    if mod.compute_metadata is not lib_compute_metadata:
+        failures.append("script.compute_metadata is not lib.compute_metadata")
+    if mod.render_html is not lib_render_html:
+        failures.append("script.render_html is not lib.render_html")
+
+    # 3. Deleted helpers should not be lurking. Catching this here prevents a
+    # half-finished port from shipping with both copies — the script-local
+    # would silently win and lib changes would have no effect.
+    for stale in (
+        "_render_user", "_render_assistant", "_render_tool_result",
+        "_render_attachment", "_render_meta", "_render_other",
+        "_render_text_with_reminders", "_render_raw", "_render_thinking_entry",
+        "_format_ts", "_ts_to_dt", "_format_elapsed", "_truncate",
+        "_first_line", "_esc", "_json_pretty", "_tool_args_summary",
+        "_tool_result_text", "_build_toc", "_format_session_url",
+        "_op_read", "_r2_endpoint_bucket", "_r2_put_bytes",
+        "_strip_auto_notifications", "_is_auto_notification_user_entry",
+        "_classify", "SYSTEM_REMINDER_RE", "AUTO_NOTIFICATION_RES",
+        "CSS", "JS",
+    ):
+        if hasattr(mod, stale):
+            failures.append(f"stale symbol survived port: {stale}")
+
+    # 4. End-to-end smoke: render a synthetic jsonl.
+    fixture = (
+        '{"type":"user","message":{"content":"hello"},"timestamp":"2026-06-06T00:00:00Z"}\n'
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]},'
+        '"timestamp":"2026-06-06T00:00:05Z"}\n'
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        f.write(fixture)
+        fixture_path = Path(f.name)
+    try:
+        entries = mod._read_entries(fixture_path)
+    finally:
+        fixture_path.unlink(missing_ok=True)
+
+    if len(entries) != 2:
+        failures.append(f"_read_entries dropped lines: got {len(entries)} expected 2")
+
+    html = mod.render_html("test-sid", entries)
+    if not html.startswith("<!DOCTYPE html>"):
+        failures.append("render_html did not produce a complete HTML document")
+    if "hello" not in html or "hi" not in html:
+        failures.append("render_html lost user/assistant content")
+
+    md = mod.compute_metadata("test-sid", entries)
+    if md.get("renderer_version") != LIB_RV:
+        failures.append(f"compute_metadata renderer_version drift: {md.get('renderer_version')}")
+    if md.get("user_turn_count") != 1:
+        failures.append(f"compute_metadata user_turn_count drift: {md.get('user_turn_count')}")
+    if md.get("assistant_turn_count") != 1:
+        failures.append(
+            f"compute_metadata assistant_turn_count drift: {md.get('assistant_turn_count')}"
+        )
+
+    if failures:
+        sys.stderr.write("RENDER-PORT PARITY FAILURES:\n")
+        for f in failures:
+            sys.stderr.write(f"  - {f}\n")
+        return 1
+
+    print(
+        f"render-port OK — RENDERER_VERSION={LIB_RV}, "
+        f"entries={len(entries)}, html_bytes={len(html.encode('utf-8'))}, "
+        f"meta_fields={len(md)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lifecycle/session-end-transcript-render.py
+++ b/scripts/lifecycle/session-end-transcript-render.py
@@ -44,19 +44,36 @@ Exits 0 on success or skip-without-error; 1 on argument or input error;
 from __future__ import annotations
 
 import argparse
-import datetime
-import html
 import json
 import os
-import re
-import shutil
-import subprocess
 import sys
 import time
 from pathlib import Path
 
-PARSER_VERSION = 3
 SCRIPT_DIR = Path(__file__).resolve().parent
+RUNTIME_ROOT = SCRIPT_DIR.parent.parent
+
+# Locate coo-harness/lib/ on sys.path so `from transcripts import ...` resolves
+# under the uv-run venv this script spawns into.
+sys.path.insert(0, str(RUNTIME_ROOT / "lib"))
+
+from transcripts import (  # noqa: E402
+    R2Error,
+    r2_client,
+    r2_coordinates,
+    write_html_object,
+    write_sidecar,
+)
+from transcripts.render import (  # noqa: E402
+    RENDERER_VERSION,
+    compute_metadata,
+    format_session_url,
+    render_html,
+)
+
+# Backward-compat alias — keep the script's PARSER_VERSION attribute name so
+# any external probe (legacy CI, transcript-export parity, etc.) still finds it.
+PARSER_VERSION = RENDERER_VERSION
 
 
 def _stderr(msg: str) -> None:
@@ -112,673 +129,32 @@ def _read_entries(jsonl_path: Path) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Classification + rendering
+# Session-URL resolution (orchestration: env + R2 lookup)
 # ---------------------------------------------------------------------------
 
-SYSTEM_REMINDER_RE = re.compile(
-    r"<system-reminder>(.*?)</system-reminder>", re.DOTALL
-)
-# Envelopes Claude Code injects into the user-message slot that aren't
-# typed by the operator: webhook events from MCP subscriptions, background
-# task completions, etc. When the user message contains only these and no
-# remaining text, it's an auto-notification, not a real user turn.
-AUTO_NOTIFICATION_RES = [
-    re.compile(r"<github-webhook-activity>.*?</github-webhook-activity>", re.DOTALL),
-    re.compile(r"<task-notification>.*?</task-notification>", re.DOTALL),
-]
 
-
-def _strip_auto_notifications(text: str) -> str:
-    """Strip system-reminders and known auto-notification envelopes.
-    Returns the residue (what the user actually typed, if anything)."""
-    out = SYSTEM_REMINDER_RE.sub("", text)
-    for r in AUTO_NOTIFICATION_RES:
-        out = r.sub("", out)
-    return out
-
-
-def _is_auto_notification_user_entry(entry: dict) -> bool:
-    """True iff a user-typed message slot carries only auto-notifications
-    (webhook activity, task completion) and no real operator content."""
-    msg = entry.get("message", {}) or {}
-    content = msg.get("content")
-    if isinstance(content, str):
-        return not _strip_auto_notifications(content).strip()
-    if isinstance(content, list):
-        any_text = False
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "text":
-                any_text = True
-                if _strip_auto_notifications(block.get("text", "")).strip():
-                    return False
-        # All-text-blocks were auto-only → True; no text blocks at all → False
-        # (must be a tool_result message, which we classify elsewhere).
-        return any_text
-    return False
-
-
-def _classify(entry: dict) -> str:
-    """Bucket a raw jsonl entry into a rendering kind."""
-    t = entry.get("type")
-    if t == "attachment":
-        return "attachment"
-    if t in ("queue-operation", "last-prompt", "mode", "summary"):
-        return "meta"
-    if t == "user":
-        msg = entry.get("message", {}) or {}
-        content = msg.get("content")
-        if isinstance(content, list):
-            kinds = {b.get("type") for b in content if isinstance(b, dict)}
-            if "tool_result" in kinds:
-                return "tool_result"
-            return "user"
-        if isinstance(content, str):
-            return "user"
-        return "user"
-    if t == "assistant":
-        msg = entry.get("message", {}) or {}
-        content = msg.get("content")
-        if isinstance(content, list):
-            kinds = [b.get("type") for b in content if isinstance(b, dict)]
-            if all(k == "thinking" for k in kinds) and kinds:
-                return "thinking"
-            if all(k == "tool_use" for k in kinds) and kinds:
-                return "tool_use"
-            return "assistant"
-        return "assistant"
-    return "other"
-
-
-def _format_ts(ts: str | None) -> str:
-    if not ts:
-        return ""
-    try:
-        dt = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
-        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
-    except (ValueError, TypeError):
-        return ts or ""
-
-
-def _ts_to_dt(ts: str | None) -> datetime.datetime | None:
-    if not ts:
-        return None
-    try:
-        return datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
-    except (ValueError, TypeError):
-        return None
-
-
-def _format_elapsed(prev: datetime.datetime | None, now: datetime.datetime | None) -> str:
-    if prev is None or now is None:
-        return ""
-    delta = (now - prev).total_seconds()
-    if delta < 0:
-        return ""
-    if delta < 1:
-        return "<1s"
-    if delta < 60:
-        return f"{int(delta)}s"
-    if delta < 3600:
-        return f"{int(delta // 60)}m{int(delta % 60):02d}s"
-    return f"{int(delta // 3600)}h{int((delta % 3600) // 60):02d}m"
-
-
-def _truncate(s: str, n: int) -> tuple[str, bool]:
-    """Return (head, was_truncated). Head has no trailing whitespace."""
-    if len(s) <= n:
-        return s, False
-    return s[:n].rstrip(), True
-
-
-def _first_line(s, max_len: int = 80) -> str:
-    if not isinstance(s, str):
-        s = "" if s is None else _json_pretty(s)
-    first = s.lstrip().splitlines()[0] if s.strip() else ""
-    head, _ = _truncate(first, max_len)
-    return head
-
-
-def _esc(s) -> str:
-    if s is None:
-        return ""
-    if not isinstance(s, str):
-        s = str(s)
-    return html.escape(s, quote=True)
-
-
-def _json_pretty(obj) -> str:
-    try:
-        return json.dumps(obj, indent=2, ensure_ascii=False)
-    except (TypeError, ValueError):
-        return repr(obj)
-
-
-def _tool_args_summary(input_obj: dict | None) -> str:
-    if not isinstance(input_obj, dict) or not input_obj:
-        return ""
-    parts = []
-    for k, v in input_obj.items():
-        if isinstance(v, str):
-            head, trunc = _truncate(v.replace("\n", " "), 60)
-            parts.append(f"{k}={head}" + ("…" if trunc else ""))
-        elif isinstance(v, (int, float, bool)) or v is None:
-            parts.append(f"{k}={v}")
-        else:
-            parts.append(f"{k}=…")
-    out, _ = _truncate(" ".join(parts), 160)
-    return out
-
-
-def _tool_result_text(content) -> str:
-    """Tool result content can be a string, list of content blocks, or dict."""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        chunks = []
-        for block in content:
-            if isinstance(block, dict):
-                if block.get("type") == "text":
-                    chunks.append(block.get("text", ""))
-                elif block.get("type") == "image":
-                    chunks.append("[image]")
-                else:
-                    chunks.append(_json_pretty(block))
-            else:
-                chunks.append(str(block))
-        return "\n".join(chunks)
-    return _json_pretty(content)
-
-
-def _render_raw(entry: dict) -> str:
-    raw = _esc(_json_pretty(entry))
-    return (
-        '<details class="raw"><summary>Show raw JSON</summary>'
-        f'<pre class="raw-json">{raw}</pre></details>'
-    )
-
-
-def _render_text_with_reminders(text: str) -> str:
-    """Split text into normal segments and folded system-reminder blocks."""
-    parts: list[str] = []
-    cursor = 0
-    for m in SYSTEM_REMINDER_RE.finditer(text):
-        prefix = text[cursor : m.start()]
-        if prefix.strip():
-            parts.append(f'<div class="text">{_esc(prefix)}</div>')
-        body = m.group(1).strip()
-        head = _first_line(body, 80)
-        parts.append(
-            '<details class="sysrem">'
-            f'<summary><span class="badge">system-reminder</span> '
-            f'<span class="preview">{_esc(head)}</span></summary>'
-            f'<pre class="content">{_esc(body)}</pre>'
-            "</details>"
-        )
-        cursor = m.end()
-    tail = text[cursor:]
-    if tail.strip():
-        parts.append(f'<div class="text">{_esc(tail)}</div>')
-    if not parts:
-        return ""
-    return "\n".join(parts)
-
-
-def _render_user(idx: int, entry: dict, elapsed: str) -> str:
-    msg = entry.get("message", {}) or {}
-    content = msg.get("content")
-    if isinstance(content, list):
-        body_parts = []
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            if block.get("type") == "text":
-                body_parts.append(_render_text_with_reminders(block.get("text", "")))
-            else:
-                body_parts.append(
-                    f'<pre class="content">{_esc(_json_pretty(block))}</pre>'
-                )
-        body = "\n".join(p for p in body_parts if p)
-    elif isinstance(content, str):
-        body = _render_text_with_reminders(content)
-    else:
-        body = f'<pre class="content">{_esc(_json_pretty(content))}</pre>'
-
-    ts = _format_ts(entry.get("timestamp"))
-    return (
-        f'<article class="entry user" id="entry-{idx}" data-role="user">'
-        f'<header><a class="anchor" href="#entry-{idx}">#{idx}</a>'
-        f'<span class="role-badge">user</span>'
-        f'<span class="ts">{_esc(ts)}</span>'
-        f'<span class="elapsed">{_esc(elapsed)}</span></header>'
-        f'<div class="body">{body}</div>'
-        f"{_render_raw(entry)}"
-        "</article>"
-    )
-
-
-def _render_assistant(idx: int, entry: dict, elapsed: str) -> str:
-    msg = entry.get("message", {}) or {}
-    content = msg.get("content")
-    usage = msg.get("usage") or {}
-    parts: list[str] = []
-    has_error = False
-
-    if isinstance(content, list):
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            btype = block.get("type")
-            if btype == "text":
-                parts.append(f'<div class="text">{_esc(block.get("text", ""))}</div>')
-            elif btype == "thinking":
-                thinking = block.get("thinking", "") or ""
-                head = _first_line(thinking, 80)
-                parts.append(
-                    '<details class="thinking">'
-                    f'<summary><span class="badge">thinking</span> '
-                    f'<span class="preview">{_esc(head)}</span></summary>'
-                    f'<pre class="content">{_esc(thinking)}</pre>'
-                    "</details>"
-                )
-            elif btype == "tool_use":
-                name = block.get("name", "?")
-                input_obj = block.get("input", {})
-                summary = _tool_args_summary(input_obj)
-                args_pretty = _json_pretty(input_obj)
-                parts.append(
-                    '<div class="tool-use">'
-                    f'<span class="badge tool">⚒ {_esc(name)}</span>'
-                    f'<span class="tool-summary">{_esc(summary)}</span>'
-                    '<details class="tool-args">'
-                    "<summary>args</summary>"
-                    f'<pre class="content">{_esc(args_pretty)}</pre>'
-                    "</details>"
-                    "</div>"
-                )
-            else:
-                parts.append(f'<pre class="content">{_esc(_json_pretty(block))}</pre>')
-    elif isinstance(content, str):
-        parts.append(f'<div class="text">{_esc(content)}</div>')
-
-    in_tok = usage.get("input_tokens")
-    out_tok = usage.get("output_tokens")
-    cache_read = usage.get("cache_read_input_tokens")
-    token_bits = []
-    if in_tok is not None:
-        token_bits.append(f"in {in_tok}")
-    if out_tok is not None:
-        token_bits.append(f"out {out_tok}")
-    if cache_read:
-        token_bits.append(f"cache {cache_read}")
-    token_badge = " · ".join(token_bits)
-
-    ts = _format_ts(entry.get("timestamp"))
-    role_cls = "assistant"
-    return (
-        f'<article class="entry {role_cls}{" error" if has_error else ""}" '
-        f'id="entry-{idx}" data-role="assistant">'
-        f'<header><a class="anchor" href="#entry-{idx}">#{idx}</a>'
-        f'<span class="role-badge">assistant</span>'
-        f'<span class="ts">{_esc(ts)}</span>'
-        f'<span class="elapsed">{_esc(elapsed)}</span>'
-        f'<span class="tokens">{_esc(token_badge)}</span></header>'
-        f'<div class="body">{"".join(parts)}</div>'
-        f"{_render_raw(entry)}"
-        "</article>"
-    )
-
-
-def _render_tool_result(idx: int, entry: dict, elapsed: str) -> str:
-    msg = entry.get("message", {}) or {}
-    content = msg.get("content")
-    if not isinstance(content, list):
-        content = []
-
-    body_parts = []
-    has_error = False
-    for block in content:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") != "tool_result":
-            continue
-        is_err = bool(block.get("is_error"))
-        has_error = has_error or is_err
-        text = _tool_result_text(block.get("content"))
-        line_count = text.count("\n") + 1 if text else 0
-        first = _first_line(text, 80)
-        tool_use_id = block.get("tool_use_id", "")
-        body_parts.append(
-            '<div class="tool-result-block">'
-            f'<span class="badge result{" err" if is_err else ""}">'
-            f'{"ERROR" if is_err else "result"}</span>'
-            f'<span class="preview">{_esc(first)}</span>'
-            f'<span class="lines">{line_count} line{"s" if line_count != 1 else ""}</span>'
-            f'<span class="tuid">{_esc(tool_use_id[:8])}</span>'
-            '<details class="tool-result-full">'
-            "<summary>full</summary>"
-            f'<pre class="content">{_esc(text)}</pre>'
-            "</details>"
-            "</div>"
-        )
-
-    ts = _format_ts(entry.get("timestamp"))
-    return (
-        f'<article class="entry tool-result{" error" if has_error else ""}" '
-        f'id="entry-{idx}" data-role="tool_result">'
-        f'<header><a class="anchor" href="#entry-{idx}">#{idx}</a>'
-        f'<span class="role-badge">tool result</span>'
-        f'<span class="ts">{_esc(ts)}</span>'
-        f'<span class="elapsed">{_esc(elapsed)}</span></header>'
-        f'<div class="body">{"".join(body_parts)}</div>'
-        f"{_render_raw(entry)}"
-        "</article>"
-    )
-
-
-def _render_attachment(idx: int, entry: dict, elapsed: str) -> str:
-    att = entry.get("attachment", {}) or {}
-    hook_name = att.get("hookName") or att.get("hookEvent") or att.get("type") or "attachment"
-    stdout = att.get("stdout") if isinstance(att.get("stdout"), str) else ""
-    stderr = att.get("stderr") if isinstance(att.get("stderr"), str) else ""
-    content = att.get("content")
-    content_str = content if isinstance(content, str) else (_json_pretty(content) if content else "")
-    exit_code = att.get("exitCode")
-    has_error = isinstance(exit_code, int) and exit_code != 0
-
-    preview = _first_line(stdout or content_str or stderr, 80)
-    body = stdout + (("\nSTDERR:\n" + stderr) if stderr else "")
-    if content_str and content_str != stdout:
-        body = body + (("\n---\n" + content_str) if body else content_str)
-
-    ts = _format_ts(entry.get("timestamp"))
-    return (
-        '<details class="entry attachment'
-        f'{" error" if has_error else ""}" id="entry-{idx}" data-role="attachment">'
-        '<summary><a class="anchor" href="#entry-{idx}">'.format(idx=idx)
-        + f'#{idx}</a>'
-        f'<span class="role-badge">attachment</span>'
-        f'<span class="hook-name">{_esc(hook_name)}</span>'
-        f'<span class="preview">{_esc(preview)}</span>'
-        f'<span class="ts">{_esc(ts)}</span>'
-        f'<span class="elapsed">{_esc(elapsed)}</span></summary>'
-        f'<pre class="content">{_esc(body)}</pre>'
-        f"{_render_raw(entry)}"
-        "</details>"
-    )
-
-
-def _render_thinking_entry(idx: int, entry: dict, elapsed: str) -> str:
-    """Assistant entry whose only content is thinking — render compact."""
-    return _render_assistant(idx, entry, elapsed)
-
-
-def _render_meta(idx: int, entry: dict, elapsed: str) -> str:
-    t = entry.get("type") or "meta"
-    body = _json_pretty(entry)
-    ts = _format_ts(entry.get("timestamp"))
-    return (
-        f'<details class="entry meta" id="entry-{idx}" data-role="meta">'
-        f'<summary><a class="anchor" href="#entry-{idx}">#{idx}</a>'
-        f'<span class="role-badge">{_esc(t)}</span>'
-        f'<span class="ts">{_esc(ts)}</span>'
-        f'<span class="elapsed">{_esc(elapsed)}</span></summary>'
-        f'<pre class="content">{_esc(body)}</pre>'
-        "</details>"
-    )
-
-
-def _render_other(idx: int, entry: dict, elapsed: str) -> str:
-    return _render_meta(idx, entry, elapsed)
-
-
-# ---------------------------------------------------------------------------
-# Document assembly
-# ---------------------------------------------------------------------------
-
-CSS = """
-:root {
-  --bg: #0d1117; --panel: #161b22; --border: #30363d; --fg: #e6edf3;
-  --muted: #8b949e; --accent: #58a6ff; --user: #79c0ff; --assistant: #d2a8ff;
-  --tool: #7ee787; --system: #8b949e; --error: #ff7b72;
-  --warning: #d29922;
-}
-@media (prefers-color-scheme: light) {
-  :root {
-    --bg: #ffffff; --panel: #f6f8fa; --border: #d0d7de; --fg: #1f2328;
-    --muted: #656d76; --accent: #0969da; --user: #0969da; --assistant: #8250df;
-    --tool: #1a7f37; --system: #656d76; --error: #cf222e;
-  }
-}
-* { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg);
-  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui,
-    sans-serif; font-size: 14px; line-height: 1.5; }
-body { display: grid; grid-template-columns: minmax(220px, 280px) 1fr;
-  min-height: 100vh; }
-nav.toc { position: sticky; top: 0; align-self: start; max-height: 100vh;
-  overflow-y: auto; padding: 16px; border-right: 1px solid var(--border);
-  background: var(--panel); font-size: 12px; }
-nav.toc h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em;
-  margin: 0 0 12px 0; color: var(--muted); }
-nav.toc ol { list-style: none; margin: 0; padding: 0; }
-nav.toc li { margin: 0 0 6px 0; }
-nav.toc a { color: var(--fg); text-decoration: none; display: block;
-  padding: 4px 6px; border-radius: 4px; }
-nav.toc a:hover { background: var(--bg); }
-main { padding: 16px 24px; min-width: 0; max-width: 100%; }
-p.back { margin: 0 0 8px 0; font-size: 12px; }
-p.back a { color: var(--muted); text-decoration: none; }
-p.back a:hover { color: var(--accent); }
-header.session { padding-bottom: 16px; border-bottom: 1px solid var(--border);
-  margin-bottom: 16px; }
-header.session h1 { margin: 0 0 4px 0; font-size: 18px; font-family: ui-monospace,
-  SFMono-Regular, Menlo, monospace; }
-header.session .meta { color: var(--muted); font-size: 12px; }
-.controls { display: flex; flex-wrap: wrap; gap: 8px; margin: 12px 0 24px;
-  align-items: center; }
-.controls input[type=search] { flex: 1 1 200px; background: var(--panel);
-  border: 1px solid var(--border); color: var(--fg); padding: 6px 10px;
-  border-radius: 6px; font: inherit; }
-.controls button { background: var(--panel); border: 1px solid var(--border);
-  color: var(--fg); padding: 6px 10px; border-radius: 6px; font: inherit;
-  cursor: pointer; }
-.controls button.active { background: var(--accent); color: var(--bg);
-  border-color: var(--accent); }
-.entry { margin: 0 0 14px 0; padding: 10px 12px; border: 1px solid var(--border);
-  border-left: 3px solid var(--system); border-radius: 6px; background: var(--panel); }
-.entry.user { border-left-color: var(--user); }
-.entry.assistant { border-left-color: var(--assistant); }
-.entry.tool-result { border-left-color: var(--tool); }
-.entry.attachment { border-left-color: var(--system); }
-.entry.meta { border-left-color: var(--system); opacity: 0.85; }
-.entry.error { border-left-color: var(--error); }
-.entry > header, .entry > summary { display: flex; flex-wrap: wrap; gap: 10px;
-  align-items: center; font-size: 12px; color: var(--muted); cursor: default; }
-.entry > summary { cursor: pointer; list-style: none; }
-.entry > summary::-webkit-details-marker { display: none; }
-.entry > summary::before { content: "▸"; color: var(--muted); width: 8px;
-  display: inline-block; transition: transform 0.1s; }
-.entry[open] > summary::before { transform: rotate(90deg); }
-.anchor { color: var(--muted); text-decoration: none; font-family: ui-monospace,
-  monospace; min-width: 32px; }
-.anchor:hover { color: var(--accent); }
-.role-badge { background: var(--bg); padding: 2px 6px; border-radius: 3px;
-  font-weight: 600; font-size: 11px; text-transform: uppercase;
-  letter-spacing: 0.03em; }
-.ts, .elapsed, .tokens, .hook-name, .tuid, .lines { font-family: ui-monospace,
-  monospace; font-size: 11px; color: var(--muted); }
-.elapsed::before { content: "+"; }
-.body { margin-top: 8px; }
-.text { white-space: pre-wrap; word-wrap: break-word; margin: 6px 0; }
-.entry pre.content, pre.raw-json { background: var(--bg); border: 1px solid var(--border);
-  border-radius: 4px; padding: 8px 10px; overflow-x: auto; font-family: ui-monospace,
-  monospace; font-size: 12px; white-space: pre-wrap; word-wrap: break-word;
-  max-width: 100%; margin: 6px 0; }
-details.sysrem, details.thinking, details.tool-args, details.tool-result-full,
-details.raw { margin: 6px 0; }
-details.sysrem > summary, details.thinking > summary, details.tool-args > summary,
-details.tool-result-full > summary, details.raw > summary {
-  cursor: pointer; color: var(--muted); font-size: 12px; list-style: none;
-  display: flex; gap: 8px; align-items: center; }
-details > summary::-webkit-details-marker { display: none; }
-details > summary::before { content: "▸"; width: 8px; display: inline-block;
-  color: var(--muted); transition: transform 0.1s; }
-details[open] > summary::before { transform: rotate(90deg); }
-.badge { background: var(--bg); padding: 2px 6px; border-radius: 3px;
-  font-size: 11px; font-weight: 600; }
-.badge.tool { color: var(--tool); }
-.badge.result { color: var(--tool); }
-.badge.result.err { color: var(--error); }
-.preview { color: var(--muted); font-family: ui-monospace, monospace;
-  font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  max-width: 60ch; }
-.tool-use { display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline;
-  margin: 4px 0; }
-.tool-summary { color: var(--fg); font-family: ui-monospace, monospace;
-  font-size: 12px; overflow-wrap: anywhere; }
-.tool-result-block { margin: 6px 0; padding: 6px 8px; background: var(--bg);
-  border-radius: 4px; }
-.tool-result-block > * { display: inline-block; vertical-align: middle;
-  margin-right: 8px; }
-.hide-attachment .entry.attachment { display: none; }
-.hide-tool-result .entry.tool-result { display: none; }
-.hide-meta .entry.meta { display: none; }
-.only-conversation .entry:not(.user):not(.assistant) { display: none; }
-mark.search-hit { background: var(--warning); color: var(--bg); }
-@media (max-width: 768px) {
-  body { grid-template-columns: 1fr; }
-  nav.toc { position: static; max-height: 280px; border-right: none;
-    border-bottom: 1px solid var(--border); }
-}
-"""
-
-JS = """
-(function(){
-  const main = document.querySelector('main');
-  const search = document.getElementById('search-box');
-  const buttons = document.querySelectorAll('.controls button[data-toggle]');
-  buttons.forEach(b => b.addEventListener('click', () => {
-    b.classList.toggle('active');
-    document.body.classList.toggle(b.dataset.toggle, b.classList.contains('active'));
-  }));
-  let timer;
-  search.addEventListener('input', () => {
-    clearTimeout(timer);
-    timer = setTimeout(() => runSearch(search.value.trim()), 150);
-  });
-  function runSearch(q) {
-    // Clear previous highlights.
-    document.querySelectorAll('mark.search-hit').forEach(m => {
-      const t = document.createTextNode(m.textContent);
-      m.parentNode.replaceChild(t, m);
-    });
-    document.querySelectorAll('.entry').forEach(e => e.style.display = '');
-    if (!q) return;
-    const ql = q.toLowerCase();
-    const entries = document.querySelectorAll('.entry');
-    entries.forEach(e => {
-      const text = e.textContent.toLowerCase();
-      if (text.indexOf(ql) === -1) {
-        e.style.display = 'none';
-      } else {
-        // expand any closed <details> inside so the match is visible
-        e.querySelectorAll('details').forEach(d => d.open = true);
-        if (e.tagName === 'DETAILS') e.open = true;
-        highlight(e, q);
-      }
-    });
-  }
-  function highlight(root, q) {
-    const ql = q.toLowerCase();
-    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-      acceptNode: n => n.parentElement.closest('script,style,mark') ? NodeFilter.FILTER_REJECT
-        : n.nodeValue.toLowerCase().indexOf(ql) !== -1 ? NodeFilter.FILTER_ACCEPT
-        : NodeFilter.FILTER_SKIP
-    });
-    const nodes = [];
-    while (walker.nextNode()) nodes.push(walker.currentNode);
-    nodes.forEach(n => {
-      const v = n.nodeValue, lv = v.toLowerCase();
-      const frag = document.createDocumentFragment();
-      let i = 0;
-      while (i < v.length) {
-        const j = lv.indexOf(ql, i);
-        if (j === -1) { frag.appendChild(document.createTextNode(v.slice(i))); break; }
-        if (j > i) frag.appendChild(document.createTextNode(v.slice(i, j)));
-        const mark = document.createElement('mark');
-        mark.className = 'search-hit';
-        mark.textContent = v.slice(j, j + q.length);
-        frag.appendChild(mark);
-        i = j + q.length;
-      }
-      n.parentNode.replaceChild(frag, n);
-    });
-  }
-  const jumpErr = document.getElementById('jump-error');
-  if (jumpErr) jumpErr.addEventListener('click', () => {
-    const e = document.querySelector('.entry.error');
-    if (e) { e.scrollIntoView({block:'start'}); if (e.tagName==='DETAILS') e.open = true; }
-  });
-})();
-"""
-
-
-def _build_toc(rendered_entries: list[tuple[int, str, str]]) -> str:
-    """Build the table-of-contents nav.
-
-    Each tuple is (idx, kind, preview). Only user turns get numbered list
-    entries; assistant turns appear underneath their preceding user turn
-    as sub-entries (visual hierarchy is the user-turn anchor).
-    """
-    items = []
-    user_n = 0
-    for idx, kind, preview in rendered_entries:
-        if kind == "user":
-            user_n += 1
-            label = f"{user_n}. {preview or '(empty)'}"
-            label_short, _ = _truncate(label, 60)
-            items.append(f'<li><a href="#entry-{idx}">{_esc(label_short)}</a></li>')
-    if not items:
-        items.append('<li><em class="muted">no user turns</em></li>')
-    return f'<nav class="toc"><h2>User turns</h2><ol>{"".join(items)}</ol></nav>'
-
-
-def _format_session_url(remote_sid: str) -> str:
-    remote_sid = remote_sid.strip()
-    if not remote_sid:
-        return ""
-    if remote_sid.startswith("cse_"):
-        remote_sid = remote_sid[4:]
-    return f"https://claude.ai/code/session_{remote_sid}"
-
-
-def _fetch_remote_sid_from_export_meta(session_id: str) -> str:
+def _fetch_remote_sid_from_export_meta(
+    session_id: str, s3=None, bucket: str | None = None
+) -> str:
     """Best-effort lookup of CLAUDE_CODE_REMOTE_SESSION_ID from the
     export pipeline's meta.json at transcripts/meta/<sid>.meta.json.
     Returns "" on any failure or absence. Schema version 3 added the
-    field; older sidecars return "" silently."""
-    access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
-    secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
-    if not access_key or not secret_key:
-        return ""
+    field; older sidecars return "" silently.
+
+    Accepts an optional s3 + bucket so the caller can resolve R2 once and
+    reuse the client. Falls back to its own resolution when called solo.
+    """
+    if s3 is None or bucket is None:
+        try:
+            coords = r2_coordinates()
+            s3 = r2_client(coords)
+            bucket = coords.bucket
+        except R2Error:
+            return ""
     try:
-        endpoint, bucket = _r2_endpoint_bucket()
-    except RuntimeError:
-        return ""
-    try:
-        import boto3
-        from botocore.config import Config
         from botocore.exceptions import ClientError
     except ImportError:
         return ""
-    s3 = boto3.client(
-        "s3",
-        endpoint_url=endpoint,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        region_name="auto",
-        config=Config(signature_version="s3v4", retries={"max_attempts": 2, "mode": "standard"}),
-    )
     try:
         resp = s3.get_object(Bucket=bucket, Key=f"transcripts/meta/{session_id}.meta.json")
         body = resp["Body"].read()
@@ -788,7 +164,9 @@ def _fetch_remote_sid_from_export_meta(session_id: str) -> str:
         return ""
 
 
-def _compute_session_url(session_id: str) -> tuple[str, str]:
+def _compute_session_url(
+    session_id: str, s3=None, bucket: str | None = None
+) -> tuple[str, str]:
     """Derive the claude.ai/code session URL for `session_id`.
 
     Lookup order:
@@ -803,323 +181,18 @@ def _compute_session_url(session_id: str) -> tuple[str, str]:
     Both source tags name authoritative provenance — sidecars carrying
     them are immutable from any future reconcile pass; only ``scan-*``
     sources are reconcile-eligible. See the briefing-039 url_source
-    enum for the full source taxonomy."""
+    enum for the full source taxonomy.
+    """
     env_sid = os.environ.get("CLAUDE_CODE_SESSION_ID", "").strip()
     if env_sid and env_sid == session_id:
         remote = os.environ.get("CLAUDE_CODE_REMOTE_SESSION_ID", "").strip()
-        url = _format_session_url(remote)
+        url = format_session_url(remote)
         if url:
             return url, "env-recovery"
-    url = _format_session_url(_fetch_remote_sid_from_export_meta(session_id))
+    url = format_session_url(_fetch_remote_sid_from_export_meta(session_id, s3, bucket))
     if url:
         return url, "export-meta-fallback"
     return "", ""
-
-
-def compute_metadata(session_id: str, entries: list[dict]) -> dict:
-    """Walk entries once; return the metadata blob for the list-page sidecar.
-
-    Schema (renderer_version=3):
-      session_id, started_at, ended_at, duration_seconds,
-      entry_count, user_turn_count, assistant_turn_count,
-      tool_call_count, error_count, first_user_preview,
-      first_user_uuid, session_url, renderer_version,
-      models (list of distinct model strings from assistant messages),
-      cwds (list of distinct cwd strings),
-      cc_version (last seen Claude Code client version).
-    """
-    first_ts: datetime.datetime | None = None
-    last_ts: datetime.datetime | None = None
-    user_count = 0
-    assistant_count = 0
-    tool_call_count = 0
-    error_count = 0
-    first_user_preview = ""
-    first_user_uuid = ""
-    models: list[str] = []
-    cwds: list[str] = []
-    cc_version = ""
-
-    def _add_unique(lst: list[str], val: str) -> None:
-        if val and val not in lst:
-            lst.append(val)
-
-    for entry in entries:
-        kind = _classify(entry)
-        ts = _ts_to_dt(entry.get("timestamp"))
-        if ts is not None:
-            if first_ts is None:
-                first_ts = ts
-            last_ts = ts
-        v = entry.get("version")
-        if isinstance(v, str) and v:
-            cc_version = v
-        cwd = entry.get("cwd")
-        if isinstance(cwd, str):
-            _add_unique(cwds, cwd)
-
-        if kind == "user":
-            if _is_auto_notification_user_entry(entry):
-                # Webhook events / task notifications injected into the user
-                # slot aren't operator turns; don't count them.
-                pass
-            else:
-                user_count += 1
-                if not first_user_uuid:
-                    uuid = entry.get("uuid")
-                    if isinstance(uuid, str) and uuid:
-                        first_user_uuid = uuid
-                if not first_user_preview:
-                    msg = entry.get("message", {}) or {}
-                    content = msg.get("content")
-                    text = ""
-                    if isinstance(content, str):
-                        text = content
-                    elif isinstance(content, list):
-                        for block in content:
-                            if isinstance(block, dict) and block.get("type") == "text":
-                                text = block.get("text", "")
-                                break
-                    text = _strip_auto_notifications(text).strip()
-                    if text:
-                        first_user_preview = _first_line(text, 140)
-        elif kind in ("assistant", "tool_use", "thinking"):
-            assistant_count += 1
-            msg = entry.get("message", {}) or {}
-            model = msg.get("model")
-            if isinstance(model, str):
-                _add_unique(models, model)
-            content = msg.get("content")
-            if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "tool_use":
-                        tool_call_count += 1
-        elif kind == "tool_result":
-            msg = entry.get("message", {}) or {}
-            content = msg.get("content")
-            if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "tool_result":
-                        if block.get("is_error"):
-                            error_count += 1
-        elif kind == "attachment":
-            att = entry.get("attachment", {}) or {}
-            exit_code = att.get("exitCode")
-            if isinstance(exit_code, int) and exit_code != 0:
-                error_count += 1
-
-    duration_seconds = 0
-    if first_ts is not None and last_ts is not None:
-        duration_seconds = max(0, int((last_ts - first_ts).total_seconds()))
-
-    session_url, url_source = _compute_session_url(session_id)
-    metadata = {
-        "session_id": session_id,
-        "started_at": first_ts.isoformat() if first_ts else None,
-        "ended_at": last_ts.isoformat() if last_ts else None,
-        "duration_seconds": duration_seconds,
-        "entry_count": len(entries),
-        "user_turn_count": user_count,
-        "assistant_turn_count": assistant_count,
-        "tool_call_count": tool_call_count,
-        "error_count": error_count,
-        "first_user_preview": first_user_preview,
-        "first_user_uuid": first_user_uuid,
-        "models": models,
-        "cwds": cwds,
-        "cc_version": cc_version,
-        "session_url": session_url,
-        "renderer_version": PARSER_VERSION,
-    }
-    if url_source:
-        metadata["url_source"] = url_source
-    return metadata
-
-
-def render_html(session_id: str, entries: list[dict]) -> str:
-    session_url, _ = _compute_session_url(session_id)
-    rendered: list[str] = []
-    toc_entries: list[tuple[int, str, str]] = []
-    prev_ts: datetime.datetime | None = None
-    first_ts: datetime.datetime | None = None
-    last_ts: datetime.datetime | None = None
-    error_count = 0
-
-    for i, entry in enumerate(entries):
-        kind = _classify(entry)
-        now_ts = _ts_to_dt(entry.get("timestamp"))
-        if now_ts is not None:
-            if first_ts is None:
-                first_ts = now_ts
-            last_ts = now_ts
-        elapsed = _format_elapsed(prev_ts, now_ts)
-        if now_ts is not None:
-            prev_ts = now_ts
-
-        preview = ""
-        is_auto_user = kind == "user" and _is_auto_notification_user_entry(entry)
-        if kind == "user" and not is_auto_user:
-            msg = entry.get("message", {}) or {}
-            content = msg.get("content")
-            if isinstance(content, str):
-                preview = _first_line(_strip_auto_notifications(content), 60)
-            elif isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        preview = _first_line(_strip_auto_notifications(block.get("text", "")), 60)
-                        break
-
-        if kind == "user":
-            html_chunk = _render_user(i, entry, elapsed)
-        elif kind == "assistant":
-            html_chunk = _render_assistant(i, entry, elapsed)
-        elif kind == "thinking":
-            html_chunk = _render_thinking_entry(i, entry, elapsed)
-        elif kind == "tool_use":
-            html_chunk = _render_assistant(i, entry, elapsed)
-        elif kind == "tool_result":
-            html_chunk = _render_tool_result(i, entry, elapsed)
-        elif kind == "attachment":
-            html_chunk = _render_attachment(i, entry, elapsed)
-        elif kind == "meta":
-            html_chunk = _render_meta(i, entry, elapsed)
-        else:
-            html_chunk = _render_other(i, entry, elapsed)
-
-        if 'class="entry' in html_chunk and " error" in html_chunk.split(">", 1)[0]:
-            error_count += 1
-
-        rendered.append(html_chunk)
-        # Auto-notification user entries don't get a TOC slot — but they
-        # still render as entries (raw form remains scrollable / Find-able).
-        toc_entries.append((i, "auto_user" if is_auto_user else kind, preview))
-
-    toc = _build_toc(toc_entries)
-    duration = _format_elapsed(first_ts, last_ts) or "—"
-    started = _format_ts(first_ts.isoformat() if first_ts else None) or "—"
-    entry_count = len(entries)
-    user_count = sum(1 for _, k, _ in toc_entries if k == "user")
-    assistant_count = sum(1 for _, k, _ in toc_entries if k == "assistant")
-
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Transcript {_esc(session_id)}</title>
-<style>{CSS}</style>
-</head>
-<body>
-{toc}
-<main>
-  <p class="back"><a href="/transcripts/">← All transcripts</a>{(' &nbsp;·&nbsp; <a href="' + _esc(session_url) + '" target="_blank" rel="noopener">Open in Claude Code ↗</a> &nbsp;·&nbsp; <a href="/sessions/' + _esc(session_url.rsplit("/session_", 1)[-1]) + '">GitHub artifacts ↗</a>') if session_url else ''}</p>
-  <header class="session">
-    <h1>{_esc(session_id)}</h1>
-    <div class="meta">
-      started {_esc(started)} · duration {_esc(duration)} ·
-      {entry_count} entries ({user_count} user, {assistant_count} assistant) ·
-      {error_count} error{"" if error_count == 1 else "s"}
-    </div>
-  </header>
-  <div class="controls">
-    <input type="search" id="search-box" placeholder="Search transcript..." autocomplete="off">
-    <button data-toggle="hide-attachment">Hide attachments</button>
-    <button data-toggle="hide-tool-result">Hide tool results</button>
-    <button data-toggle="hide-meta">Hide meta</button>
-    <button data-toggle="only-conversation">Only user + assistant</button>
-    <button id="jump-error">Jump to first error</button>
-  </div>
-  <div class="entries">
-    {"".join(rendered)}
-  </div>
-</main>
-<script>{JS}</script>
-</body>
-</html>
-"""
-
-
-# ---------------------------------------------------------------------------
-# R2 upload (duplicated minimal helpers from session-end-transcript-export.py;
-# factor into scripts/lib/r2.py when a third caller emerges)
-# ---------------------------------------------------------------------------
-
-
-def _op_read(ref: str) -> str:
-    if not shutil.which("op"):
-        return ""
-    try:
-        out = subprocess.run(
-            ["op", "read", ref],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        return out.stdout.strip()
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return ""
-
-
-def _r2_endpoint_bucket() -> tuple[str, str]:
-    endpoint = _op_read("op://COO/r2-transcripts/endpoint")
-    bucket = _op_read("op://COO/r2-transcripts/bucket")
-    if not endpoint or not bucket:
-        raise RuntimeError(
-            "R2 endpoint or bucket not readable from op://COO/r2-transcripts/{endpoint,bucket}"
-        )
-    return endpoint, bucket
-
-
-def _r2_put_bytes(
-    body: bytes,
-    key: str,
-    *,
-    overwrite: bool,
-    content_type: str,
-    cache_control: str = "private, max-age=0, must-revalidate",
-) -> dict:
-    access_key = os.environ.get("R2_TRANSCRIPTS_ACCESS_KEY_ID", "").strip()
-    secret_key = os.environ.get("R2_TRANSCRIPTS_SECRET_ACCESS_KEY", "").strip()
-    if not access_key or not secret_key:
-        raise RuntimeError(
-            "R2_TRANSCRIPTS_ACCESS_KEY_ID / R2_TRANSCRIPTS_SECRET_ACCESS_KEY missing"
-        )
-    endpoint, bucket = _r2_endpoint_bucket()
-
-    import boto3
-    from botocore.config import Config
-    from botocore.exceptions import ClientError
-
-    s3 = boto3.client(
-        "s3",
-        endpoint_url=endpoint,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        region_name="auto",
-        config=Config(signature_version="s3v4", retries={"max_attempts": 3, "mode": "standard"}),
-    )
-
-    put_kwargs = {
-        "Bucket": bucket,
-        "Key": key,
-        "Body": body,
-        "ContentType": content_type,
-        "CacheControl": cache_control,
-    }
-    if not overwrite:
-        put_kwargs["IfNoneMatch"] = "*"
-
-    try:
-        s3.put_object(**put_kwargs)
-        return {"bucket": bucket, "key": key, "endpoint": endpoint, "ceded": False}
-    except ClientError as e:
-        code = e.response.get("Error", {}).get("Code", "")
-        status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
-        if code == "PreconditionFailed" or status == 412:
-            _stderr(f"R2 PUT ceded (key exists, no-overwrite): {key}")
-            return {"bucket": bucket, "key": key, "endpoint": endpoint, "ceded": True}
-        raise
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1148,37 +221,56 @@ def main(argv: list[str] | None = None) -> int:
     if not entries:
         _stderr(f"no entries in {jsonl_path}")
         return 1
-    html_doc = render_html(session_id, entries)
-    html_bytes = html_doc.encode("utf-8")
-    _stderr(f"rendered {len(entries)} entries → {len(html_bytes)} bytes")
-
-    if args.output is not None:
-        args.output.write_bytes(html_bytes)
-        _stderr(f"wrote {args.output}")
 
     skip_upload = args.no_upload or args.output is not None
     if skip_upload:
-        if args.output is None:
+        # Output paths skip R2 entirely — render without an R2 client.
+        session_url, _ = _compute_session_url(session_id)
+        html_doc = render_html(session_id, entries, session_url=session_url)
+        html_bytes = html_doc.encode("utf-8")
+        _stderr(f"rendered {len(entries)} entries → {len(html_bytes)} bytes")
+        if args.output is not None:
+            args.output.write_bytes(html_bytes)
+            _stderr(f"wrote {args.output}")
+        else:
             sys.stdout.write(html_doc)
         return 0
+
+    try:
+        coords = r2_coordinates()
+        s3 = r2_client(coords)
+    except R2Error as e:
+        _stderr(str(e))
+        return 2
+
+    session_url, url_source = _compute_session_url(
+        session_id, s3=s3, bucket=coords.bucket,
+    )
+    html_doc = render_html(session_id, entries, session_url=session_url)
+    html_bytes = html_doc.encode("utf-8")
+    _stderr(f"rendered {len(entries)} entries → {len(html_bytes)} bytes")
 
     key_prefix = args.key_prefix.rstrip("/")
     html_key = f"{key_prefix}/{session_id}.html"
     meta_key = f"{key_prefix}/{session_id}.meta.json"
+
     try:
-        html_result = _r2_put_bytes(
-            html_bytes, html_key,
-            overwrite=args.overwrite,
-            content_type="text/html; charset=utf-8",
+        html_written = write_html_object(
+            session_id, html_bytes,
+            key_prefix=key_prefix, overwrite=args.overwrite, s3=s3,
         )
     except Exception as e:
         _stderr(f"R2 upload (html) failed: {e}")
         return 2
-    _stderr(f"uploaded → {html_result['endpoint']}/{html_result['bucket']}/{html_result['key']}"
-            + (" (ceded)" if html_result.get("ceded") else ""))
+    _stderr(
+        f"uploaded → {coords.endpoint}/{coords.bucket}/{html_key}"
+        + ("" if html_written else " (ceded)")
+    )
 
-    metadata = compute_metadata(session_id, entries)
-    meta_bytes = json.dumps(metadata, separators=(",", ":")).encode("utf-8")
+    metadata = compute_metadata(
+        session_id, entries, session_url=session_url, url_source=url_source,
+    )
+
     # Retry the sidecar upload — without it the list page's union-find
     # can't group rotation siblings (it joins on session_url /
     # first_user_uuid from the sidecar), so the row falls out as an
@@ -1190,13 +282,14 @@ def main(argv: list[str] | None = None) -> int:
     last_err: Exception | None = None
     for attempt in range(3):
         try:
-            meta_result = _r2_put_bytes(
-                meta_bytes, meta_key,
-                overwrite=args.overwrite,
-                content_type="application/json; charset=utf-8",
+            meta_written = write_sidecar(
+                session_id, metadata,
+                key_prefix=key_prefix, overwrite=args.overwrite, s3=s3,
             )
-            _stderr(f"uploaded → {meta_result['endpoint']}/{meta_result['bucket']}/{meta_result['key']}"
-                    + (" (ceded)" if meta_result.get("ceded") else ""))
+            _stderr(
+                f"uploaded → {coords.endpoint}/{coords.bucket}/{meta_key}"
+                + ("" if meta_written else " (ceded)")
+            )
             return 0
         except Exception as e:
             last_err = e


### PR DESCRIPTION
Sixth slice on coo-labs/coo-memory#1147: extract the rendering core from `scripts/lifecycle/session-end-transcript-render.py` (1211 LOC Stop-hook) into `lib/transcripts/render.py`, then port the script to import from the new module. Closes the lib-extraction half of #1147; PR-2 (R2-inventory cron in coo-console) is the last sub-issue.

Closes: n/a (coo-labs/coo-memory#1147 has PR-2 — the R2-inventory cron — remaining; see "Out of scope" below).

## What ships

**`lib/transcripts/render.py`** (new, 658 LOC) — pure-Python rendering core:

- `RENDERER_VERSION` constant (canonical; schema.py's `PARSER_VERSION` keeps its current `= 3` value as a co-equal source — the parity check guards them against drift).
- Time + string formatting: `format_ts`, `ts_to_dt`, `format_elapsed`, `truncate`, `first_line`, `esc`, `json_pretty`, `format_session_url`.
- Tool args / result helpers: `tool_args_summary`, `tool_result_text`.
- Per-entry rendering: `render_user`, `render_assistant`, `render_tool_result`, `render_attachment`, `render_thinking_entry`, `render_meta`, `render_other`, `render_raw`, `render_text_with_reminders`.
- Document assembly: `build_toc`, `CSS`, `JS`, `render_html`.
- `compute_metadata` — walks entries once → renderer-side sidecar dict. `session_url` + `url_source` are now inputs (parameters), not resolved internally — env / R2 lookup stays in the script per the primitive/orchestration split.

Pure stdlib + `transcripts.jsonl` imports. No pydantic dependency, so the Stop-hook imports the rendering core under `uv run --script` without paying for pydantic at boot (same constraint as the lazy-schema fix in [#527](https://github.com/coo-labs/coo-harness/pull/527)).

**`scripts/lifecycle/session-end-transcript-render.py`** — 1211 LOC → 304 LOC. Deletions:

- `_op_read`, `_r2_endpoint_bucket`, `_r2_put_bytes` → uses `r2_coordinates()` + `r2_client()` + `write_html_object()` + `write_sidecar()` from the lib.
- All `_render_*` helpers, `_strip_auto_notifications` / `_is_auto_notification_user_entry` / `_classify`, `_format_*` / `_truncate` / `_first_line` / `_esc` / `_json_pretty`, `_tool_*`, `_build_toc`, `_format_session_url`, `CSS`, `JS`, the inlined `compute_metadata`, `render_html` → all gone.

What stays in the script: `_resolve_session_id_and_jsonl` (FS access), `_read_entries` (the renderer's stderr-shape differs from lib's `read_entries`), `_fetch_remote_sid_from_export_meta` + `_compute_session_url` (orchestration: env + R2 get_object — both now accept an optional pre-resolved `s3` + `bucket` so `main()` reuses one client), `main()`.

**`lib/transcripts/tests/test_render.py`** (new, 58 tests) — covers the rendering primitives, time/string helpers, per-entry renderers, `build_toc` edge cases, `compute_metadata` branches (empty entries, auto-notification skip, error count from `tool_result` + attachment, `cc_version` + `cwds` dedupe), and `render_html` document shape (DOCTYPE + session_url chrome + CSS/JS inclusion). 96.60% lib coverage maintained.

**`scripts/ci/test-lib-transcripts-parity.py`** — pivots from value-equality (no inlined copies remain) to structural shape: `renderer.compute_metadata is lib.compute_metadata`, `renderer.render_html is lib.render_html`, `renderer.PARSER_VERSION == lib.RENDERER_VERSION`, `schema.PARSER_VERSION == lib.RENDERER_VERSION`. Catches a half-done port where a stale local copy would shadow the lib export.

**`scripts/ci/test-session-end-transcript-render.py`** (new) — per-port smoke. Confirms the script loads under the lib import surface and that 29 deleted helpers don't survive the port. End-to-end: synthesize a 2-entry jsonl, run `_read_entries` → `render_html` → `compute_metadata`; verify `renderer_version` + entry counts come through.

**`pyproject.toml`** — per-file ignore for `render.py`: PLR0912 (render_html + compute_metadata branch on every entry kind by design), PLR0915 (rendering pipelines are statement-heavy), E501 (the session_url chrome line in `render_html` builds two anchor tags inline; splitting would obscure parity vs the original).

**`.github/workflows/lib-transcripts.yml`** — adds the ported Stop-hook + smoke to trigger paths and wires the new smoke step.

## Smoke + parity verification (local)

- `python3 scripts/ci/test-session-end-transcript-render.py` — `render-port OK — RENDERER_VERSION=3, entries=2, html_bytes=11261, meta_fields=16`.
- `python3 scripts/ci/test-lib-transcripts-parity.py` — `parity OK — renderer ports → lib; RENDERER_VERSION=3`.
- `python3 scripts/ci/test-session-end-transcript-export.py` — unchanged, passes.
- `python3 scripts/ci/test-transcript-{render,url,rerender-v3}-backfill.py` — unchanged, all pass.
- `pytest` — 292 tests pass (58 new for `test_render.py`), 96.60% lib coverage.
- `ruff check lib/transcripts` + `ruff format --check lib/transcripts` clean.
- `mypy lib/transcripts` clean.

## Risk

- Render output: verified byte-equivalent before format ran (lib `render_html` produced identical HTML to the script's inlined `render_html` on synthetic fixtures). After `ruff format`, the lib's output still passes shape asserts (the test suite covers structure, not byte-for-byte against the deleted script copy).
- `compute_metadata`: same logic, new parameter shape. `main()` now passes `session_url` + `url_source` as keyword args; previous behavior had `compute_metadata` call `_compute_session_url` internally. Net: identical resulting dict.
- Sidecar JSON: `write_sidecar` uses `separators=(",", ":")` (minified + `charset=utf-8` + `IfNoneMatch` atomic-create). The prior script also minified before upload; on-the-wire shape unchanged.
- HTML upload: `write_html_object` writes the same body with the same cache-control header.
- Stop-hook resilience: the script no longer wraps main in `except BaseException`, but `main()`'s exit codes are unchanged. Any new exception shape from the lib (`R2Error` inherits from `RuntimeError`) returns exit 2 — same as the prior code paths that raised `RuntimeError`.

## Out of scope

- PR-2: the R2-inventory cron in `coo-console`. Now has both `lib/transcripts/state.py` math (Python reference; the Worker ports the shape to TS) and the rendering primitives if list-page rendering ever needs to share code with the Stop-hook.
- Any further rendering improvements (theme, more entry kinds, search UX). Rendering surface frozen for this port.

https://claude.ai/code/session_01HqaFJxXTYs67BDHZnucsky