### PR TITLE
op fallback: extend SA-token chain from 2 to 3 (primary + backup + backup2)

### DIFF
--- a/scripts/boot/coo-bootstrap.sh
+++ b/scripts/boot/coo-bootstrap.sh
@@ -284,47 +284,63 @@ if ! retry 5 op whoami >/dev/null; then
   exit 1
 fi
 
-# ── Rate-limit auto-fallback to OP_SERVICE_ACCOUNT_TOKEN_BACKUP ─────────
-# 1P enforces a per-SA item-read rate limit (1000 read+write per 24h on
-# Personal/Teams). Approaching the ceiling, `op whoami` continues to work
+# ── Rate-limit auto-fallback to OP_SERVICE_ACCOUNT_TOKEN_BACKUP[2] ─────────
+# 1P enforces a per-SA-token rate limit (e.g. 10k read+1k write per hour on
+# Business; 1k+100 on Teams) AND a per-account daily ceiling (50k/24h on
+# Business; 5k on Teams). Approaching either, `op whoami` continues to work
 # while `op read op://COO/...` returns "Too many requests" rc=1 — which
 # fails install_coo_ssh_keys and downstream.
 #
-# When OP_SERVICE_ACCOUNT_TOKEN_BACKUP is set, sentinel-read a small COO
-# vault item. On rate-limit (or any read failure when the primary
-# whoami is fine), swap to BACKUP for the rest of the bootstrap. BACKUP's
-# SA identity must already be in the .op-sa-identity allowlist (multi-line
-# acceptable) — operator authorizes by appending to the file.
+# Operationally observed: when a token's per-token bucket has gone "sticky"
+# (see MEMO-2026-06-07-...), the per-token throttle persists even after
+# tier upgrade lifts the account ceiling. The fix shape is to provision
+# additional fresh SA tokens; their per-token buckets are independent.
+#
+# Up to two fallback tokens supported: OP_SERVICE_ACCOUNT_TOKEN_BACKUP and
+# OP_SERVICE_ACCOUNT_TOKEN_BACKUP2. Each fallback's SA identity must already
+# be in the .op-sa-identity allowlist — the swap path auto-appends on first
+# successful use (operator authorizes by setting the env var in cloud-env).
 COO_BOOTSTRAP_STEP="op_sentinel_read"
-if [ -n "${OP_SERVICE_ACCOUNT_TOKEN_BACKUP:-}" ]; then
-  # Stderr-captured probe. The `|| _sentinel_rc=$?` consumes the
-  # non-zero exit so `set -e` doesn't trip on the command substitution.
-  _sentinel_out=""
-  _sentinel_rc=0
-  _sentinel_out="$(op read 'op://COO/vade-coo-ssh-auth/public key' 2>&1 >/dev/null)" || _sentinel_rc=$?
-  if [ "$_sentinel_rc" -ne 0 ] && printf '%s' "$_sentinel_out" | grep -qiE 'rate.?limit|too many requests'; then
-    log "coo-bootstrap: standard SA token rate-limited on op read; swapping to OP_SERVICE_ACCOUNT_TOKEN_BACKUP"
-    export OP_SERVICE_ACCOUNT_TOKEN="$OP_SERVICE_ACCOUNT_TOKEN_BACKUP"
-    if ! retry 3 op whoami >/dev/null; then
-      log "FATAL: BACKUP SA token failed op whoami after standard rate-limited"
-      log "  See: coo-memory/operations/secrets/README.md §3.6"
-      exit 1
+
+# Helper: try a sentinel probe on the fallback token at $2; on success
+# persist the marker letter $1 and append the SA identity to the allowlist.
+# Returns 0 on a working token, 1 on rate-limit (caller advances), exits
+# FATAL on a non-rate-limit error (token revoked / wrong scopes / etc).
+_try_sa_fallback() {
+  local _marker="$1" _varname="$2"
+  local _tok="${!_varname:-}"
+  [ -n "$_tok" ] || return 1
+  log "coo-bootstrap: swapping OP_SERVICE_ACCOUNT_TOKEN to $_varname"
+  export OP_SERVICE_ACCOUNT_TOKEN="$_tok"
+  local _probe_out="" _probe_rc=0
+  _probe_out="$(op read 'op://COO/vade-coo-ssh-auth/public key' 2>&1 >/dev/null)" || _probe_rc=$?
+  if [ "$_probe_rc" -ne 0 ]; then
+    if printf '%s' "$_probe_out" | grep -qiE 'rate.?limit|too many requests'; then
+      log "coo-bootstrap: $_varname also rate-limited; advancing"
+      return 1
     fi
-    log "coo-bootstrap: BACKUP SA token active"
-    # Persist the swap for the rest of the session. The op-coo-wrap shim
-    # (installed by session-start-sync.sh ensure_op_coo_wrap, runs before
-    # this hook) reads this marker on every `op` invocation to choose the
-    # active token. Without this, every Bash-tool subprocess would re-probe
-    # the rate-limit on its first op-read. Tmpfs, container-ephemeral.
-    _op_pref_dir="${XDG_RUNTIME_DIR:-/tmp}/coo-op-wrap"
-    mkdir -p "$_op_pref_dir" 2>/dev/null || true
-    chmod 0700 "$_op_pref_dir" 2>/dev/null || true
-    printf B > "$_op_pref_dir/active" 2>/dev/null || true
-    # Auto-append BACKUP's identity to the allowlist on first successful
-    # swap. Authorization signal is the operator setting the BACKUP env
-    # var; this avoids a FATAL on the identity-check immediately below
-    # when a fresh container has not yet seen BACKUP. Idempotent.
-    _backup_id="$(op whoami --format=json 2>/dev/null | python3 -c "
+    log "FATAL: $_varname sentinel-read failed with non-rate-limit error"
+    log "  Probe output: $(printf '%s' "$_probe_out" | head -c 200)"
+    log "  See: coo-memory/operations/secrets/README.md §3.6"
+    exit 1
+  fi
+  if ! retry 3 op whoami >/dev/null; then
+    log "FATAL: $_varname failed op whoami after swap"
+    log "  See: coo-memory/operations/secrets/README.md §3.6"
+    exit 1
+  fi
+  log "coo-bootstrap: $_varname active"
+  # Persist marker so subsequent Bash-tool subprocesses skip the doomed
+  # primary on their op-reads. The op-coo-wrap shim consumes this.
+  _op_pref_dir="${XDG_RUNTIME_DIR:-/tmp}/coo-op-wrap"
+  mkdir -p "$_op_pref_dir" 2>/dev/null || true
+  chmod 0700 "$_op_pref_dir" 2>/dev/null || true
+  printf '%s' "$_marker" > "$_op_pref_dir/active" 2>/dev/null || true
+  # Auto-append this SA's identity to the allowlist on first successful
+  # swap. Authorization signal is the operator setting the fallback env
+  # var; this avoids a FATAL on the identity-check immediately below.
+  local _fb_id
+  _fb_id="$(op whoami --format=json 2>/dev/null | python3 -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -334,15 +350,30 @@ try:
 except Exception:
     pass
 " 2>/dev/null || true)"
-    if [ -n "$_backup_id" ]; then
-      mkdir -p "$(dirname "${HOME}/.vade/.op-sa-identity")"
-      touch "${HOME}/.vade/.op-sa-identity"
-      if ! grep -Fxq "$_backup_id" "${HOME}/.vade/.op-sa-identity" 2>/dev/null; then
-        printf '%s\n' "$_backup_id" >> "${HOME}/.vade/.op-sa-identity"
-        log "coo-bootstrap: appended BACKUP identity '${_backup_id}' to .op-sa-identity allowlist"
+  if [ -n "$_fb_id" ]; then
+    mkdir -p "$(dirname "${HOME}/.vade/.op-sa-identity")"
+    touch "${HOME}/.vade/.op-sa-identity"
+    if ! grep -Fxq "$_fb_id" "${HOME}/.vade/.op-sa-identity" 2>/dev/null; then
+      printf '%s\n' "$_fb_id" >> "${HOME}/.vade/.op-sa-identity"
+      log "coo-bootstrap: appended ${_marker}-token identity '${_fb_id}' to .op-sa-identity allowlist"
+    fi
+  fi
+  return 0
+}
+
+if [ -n "${OP_SERVICE_ACCOUNT_TOKEN_BACKUP:-}" ] || [ -n "${OP_SERVICE_ACCOUNT_TOKEN_BACKUP2:-}" ]; then
+  # Stderr-captured probe. The `|| _sentinel_rc=$?` consumes the
+  # non-zero exit so `set -e` doesn't trip on the command substitution.
+  _sentinel_out=""
+  _sentinel_rc=0
+  _sentinel_out="$(op read 'op://COO/vade-coo-ssh-auth/public key' 2>&1 >/dev/null)" || _sentinel_rc=$?
+  if [ "$_sentinel_rc" -ne 0 ] && printf '%s' "$_sentinel_out" | grep -qiE 'rate.?limit|too many requests'; then
+    log "coo-bootstrap: standard SA token rate-limited on op read"
+    if ! _try_sa_fallback B OP_SERVICE_ACCOUNT_TOKEN_BACKUP; then
+      if ! _try_sa_fallback C OP_SERVICE_ACCOUNT_TOKEN_BACKUP2; then
+        log "WARN: primary and all configured fallback SA tokens rate-limited; downstream op-reads may fail"
       fi
     fi
-    unset _backup_id
   fi
   unset _sentinel_out _sentinel_rc
 fi

--- a/scripts/ci/test-op-coo-wrap.sh
+++ b/scripts/ci/test-op-coo-wrap.sh
@@ -23,17 +23,18 @@ WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
 # Mock op-real: behaves per env switches.
-#   MOCK_OP_TOKEN_A_VALUE / _B_VALUE — the strings the test will set
-#     OP_SERVICE_ACCOUNT_TOKEN / OP_SERVICE_ACCOUNT_TOKEN_BACKUP to.
-#     Mock reports which bucket the actual OP_SERVICE_ACCOUNT_TOKEN
-#     matches ("A", "B", or "OTHER") by comparing values.
-#   MOCK_OP_FAIL_A / _B — set to "rate_limit" / "other_error" / "ok".
+#   MOCK_OP_TOKEN_A_VALUE / _B_VALUE / _C_VALUE — the strings the test will set
+#     OP_SERVICE_ACCOUNT_TOKEN / OP_SERVICE_ACCOUNT_TOKEN_BACKUP /
+#     OP_SERVICE_ACCOUNT_TOKEN_BACKUP2 to. Mock reports which bucket the actual
+#     OP_SERVICE_ACCOUNT_TOKEN matches ("A", "B", "C", or "OTHER") by value.
+#   MOCK_OP_FAIL_A / _B / _C — set to "rate_limit" / "other_error" / "ok".
 #     Controls exit code + stderr based on which bucket was passed.
 cat > "$WORK/op-real" <<'EOF'
 #!/usr/bin/env bash
 got="${OP_SERVICE_ACCOUNT_TOKEN:-<unset>}"
 if   [ "$got" = "${MOCK_OP_TOKEN_A_VALUE:-__no_a__}" ]; then bucket="A"
 elif [ "$got" = "${MOCK_OP_TOKEN_B_VALUE:-__no_b__}" ]; then bucket="B"
+elif [ "$got" = "${MOCK_OP_TOKEN_C_VALUE:-__no_c__}" ]; then bucket="C"
 else bucket="OTHER"
 fi
 printf 'TOKEN_BUCKET=%s\n' "$bucket"
@@ -43,6 +44,7 @@ printf 'ARGV=%s\n' "$*"
 case "$bucket" in
   A) fail_mode="${MOCK_OP_FAIL_A:-ok}" ;;
   B) fail_mode="${MOCK_OP_FAIL_B:-ok}" ;;
+  C) fail_mode="${MOCK_OP_FAIL_C:-ok}" ;;
   *) fail_mode="${MOCK_OP_FAIL_OTHER:-ok}" ;;
 esac
 
@@ -114,7 +116,8 @@ export MOCK_OP_TOKEN_B_VALUE="backup_token_BBBBBB"
 # this is a no-op; on a clean runner (CI), the omission would make every
 # reassignment a non-exported local → wrapper sees the var as unset →
 # mock op-real reports bucket=OTHER and every assertion fails.
-export OP_SERVICE_ACCOUNT_TOKEN="" OP_SERVICE_ACCOUNT_TOKEN_BACKUP=""
+export OP_SERVICE_ACCOUNT_TOKEN="" OP_SERVICE_ACCOUNT_TOKEN_BACKUP="" OP_SERVICE_ACCOUNT_TOKEN_BACKUP2=""
+export MOCK_OP_TOKEN_C_VALUE="backup2_token_CCCCCC"
 
 # ---- TEST 1: primary OK → uses A, no marker write ----
 fresh_env
@@ -236,6 +239,96 @@ if printf '%s' "$out_stderr" | grep -q "Too many requests"; then
 else
   PASS=$((PASS+1)); printf '  PASS  RL swap success: primary RL stderr suppressed\n'
 fi
+
+# ---- TEST 10: A+B rate-limited, C ok → cascades to C, marker=C ----
+# Re-export the SA-token vars in case prior tests unset OP_SERVICE_ACCOUNT_TOKEN_BACKUP
+# (TEST 7 does so); a plain prefix-assignment after unset doesn't restore the export
+# attribute, and the subshell wouldn't see B as a result.
+fresh_env
+export MOCK_OP_FAIL_A="rate_limit"; export MOCK_OP_FAIL_B="rate_limit"; unset MOCK_OP_FAIL_C
+export OP_SERVICE_ACCOUNT_TOKEN OP_SERVICE_ACCOUNT_TOKEN_BACKUP OP_SERVICE_ACCOUNT_TOKEN_BACKUP2
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP2="$MOCK_OP_TOKEN_C_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "A+B RL, C ok: attempted A" "$out" "TOKEN_BUCKET=A"
+assert_contains "A+B RL, C ok: attempted B" "$out" "TOKEN_BUCKET=B"
+assert_contains "A+B RL, C ok: cascaded to C" "$out" "TOKEN_BUCKET=C"
+assert_eq "A+B RL, C ok: rc=0" "$rc" "0"
+assert_eq "A+B RL, C ok: marker=C" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null)" "C"
+
+# ---- TEST 11: all three rate-limited → all attempted, rc=1, marker unchanged ----
+fresh_env
+export MOCK_OP_FAIL_A="rate_limit"; export MOCK_OP_FAIL_B="rate_limit"; export MOCK_OP_FAIL_C="rate_limit"
+export OP_SERVICE_ACCOUNT_TOKEN OP_SERVICE_ACCOUNT_TOKEN_BACKUP OP_SERVICE_ACCOUNT_TOKEN_BACKUP2
+mkdir -p "$XDG_RUNTIME_DIR/coo-op-wrap"
+printf A > "$XDG_RUNTIME_DIR/coo-op-wrap/active"
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP2="$MOCK_OP_TOKEN_C_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "all RL: attempted A" "$out" "TOKEN_BUCKET=A"
+assert_contains "all RL: attempted B" "$out" "TOKEN_BUCKET=B"
+assert_contains "all RL: attempted C" "$out" "TOKEN_BUCKET=C"
+assert_eq "all RL: rc=1" "$rc" "1"
+assert_eq "all RL: marker unchanged=A" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null)" "A"
+
+# ---- TEST 12: marker=C + C ok → uses C straight away, no A/B probe ----
+fresh_env
+unset MOCK_OP_FAIL_A MOCK_OP_FAIL_B MOCK_OP_FAIL_C
+mkdir -p "$XDG_RUNTIME_DIR/coo-op-wrap"
+printf C > "$XDG_RUNTIME_DIR/coo-op-wrap/active"
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP2="$MOCK_OP_TOKEN_C_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "marker=C: uses bucket=C" "$out" "TOKEN_BUCKET=C"
+if printf '%s' "$out" | grep -qE "TOKEN_BUCKET=(A|B)"; then
+  FAIL=$((FAIL+1)); FAILURES+=("marker=C: should not probe A or B")
+  printf '  FAIL  marker=C: should not probe A or B\n'
+else
+  PASS=$((PASS+1)); printf '  PASS  marker=C: no A/B probe\n'
+fi
+assert_eq "marker=C: rc=0" "$rc" "0"
+
+# ---- TEST 13: marker=C circular wrap on C-RL → tries C then A then B ----
+fresh_env
+export MOCK_OP_FAIL_C="rate_limit"; unset MOCK_OP_FAIL_A MOCK_OP_FAIL_B
+mkdir -p "$XDG_RUNTIME_DIR/coo-op-wrap"
+printf C > "$XDG_RUNTIME_DIR/coo-op-wrap/active"
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP="$MOCK_OP_TOKEN_B_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP2="$MOCK_OP_TOKEN_C_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+# Order should be C (first, RL), then A (next, ok). Should NOT reach B.
+assert_contains "circular C: tried C first" "$out" "TOKEN_BUCKET=C"
+assert_contains "circular C: swapped to A" "$out" "TOKEN_BUCKET=A"
+if printf '%s' "$out" | grep -q "TOKEN_BUCKET=B"; then
+  FAIL=$((FAIL+1)); FAILURES+=("circular C: should not reach B after A succeeded")
+  printf '  FAIL  circular C: should not reach B after A succeeded\n'
+else
+  PASS=$((PASS+1)); printf '  PASS  circular C: stopped at A (no B probe)\n'
+fi
+assert_eq "circular C: rc=0" "$rc" "0"
+assert_eq "circular C: marker=A" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null)" "A"
+
+# ---- TEST 14: BACKUP2 set but BACKUP unset → A → C (skips B slot cleanly) ----
+fresh_env
+export MOCK_OP_FAIL_A="rate_limit"; unset MOCK_OP_FAIL_C
+unset OP_SERVICE_ACCOUNT_TOKEN_BACKUP
+OP_SERVICE_ACCOUNT_TOKEN="$MOCK_OP_TOKEN_A_VALUE" \
+OP_SERVICE_ACCOUNT_TOKEN_BACKUP2="$MOCK_OP_TOKEN_C_VALUE" \
+rc=0; out="$("$WRAPPER" read 'op://fake/x' 2>&1)" || rc=$?
+assert_contains "skip B: attempted A" "$out" "TOKEN_BUCKET=A"
+assert_contains "skip B: cascaded directly to C" "$out" "TOKEN_BUCKET=C"
+if printf '%s' "$out" | grep -q "TOKEN_BUCKET=B"; then
+  FAIL=$((FAIL+1)); FAILURES+=("skip B: should not attempt B (unset)")
+  printf '  FAIL  skip B: attempted B despite being unset\n'
+else
+  PASS=$((PASS+1)); printf '  PASS  skip B: B slot pruned (unset)\n'
+fi
+assert_eq "skip B: rc=0" "$rc" "0"
+assert_eq "skip B: marker=C" "$(cat "$XDG_RUNTIME_DIR/coo-op-wrap/active" 2>/dev/null)" "C"
 
 # ---- Summary ----
 echo

--- a/scripts/op-coo-wrap.sh
+++ b/scripts/op-coo-wrap.sh
@@ -90,26 +90,44 @@ PREF_FILE="$PREF_DIR/active"
 mkdir -p "$PREF_DIR" 2>/dev/null || true
 chmod 0700 "$PREF_DIR" 2>/dev/null || true
 
-# Capture both candidate tokens as locals so we can swap freely without
-# losing track of either. If only one is set, we degrade to single-attempt.
+# Capture all candidate tokens as locals so we can swap freely without
+# losing track of any. If a slot is unset we skip it in the rotation;
+# if only one is set, we degrade to single-attempt.
 _token_a="${OP_SERVICE_ACCOUNT_TOKEN:-}"
 _token_b="${OP_SERVICE_ACCOUNT_TOKEN_BACKUP:-}"
+_token_c="${OP_SERVICE_ACCOUNT_TOKEN_BACKUP2:-}"
 
 # Read marker preference. Default to A (the env's OP_SERVICE_ACCOUNT_TOKEN).
 _pref="A"
 if [ -f "$PREF_FILE" ]; then
   _pref="$(cat "$PREF_FILE" 2>/dev/null || echo A)"
-  case "$_pref" in A|B) ;; *) _pref="A" ;; esac
+  case "$_pref" in A|B|C) ;; *) _pref="A" ;; esac
 fi
 
-# Decide first-try and fallback tokens based on preference + availability.
-if [ "$_pref" = "B" ] && [ -n "$_token_b" ]; then
-  _first="$_token_b" ; _first_name="B"
-  _second="$_token_a" ; _second_name="A"
-else
-  _first="$_token_a" ; _first_name="A"
-  _second="$_token_b" ; _second_name="B"
-fi
+# Build the attempt order as a circular rotation starting at the marker.
+# Order A: A B C | order B: B C A | order C: C A B. Unset slots get pruned
+# below so a single configured token still works as a single-attempt path.
+case "$_pref" in
+  A) _order="A B C" ;;
+  B) _order="B C A" ;;
+  C) _order="C A B" ;;
+esac
+
+# Resolve names to tokens, skipping unset slots. Parallel arrays for token
+# value and name; iterated in attempt order.
+_names=()
+_toks=()
+for _n in $_order; do
+  case "$_n" in
+    A) _t="$_token_a" ;;
+    B) _t="$_token_b" ;;
+    C) _t="$_token_c" ;;
+  esac
+  if [ -n "$_t" ]; then
+    _names+=("$_n")
+    _toks+=("$_t")
+  fi
+done
 
 _trace() {
   [ "${COO_OP_WRAP_TRACE:-0}" = "1" ] || return 0
@@ -131,35 +149,49 @@ trap _cleanup EXIT
 _err_tmp="$(mktemp 2>/dev/null || echo "/tmp/op-coo-wrap.$$.err")"
 : > "$_err_tmp"
 
-# First attempt.
-_trace "attempt 1: token=$_first_name argv=$*"
-if [ -n "$_first" ]; then
-  OP_SERVICE_ACCOUNT_TOKEN="$_first" "$REAL_OP" "$@" 2>"$_err_tmp"
-  _rc=$?
-else
-  # No token in slot A and pref says A. Run anyway — op will surface its
-  # own auth error, which is more useful than a synthetic one from us.
+# Iterate through configured tokens. Each attempt:
+#   - rc=0 OR non-rate-limit error → stop (don't keep probing on legitimate failures)
+#   - rate-limit AND another token available → advance to next
+#   - rate-limit AND last token → surface rate-limit error
+# On a stop, if the stopping token differs from the marker preference,
+# update the marker so subsequent invocations skip the doomed-token probe.
+_rc=0
+_stopped_name=""
+_attempt=0
+_n_tokens=${#_toks[@]}
+
+if [ "$_n_tokens" -eq 0 ]; then
+  # No tokens at all — let op surface its own auth error.
+  _trace "attempt 1: no tokens configured; running real op without OP_SERVICE_ACCOUNT_TOKEN"
   "$REAL_OP" "$@" 2>"$_err_tmp"
   _rc=$?
-fi
+else
+  for _i in "${!_toks[@]}"; do
+    _attempt=$((_attempt + 1))
+    _n="${_names[$_i]}"
+    _t="${_toks[$_i]}"
+    [ "$_attempt" -gt 1 ] && : > "$_err_tmp"
+    _trace "attempt $_attempt: token=$_n argv=$*"
+    OP_SERVICE_ACCOUNT_TOKEN="$_t" "$REAL_OP" "$@" 2>"$_err_tmp"
+    _rc=$?
+    if [ "$_rc" -eq 0 ] || ! _is_rate_limit "$(cat "$_err_tmp" 2>/dev/null)"; then
+      _stopped_name="$_n"
+      break
+    fi
+    # Rate-limited: if a next token exists, advance and retry.
+    if [ "$((_i + 1))" -lt "$_n_tokens" ]; then
+      _next_n="${_names[$((_i + 1))]}"
+      _trace "attempt $_attempt rate-limited; advancing $_n -> $_next_n"
+    else
+      _trace "attempt $_attempt rate-limited; no further tokens; marker unchanged ($_pref)"
+    fi
+  done
 
-# Swap-and-retry path: non-zero exit, rate-limit shape, alternate exists
-# and differs from the first.
-if [ "$_rc" -ne 0 ] \
-   && [ -n "$_second" ] \
-   && [ "$_second" != "$_first" ] \
-   && _is_rate_limit "$(cat "$_err_tmp" 2>/dev/null)"; then
-  _trace "attempt 1 rate-limited; swapping $_first_name -> $_second_name"
-  : > "$_err_tmp"
-  OP_SERVICE_ACCOUNT_TOKEN="$_second" "$REAL_OP" "$@" 2>"$_err_tmp"
-  _rc=$?
-  # Update marker iff the retry didn't also rate-limit. If both
-  # are rate-limited, leave the marker untouched.
-  if [ "$_rc" -eq 0 ] || ! _is_rate_limit "$(cat "$_err_tmp" 2>/dev/null)"; then
-    printf '%s' "$_second_name" > "$PREF_FILE" 2>/dev/null || true
-    _trace "attempt 2 success/non-rl; marker -> $_second_name"
-  else
-    _trace "attempt 2 also rate-limited; marker unchanged ($_pref)"
+  # Update marker if we stopped on a token other than the preferred one.
+  # If _stopped_name is empty, every token rate-limited; leave marker untouched.
+  if [ -n "$_stopped_name" ] && [ "$_stopped_name" != "$_pref" ]; then
+    printf '%s' "$_stopped_name" > "$PREF_FILE" 2>/dev/null || true
+    _trace "marker -> $_stopped_name (was $_pref)"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Extends the 1Password SA-token fallback chain from 2 tokens (primary + backup) to 3 (primary + backup + backup2). Refactors `op-coo-wrap.sh` (path-shadow shim) and `coo-bootstrap.sh` (sentinel-swap) to N-token circular rotation, driven by a new `OP_SERVICE_ACCOUNT_TOKEN_BACKUP2` env var alongside the existing two. Sibling schema declaration in [coo-labs/coo-memory#TBD](https://github.com/coo-labs/coo-memory/pull/new/claude/confident-einstein-IkpID) (push lands first; will update with PR# after).

Closes #492.

## Why

1Password Service Accounts enforce two independent throttles: a per-SA-token hourly rate-limit, and a per-account 24h daily ceiling. Empirically discovered today that the per-token throttle goes "sticky" — persisting against actual `op read` calls even after an account-tier upgrade lifts the daily ceiling and the `op service-account ratelimit` counter shows headroom. A fresh SA's per-token bucket bypasses the sticky throttle (live-confirmed via probe).

Both existing SAs (primary + backup) hit this state today, blocking the entire substrate. The dual-SA design only handles SA-level outages and concurrency burst — it doesn't escape sticky-throttle when both buckets are pinned simultaneously. A third SA provides the escape hatch.

## What changed

### `scripts/op-coo-wrap.sh` — array-based N-token rotation

Replaces the binary first/second token selection with an ordered array keyed on the marker preference (`A B C` / `B C A` / `C A B`). Unset slots are pruned at array-build time, so 1-token and 2-token deployments still work identically — backward-compatible behavior verified by the existing 30-assertion test suite (all green post-refactor).

On rate-limit, advance to next token. On any non-rate-limit response (success or other error), stop. Update the marker only when the stopping token differs from the prior preference. When all configured tokens rate-limit, leave the marker untouched (no point ping-ponging) and surface the rate-limit error.

### `scripts/boot/coo-bootstrap.sh` — `_try_sa_fallback` helper

Extracts the swap-verify-persist-allowlist pattern into a helper function called twice in sequence: once for `OP_SERVICE_ACCOUNT_TOKEN_BACKUP`, then on rate-limit again for `OP_SERVICE_ACCOUNT_TOKEN_BACKUP2`. Key behavior change: each fallback now does its OWN sentinel re-probe (`op read` against the SSH-key public field), not just `op whoami` — because whoami succeeds on a rate-limited token, so the prior 2-token design wouldn't actually detect a rate-limited backup. The helper auto-appends each working SA's identity to `~/.vade/.op-sa-identity` on first swap, so operator authorization is exactly "set the env var; the bootstrap accepts the rest."

### `scripts/ci/test-op-coo-wrap.sh` — extended to 53 assertions

Added TESTS 10–14 covering:
- A+B rate-limited, C ok → cascades through to C, marker=C.
- All three rate-limited → all attempted, rc=1, marker unchanged.
- marker=C + C ok → uses C straight away, no A/B probe.
- marker=C + C rate-limited → circular wrap (C → A → B), correct marker update.
- BACKUP2 set but BACKUP unset → A → C cleanly (slot pruning works).

Also extended the mock op-real to recognize a third token bucket. All 53 assertions green (30 existing + 23 new).

## Out of scope

- Generalization to N-token (e.g. an env-var-list approach). Bounded at 3 by YAGNI — 3 matches the operational shape (primary + immediate backup + sticky-throttle escape). Re-evaluate if we ever burn through 3 simultaneously.
- Schema-side declaration of the new credential. Sibling PR in coo-memory (linked above).
- Tier-upgrade-propagation memo. Will follow as case-law record after PR lands.

### Priority

P1

### Readiness

Ready

Closes #492

https://claude.ai/code/session_019qaf9VEGde3SzseEGWy84k