### PR TITLE
test-gh-coo-wrap: env-isolate the no-public-PAT case, wire into bootstrap CI

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -165,11 +165,6 @@ jobs:
     # Step order: PreToolUse hooks → Write|Edit/Read hooks → spawn hooks
     # → PostToolUse hooks → wrappers → token+cache helpers → transcript
     # + lifecycle → boot brake → Group S → schema iterator.
-    #
-    # Excluded for now:
-    #   - test-gh-coo-wrap.sh: env-isolation bug (host GITHUB_MCP_PAT
-    #     leaks into the wrapper under test, masking the
-    #     PUBLIC_PAT-unset assertion). File as follow-on under #933.
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
@@ -209,6 +204,9 @@ jobs:
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-auto-subscribe-pr.sh"
 
       # ── Wrapper contracts (R11) ──────────────────────────────
+      - name: Wrapper — gh-coo-wrap (PAT routing + body augmentation; coo-memory#1252)
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/test-gh-coo-wrap.sh"
+
       - name: Wrapper — op-coo-wrap (SA token rate-limit fallback to BACKUP)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-op-coo-wrap.sh"
 

--- a/scripts/ci/test-gh-coo-wrap.sh
+++ b/scripts/ci/test-gh-coo-wrap.sh
@@ -331,9 +331,25 @@ assert_contains "gh repo create --template foreign/X coo-labs/Y: keeps MCP_PAT (
 out="$("$WRAPPER" repo create --template coo-labs/foo venpopov/new --public)"
 assert_contains "gh repo create --template coo-labs/X venpopov/Y: swaps to PUBLIC_PAT (target wins)" "$out" "GH_TOKEN=PUBLIC_PAT_TESTING"
 
-# --- GITHUB_PUBLIC_PAT unset: no override even for non-coo-labs ---
-
-out="$(env -u GITHUB_PUBLIC_PAT GITHUB_MCP_PAT="$GITHUB_MCP_PAT" GH_TOKEN="$GH_TOKEN" CLAUDE_CODE_REMOTE_SESSION_ID="$CLAUDE_CODE_REMOTE_SESSION_ID" COO_GH_REAL="$WORK/gh-real" "$WRAPPER" repo fork venpopov/foo)"
+# --- GITHUB_PUBLIC_PAT unset AND no fallback source: no swap ---
+#
+# Full env-isolation (`env -i`) is load-bearing here: we are asserting
+# that the wrapper finds NO source for the PUBLIC PAT, so it must not
+# observe the host's $OP_SERVICE_ACCOUNT_TOKEN (op-read fallback would
+# fire), $XDG_RUNTIME_DIR (a pre-populated tmpfs cache from a real-gh
+# call earlier in the session would serve a real PAT), or a $PATH that
+# includes `op`. The earlier `env -u GITHUB_PUBLIC_PAT …` form leaked
+# all three and the test asserted against a real `vade-coo` ghp_* PAT
+# materialized by the wrapper — coo-memory#1252.
+out="$(env -i \
+       PATH="/usr/bin:/bin" \
+       HOME="$HOME" \
+       XDG_RUNTIME_DIR="$WORK/iso-runtime" \
+       GITHUB_MCP_PAT="$GITHUB_MCP_PAT" \
+       GH_TOKEN="$GH_TOKEN" \
+       CLAUDE_CODE_REMOTE_SESSION_ID="$CLAUDE_CODE_REMOTE_SESSION_ID" \
+       COO_GH_REAL="$WORK/gh-real" \
+       "$WRAPPER" repo fork venpopov/foo)"
 assert_contains "GITHUB_PUBLIC_PAT unset: no swap, keeps MCP_PAT" "$out" "GH_TOKEN=MCP_PAT_TESTING"
 
 # --- uncovered subcommands: no swap ---

--- a/scripts/ci/test-gh-coo-wrap.sh
+++ b/scripts/ci/test-gh-coo-wrap.sh
@@ -231,9 +231,19 @@ assert_contains "-R before --body-file: file content augmented" "$out" "$EXPECTE
 assert_contains "-R before --body-file: original content preserved" "$out" "from a file (with -R)"
 
 # ---- TEST 25: real binary missing AND none on PATH — exit 127 ----
-# Set PATH to dirs that don't contain gh so the fallback also fails.
+# Stage a scratch bin with the wrapper's minimal tooling but no `gh`.
+# Plain PATH=/usr/bin:/bin would pick up a pre-installed `gh` on
+# distros that ship it (notably ubuntu-latest's GitHub Actions image,
+# where /usr/bin/gh is preinstalled and the wrapper would exec it +
+# get a non-127 auth complaint).
+NO_GH_BIN="$WORK/no-gh-bin"
+mkdir -p "$NO_GH_BIN"
+for b in dirname basename grep; do
+  src="$(command -v "$b" 2>/dev/null || true)"
+  [ -n "$src" ] && ln -s "$src" "$NO_GH_BIN/$b"
+done
 ec=0
-err="$(env -i PATH=/usr/bin:/bin HOME="$HOME" COO_GH_REAL=/nonexistent/path \
+err="$(env -i PATH="$NO_GH_BIN" HOME="$HOME" COO_GH_REAL=/nonexistent/path \
        "$WRAPPER" pr create --body "x" 2>&1 >/dev/null)" || ec=$?
 if [ "$ec" = "127" ]; then
   PASS=$((PASS+1))


### PR DESCRIPTION
Fixes the env-isolation bug in `scripts/ci/test-gh-coo-wrap.sh` that
made the `GITHUB_PUBLIC_PAT unset: no swap, keeps MCP_PAT` case fail
on the dev container (108/109 pass), and wires the test into the
`hook-and-wrapper-tests` job in `bootstrap-regression.yml`.

## The bug

The failing case used `env -u GITHUB_PUBLIC_PAT GITHUB_MCP_PAT="$GITHUB_MCP_PAT" …`,
which preserves the rest of the host env. That left three load-bearing
host values reachable by the wrapper under test:

1. `OP_SERVICE_ACCOUNT_TOKEN` (set on the dev container) — enables the
   wrapper's `op read` fallback path.
2. `PATH` (includes `/home/user/.local/bin`) — `op` binary on PATH.
3. `XDG_RUNTIME_DIR` (unset on host → defaults to `/tmp`) — the cache
   dir `/tmp/coo-gh-pat-cache/PUBLIC` was already populated by a real
   `gh` call earlier in the boot.

`_resolve_pat PUBLIC` then materialized the live `vade-coo` PUBLIC PAT
via cache-hit (or op-read), the wrapper exported it as `GH_TOKEN`, and
the assertion against `GH_TOKEN=MCP_PAT_TESTING` failed. The wrapper
was correct per the Phase-2 op-read + tmpfs-cache fallback; the test
just predated it.

`bash -x` trace confirmed a `ghp_*` (classic-PAT shape) value where
the fixture `MCP_PAT_TESTING` was expected.

## The fix

Switch the failing case to `env -i` + minimal allowlist:

* `PATH=/usr/bin:/bin` — no `op` reachable.
* `HOME=$HOME` — for subshell behavior.
* `XDG_RUNTIME_DIR=$WORK/iso-runtime` — clean per-test cache dir.
* `GITHUB_MCP_PAT`, `GH_TOKEN`, `CLAUDE_CODE_REMOTE_SESSION_ID`,
  `COO_GH_REAL` — the test fixtures.
* Deliberately omit `OP_SERVICE_ACCOUNT_TOKEN` and `GITHUB_PUBLIC_PAT`.

`_resolve_pat PUBLIC` returns empty (no env, no op, no cache); the
wrapper preserves the inherited `MCP_PAT_TESTING`.

This is consistent with the existing `env -i` pattern at the
"missing real binary" case earlier in the same file, and with the
`_cache_test_env` helper that drives the PAT materialization cache
tests.

## Verification

```
$ bash scripts/ci/test-gh-coo-wrap.sh 2>&1 | tail -1
Total: 109 pass, 0 fail
```

(previously: 108 pass, 1 fail)

## Workflow wire-up

Removes the `Excluded for now: test-gh-coo-wrap.sh …` block from
`hook-and-wrapper-tests` (the comment slot that the issue notes
was prepared), and adds the test as the first step in the
"Wrapper contracts (R11)" group. Bootstrap-regression now exercises
the gh-coo-wrap PAT routing + body-augmentation contracts on every
PR that touches `scripts/`, `.claude/`, `.mcp.json`, or
`versions.lock`.

The workflow file commit lands as `vade-coo-app[bot]` via the
App-token contents API (OAuth lacks `workflow` scope on direct
`git push`).

Closes coo-labs/coo-memory#1252

https://claude.ai/code/session_01Y9SSgv9yRvNkM13F2fACXB