### PR TITLE
ci: substrate-staleness-lint thin trigger

### DIFF
--- a/.github/workflows/auto-merge-sync-pr-reusable.yml
+++ b/.github/workflows/auto-merge-sync-pr-reusable.yml
@@ -5,7 +5,7 @@ name: Auto-merge sync PR (reusable)
 # this repo) which labels every PR it opens with `sync,sync:templates`. Once
 # CI on the consumer PR passes, GitHub's auto-merge feature lands it.
 #
-# Callers: 8 consumer thin-triggers per coo/operations/workflow-centralization.md
+# Callers: 8 consumer thin-triggers per operations/workflow-centralization.md
 # row "auto-merge-sync-pr-reusable.yml". The caller fires on `pull_request:
 # types: [labeled]` and forwards to here; the caller's `if:` gate decides
 # whether the label warrants auto-merge (currently: any label starting with

--- a/.github/workflows/auto-tag-issues-reusable.yml
+++ b/.github/workflows/auto-tag-issues-reusable.yml
@@ -9,7 +9,7 @@ name: Auto-tag new issues (reusable)
 # so private + public consumers can both invoke (Public→Private workflow_call
 # resolution fails despite access_level=organization; bridge-form-fields-to-natives.yml
 # is the live in-org precedent for "public canonical, mixed consumers").
-# Operations doc: coo-labs/coo-memory/coo/operations/workflow-centralization.md
+# Operations doc: coo-labs/coo-memory/operations/workflow-centralization.md
 # Canonical taxonomy: https://github.com/coo-labs/coo-memory/blob/main/.claude/skills/filing-issues/references/issue-fields-and-types.md
 # Canonical project:  https://github.com/orgs/coo-labs/projects/1 (VADE)
 #   Project node ID:  PVT_kwDOEGdN_84BUV2r
@@ -224,7 +224,7 @@ jobs:
                  none). Use the GitHub UI title (e.g.,
                  "Substrate Hygiene and Tooling"), NOT the M-prefix.
                  Pick at most one per its scope-rule + test (canonical:
-                 https://github.com/coo-labs/coo-memory/blob/main/coo/audits/2026-05-20_milestone-taxonomy/README.md):
+                 https://github.com/coo-labs/coo-memory/blob/main/audits/2026-05-20_milestone-taxonomy/README.md):
                    "Decentering the Mind" — substantive edit / review /
                      support for the "Decentering the Mind" essay or
                      its peer-review atoms. Excludes the general

--- a/.github/workflows/bridge-form-fields-trigger.yml
+++ b/.github/workflows/bridge-form-fields-trigger.yml
@@ -7,7 +7,7 @@ name: Bridge issue-form widgets to native fields (trigger)
 # This file is hand-mirrored across coo-memory / coo-harness /
 # vade-canvas / coo-logs. Edit canonical in coo-memory and
 # port to siblings (workflow-sync convention; see
-# coo/operations/issue-pr-hygiene.md).
+# operations/issue-pr-hygiene.md).
 #
 # Bridge design + script source: coo-labs/coo-harness#TBD.
 # Stage 2 design: coo-labs/coo-memory#811.

--- a/.github/workflows/coo-on-assign-reusable.yml
+++ b/.github/workflows/coo-on-assign-reusable.yml
@@ -8,8 +8,8 @@ name: COO on issue assign (reusable)
 # Centralization design: coo-memory#939 (F7); moved to coo-harness
 # (public) per #939 comment because Public→Private workflow_call resolution
 # fails despite access_level=organization on the target.
-# Operations doc: coo-labs/coo-memory:coo/operations/workflow-centralization.md
-# Workflow rationale: coo-labs/coo-memory:coo/operations/coo-on-assign.md
+# Operations doc: coo-labs/coo-memory:operations/workflow-centralization.md
+# Workflow rationale: coo-labs/coo-memory:operations/coo-on-assign.md
 #
 # COO_SCOPE_REPOS source: fetched at job time from the canonical registry
 # at coo-labs/.github/repos.yaml (status == "active" filter; all tiers
@@ -169,7 +169,7 @@ jobs:
               `The session opens when you click — claude.ai/code needs a signed-in human (you) to spawn the container. Re-assign me to post a fresh link (e.g. after a session ends or gets stuck).`,
               ``,
               `---`,
-              `<sub>posted by \`coo-on-assign\` workflow · design: coo-labs/coo-memory#801 · [operations doc](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/coo-on-assign.md)</sub>`,
+              `<sub>posted by \`coo-on-assign\` workflow · design: coo-labs/coo-memory#801 · [operations doc](https://github.com/coo-labs/coo-memory/blob/main/operations/coo-on-assign.md)</sub>`,
             ].join('\n');
 
             await github.rest.issues.createComment({

--- a/.github/workflows/issue-pr-hygiene-reusable.yml
+++ b/.github/workflows/issue-pr-hygiene-reusable.yml
@@ -1,7 +1,7 @@
 name: Issue / PR hygiene (reusable)
 
 # Reusable workflow: enforces the four issue/PR hygiene patterns
-# documented in coo-labs/coo-memory:coo/operations/issue-pr-hygiene.md:
+# documented in coo-labs/coo-memory:operations/issue-pr-hygiene.md:
 #
 #   A — Epic-type issues use GitHub's native sub-issue API (advisory)
 #   B — PRs that resolve issues include a closing keyword     (blocking or advisory, per caller)
@@ -16,9 +16,9 @@ name: Issue / PR hygiene (reusable)
 # Canonical home: coo-labs/coo-harness/.github/workflows/issue-pr-hygiene-reusable.yml
 # Centralization design: coo-memory#939 (F7); absorbs coo-memory#767.
 # Host=coo-harness per #939 comment (Public→Private workflow_call fails).
-# Operations doc: coo-labs/coo-memory:coo/operations/workflow-centralization.md
+# Operations doc: coo-labs/coo-memory:operations/workflow-centralization.md
 # Pattern-B promotion cadence: coo-labs/coo-memory:coo/adoption_tracker.md (≥14 days clean)
-# Authority + audit: coo-labs/coo-memory:coo/audits/2026-05-01_issue-pr-hygiene/synthesis.md
+# Authority + audit: coo-labs/coo-memory:audits/2026-05-01_issue-pr-hygiene/synthesis.md
 #
 # Per-repo behavior:
 #   - Pattern-B mode (blocking vs advisory) is the only per-caller knob.
@@ -123,7 +123,7 @@ jobs:
             const isBlocking = (mode === 'blocking');
 
             // ---- Exempt-class detection (skip enforcement entirely) ----
-            // Authority: coo/operations/issue-pr-hygiene.md §"Exempt-class registry"
+            // Authority: operations/issue-pr-hygiene.md §"Exempt-class registry"
             // Defensive union across all caller repos — patterns are
             // whitelists, safe to run anywhere.
 
@@ -240,7 +240,7 @@ jobs:
                 `GitHub's parser only auto-closes the FIRST issue; subsequent refs ` +
                 `stay open silently. Use one \`Closes\` keyword per issue:\n\n` +
                 `    Closes coo-labs/<repo>#N\n    Closes coo-labs/<repo>#M\n\n` +
-                `See coo/operations/issue-pr-hygiene.md §"Closing-keyword discipline" ` +
+                `See operations/issue-pr-hygiene.md §"Closing-keyword discipline" ` +
                 `(in coo-labs/coo-memory).`;
               if (isBlocking) {
                 core.setFailed(`Pattern B (closing keywords) — BLOCKING\n\n${msg}`);
@@ -286,7 +286,7 @@ jobs:
             }
 
             const summary = reasons.join('\n\n');
-            const seeDocs = `See coo/operations/issue-pr-hygiene.md §"Closing-keyword discipline" ` +
+            const seeDocs = `See operations/issue-pr-hygiene.md §"Closing-keyword discipline" ` +
               `(in coo-labs/coo-memory).`;
 
             if (isBlocking) {
@@ -396,7 +396,7 @@ jobs:
             if (!grandfatheredItems.has(pr.number)) {
               // Plural-form noun (`s?`) and range suffix (`#N-#M`, `#N–#M`,
               // `#N - #M`) added per coo-memory#757 audit
-              // (coo/audits/2026-05-13_hyperlinking-sweep/synthesis.md §6).
+              // (audits/2026-05-13_hyperlinking-sweep/synthesis.md §6).
               // The 2026-05-01 audit named the en-dash miss; it remained
               // open in the regex until this extension.
               const collisionTerms = /\b(quorum|instance|briefing|memo|stage|phase|finding|oq|audit|committee|persona|agent|chunk|round|track|step|tier|band|mechanism|hypothesis)s?\s+#\d+(?:\s*[-–]\s*#?\d+)?\b/gi;
@@ -422,7 +422,7 @@ jobs:
                   `(prevents the false-positive autolink; \`MEMO-...\` already has a click-through autolink configured.) ` +
                   `Examples found:\n\n` +
                   dMatches.slice(0, 5).map(m => `  - \`${m[0]}\``).join('\n') +
-                  `\n\nSee \`coo/operations/issue-pr-hygiene.md\` §"Notation rules" (in coo-labs/coo-memory).`
+                  `\n\nSee \`operations/issue-pr-hygiene.md\` §"Notation rules" (in coo-labs/coo-memory).`
                 );
               }
             }
@@ -490,7 +490,7 @@ jobs:
             //   mutation). Distinct from trackedIssues, which reflects markdown
             //   `- [ ] #N` task-list connections only and returns 0 for issues
             //   whose children were linked via the native API. See
-            //   coo/operations/issue-pr-hygiene.md §"GraphQL gotchas" (in coo-labs/coo-memory).
+            //   operations/issue-pr-hygiene.md §"GraphQL gotchas" (in coo-labs/coo-memory).
             let result;
             try {
               result = await github.graphql(`
@@ -546,7 +546,7 @@ jobs:
               `they're invisible to GraphQL queries and the project board's tracker UI.\n\n` +
               `Add sub-issues via the GitHub UI's "Add sub-issue" button on this issue, ` +
               `or via the GraphQL \`addSubIssue\` mutation.\n\n` +
-              `See \`coo/operations/issue-pr-hygiene.md\` §"Sub-issue linkage" ` +
+              `See \`operations/issue-pr-hygiene.md\` §"Sub-issue linkage" ` +
               `(in coo-labs/coo-memory).\n\n` +
               `*This is advisory; the check does not block merge. ` +
               `Apply label \`hygiene:exempt\` to suppress on this issue.*`;

--- a/.github/workflows/substrate-staleness-lint.yml
+++ b/.github/workflows/substrate-staleness-lint.yml
@@ -1,0 +1,26 @@
+name: Substrate staleness lint
+
+# Thin trigger — fires on PR events and delegates to the canonical
+# reusable workflow at coo-labs/coo-harness/.github/workflows/substrate-staleness-lint-reusable.yml.
+#
+# Per coo-memory/operations/ci-strategy.md G2 (drift-watch). Synchronized
+# arc across 9 active siblings per coo-memory#1219 locked design item 2
+# (F7 reusable + thin triggers).
+#
+# Edit the canonical reusable, not this thin trigger.
+
+on:
+  pull_request:
+    # `synchronize` IS needed — file contents change on new commits.
+    # (Distinct from issue-pr-hygiene which drops synchronize because
+    # it inspects PR title/body only.)
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    uses: coo-labs/coo-harness/.github/workflows/substrate-staleness-lint-reusable.yml@main
+    secrets: inherit

--- a/.github/workflows/sync-issue-templates.yml
+++ b/.github/workflows/sync-issue-templates.yml
@@ -6,9 +6,9 @@ name: Sync issue templates
 # coo-labs/.github/repos.yaml (minus coo-harness, the canonical).
 #
 # Centralization: coo-memory#938 (F8). Mechanism rationale (sync-action
-# vs symlink vs build-time): coo-memory/coo/audits/2026-05-24_org-infrastructure-audit/
+# vs symlink vs build-time): coo-memory/audits/2026-05-24_org-infrastructure-audit/
 # f7-f8-centralization-design.md §"Issue templates". Operations doc:
-# coo-memory/coo/operations/template-centralization.md.
+# coo-memory/operations/template-centralization.md.
 #
 # Canonical-host pivot (vcm → vrt): vrt aligns with the F7 pattern — harness
 # owns operational infrastructure; ops doc + case-law live in vcm. Templates


### PR DESCRIPTION
Synchronized arc of 9 PRs — one per active sibling — landing the thin trigger that consumes the reusable workflow from [coo-labs/coo-harness#553](https://github.com/coo-labs/coo-harness/pull/553).

## What this PR adds

`.github/workflows/substrate-staleness-lint.yml` — a ~25-line thin trigger that fires on `pull_request` (types: opened, edited, reopened, synchronize) and delegates to:

```yaml
uses: coo-labs/coo-harness/.github/workflows/substrate-staleness-lint-reusable.yml@main
secrets: inherit
```

The actual lint logic lives in the reusable — edit the canonical, not this file.

## Why `synchronize` (vs the body-only checks that drop it)

Body-only checks (`issue-pr-hygiene-reusable`) skip `synchronize` because the PR title/body — the only inputs they examine — don't change when commits are pushed. The staleness lint inspects **file contents**, which DO change on new commits, so synchronize is needed to catch drift introduced mid-PR.

## Permissions

`pull-requests: write` is needed so the reusable can post the advisory comment on drift (the body details which manifest + which file:line site).

## Verification

The reusable workflow's behavior is identical across consumers — only the host repo's tree differs. Verification on first run will exercise the full path (checkout caller PR head + coo-memory for script + run verify across all manifests).

## Arc context

Part of the [coo-labs/coo-memory#1219](https://github.com/coo-labs/coo-memory/issues/1219) arc:

- [coo-labs/coo-memory#1306](https://github.com/coo-labs/coo-memory/pull/1306) (merged) — substrate-side lifecycle log entries + `migration-sweep --ignore-missing-new` flag.
- [coo-labs/coo-harness#553](https://github.com/coo-labs/coo-harness/pull/553) (merged) — kernel-side schema + reusable workflow.
- [coo-labs/.github#5](https://github.com/coo-labs/.github/pull/5) (open) — daily cross-repo cron sweep + sticky drift report.
- **This PR** — thin trigger; one of 9 synchronized.
- PR-5 — paired memo, after the arc settles.

Closes: n/a

Refs coo-labs/coo-memory#1219, coo-labs/coo-harness#553.

Closes: n/a

https://claude.ai/code/session_01XoEXpwvNjDQbCL2nBrPTFU