### PR TITLE
trace: upload-trace-bundle.py + render-trace-timeline.py --json (#832 PR-B)

### DIFF
--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -142,6 +142,27 @@ first positional argument; second positional is the HTML output path.
 Also surfaced as the `trace-timeline` skill — the agent will pick this
 up when you ask it to "visualize" or "show" a trace.
 
+### Upload to the Console viewer (preferred)
+
+```bash
+python3 /home/user/coo-harness/scripts/debug/upload-trace-bundle.py
+# → POSTs the parsed data blob to console.vade-app.dev/trace/data
+#   and prints the viewer URL: https://console.vade-app.dev/trace/?run-id=<id>
+```
+
+The uploader invokes `render-trace-timeline.py --json` to parse the
+trace, then POSTs the data blob to the Console Worker, which writes it
+to R2 at `vade-agent-transcripts/console-traces/<run-id>/data.json`
+([coo-labs/coo-memory#832](https://github.com/coo-labs/coo-memory/issues/832)).
+The Console's `/trace/` React route fetches the same data blob and
+renders the timeline live, replacing the static-HTML flow above.
+
+Auth: bearer token from `op://COO/console-token-2026-05/credential`
+(or set `CONSOLE_TOKEN` in env). The R2 prefix is auth-gated on both
+read and write. Pass `--dry-run` to parse + validate without uploading.
+`--data-json <path>` skips parsing and uploads a pre-rendered blob —
+useful for re-uploading a saved bundle.
+
 ## How to stop the trace
 
 Three options, descending order of operational simplicity:

--- a/scripts/debug/render-trace-timeline.py
+++ b/scripts/debug/render-trace-timeline.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 """Render an interactive HTML timeline from a bootstrap-trace run.
 
-Usage: render-trace-timeline.py [<trace-dir>] [<output-html>]
+Usage: render-trace-timeline.py [<trace-dir>] [<output-html>] [--json]
 Default trace-dir: ~/.vade/traces/$(cat ~/.vade/traces/CURRENT_RUN_ID)
-Default output:    /tmp/trace-timeline.html
+Default output:    /tmp/trace-timeline.html (or /tmp/trace-data.json with --json)
+
+The ``--json`` flag emits the parsed data blob (the same object the HTML
+renderer embeds inline) and skips HTML emission. Used by
+``upload-trace-bundle.py`` to ship traces to the Console R2 prefix.
 """
 import datetime
 import json
@@ -21,8 +25,12 @@ def find_default_trace_dir():
     raise SystemExit("no trace dir given and CURRENT_RUN_ID not found")
 
 
-TRACE_DIR = sys.argv[1] if len(sys.argv) > 1 else find_default_trace_dir()
-OUTPUT = sys.argv[2] if len(sys.argv) > 2 else "/tmp/trace-timeline.html"
+_ARGS = [a for a in sys.argv[1:] if a != "--json"]
+JSON_MODE = "--json" in sys.argv
+TRACE_DIR = _ARGS[0] if len(_ARGS) > 0 else find_default_trace_dir()
+OUTPUT = _ARGS[1] if len(_ARGS) > 1 else (
+    "/tmp/trace-data.json" if JSON_MODE else "/tmp/trace-timeline.html"
+)
 
 meta_path = os.path.join(TRACE_DIR, "meta.json")
 meta = json.load(open(meta_path)) if os.path.exists(meta_path) else {}
@@ -347,6 +355,15 @@ print(
     f"duration={data['duration_ms']:.0f}ms",
     file=sys.stderr,
 )
+
+if JSON_MODE:
+    if OUTPUT == "-":
+        json.dump(data, sys.stdout)
+    else:
+        with open(OUTPUT, "w") as f:
+            json.dump(data, f)
+        print(f"Wrote {OUTPUT}", file=sys.stderr)
+    sys.exit(0)
 
 run_id = escape(meta.get("run_id", "?"))
 started_at = escape(meta.get("started_at", "?"))

--- a/scripts/debug/upload-trace-bundle.py
+++ b/scripts/debug/upload-trace-bundle.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Upload a parsed bootstrap-trace bundle to the Console R2 prefix.
+
+Usage:
+    upload-trace-bundle.py [<trace-dir>] [--run-id <id>] [--console-url <url>]
+    upload-trace-bundle.py --data-json <path.json> [--run-id <id>]
+
+The script:
+1. Either invokes ``render-trace-timeline.py --json`` to parse the trace
+   bundle into the data blob the React ``/trace/`` route consumes, or
+   reads a pre-parsed ``data.json`` via ``--data-json``.
+2. Sources the Console bearer token from ``CONSOLE_TOKEN`` env or from
+   ``op://COO/console-token-2026-05/credential``.
+3. POSTs the JSON to ``{console-url}/trace/data?run-id={id}``.
+4. Prints the Console viewer URL on success.
+
+R2 layout: ``vade-agent-transcripts/console-traces/<run-id>/data.json``
+(bucket reused; prefix is per ``coo-labs/coo-memory#832`` spec).
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_CONSOLE = "https://console.vade-app.dev"
+RUN_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+def find_default_trace_dir() -> str:
+    cur = os.path.expanduser("~/.vade/traces/CURRENT_RUN_ID")
+    if os.path.exists(cur):
+        run_id = open(cur).read().strip()
+        return os.path.expanduser(f"~/.vade/traces/{run_id}")
+    raise SystemExit("no trace dir given and CURRENT_RUN_ID not found")
+
+
+def read_console_token() -> str:
+    env = os.environ.get("CONSOLE_TOKEN")
+    if env:
+        return env
+    try:
+        out = subprocess.check_output(
+            ["op", "read", "op://COO/console-token-2026-05/credential"],
+            stderr=subprocess.PIPE,
+        ).decode().strip()
+    except FileNotFoundError:
+        raise SystemExit(
+            "CONSOLE_TOKEN env unset and op CLI not on PATH"
+        )
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(
+            f"op read for CONSOLE_TOKEN failed: {e.stderr.decode().strip()}"
+        )
+    if not out:
+        raise SystemExit("op read returned empty CONSOLE_TOKEN")
+    return out
+
+
+def parse_via_renderer(trace_dir: str) -> dict:
+    """Shell out to render-trace-timeline.py --json - to get the data dict."""
+    renderer = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "render-trace-timeline.py",
+    )
+    if not os.path.exists(renderer):
+        raise SystemExit(f"renderer not found at {renderer}")
+    out = subprocess.check_output(
+        [sys.executable, renderer, trace_dir, "-", "--json"]
+    )
+    return json.loads(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "trace_dir",
+        nargs="?",
+        default=None,
+        help="bootstrap-trace run directory (default: CURRENT_RUN_ID)",
+    )
+    ap.add_argument(
+        "--run-id",
+        default=None,
+        help="override run-id (default: reads from meta.json or --data-json)",
+    )
+    ap.add_argument(
+        "--console-url",
+        default=DEFAULT_CONSOLE,
+        help=f"Console base URL (default {DEFAULT_CONSOLE})",
+    )
+    ap.add_argument(
+        "--data-json",
+        default=None,
+        help="upload a pre-rendered data.json (skips renderer invocation)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="parse + validate but do not POST",
+    )
+    args = ap.parse_args()
+
+    if args.data_json:
+        with open(args.data_json) as f:
+            data = json.load(f)
+    else:
+        trace_dir = args.trace_dir or find_default_trace_dir()
+        if not os.path.isdir(trace_dir):
+            print(f"Trace dir not found: {trace_dir}", file=sys.stderr)
+            return 1
+        data = parse_via_renderer(trace_dir)
+
+    meta = data.get("meta") or {}
+    run_id = args.run_id or meta.get("run_id")
+    if not run_id:
+        print(
+            "No run-id; pass --run-id or ensure meta.json has run_id",
+            file=sys.stderr,
+        )
+        return 1
+    if not RUN_ID_RE.match(run_id):
+        print(
+            f"run-id {run_id!r} fails sanitization "
+            "(allowed: A-Z a-z 0-9 . _ -, length 1-128)",
+            file=sys.stderr,
+        )
+        return 1
+
+    body = json.dumps(data).encode("utf-8")
+    target = f"{args.console_url}/trace/data?run-id={run_id}"
+    print(
+        f"PIDs={len(data.get('pids', []))}  "
+        f"events={len(data.get('events', []))}  "
+        f"snapshots={len(data.get('snapshots', []))}  "
+        f"bytes={len(body)}",
+        file=sys.stderr,
+    )
+    print(f"target: {target}", file=sys.stderr)
+
+    if args.dry_run:
+        print("dry-run; skipping upload", file=sys.stderr)
+        return 0
+
+    token = read_console_token()
+    req = urllib.request.Request(
+        target,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "upload-trace-bundle.py (coo-harness)",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            response = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace") if e.fp else ""
+        print(f"HTTP {e.code}: {detail.strip()}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"Network error: {e.reason}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(response, indent=2), file=sys.stderr)
+    print(f"{args.console_url}/trace/?run-id={run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Ships the companion ingest script paired with coo-labs/coo-console#36 (Worker endpoints). Closes the R2-ingest half of coo-labs/coo-memory#832; PR-A (React port) landed at coo-labs/coo-console#35.

## render-trace-timeline.py

Minimal refactor to expose the parser output as JSON, no behavior change to the default HTML flow:

- ` --json` flag emits the data dict (the same blob the HTML renderer embeds inline as \`const DATA = …\`) and skips HTML emission.
- Output target defaults to \`/tmp/trace-data.json\` under \`--json\`; \`-\` routes to stdout so the upload script can pipe it.
- Existing CLI behavior (no flag, HTML render to \`/tmp/trace-timeline.html\`) unchanged.

## upload-trace-bundle.py

Self-contained uploader, no third-party deps — just \`urllib\`:

\`\`\`
upload-trace-bundle.py [<trace-dir>] [--run-id <id>] [--console-url <url>]
upload-trace-bundle.py --data-json <path> [--run-id <id>]
\`\`\`

- Sources \`CONSOLE_TOKEN\` from env or \`op://COO/console-token-2026-05/credential\`.
- POSTs \`application/json\` to \`{console}/trace/data?run-id={id}\`.
- Prints the Console viewer URL on success: \`https://console.vade-app.dev/trace/?run-id=<id>\`.
- ` --dry-run\` parses + validates without uploading; ` --data-json <path>\` skips the renderer when a pre-rendered blob is already on disk.

Run-id sanitization matches the Worker's: \`^[A-Za-z0-9._-]{1,128}\$\`.

## Smoke (this branch)

\`\`\`bash
# Synthetic trace dir built inline (3 PIDs, 6 events)
mkdir -p /tmp/fake-trace/snapshots
cat > /tmp/fake-trace/meta.json <<EOM
{\"run_id\": \"fake-2026-06-07\", \"started_at\": \"2026-06-07T08:00:00Z\", \"first_pid\": 200}
EOM
# … xtrace.log with 8 sample lines …
python3 scripts/debug/upload-trace-bundle.py /tmp/fake-trace --dry-run
# → PIDs=3 events=6 snapshots=0 bytes=3299
#   target: https://console.vade-app.dev/trace/data?run-id=fake-2026-06-07
#   dry-run; skipping upload
\`\`\`

End-to-end smoke against production runs after the paired coo-console PR-B deploys.

## Doc

\`scripts/debug/README.md\` gains an \"Upload to the Console viewer (preferred)\" section right after the existing static-HTML render section. The static-HTML path stays available — it's still useful for offline / share-a-file workflows — but the Console URL is now the recommended view.

Closes: n/a — closes the second half of coo-labs/coo-memory#832; epic remains open at coo-labs/coo-memory#827.

Closes: n/a

https://claude.ai/code/session_01PWLtDAXqtcXnv6YnpqLFZj