### PR TITLE
rollup: --combine-with-actions for session+actions daily total

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,37 @@ or jsonl access), exact `files` (needs jsonl decryption in the Action),
 token-count and cost columns. The current schema and data sources are
 documented in `coo-labs/coo-logs/index/README.md`.
 
+## Op-read consumption telemetry — `bin/op-read-rollup.py`
+
+`bin/op-read-rollup.py` aggregates per-day 1Password op-read consumption
+across two sources:
+
+- **Session side** — per-call jsonl events emitted by `op-coo-wrap.sh`
+  (Layer 2) and `gh-coo-wrap.sh` `_resolve_pat` (Layer 1), rolled to
+  per-session sidecars at `coo-logs/sessions/YYYY/MM/DD/coo-*.op-reads.jsonl`
+  by the `/end-session` skill (shipped in coo-labs/coo-harness#540).
+- **Actions side** — daily rollup of `1password/load-secrets-action@v2`
+  consumption across `coo-labs/*` workflows, written nightly to
+  `coo-logs/telemetry/op-reads-actions-YYYY-MM-DD.json` by the
+  `op-reads-actions` Action in `coo-labs/coo-logs` (shipped in
+  coo-labs/coo-harness#541).
+
+```sh
+# Session-side rollups (per-script / per-path / per-phase histograms)
+op-read-rollup.py --date 2026-06-07 --by script
+op-read-rollup.py --range 2026-06-01:2026-06-07 --by path
+
+# Combined daily total: sessions + actions
+op-read-rollup.py --combine-with-actions 2026-06-07
+```
+
+The combined view is the canonical answer to "what's our total daily
+op-read consumption?" — the session-side and Actions-side draw on the
+same `OP_SERVICE_ACCOUNT_TOKEN` quota, so neither alone is sufficient.
+
+Origin: briefing-040 (`coo-memory/briefings/040-op-request-volume.md`)
+and its followup plan §4 (`briefings/_followups/040-op-request-volume-plan-2026-06-07-mrcc.md`).
+
 ## Bootstrap CI
 
 PRs that touch `scripts/`, `.claude/`, `.mcp.json`, or

--- a/bin/op-read-rollup.py
+++ b/bin/op-read-rollup.py
@@ -12,12 +12,18 @@ per-path / per-phase histograms with p50/p95/p99 latency.
 
 Output: markdown table to stdout; --json-out writes structured JSON.
 
+The --combine-with-actions <date> mode merges the session-side jsonl with
+the Actions-side rollup at coo-logs/telemetry/op-reads-actions-<date>.json
+(produced by coo-labs/coo-logs/bin/op-reads-actions.py per
+coo-labs/coo-harness#541) to report total daily op-read consumption.
+
 Usage:
   op-read-rollup.py --date 2026-06-07 --by script
   op-read-rollup.py --date 2026-06-07 --by path
   op-read-rollup.py --date 2026-06-07 --by phase
   op-read-rollup.py --range 2026-06-01:2026-06-07 --by script
   op-read-rollup.py --date 2026-06-07 --input-dir /path/to/coo-logs/sessions
+  op-read-rollup.py --combine-with-actions 2026-06-07    # sessions + actions
 
 Exit codes:
   0 — rollup produced
@@ -40,6 +46,12 @@ def parse_args():
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument("--date", help="YYYY-MM-DD single-day rollup")
     g.add_argument("--range", help="YYYY-MM-DD:YYYY-MM-DD inclusive range")
+    g.add_argument(
+        "--combine-with-actions",
+        metavar="YYYY-MM-DD",
+        help="Combine session-side jsonl with the Actions-side rollup at "
+             "coo-logs/telemetry/op-reads-actions-<date>.json for total daily total",
+    )
     p.add_argument(
         "--by",
         choices=("script", "path", "phase", "layer", "decision"),
@@ -203,8 +215,118 @@ def render_markdown(groups, by, days, total_rows):
     return "\n".join(lines) + "\n"
 
 
+def _coo_logs_root(input_dir):
+    """Resolve the coo-logs repo root from --input-dir.
+
+    --input-dir may point at the coo-logs root or its sessions/ subdir; the
+    Actions-side rollup file lives under coo-logs/telemetry/ either way.
+    """
+    p = Path(input_dir)
+    if (p / "sessions").is_dir() and (p / "telemetry").is_dir():
+        return p
+    if p.name == "sessions" and (p.parent / "telemetry").is_dir():
+        return p.parent
+    if (p / "telemetry").is_dir():
+        return p
+    return p.parent if p.parent != p else p
+
+
+def combine_with_actions(args):
+    """Combined daily-total view: session-side + Actions-side."""
+    try:
+        target = datetime.strptime(args.combine_with_actions, "%Y-%m-%d").date()
+    except ValueError as e:
+        print(f"op-read-rollup: bad --combine-with-actions date: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    # Session side — read the same jsonl sidecars (both layers).
+    rows = load_events(args.input_dir, [target], "both")
+    session_total = len(rows)
+    session_by_layer = defaultdict(int)
+    for ev in rows:
+        session_by_layer[ev.get("layer") or "unknown"] += 1
+
+    # Actions side — read coo-logs/telemetry/op-reads-actions-<date>.json.
+    logs_root = _coo_logs_root(args.input_dir)
+    actions_path = logs_root / "telemetry" / f"op-reads-actions-{target.isoformat()}.json"
+    actions_payload = None
+    if actions_path.is_file():
+        try:
+            actions_payload = json.loads(actions_path.read_text())
+        except json.JSONDecodeError as e:
+            print(
+                f"op-read-rollup: bad Actions-side JSON at {actions_path}: {e}",
+                file=sys.stderr,
+            )
+    actions_summary = (actions_payload or {}).get("summary") or {}
+    actions_total = int(actions_summary.get("total_op_reads") or 0)
+    actions_runs = int(actions_summary.get("total_runs_counted") or 0)
+
+    grand_total = session_total + actions_total
+
+    lines = [
+        f"# op-read combined rollup — {target.isoformat()}",
+        "",
+        f"Grand total: **{grand_total}** op-read events",
+        "",
+        "| source | events | notes |",
+        "|---|---:|---|",
+        f"| sessions (L1 + L2) | {session_total} | L1={session_by_layer.get('L1', 0)}, L2={session_by_layer.get('L2', 0)} (input: {args.input_dir}) |",
+    ]
+    if actions_payload is None:
+        lines.append(f"| actions | _missing_ | expected at {actions_path} |")
+    else:
+        wf_count = len(actions_payload.get("workflows") or [])
+        lines.append(
+            f"| actions (load-secrets-action@v2) | {actions_total} | {actions_runs} counted runs across {wf_count} loader workflows ({actions_path}) |"
+        )
+    lines.append("")
+
+    if actions_payload and (actions_payload.get("workflows") or []):
+        lines += [
+            "## Actions-side per-workflow",
+            "",
+            "| repo | workflow | ref-list-size | runs | op-reads |",
+            "|---|---|---:|---:|---:|",
+        ]
+        for w in actions_payload["workflows"]:
+            lines.append(
+                f"| {w.get('repo')} | {w.get('path')} | {w.get('ref_list_size')} | "
+                f"{w.get('runs_counted')} | {w.get('op_reads')} |"
+            )
+        lines.append("")
+
+    out_md = "\n".join(lines) + "\n"
+    sys.stdout.write(out_md)
+
+    if args.json_out:
+        payload = {
+            "date": target.isoformat(),
+            "session_side": {
+                "total_events": session_total,
+                "by_layer": dict(session_by_layer),
+                "input_dir": str(args.input_dir),
+            },
+            "actions_side": {
+                "total_op_reads": actions_total,
+                "total_runs_counted": actions_runs,
+                "source_path": str(actions_path),
+                "present": actions_payload is not None,
+                "by_repo": actions_summary.get("by_repo") or {},
+            },
+            "grand_total": grand_total,
+        }
+        out_path = Path(args.json_out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(payload, indent=2) + "\n")
+        print(f"op-read-rollup: wrote {out_path}", file=sys.stderr)
+
+
 def main():
     args = parse_args()
+    if args.combine_with_actions:
+        combine_with_actions(args)
+        return
     try:
         days = date_range(args)
     except SystemExit:


### PR DESCRIPTION
Companion to coo-labs/coo-logs#737. Per briefing-040 §4.

## What ships

- `bin/op-read-rollup.py` — adds `--combine-with-actions <date>` mode.
  Reads session-side jsonl events (existing surface) and the Actions-side
  rollup at `coo-logs/telemetry/op-reads-actions-<date>.json` (produced
  nightly by the new `op-reads-actions` Action in coo-labs/coo-logs);
  emits a single markdown table — sessions L1+L2 + Actions per-workflow
  + grand total. Existing `--date` / `--range` modes preserved.
- `CLAUDE.md` — new "Op-read consumption telemetry — `bin/op-read-rollup.py`"
  section documenting both sources, the combined-mode usage, and the
  origin (briefing-040 + the followup plan §4). Sits between the
  `coo-search` and `Bootstrap CI` sections.

## Why two PRs

The script lives in coo-logs (where the telemetry data lives). The
rollup CLI and the user-facing documentation live in coo-harness
(where the operator runs `op-read-rollup.py` and where the kernel-side
docs aggregate). The PR pair is structurally minimal — neither side
imports the other; the combined-mode reads the Actions-side JSON by
path lookup against the coo-logs checkout.

## Verification

```sh
# After the coo-logs PR lands and the Action has run once:
python3 bin/op-read-rollup.py --combine-with-actions 2026-06-07

# Smoke-tested locally against a dry-run of the Actions-side script;
# render renders cleanly, grand total = session_total + actions_total.
```

Existing `--date` mode still works:

```
usage: op-read-rollup.py [-h]
                         (--date DATE | --range RANGE | --combine-with-actions YYYY-MM-DD)
                         [--by {script,path,phase,layer,decision}]
                         [--input-dir INPUT_DIR] [--json-out JSON_OUT]
                         [--layer {L1,L2,both}]
```

Closes: n/a (issue closes via coo-labs/coo-logs#737)

Refs: coo-labs/coo-harness#541

Closes: n/a

https://claude.ai/code/session_01Uyabo4DGv3KiKumRbMVjRL