### PR TITLE
ci: wire test-track4-schema-iterator with production-shape fixture

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -318,16 +318,21 @@ jobs:
           pip install --quiet jsonschema pyyaml
           bash "$GITHUB_WORKSPACE/scripts/ci/test-integrity-group-s.sh"
 
-      # test-track4-schema-iterator deliberately NOT wired here. Its
-      # assertions require a schema fixture whose credentials carry the
-      # production env_aliases (GITHUB_MCP_PAT, MEM0_API_KEY,
-      # TRANSCRIPTS_AGE_IDENTITY, etc.); the existing fixture at
-      # scripts/ci/fixtures/secrets-schema-clean.yaml uses synthetic
-      # credential names (test-github-pat / test-multi-field / test-
-      # dormant) shaped for test-integrity-group-s.sh's invariants. The
-      # schema iterator is exercised end-to-end by bootstrap-end-to-end
-      # via cloud-setup.sh -> fetch_coo_secrets -> schema-fetch-secrets
-      # .py -> settings.json.env; a broken iterator fails Group D's
-      # invariants. Direct contract testing (§5 fail-closed on invalid
-      # YAML, §6 fail-closed on missing schema) is filed as a follow-on
-      # under coo-memory#933.
+      # ── Track 4 schema-iterator (R7) ─────────────────────────
+      # Direct contract test for scripts/boot/schema-fetch-secrets.py:
+      # per-credential env-alias round-trip on a production-shape fixture
+      # (GITHUB_MCP_PAT, MEM0_API_KEY, TRANSCRIPTS_AGE_IDENTITY, etc.) +
+      # fail-closed paths on invalid / missing schema. Complements the
+      # indirect coverage via bootstrap-end-to-end (cloud-setup.sh ->
+      # fetch_coo_secrets -> schema-fetch-secrets.py -> settings.json.env;
+      # a broken iterator fails Group D's invariants). Wired per
+      # coo-labs/coo-memory#1253.
+      - name: Track 4 schema-iterator (per-credential env-alias round-trip)
+        env:
+          VADE_CI_SCHEMA_PATH: ${{ github.workspace }}/scripts/ci/fixtures/secrets-schema-bootstrap.yaml
+        run: |
+          # Mock op binary on PATH so schema-fetch-secrets.py's
+          # subprocess.run(["op", "read", ...]) resolves to the fake-env
+          # CLI that returns canned vade-coo-shaped responses.
+          export PATH="$GITHUB_WORKSPACE/scripts/ci/mocks:$PATH"
+          bash "$GITHUB_WORKSPACE/scripts/ci/test-track4-schema-iterator.sh"

--- a/scripts/ci/fixtures/secrets-schema-bootstrap.yaml
+++ b/scripts/ci/fixtures/secrets-schema-bootstrap.yaml
@@ -1,0 +1,120 @@
+# CI fixture schema for bootstrap-regression + Track 4 schema-iterator
+# (coo-memory#871, coo-memory#1253).
+#
+# Mirrors operations/secrets/schema.yaml as of the 2026-06-06 op_item
+# rename pass — credential ids + op_items + env_aliases reflect the
+# production names the mock `op` binary (scripts/ci/mocks/op) handles.
+# Kept minimal: only the entries needed to exercise the schema-iterator
+# paths the CI suite asserts against. Not coupled to every future
+# production schema change.
+#
+# Consumers:
+#   - scripts/ci/run-bootstrap-regression.sh — staged to
+#     $COO_MEM_DST/operations/secrets/schema.yaml so cloud-setup.sh ->
+#     fetch_coo_secrets -> schema-fetch-secrets.py finds it at the
+#     production path.
+#   - scripts/ci/test-track4-schema-iterator.sh — read directly via
+#     $VADE_CI_SCHEMA_PATH; asserts per-credential env-alias round-trip
+#     + fail-closed paths on invalid / missing YAML.
+
+schema_version: 1
+vault: COO
+
+credentials:
+  - id: github-pat-vade-coo
+    op_item: github-pat-vade-coo
+    op_field: token
+    status: active
+    rotation_class: III
+    env_aliases:
+      - GITHUB_MCP_PAT
+      - GITHUB_TOKEN
+
+  - id: github-pat-classic-public
+    op_item: github-pat-classic-public
+    op_field: credential
+    status: active
+    rotation_class: III
+    env_aliases:
+      - GITHUB_PUBLIC_PAT
+
+  - id: agentmail-api-vade-coo
+    op_item: agentmail-api-vade-coo
+    op_field: credential
+    status: active
+    rotation_class: III
+    env_aliases:
+      - AGENTMAIL_API_KEY
+
+  - id: mem0-api-vade-coo
+    op_item: mem0-api-vade-coo
+    op_field: credential
+    status: active
+    rotation_class: III
+    env_aliases:
+      - MEM0_API_KEY
+
+  - id: r2-transcripts
+    op_item: r2-transcripts
+    op_field: secret-access-key
+    op_alt_fields:
+      - access-key-id
+      - endpoint
+      - bucket
+    status: active
+    rotation_class: I
+    env_aliases:
+      - R2_TRANSCRIPTS_ACCESS_KEY_ID
+      - R2_TRANSCRIPTS_SECRET_ACCESS_KEY
+      - R2_TRANSCRIPTS_ENDPOINT
+      - R2_TRANSCRIPTS_BUCKET
+
+  - id: transcripts-age-key
+    op_item: transcripts-age-key
+    op_field: credential
+    status: active
+    rotation_class: IV
+    env_aliases:
+      - TRANSCRIPTS_AGE_IDENTITY
+
+  - id: cloudflare-api-vade-coo
+    op_item: cloudflare-api-vade-coo
+    op_field: credential
+    op_alt_fields:
+      - account_id
+    status: active
+    rotation_class: I
+    env_aliases:
+      - CLOUDFLARE_API_TOKEN
+      - CLOUDFLARE_ACCOUNT_ID
+
+  - id: github-app-vade-coo-app
+    op_item: github-app-vade-coo
+    op_field: private_key
+    op_alt_fields:
+      - app_id
+      - installation_id
+    status: active
+    rotation_class: II
+    env_aliases:
+      - GITHUB_APP_PRIVATE_KEY
+      - GITHUB_APP_ID
+      - GITHUB_APP_INSTALLATION_ID
+
+  - id: vade-coo-ssh-sign
+    op_item: vade-coo-ssh-sign
+    op_field: "private key"
+    op_alt_fields:
+      - "public key"
+    status: active
+    rotation_class: IV
+    env_aliases: []
+
+  - id: vade-coo-ssh-auth
+    op_item: vade-coo-ssh-auth
+    op_field: "private key"
+    op_alt_fields:
+      - "public key"
+    status: dormant
+    rotation_class: IV
+    env_aliases: []

--- a/scripts/ci/run-bootstrap-regression.sh
+++ b/scripts/ci/run-bootstrap-regression.sh
@@ -102,101 +102,13 @@ rm -rf "$WORKSPACE_ROOT/CLAUDE.md" "$WORKSPACE_ROOT/.mcp.json" \
        "$WORKSPACE_ROOT/.vade-cloud-state"
 mkdir -p "$COO_MEM_DST/coo" "$COO_MEM_DST/identity"
 # Track 4 Phase 1: stage the secrets schema so schema-fetch-secrets.py
-# can parse it during the CI bootstrap. We stage a minimal fixture
-# schema that matches the active credentials the mock op understands,
-# so the schema-iterator path exercises correctly in fake-env mode.
+# can parse it during the CI bootstrap. The fixture lives canonically
+# at scripts/ci/fixtures/secrets-schema-bootstrap.yaml so the same file
+# can be reused by test-track4-schema-iterator.sh — removes the drift
+# point where the embedded heredoc lagged the production op_item names.
 mkdir -p "$COO_MEM_DST/operations/secrets"
-cat > "$COO_MEM_DST/operations/secrets/schema.yaml" << 'SCHEMA_EOF'
-# CI fixture schema for bootstrap-regression (Track 4 Phase 1, coo-memory#871).
-# Contains only the active credentials the mock `op` binary handles.
-# Mirrors the shape of the real schema.yaml; kept minimal to avoid
-# coupling the CI fixture to every future schema change.
-schema_version: 1
-vault: COO
-credentials:
-  - id: github-pat-vade-coo
-    op_item: vade-coo-self-2026-04
-    op_field: token
-    status: active
-    rotation_class: III
-    env_aliases:
-      - GITHUB_MCP_PAT
-      - GITHUB_TOKEN
-
-  - id: github-pat-classic-public
-    op_item: GITHUB_PUBLIC_PAT
-    op_field: credential   # mock uses credential; real schema uses token (TBD confirm)
-    status: active
-    rotation_class: III
-    env_aliases:
-      - GITHUB_PUBLIC_PAT
-
-  - id: agentmail-api-vade-coo
-    op_item: agentmail-vade-coo
-    op_field: credential
-    status: active
-    rotation_class: III
-    env_aliases:
-      - AGENTMAIL_API_KEY
-
-  - id: mem0-api-vade-coo
-    op_item: mem0-vade-coo
-    op_field: credential
-    status: active
-    rotation_class: III
-    env_aliases:
-      - MEM0_API_KEY
-
-  - id: r2-transcripts
-    op_item: r2-transcripts
-    op_field: secret-access-key
-    status: active
-    rotation_class: I
-    env_aliases:
-      - R2_TRANSCRIPTS_ACCESS_KEY_ID
-      - R2_TRANSCRIPTS_SECRET_ACCESS_KEY
-
-  - id: transcripts-age-key
-    op_item: transcripts-age-key
-    op_field: credential
-    status: active
-    rotation_class: IV
-    env_aliases:
-      - TRANSCRIPTS_AGE_IDENTITY
-
-  - id: cloudflare-api-vade-coo
-    op_item: cloudflare-api-token-vade-coo
-    op_field: credential
-    status: active
-    rotation_class: I
-    env_aliases:
-      - CLOUDFLARE_API_TOKEN
-      - CLOUDFLARE_ACCOUNT_ID
-
-  - id: github-app-vade-coo-app
-    op_item: vade-coo-app
-    op_field: private_key
-    status: active
-    rotation_class: II
-    env_aliases:
-      - GITHUB_APP_PRIVATE_KEY
-      - GITHUB_APP_ID
-      - GITHUB_APP_INSTALLATION_ID
-
-  - id: vade-coo-ssh-sign
-    op_item: vade-coo-sign
-    op_field: "private key"
-    status: active
-    rotation_class: IV
-    env_aliases: []
-
-  - id: vade-coo-ssh-auth
-    op_item: vade-coo-auth
-    op_field: "private key"
-    status: dormant
-    rotation_class: IV
-    env_aliases: []
-SCHEMA_EOF
+cp "$RUNTIME_DST/scripts/ci/fixtures/secrets-schema-bootstrap.yaml" \
+   "$COO_MEM_DST/operations/secrets/schema.yaml"
 log "Staged CI fixture schema at $COO_MEM_DST/operations/secrets/schema.yaml"
 cat > "$COO_MEM_DST/CLAUDE.md" <<'EOF'
 # coo-memory CLAUDE.md (CI bootstrap-regression stub)


### PR DESCRIPTION
Wires `scripts/ci/test-track4-schema-iterator.sh` into the `hook-and-wrapper-tests` job in `bootstrap-regression.yml` and extracts the embedded schema fixture from the runner heredoc into a tracked file.

## What

- **`scripts/ci/fixtures/secrets-schema-bootstrap.yaml`** (new) — production-shape fixture with the post-2026-06-06 op_item names (`github-pat-vade-coo`, `github-pat-classic-public`, `agentmail-api-vade-coo`, `mem0-api-vade-coo`, `cloudflare-api-vade-coo`, `github-app-vade-coo`, etc.) the mock op binary handles. Carries the production env_aliases (`GITHUB_MCP_PAT`, `GITHUB_TOKEN`, `AGENTMAIL_API_KEY`, `MEM0_API_KEY`, `TRANSCRIPTS_AGE_IDENTITY`, …) the iterator test asserts on.
- **`scripts/ci/run-bootstrap-regression.sh`** — replaces the inline heredoc (lines ~109–199) with a `cp` from the new fixture file. Closes a drift point — the embedded heredoc had stale op_item names (`vade-coo-self-2026-04`, `GITHUB_PUBLIC_PAT`, etc.) that no longer matched the mock or production schema after the 1P UI rename pass.
- **`.github/workflows/bootstrap-regression.yml`** — adds the `Track 4 schema-iterator` step to `hook-and-wrapper-tests`, prepending `scripts/ci/mocks/` to PATH and pointing `VADE_CI_SCHEMA_PATH` at the new fixture. Drops the prior "deliberately NOT wired here" comment block.

## Why

Per #1253: the test exercises `schema-fetch-secrets.py` directly — per-credential env-alias round-trip, fail-closed on invalid YAML (§5), fail-closed on missing schema (§6). The indirect end-to-end coverage via `cloud-setup.sh → fetch_coo_secrets → schema-fetch-secrets.py → settings.json.env` stays in place; this adds the tighter contract assertion on top.

## Verification

Local run of `test-track4-schema-iterator.sh` against the new fixture (mock op on PATH):

```
SCHEMA_FETCH_GOT=11
PASS: SCHEMA_FETCH_GOT=11 (at least one secret fetched)
PASS: GITHUB_MCP_PAT is set (len=42)
PASS: GITHUB_TOKEN is set (len=42)
PASS: AGENTMAIL_API_KEY is set (len=34)
PASS: MEM0_API_KEY is set (len=29)
PASS: TRANSCRIPTS_AGE_IDENTITY is set (len=70)
PASS: Dormant credential (vade-coo-ssh-auth) not in env (expected)
PASS: schema-fetch-secrets.py exits non-zero on invalid schema (fail-closed)
PASS: schema-fetch-secrets.py exits non-zero when schema file missing
All assertions passed
```

Full `run-bootstrap-regression.sh` against the extracted fixture: passes with `VADE_CI_ALLOWLIST=S2` (the CI default). S2 still degrades on the same 3 env_aliases the mock op doesn't cover (`R2_TRANSCRIPTS_ENDPOINT`, `R2_TRANSCRIPTS_BUCKET`, `CLOUDFLARE_API_TOKEN`) — improved from the prior heredoc-drift state where most credentials silently failed to fetch because op_item names didn't match the mock.

Refs: #871 (Track 4 parent), coo-labs/coo-memory#933 (CI strategy epic).

Closes coo-labs/coo-memory#1253

Closes coo-labs/coo-memory#1253

https://claude.ai/code/session_016KasBk2rKMPiM7TLatjwaK