### PR TITLE
ci-health: schema.yaml seed + substrate-staleness-lint reusable

### DIFF
--- a/.github/workflows/substrate-staleness-lint-reusable.yml
+++ b/.github/workflows/substrate-staleness-lint-reusable.yml
@@ -1,0 +1,182 @@
+name: Substrate staleness lint (reusable)
+
+# Reusable workflow: at-PR-open lint against the cross-substrate
+# refactor manifests in coo-memory/bin/manifests/. Catches new
+# SWEEP-class stale references a PR introduces, before they accumulate.
+#
+# Per coo-memory/operations/ci-strategy.md §"The five substrate
+# guarantees" G2 (drift-watch) and #1219 locked design (annotation on
+# exit 1, hard-fail on exit 2). Defense-in-depth-perpetual pairs with
+# the cron sweep at coo-labs/.github/.github/workflows/substrate-staleness-cron.yml.
+#
+# Canonical home: coo-labs/coo-harness/.github/workflows/substrate-staleness-lint-reusable.yml
+# Substrate-side counterpart: coo-memory/operations/ci-lifecycle/log.jsonl
+# (birth entry: check_id=substrate-staleness-lint).
+# Schema entry: coo-harness/config/ci-health/schema.yaml.
+#
+# Trigger contract for callers (thin trigger lives at
+# .github/workflows/substrate-staleness-lint.yml in each consumer):
+#
+#   on:
+#     pull_request:
+#       types: [opened, edited, reopened, synchronize]
+#       # `synchronize` IS needed here — unlike body-only checks
+#       # (issue-pr-hygiene drops synchronize to save runner-minutes),
+#       # this lint inspects file contents which DO change on new
+#       # commits. Skipping synchronize would miss drift introduced
+#       # in mid-PR commits.
+#   permissions:
+#     contents: read
+#     pull-requests: write  # for advisory comments
+#   jobs:
+#     lint:
+#       uses: coo-labs/coo-harness/.github/workflows/substrate-staleness-lint-reusable.yml@main
+#       secrets: inherit
+
+on:
+  workflow_call:
+    secrets:
+      VADE_FIELDS_ADMIN_PAT:
+        description: "Org-secret PAT with read access to coo-memory (private). Used to checkout migration-sweep.py + manifests."
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: staleness-lint-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout caller PR head
+        uses: actions/checkout@v4
+        with:
+          path: caller
+
+      - name: Checkout coo-memory (script + manifests)
+        uses: actions/checkout@v4
+        with:
+          repository: coo-labs/coo-memory
+          token: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}
+          path: substrate
+          # Pin to @main — manifests are append-only, and pinning to a
+          # SHA would mean every new manifest needs a coo-harness PR to
+          # bump the pin. The verify discipline doesn't permit drift
+          # going the other way; manifests are the canonical map.
+
+      - name: Run migration-sweep verify across all manifests
+        id: sweep
+        env:
+          # repos.yaml lives in coo-labs/.github (public); the resolver
+          # in migration-sweep.py finds it via the multi-candidate path.
+          # Forcing /dev/null here — at-PR-open lint is local-scope by
+          # design (the caller's PR head only). The cross-repo sweep is
+          # the cron's job.
+          REPOS_YAML: /dev/null
+        run: |
+          set -e
+          script="$GITHUB_WORKSPACE/substrate/bin/migration-sweep.py"
+          manifests=( "$GITHUB_WORKSPACE/substrate/bin/manifests"/*.yaml )
+          cd "$GITHUB_WORKSPACE/caller"
+
+          failed=()
+          passed=()
+          report=""
+
+          for m in "${manifests[@]}"; do
+            mname=$(basename "$m" .yaml)
+            echo "::group::manifest=$mname"
+            set +e
+            out=$(python3 "$script" --mode verify --manifest "$m" --root . \
+                    --repos-yaml "$REPOS_YAML" --ignore-missing-new \
+                    --format text 2>&1)
+            rc=$?
+            set -e
+            echo "$out"
+            echo "::endgroup::"
+
+            if [ $rc -eq 0 ]; then
+              passed+=("$mname")
+            elif [ $rc -eq 2 ]; then
+              failed+=("$mname")
+              report="${report}### \`${mname}\` — actionable drift\n\n\`\`\`\n${out}\n\`\`\`\n\n"
+            else
+              # Unexpected exit code (3 = manifest load error, anything else).
+              # Treat as hard failure: the lint must be loud, not silent.
+              failed+=("$mname (exit $rc)")
+              report="${report}### \`${mname}\` — lint error (exit ${rc})\n\n\`\`\`\n${out}\n\`\`\`\n\n"
+            fi
+          done
+
+          {
+            echo "passed_count=${#passed[@]}"
+            echo "failed_count=${#failed[@]}"
+            echo "passed_list=${passed[*]}"
+            echo "failed_list=${failed[*]}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ ${#failed[@]} -gt 0 ]; then
+            {
+              echo 'report<<EOF'
+              printf '%b' "$report"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+            exit 1   # job-level fail; the comment-post step below uses
+                     # `if: failure()` to surface the report.
+          fi
+
+      - name: Post advisory comment with drift report
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const report = process.env.REPORT || '';
+            const failedList = process.env.FAILED_LIST || '(unknown)';
+            const marker = '<!-- substrate-staleness-lint -->';
+            const body = `${marker}\n\n` +
+              `### Substrate staleness lint — actionable drift\n\n` +
+              `This PR introduces or carries SWEEP-class references to ` +
+              `OLD paths in the following manifest(s): \`${failedList}\`.\n\n` +
+              `Each entry below is a file:line site where an OLD path appears ` +
+              `in a non-historical surface. Use the manifest's NEW path instead, ` +
+              `or move the reference under \`_archive/\` / \`audits/\` / a memo body ` +
+              `if it's intentionally historical.\n\n` +
+              `${report}\n\n` +
+              `See \`coo-memory/bin/migration-sweep.py --help\` for the classifier.\n\n` +
+              `*This check is BLOCKING. The cron sweep at ` +
+              `\`coo-labs/.github/.github/workflows/substrate-staleness-cron.yml\` ` +
+              `catches drift that lands without a PR (renames, manual edits).*`;
+
+            const pr = context.payload.pull_request;
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            const existing = comments.data.find(c =>
+              c.body && c.body.includes(marker) && c.user.type === 'Bot'
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+            }
+        env:
+          REPORT: ${{ steps.sweep.outputs.report }}
+          FAILED_LIST: ${{ steps.sweep.outputs.failed_list }}

--- a/config/ci-health/schema.yaml
+++ b/config/ci-health/schema.yaml
@@ -1,0 +1,111 @@
+# CI-health schema — declarative inventory of every CI primitive on the
+# substrate's CI surface. Per coo-memory/operations/ci-strategy.md
+# §"CI-surface observability". Schema location is kernel-scope per
+# MEMO-2026-05-26-t65q (schemas are kernel; the strategy doc itself
+# lives in coo-memory).
+#
+# This file is the source-of-truth Group W's W0 probe (when it lands)
+# will cross-check against the lifecycle log at
+# coo-memory/operations/ci-lifecycle/log.jsonl. Schema entries here +
+# birth events there must be in 1:1 correspondence.
+#
+# Seed entries: the five post-strategy CI primitives + the workflow
+# the same arc lands (substrate-staleness-lint). Future primitives
+# added via PR; the four-slot question (guarantee, loop_position,
+# retirement_criterion, owner) must be answered at birth.
+#
+# Schema authority: per ci-strategy.md §"Schema authority table" —
+# add/remove entries by COO PR (review by receiving session before
+# merge); threshold/ceiling adjustments per the same table.
+
+schema_version: 1
+
+# Implementation status: seed. Per-entry `invariants:` blocks (with
+# threshold/ceiling for the per-check metrics) come with the Group W
+# integrity-check probes (W0-W4 primary + W5-W6 corroborating) in a
+# follow-on epic. The shape of each entry is fixed at seed-time so
+# future probes can attach without renaming.
+implementation_status: seed
+
+checks:
+  - id: pre-push-pr-hygiene
+    tier: 1
+    guarantee: G1
+    loop_position: pre-push
+    owner: vade-coo
+    retirement_criterion: defense-in-depth-perpetual
+    canonical_doc: coo-memory/operations/issue-pr-hygiene.md
+    lifecycle_birth: coo-memory#1016
+    # Defense-in-depth pair with `issue-pr-hygiene-reusable` (at-PR-open).
+    invariants: {}
+
+  - id: pr-ven-human-action-marker
+    tier: 0
+    guarantee: G2
+    loop_position: at-PR-open
+    owner: vade-coo
+    retirement_criterion: structural-fix-cite
+    # Retires when squash-merge format changes or F4 attribution is
+    # restructured (e.g., a single-writer fix replaces the marker
+    # mechanism with a structural rule).
+    canonical_doc: coo-harness/scripts/boot/integrity-check.sh
+    lifecycle_birth: coo-memory#1015
+    invariants: {}
+
+  - id: memo-shape-lint
+    tier: 0
+    guarantee: G1
+    loop_position: at-PR-open
+    owner: vade-coo
+    retirement_criterion: defense-in-depth-perpetual
+    # Defense-in-depth pair with `bin/memo-shape-check.py` pre-push hook.
+    canonical_doc: coo-memory/operations/memo_protocol.md
+    lifecycle_birth: coo-memory#1015
+    invariants: {}
+
+  - id: daily-link-hygiene-flag
+    tier: 0
+    guarantee: G2
+    loop_position: cron
+    owner: vade-coo
+    retirement_criterion: defense-in-depth-perpetual
+    # Daily LLM-driven link-hygiene scan; advisory issue surface.
+    canonical_doc: coo-memory/operations/entity-hyperlinking.md
+    lifecycle_birth: coo-memory#1015
+    invariants: {}
+
+  - id: registry-check
+    tier: 0
+    guarantee: G2
+    loop_position: cron+at-PR-open
+    owner: vade-coo
+    retirement_criterion: defense-in-depth-perpetual
+    canonical_doc: coo-harness/scripts/registry-check.sh
+    lifecycle_birth: coo-memory#1018
+    invariants: {}
+
+  - id: bootstrap-regression
+    tier: 0
+    guarantee: G2
+    loop_position: at-PR-open
+    owner: vade-coo
+    retirement_criterion: defense-in-depth-perpetual
+    # Layer-1 SDK-driven harness test; watches the cloud bootstrap chain
+    # against script-level regressions at PR-open time.
+    canonical_doc: coo-harness/CLAUDE.md "Bootstrap CI"
+    lifecycle_birth: coo-memory#1013
+    invariants: {}
+
+  - id: substrate-staleness-lint
+    tier: 0
+    guarantee: G2
+    loop_position: at-PR-open+cron
+    owner: vade-coo
+    retirement_criterion: defense-in-depth-perpetual
+    # The substrate drift-prevention scaffold: at-PR-open lint catches
+    # new SWEEP-class stale refs introduced by a PR; cron sweep catches
+    # accumulated drift in surfaces no PR touches. Manifest convention:
+    # one file per cross-cutting refactor at coo-memory/bin/manifests/.
+    canonical_doc: coo-memory/operations/ci-strategy.md
+    lifecycle_birth: coo-memory#1219
+    invariants: {}


### PR DESCRIPTION
Second PR of the [coo-labs/coo-memory#1219](https://github.com/coo-labs/coo-memory/issues/1219) arc — the kernel-side counterpart to PR-1 ([coo-memory#1306](https://github.com/coo-labs/coo-memory/pull/1306)). Lands the declarative schema + the F7 reusable that consumers will call.

## Two commits

### `config/ci-health/schema.yaml` (5356793)

Seven seed entries — 1:1 with the lifecycle log at `coo-memory/operations/ci-lifecycle/log.jsonl`. Per-entry shape per the CI strategy's example (line 322): `id`, `tier`, `guarantee`, `loop_position`, `owner`, `retirement_criterion`, `canonical_doc`, `lifecycle_birth`. Per-entry `invariants:` blocks (threshold/ceiling) land with Group W probes in a follow-on epic; the shape is fixed at seed-time so future probes can attach without renaming.

Schema authority per ci-strategy.md §"Schema authority table" — COO PR to add/remove entries; threshold/ceiling adjustments per the same table.

### `.github/workflows/substrate-staleness-lint-reusable.yml` (a1d60f7, App-token commit)

F7 reusable workflow. Triggered via `workflow_call` from 9 active-sibling thin triggers (PR-4 of this arc). Shape:

1. Checks out the caller's PR head into `caller/`.
2. Checks out `coo-labs/coo-memory` into `substrate/` using `VADE_FIELDS_ADMIN_PAT` (coo-memory is private). Pinned to `@main` — manifests are append-only; SHA-pinning would force a coo-harness PR on every new manifest.
3. Iterates ALL `coo-memory/bin/manifests/*.yaml` — new manifest = new check, automatic.
4. Per manifest: runs `migration-sweep --mode verify --ignore-missing-new --root caller/` (the verify-mode flag landed in [#1306](https://github.com/coo-labs/coo-memory/pull/1306); ignores the legitimately-zero-refs case).
5. Exit 0 from all manifests → pass. Exit 2 from any manifest → fail + advisory comment enumerating drift per manifest. Exit ≠ 0/2 from any manifest → treated as hard fail (loud over silent).

Loop position: at-PR-open with `synchronize` (file contents change on new commits, unlike body-only hygiene checks).

Defense-in-depth pair: PR-3 of this arc lands the cron sweep at `coo-labs/.github/.github/workflows/substrate-staleness-cron.yml`.

## Verification

- `python3 -c "import yaml; data = yaml.safe_load(open('config/ci-health/schema.yaml')); assert len(data['checks']) == 7"` — parses; 7 entries match the lifecycle log.
- Workflow file lint: 182 lines, no shellcheck concerns; uses `actions/checkout@v4` and `actions/github-script@v7` (both pinned major versions per substrate convention).
- Per-manifest behavior matches PR-1's `--ignore-missing-new` test suite: empty consumer → exit 0; drift-introducing PR → exit 2.

The reusable's at-PR-open behavior is **only fully testable once a consumer thin trigger exists** — PR-4 of this arc. This PR is the kernel substrate; the integration test is the first thin trigger's first run.

## Out of scope (follow-ups)

- **PR-3**: cron sweep in `coo-labs/.github`. Needs PR-2 (this PR) but is otherwise independent — uses `migration-sweep` directly, not the reusable.
- **PR-4**: 9 thin triggers consuming this reusable. Synchronized arc.
- **PR-5**: paired memo.

Closes: n/a

Refs coo-labs/coo-memory#1219, coo-labs/coo-memory#1306.

Closes: n/a

https://claude.ai/code/session_01XoEXpwvNjDQbCL2nBrPTFU