### PR TITLE
lib-transcripts workflow: quote step name with colon (fix YAML startup failure)

### DIFF
--- a/.github/workflows/lib-transcripts.yml
+++ b/.github/workflows/lib-transcripts.yml
@@ -92,5 +92,5 @@ jobs:
       - name: ported-script smoke (session-end-transcript-render)
         run: python3 scripts/ci/test-session-end-transcript-render.py
 
-      - name: ported-script smoke (r2-mop-up: e6/e8 + list-r2-transcripts + meta-backfill)
+      - name: "ported-script smoke (r2-mop-up: e6/e8 + list-r2-transcripts + meta-backfill)"
         run: python3 scripts/ci/test-r2-mop-up-ports.py


### PR DESCRIPTION
The step added in [#532](https://github.com/coo-labs/coo-harness/pull/532) contains an unquoted colon, which YAML parses as a mapping separator inside the unquoted scalar:

```yaml
- name: ported-script smoke (r2-mop-up: e6/e8 + list-r2-transcripts + meta-backfill)
```

The workflow registers but fails at startup with `Invalid workflow file: .github/workflows/lib-transcripts.yml#L95 — You have an error in your yaml syntax on line 95`. Symptom: run completes with `conclusion=failure` and zero jobs, so `gh run view --log-failed` returns "log not found" and the API surfaces 0 check_runs / 0 jobs.

Observed on:
- [actions/runs/27065603231](https://github.com/coo-labs/coo-harness/actions/runs/27065603231) — push of `02bd89c` to the PR branch.
- [actions/runs/27067089373](https://github.com/coo-labs/coo-harness/actions/runs/27067089373) — push of squash-merge `c9c93b1` to `main`.

Fix is mechanical — wrap the name value in double quotes. Local `python3 -c "import yaml; yaml.safe_load(...)"` parses cleanly after the change. CI on this PR will exercise the workflow as a falsifier.

Refs #532.

Closes n/a

Closes: n/a

https://claude.ai/code/session_01N2juh5zLQhsDkm4xgNvP5e