### PR TITLE
cloud-setup: install claude-thinking-display-wrap at /root/.local/bin/claude (MEMO-2026-06-07-4bat)

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -223,6 +223,9 @@ jobs:
       - name: Wrapper — issue-comments (default projection, --full, --limit, --max-bytes)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-issue-comments.sh"
 
+      - name: Wrapper — claude-thinking-display-wrap (CLI-arg injection contract)
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/test-claude-thinking-display-wrap.sh"
+
       # ── Token + cache helpers (R11) ──────────────────────────
       - name: op-read retry recovery — install_coo_ssh_keys path
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-op-retry-recovery.sh"

--- a/scripts/boot/cloud-setup.sh
+++ b/scripts/boot/cloud-setup.sh
@@ -205,6 +205,21 @@ else
   log "Warning: ensure_pyyaml failed; if the base image lacks python3-yaml, coo-bootstrap will fail at fetch_coo_secrets."
 fi
 
+# Install the claude-thinking-display wrapper at /root/.local/bin/claude so
+# Anthropic's env-manager resolves through the wrapper (which appends
+# --thinking-display summarized on agent invocations) before reaching the
+# real binary at /opt/node22/bin/claude. Restores thinking summaries on
+# Opus 4.7+ Web/SDK/headless sessions; supersedes MEMO-2026-05-25-ikqp's
+# model-family routing rule once verified live. See
+# scripts/claude-thinking-display-wrap.sh for detection conditions.
+# Best-effort: skipped under VADE_CLAUDE_WRAP_DISABLE=1 or when the real
+# binary isn't where we expect, leaving the session unchanged.
+if install_claude_thinking_display_wrap "$RUNTIME_DIR/scripts/claude-thinking-display-wrap.sh"; then
+  build_log_record OK "cloud-setup: claude-thinking-display-wrap installed at build time"
+else
+  build_log_record WARN "cloud-setup: claude-thinking-display-wrap install failed at build time; sessions will not get thinking summaries on Opus 4.7+"
+fi
+
 # Pre-fetch the 1Password MCP server (@takescake/1password-mcp) so
 # first-session `npx -y` resolves offline. Closes the rotated-PAT →
 # restart class (coo-harness#164): the MCP can re-read secrets mid-session

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1510,6 +1510,44 @@ ensure_op_coo_wrap() {
   log "op-coo-wrap: installed (wrapper at $op_path, real binary at $real_path)"
 }
 
+# Install the claude-thinking-display wrapper at /root/.local/bin/claude so
+# every Claude-Code-on-the-Web launch gets `--thinking-display summarized`
+# appended on agent invocations. Restores thinking summaries on Opus 4.7+,
+# whose API default for `thinking.display` is `"omitted"` and whose client-side
+# fallback (`showThinkingSummaries → "summarized"`) is gated by the `!p6()`
+# non-interactive short-circuit. CLI flag bypasses the gate.
+#
+# Mechanism: env-manager's PATH places `/root/.local/bin` before
+# `/opt/node22/bin` (where Anthropic's symlink to the real binary lives), so
+# `claude` resolves through the wrapper, which exec's `/opt/node22/bin/claude`
+# with the flag appended. See scripts/claude-thinking-display-wrap.sh for
+# detection conditions and override knobs.
+#
+# Bypass: VADE_CLAUDE_WRAP_DISABLE=1 in the cloud env config skips install
+# entirely. The wrapper itself honors CC_THINKING_DISPLAY=omitted at runtime
+# for a softer per-session opt-out.
+#
+# Cloud-only path guard (root + /home/user); macOS/local installs are
+# untouched.
+install_claude_thinking_display_wrap() {
+  [ "$(id -u)" = "0" ] && [ -d /home/user ] || return 0
+  [ "${VADE_CLAUDE_WRAP_DISABLE:-0}" = "1" ] && { log "claude-thinking-display-wrap: bypass set; skipping"; return 0; }
+  local wrapper_src="${1:-}"
+  local install_path="/root/.local/bin/claude"
+  local real_path="/opt/node22/bin/claude"
+  if [ -z "$wrapper_src" ] || [ ! -f "$wrapper_src" ]; then
+    log "claude-thinking-display-wrap: source script missing; skipping"
+    return 0
+  fi
+  if [ ! -e "$real_path" ]; then
+    log "claude-thinking-display-wrap: real binary missing at $real_path; skipping"
+    return 0
+  fi
+  mkdir -p "$(dirname "$install_path")"
+  install -m 0755 "$wrapper_src" "$install_path"
+  log "claude-thinking-display-wrap: installed (wrapper at $install_path, real binary at $real_path)"
+}
+
 # Fetch COO secrets from 1Password via a schema-driven iterator.
 #
 # Reads operations/secrets/schema.yaml (Track 4 Phase 1 refactor,


### PR DESCRIPTION
Follow-up to coo-harness#534 (the wrapper + tests, already merged).

Decision recorded as MEMO-2026-06-07-4bat; supersedes MEMO-2026-05-25-ikqp.

## What this PR ships

- `scripts/lib/common.sh` — `install_claude_thinking_display_wrap()` helper.
  Copies the wrapper source to `/root/.local/bin/claude` (mode 0755). Honors
  `VADE_CLAUDE_WRAP_DISABLE=1` for hard-bypass; skips cleanly if the source
  or the underlying real binary at `/opt/node22/bin/claude` is missing.
- `scripts/boot/cloud-setup.sh` — call site, gated on the snapshot-build
  side so the wrapper is in place before env-manager launches `claude` in a
  freshly-resumed container. `build_log_record OK/WARN` for receipt visibility.
- `.github/workflows/bootstrap-regression.yml` — wires the 16-case smoke
  test into the `hook-and-wrapper-tests` job, alongside the other R11
  wrapper contracts. Landed via App-token contents API (OAuth lacks
  `workflow` scope).

## Verification path post-merge

1. Snapshot rebuild. Wait for Anthropic's next bake (or trigger one if
   that surface exists).
2. Start a fresh Web session.
3. Confirm `which claude` resolves to `/root/.local/bin/claude` from inside
   the new session (or, more decisively, `ps -ef | grep claude` shows the
   parent invoked `claude` and the wrapper exec'd
   `/opt/node22/bin/claude --thinking-display summarized ...`).
4. Observe thinking blocks in the transcript sidecar: `tj extract` should
   show populated `thinking` fields instead of empty strings. Regression
   sanity: `claude --version`, `claude mcp list`, interactive TUI on local
   Mac.
5. If green, MEMO-2026-05-25-ikqp's routing rule retires and we can spawn
   COT-load-bearing sessions on Opus 4.7 + this wrapper instead of falling
   back to sonnet-4-6 / opus-4-6.

## Risks (per the framing acked on the parent thread)

- Intercepts Anthropic's binary launch in their managed container, in
  service of documented client-side bug `anthropics/claude-code#49268`.
- Brittle to launch-convention changes: silent fallthrough to the pre-shim
  posture (no summaries, same as today on 4.7) if our detection markers go
  stale. No regression beyond status-quo on failure.
- Wrapper bug = session won't start. Mitigated by the 16-case test suite,
  the conservative skip-set, and the `CC_THINKING_DISPLAY=omitted` /
  `VADE_CLAUDE_WRAP_DISABLE=1` escape hatches.

Closes nothing directly; MEMO-2026-06-07-4bat carries the decision and
retirement conditions.

Closes: n/a

https://claude.ai/code/session_01XCm8Rovnu5vcCzKVv6mWJT