### PR TITLE
ci: add test-check-pat-freshness.sh (R10 of bootstrap-regression refactor)

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -39,7 +39,8 @@ name: Bootstrap regression
 #                              fault injection (coo-memory#1250
 #                              Layer-1.5).
 #   R10 PAT-cache freshness    Silent gh-write detection on stale PAT
-#                              cache (memo -r9rt). No test exists yet.
+#                              cache (memo -r9rt). Covered by
+#                              test-check-pat-freshness.sh.
 #   R11 hook + wrapper         Per-script smoke tests for individual
 #       contracts              hooks under scripts/hooks/ and wrappers
 #                              under scripts/{gh,op,git}-*.
@@ -236,6 +237,10 @@ jobs:
 
       - name: materialize_mcp_env (tmpfs MCP env templates; no op:// refs at boot)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-materialize-mcp-env.sh"
+
+      # ── PAT-cache freshness (R10) ────────────────────────────
+      - name: check-pat-freshness — diagnostic contract (4 exit codes + stdout shapes)
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/test-check-pat-freshness.sh"
 
       # ── Transcript + lifecycle (R11) ─────────────────────────
       - name: Transcript redaction engine — corpus + thinking + negative tests

--- a/scripts/ci/test-check-pat-freshness.sh
+++ b/scripts/ci/test-check-pat-freshness.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# test-check-pat-freshness: pin the contract of the canonical PAT-cache
+# freshness diagnostic, the COO's first-response when a `gh` write fails
+# silently (exit 1, zero bytes stdout, zero bytes stderr). See
+# MEMO-2026-05-21-r9rt (superseded by MEMO-2026-05-22-3678), Phase-2
+# rewrite per coo-memory#873, and the contract documented in
+# coo-memory/CLAUDE.md §"GitHub writes".
+#
+# The script's contract is:
+#
+#   OK <sha8>                     exit 0  cache matches 1Password
+#   STALE cache=<sha8> op=<sha8>  exit 1  cache drifted; rm + retry
+#   OP-UNREACHABLE <reason>       exit 2  could not read 1Password
+#   CACHE-MISS                    exit 3  tmpfs cache absent / empty
+#
+# A subtle drift in any of these surfaces breaks the COO's first-response
+# playbook. This suite pins each exit code + exact stdout shape.
+#
+# Strategy mirrors test-op-coo-wrap.sh: install a mock `op` binary via
+# PATH-shadowing, control its behavior with env switches, run the
+# script under a fresh XDG_RUNTIME_DIR per case so cache state doesn't
+# bleed.
+#
+# Run: bash scripts/ci/test-check-pat-freshness.sh
+# Exit: 0 if all assertions pass, non-zero otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../check-pat-freshness.sh"
+
+[ -x "$SCRIPT" ] || { echo "FAIL: script not executable at $SCRIPT"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Mock op binary controlled by env switches:
+#   MOCK_OP_STDOUT   bytes emitted on stdout (default empty)
+#   MOCK_OP_EXITCODE exit code (default 0)
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/op" <<'EOF'
+#!/usr/bin/env bash
+if [ -n "${MOCK_OP_STDOUT:-}" ]; then
+  printf '%s' "$MOCK_OP_STDOUT"
+fi
+exit "${MOCK_OP_EXITCODE:-0}"
+EOF
+chmod 0755 "$WORK/bin/op"
+
+# PATH for the script subprocess. Two variants: one carries the mock op,
+# the other strips it for the op-cli-missing case. /usr/bin + /bin gives
+# the script everything else it needs (sha256sum, cat, printf).
+PATH_WITH_OP="$WORK/bin:/usr/bin:/bin"
+PATH_NO_OP="/usr/bin:/bin"
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+assert_eq() {
+  local name="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1)); printf '  PASS  %s\n' "$name"
+  else
+    FAIL=$((FAIL+1)); FAILURES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+    printf '         want: %s\n' "$want"
+    printf '         got:  %s\n' "$got"
+  fi
+}
+
+# sha8 of a string the way the script does it.
+sha8() { printf '%s' "$1" | sha256sum | cut -c1-8; }
+
+# Fresh XDG dir per test so cache state doesn't bleed.
+fresh_env() {
+  XDG_RUNTIME_DIR="$(mktemp -d)"
+  export XDG_RUNTIME_DIR
+}
+
+# Pre-populate the tmpfs cache slot that gh-coo-wrap._resolve_pat writes.
+write_cache() {
+  mkdir -p "$XDG_RUNTIME_DIR/coo-gh-pat-cache"
+  printf '%s' "$1" > "$XDG_RUNTIME_DIR/coo-gh-pat-cache/MCP"
+}
+
+# Unset any host MOCK_* leaking in from the operator's env.
+unset MOCK_OP_STDOUT MOCK_OP_EXITCODE
+
+# ---- TEST 1: OK — cache matches 1Password ----
+fresh_env
+write_cache "pat_value_AAAAAA"
+rc=0
+out="$(PATH="$PATH_WITH_OP" \
+       OP_SERVICE_ACCOUNT_TOKEN="sa-token" \
+       MOCK_OP_STDOUT="pat_value_AAAAAA" \
+       MOCK_OP_EXITCODE=0 \
+       "$SCRIPT" 2>&1)" || rc=$?
+expect_sha="$(sha8 "pat_value_AAAAAA")"
+assert_eq "OK: stdout" "$out" "OK $expect_sha"
+assert_eq "OK: exit 0" "$rc" "0"
+
+# ---- TEST 2: gh-shaped silent failure → STALE diagnosis ----
+# Canonical first-response scenario from MEMO-2026-05-21-r9rt: PAT
+# rotated externally, in-session cache holds the old value, the next
+# `gh` write fails silently. Running this script must correctly
+# fingerprint the stale cache so the documented recovery (rm
+# $XDG_RUNTIME_DIR/coo-gh-pat-cache/MCP*) follows.
+fresh_env
+write_cache "stale_value_XXXXXX"
+rc=0
+out="$(PATH="$PATH_WITH_OP" \
+       OP_SERVICE_ACCOUNT_TOKEN="sa-token" \
+       MOCK_OP_STDOUT="fresh_value_YYYYYY" \
+       MOCK_OP_EXITCODE=0 \
+       "$SCRIPT" 2>&1)" || rc=$?
+stale_sha="$(sha8 "stale_value_XXXXXX")"
+fresh_sha="$(sha8 "fresh_value_YYYYYY")"
+assert_eq "STALE: stdout" "$out" "STALE cache=$stale_sha op=$fresh_sha"
+assert_eq "STALE: exit 1" "$rc" "1"
+
+# ---- TEST 3: CACHE-MISS — cache file absent (fresh session) ----
+fresh_env
+rc=0
+out="$(PATH="$PATH_WITH_OP" \
+       OP_SERVICE_ACCOUNT_TOKEN="sa-token" \
+       MOCK_OP_STDOUT="any_value" \
+       MOCK_OP_EXITCODE=0 \
+       "$SCRIPT" 2>&1)" || rc=$?
+assert_eq "CACHE-MISS absent: stdout" "$out" "CACHE-MISS"
+assert_eq "CACHE-MISS absent: exit 3" "$rc" "3"
+
+# ---- TEST 4: CACHE-MISS — cache file present but empty ----
+# Same operational meaning as absent per the script's docstring.
+fresh_env
+mkdir -p "$XDG_RUNTIME_DIR/coo-gh-pat-cache"
+: > "$XDG_RUNTIME_DIR/coo-gh-pat-cache/MCP"
+rc=0
+out="$(PATH="$PATH_WITH_OP" \
+       OP_SERVICE_ACCOUNT_TOKEN="sa-token" \
+       MOCK_OP_STDOUT="any_value" \
+       MOCK_OP_EXITCODE=0 \
+       "$SCRIPT" 2>&1)" || rc=$?
+assert_eq "CACHE-MISS empty: stdout" "$out" "CACHE-MISS"
+assert_eq "CACHE-MISS empty: exit 3" "$rc" "3"
+
+# ---- TEST 5: OP-UNREACHABLE — op CLI missing from PATH ----
+fresh_env
+write_cache "any_value"
+rc=0
+out="$(PATH="$PATH_NO_OP" \
+       OP_SERVICE_ACCOUNT_TOKEN="sa-token" \
+       "$SCRIPT" 2>&1)" || rc=$?
+assert_eq "OP-UNREACHABLE cli-missing: stdout" "$out" "OP-UNREACHABLE op-cli-missing"
+assert_eq "OP-UNREACHABLE cli-missing: exit 2" "$rc" "2"
+
+# ---- TEST 6: OP-UNREACHABLE — OP_SERVICE_ACCOUNT_TOKEN unset ----
+fresh_env
+write_cache "any_value"
+rc=0
+out="$(PATH="$PATH_WITH_OP" \
+       OP_SERVICE_ACCOUNT_TOKEN="" \
+       "$SCRIPT" 2>&1)" || rc=$?
+assert_eq "OP-UNREACHABLE sa-token-unset: stdout" "$out" "OP-UNREACHABLE op-service-account-token-unset"
+assert_eq "OP-UNREACHABLE sa-token-unset: exit 2" "$rc" "2"
+
+# ---- TEST 7: OP-UNREACHABLE — op read fails (non-zero exit) ----
+fresh_env
+write_cache "any_value"
+rc=0
+out="$(PATH="$PATH_WITH_OP" \
+       OP_SERVICE_ACCOUNT_TOKEN="sa-token" \
+       MOCK_OP_EXITCODE=1 \
+       "$SCRIPT" 2>&1)" || rc=$?
+assert_eq "OP-UNREACHABLE read-failed: stdout" "$out" "OP-UNREACHABLE op-read-failed"
+assert_eq "OP-UNREACHABLE read-failed: exit 2" "$rc" "2"
+
+# ---- TEST 8: OP-UNREACHABLE — op read succeeds but returns empty ----
+fresh_env
+write_cache "any_value"
+rc=0
+out="$(PATH="$PATH_WITH_OP" \
+       OP_SERVICE_ACCOUNT_TOKEN="sa-token" \
+       MOCK_OP_STDOUT="" \
+       MOCK_OP_EXITCODE=0 \
+       "$SCRIPT" 2>&1)" || rc=$?
+assert_eq "OP-UNREACHABLE read-empty: stdout" "$out" "OP-UNREACHABLE op-read-empty"
+assert_eq "OP-UNREACHABLE read-empty: exit 2" "$rc" "2"
+
+# ---- Summary ----
+echo
+echo "----------------------------------------"
+echo "check-pat-freshness test summary: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failing tests:"
+  for f in "${FAILURES[@]}"; do echo "  - $f"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Pins the contract of `check-pat-freshness.sh` — the COO's first-response diagnostic when a `gh` write fails silently (exit 1, zero stdout, zero stderr), per MEMO-2026-05-21-r9rt and the Phase-2 rewrite in coo-labs/coo-memory#873. A subtle drift in any of the four exit codes or their stdout shapes breaks the documented playbook; this test makes such drift fail CI instead.

## What

- **New** `scripts/ci/test-check-pat-freshness.sh` — 8 cases, 16 assertions covering all four exit codes and their exact stdout shapes:
  - `OK <sha8>` (exit 0) — cache matches 1Password
  - `STALE cache=<sha8> op=<sha8>` (exit 1) — cache drifted (gh-shaped silent-failure scenario)
  - `OP-UNREACHABLE <reason>` (exit 2) — covers `op-cli-missing`, `op-service-account-token-unset`, `op-read-failed`, `op-read-empty`
  - `CACHE-MISS` (exit 3) — file absent, plus file-present-but-empty edge

  Strategy mirrors `scripts/ci/test-op-coo-wrap.sh`: mock `op` binary via PATH-shadow, env-driven behavior switches (`MOCK_OP_STDOUT`, `MOCK_OP_EXITCODE`), fresh `XDG_RUNTIME_DIR` per case so cache state doesn't bleed.

- **`.github/workflows/bootstrap-regression.yml`** — new R10 step in `hook-and-wrapper-tests` (placed between the Token + cache helpers block and the Transcript + lifecycle block); R10 entry in the regression-class taxonomy comment moves from "No test exists yet" to "Covered by test-check-pat-freshness.sh".

## Verification

```
$ bash scripts/ci/test-check-pat-freshness.sh
  PASS  OK: stdout
  PASS  OK: exit 0
  PASS  STALE: stdout
  PASS  STALE: exit 1
  PASS  CACHE-MISS absent: stdout
  PASS  CACHE-MISS absent: exit 3
  PASS  CACHE-MISS empty: stdout
  PASS  CACHE-MISS empty: exit 3
  PASS  OP-UNREACHABLE cli-missing: stdout
  PASS  OP-UNREACHABLE cli-missing: exit 2
  PASS  OP-UNREACHABLE sa-token-unset: stdout
  PASS  OP-UNREACHABLE sa-token-unset: exit 2
  PASS  OP-UNREACHABLE read-failed: stdout
  PASS  OP-UNREACHABLE read-failed: exit 2
  PASS  OP-UNREACHABLE read-empty: stdout
  PASS  OP-UNREACHABLE read-empty: exit 2

check-pat-freshness test summary: 16 passed, 0 failed
```

## CI strategy slot

- **Guarantee**: G2 `drift-watch` (script-contract drift)
- **Loop position**: At-PR-open (PR-trigger gate on coo-harness boot-scope changes)
- **Retirement criterion**: (d) `defense-in-depth-perpetual`
- **Owner**: vade-coo

## Drift noted (separate follow-up)

The `STALE` stdout label observed by the implementation is `cache=<sha8> op=<sha8>` (correct for the Phase-2 tmpfs cache model), while `coo-memory/CLAUDE.md` §"GitHub writes" and the issue body both still document the pre-Phase-2 form `STALE env=<sha8> op=<sha8>`. The test pins the implementation's actual contract; the doc drift in `coo-memory/CLAUDE.md` is a separate clean-up (not bundled here to keep this PR single-purpose).

## Why two commits / why the workflow file is App-token-attributed

The workflow file change can't ride a normal `git push` from this surface (OAuth lacks `workflow` scope). Split: test file via standard push (`vade-coo` attribution), workflow file via the `vade-coo-app` install token's contents API (`vade-coo-app[bot]` attribution). Both land on the same branch, same PR.

Closes coo-labs/coo-memory#1251

https://claude.ai/code/session_01Bbft6YBAb8RLhyaCPuuENh