### PR TITLE
settings: enableWorkflows: true (cloud Claude Code dynamic workflows)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "enableWorkflows": true,
   "model": "opusplan",
   "effortLevel": "high",
   "showThinkingSummaries": true,


### PR DESCRIPTION
Sets \`enableWorkflows: true\` in \`coo-harness/.claude/settings.json\` so every cloud Claude Code session boots with the user opt-in for dynamic workflows already on (https://code.claude.com/docs/en/workflows).

## Why

Cloud Claude Code 2.1.168 session (2026-06-07): \`ultracode:\` keyword fires the harness's system-reminder pointing at the Workflow tool, but the tool is absent from the model's tool surface because both gates were unset. Binary's gate chain (\`_A7()\` → \`AA7()\` → \`L7("allow_workflows")\` + user setting \`enableWorkflows\`) requires the user-side opt-in regardless of the upstream entitlement. This commit flips the user-side toggle to its true position; the upstream \`allow_workflows\` GrowthBook entitlement is account-level and out of scope here.

## What this doesn't do

- Does **not** unblock workflows if the upstream GrowthBook \`allow_workflows\` entitlement is off for the account. That's the dominant gate. If the entitlement is on (or lazy-loads on a fresh session start that this current container never triggered), this toggle is now in the right position and the tool should project.
- Does **not** affect any other behavior. \`disableWorkflows\` remains unset (off); \`workflowKeywordTriggerEnabled\` remains the default true.

## Verification path

Next cloud Claude Code session that boots with this branch in coo-harness's checkout will run \`session-start-sync.sh\`, which copies \`coo-harness/.claude/settings.json\` to \`/root/.claude/settings.json\` and (when \`CLAUDE_CODE_REMOTE=true\`) also to \`/home/user/.claude/settings.json\`. The new session can verify by:

1. \`ToolSearch select:Workflow\` — should return the Workflow tool's schema if the upstream entitlement is also lit.
2. \`jq .enableWorkflows /root/.claude/settings.json\` — should print \`true\`.
3. If still no Workflow tool but \`enableWorkflows: true\`, the upstream \`allow_workflows\` entitlement is the gate; file with Anthropic.

Closes n/a.

Closes: n/a

https://claude.ai/code/session_0138gcTTs4CFbBmGYjvURnTf