### PR TITLE
docs: fix stale op:// path in upload-trace-bundle.py

### DIFF
--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -157,7 +157,7 @@ to R2 at `vade-agent-transcripts/console-traces/<run-id>/data.json`
 The Console's `/trace/` React route fetches the same data blob and
 renders the timeline live, replacing the static-HTML flow above.
 
-Auth: bearer token from `op://COO/console-token-2026-05/credential`
+Auth: bearer token from `op://COO/console-bearer-ven/credential`
 (or set `CONSOLE_TOKEN` in env). The R2 prefix is auth-gated on both
 read and write. Pass `--dry-run` to parse + validate without uploading.
 `--data-json <path>` skips parsing and uploads a pre-rendered blob —

--- a/scripts/debug/upload-trace-bundle.py
+++ b/scripts/debug/upload-trace-bundle.py
@@ -10,7 +10,7 @@ The script:
    bundle into the data blob the React ``/trace/`` route consumes, or
    reads a pre-parsed ``data.json`` via ``--data-json``.
 2. Sources the Console bearer token from ``CONSOLE_TOKEN`` env or from
-   ``op://COO/console-token-2026-05/credential``.
+   ``op://COO/console-bearer-ven/credential``.
 3. POSTs the JSON to ``{console-url}/trace/data?run-id={id}``.
 4. Prints the Console viewer URL on success.
 
@@ -45,7 +45,7 @@ def read_console_token() -> str:
         return env
     try:
         out = subprocess.check_output(
-            ["op", "read", "op://COO/console-token-2026-05/credential"],
+            ["op", "read", "op://COO/console-bearer-ven/credential"],
             stderr=subprocess.PIPE,
         ).decode().strip()
     except FileNotFoundError:


### PR DESCRIPTION
Follow-up to coo-labs/coo-harness#549 (now merged). Smoke test against the deployed Console Worker hit \`op read\` errors because the 1Password item was renamed 2026-06-06 from \`console-token-2026-05\` to \`console-bearer-ven\` per the schema's \`<service>-<role>-<owner>\` convention. \`upload-trace-bundle.py\`'s \`read_console_token()\` and the debug README's auth note both still cited the old name.

Schema source of truth: \`coo-memory/operations/secrets/schema.yaml\` \`id=console-bearer-ven\`.

Smoke after fix:

\`\`\`
python3 scripts/debug/upload-trace-bundle.py /tmp/fake-trace
→ 201 with {ok: true, run_id, ...}
→ prints https://console.vade-app.dev/trace/?run-id=…
\`\`\`

Closes: n/a — doc + script-string-only.

Closes: n/a

https://claude.ai/code/session_01PWLtDAXqtcXnv6YnpqLFZj