### PR TITLE
briefing-40 T1.x: PAT-cache TTL 5min→1hr + _op_to_file rate-limit fast-fail

### DIFF
--- a/scripts/ci/test-op-retry-recovery.sh
+++ b/scripts/ci/test-op-retry-recovery.sh
@@ -9,11 +9,17 @@
 # bootstrap-regression suite). Verify:
 #
 #   1. _op_to_file recovers within the 5-attempt retry budget when
-#      N=2 (first two op-reads fail, third succeeds) — rc=0, target
-#      file written with expected content.
-#   2. _op_to_file fails cleanly when N=5 (every attempt exhausts the
-#      budget) — rc=1, no half-written target file.
-#   3. The structured observability event lands in
+#      N=2 (first two op-reads fail with a transient 503, third
+#      succeeds) — rc=0, target file written with expected content.
+#   2. _op_to_file fails cleanly when N=5 (every transient attempt
+#      exhausts the budget) — rc=1, no half-written target file.
+#   3. _op_to_file fast-fails on rate-limit (post briefing-40 T1.2):
+#      the first op-read attempt returns rate-limit stderr; the loop
+#      breaks immediately without burning the full budget. Wrap shim's
+#      3-token swap-and-retry has already exhausted the cascade by
+#      the time rate-limit surfaces here, so further retries are
+#      pure waste. See coo-harness#545.
+#   4. The structured observability event lands in
 #      ~/.vade/op-read-failures.jsonl with the expected schema.
 #
 # Run: bash scripts/ci/test-op-retry-recovery.sh
@@ -53,13 +59,14 @@ _pass() { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
 _fail() { FAIL=$((FAIL+1)); FAILURES+=("$1"); printf '  FAIL  %s\n' "$1"; }
 
 # ── Test 1: N=2 → recovers within retry budget ───────────────────
-printf '\nTest 1: _op_to_file recovers when first 2 op-reads fail\n'
+printf '\nTest 1: _op_to_file recovers when first 2 op-reads fail (transient)\n'
 COUNTER="$WORK/counter1"
 echo 0 > "$COUNTER"
 
 # Override `op` as a bash function that consults the counter. First
-# N invocations exit 1 with rate-limit stderr (matching the wrapper's
-# rate-limit detection regex); subsequent invocations succeed.
+# N invocations exit 1 with a transient stderr (503 Service Unavailable
+# — must NOT match the wrapper's `rate.?limit|too many requests` regex
+# or T1.2 fast-fail kicks in); subsequent invocations succeed.
 op() {
   if [ "${1:-}" = "read" ]; then
     local cur next
@@ -67,7 +74,7 @@ op() {
     next=$((cur + 1))
     echo "$next" > "$COUNTER"
     if [ "$cur" -lt 2 ]; then
-      printf '[ERROR] could not read secret: Too many requests. Your client has been rate-limited.\n' >&2
+      printf '[ERROR] could not read secret: HTTP 503 Service Unavailable\n' >&2
       return 1
     fi
     # Successful path: echo the expected canned content for the ref.
@@ -117,10 +124,11 @@ else
 fi
 
 # ── Test 2: N=5 → exhausts budget, _op_to_file fails ─────────────
-printf '\nTest 2: _op_to_file fails cleanly when all 5 retries fail\n'
+printf '\nTest 2: _op_to_file fails cleanly when all 5 transient retries fail\n'
 echo 0 > "$COUNTER"
 
-# Same override; raise the failure budget so all 5 attempts fail.
+# Same override; raise the failure budget so all 5 attempts fail. Use
+# a transient stderr (502) — rate-limit would short-circuit at attempt 1.
 op() {
   if [ "${1:-}" = "read" ]; then
     local cur next
@@ -128,7 +136,7 @@ op() {
     next=$((cur + 1))
     echo "$next" > "$COUNTER"
     if [ "$cur" -lt 5 ]; then
-      printf '[ERROR] could not read secret: Too many requests.\n' >&2
+      printf '[ERROR] could not read secret: HTTP 502 Bad Gateway\n' >&2
       return 1
     fi
     echo "should-not-be-reached"
@@ -168,6 +176,51 @@ if grep -q '"ref":"op://COO/exhaust-ref/value"' "$HOME/.vade/op-read-failures.js
   _pass "N=5: jsonl event recorded with rc!=0 for exhaust-ref"
 else
   _fail "N=5: jsonl missing rc!=0 event for exhaust-ref"
+fi
+
+# ── Test 3: rate-limit → fast-fail (briefing-40 T1.2) ────────────
+printf '\nTest 3: _op_to_file fast-fails on rate-limit (no full-budget burn)\n'
+COUNTER3="$WORK/counter3"
+echo 0 > "$COUNTER3"
+
+# Every attempt returns rate-limit stderr. With T1.2 in place, the loop
+# must break after attempt 1, leaving the counter at exactly 1. With
+# the prior `retry 5 op read`, the counter would reach 5.
+op() {
+  if [ "${1:-}" = "read" ]; then
+    local cur next
+    cur="$(cat "$COUNTER3" 2>/dev/null || echo 0)"
+    next=$((cur + 1))
+    echo "$next" > "$COUNTER3"
+    printf '[ERROR] could not read secret: Too many requests. Your client has been rate-limited.\n' >&2
+    return 1
+  fi
+  return 0
+}
+export -f op
+
+TARGET3="$WORK/target3"
+rm -f "$TARGET3"
+RC3=0
+_op_to_file "op://COO/rate-limit-ref/value" "$TARGET3" 0600 || RC3=$?
+
+if [ "$RC3" -ne 0 ]; then
+  _pass "rate-limit: _op_to_file returned rc=$RC3 (expected non-zero)"
+else
+  _fail "rate-limit: _op_to_file rc=0 (expected non-zero — wrap shim cascade exhausted)"
+fi
+
+if [ ! -f "$TARGET3" ]; then
+  _pass "rate-limit: target file not written"
+else
+  _fail "rate-limit: target file written at $TARGET3 despite rate-limit"
+fi
+
+COUNTER_FINAL3="$(cat "$COUNTER3" 2>/dev/null || echo 0)"
+if [ "$COUNTER_FINAL3" = "1" ]; then
+  _pass "rate-limit: exactly 1 op-read attempt consumed (T1.2 fast-fail)"
+else
+  _fail "rate-limit: counter=$COUNTER_FINAL3 (expected 1; full-budget burn implies T1.2 regression)"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────

--- a/scripts/gh-coo-wrap.sh
+++ b/scripts/gh-coo-wrap.sh
@@ -84,10 +84,14 @@ SESSION_URL=""
 # <NAME>.expiry file holding the unix-time expiry stamp. Tmpfs is in-
 # memory, container-ephemeral, dies on container reboot — within the
 # spirit of Phase 2's "no plaintext at rest" (no disk persistence, no
-# backup surface). TTL is generous (5 min) since PAT rotation runs
-# daily; cache is for amortizing op-read latency + rate-limit pressure,
-# not for freshness control. On op rate-limit or unavailability, stale
-# cache is used as graceful degradation.
+# backup surface). TTL is generous (1 hour, post briefing-40 T1.1) since
+# PAT rotation runs daily; cache is for amortizing op-read latency +
+# rate-limit pressure, not for freshness control. On op rate-limit or
+# unavailability, stale cache is used as graceful degradation. The
+# original 5-min TTL was a guess; instrumentation (Layer 1 jsonl,
+# coo-harness#540) showed observed cache_age_sec p75 ~104s, well under
+# even the 5-min ceiling. Bump rationale + measurement window in
+# MEMO-2026-06-07-ax4s.
 #
 # Cost model:
 #  - env var set (legacy session)        → 0 op-read, env passthrough
@@ -152,7 +156,7 @@ _resolve_pat() {
   local cache_dir="${XDG_RUNTIME_DIR:-/tmp}/coo-gh-pat-cache"
   local cache_file="$cache_dir/$name"
   local expiry_file="$cache_dir/$name.expiry"
-  local ttl=300
+  local ttl=3600
   local now; now="$(date +%s 2>/dev/null || echo 0)"
   # cache_age_sec: file-mtime-based; -1 when cache file absent.
   local _cache_age=-1

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -2223,19 +2223,44 @@ _op_to_file() {
   # (`VADE_FORCE_COO_BOOTSTRAP=1`) succeeded after 2 retries on the
   # same ref, suggesting 3 attempts was inside the cold-start window
   # but 5 clears it comfortably.
+  #
+  # Rate-limit fast-fail (briefing-40 T1.2, coo-harness#545): the loop
+  # is inline rather than the generic `retry` helper because we need
+  # to short-circuit on op rate-limit. op-coo-wrap.sh's swap-and-retry
+  # already exhausts the 3-token cascade before any rate-limit error
+  # surfaces here; another 4 attempts at this layer just burns wall
+  # time. Transient errors (5xx, network, timeout) still get the full
+  # 5-attempt budget.
   err_file="$(mktemp 2>/dev/null || echo "/tmp/op-to-file.$$.err")"
   : > "$err_file"
   pref_before="$(cat "${XDG_RUNTIME_DIR:-/tmp}/coo-op-wrap/active" 2>/dev/null || echo "?")"
   start_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
-  # Capture stderr from the retry chain to err_file so we can both
-  # (a) replay it to the operator (preserving prior log behavior) and
-  # (b) record its tail in the structured jsonl event for #451.
-  content="$(retry 5 op read "$ref" 2>"$err_file")" || rc=$?
+  local _attempt=0 _delay=1
+  local _max=5
+  content=""
+  while [ "$_attempt" -lt "$_max" ]; do
+    _attempt=$((_attempt + 1))
+    rc=0
+    content="$(op read "$ref" 2>"$err_file")" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      break
+    fi
+    if grep -qiE 'rate.?limit|too many requests' "$err_file" 2>/dev/null; then
+      log_err "  FAIL after ${_attempt}/${_max} attempts: op read $ref (rate-limited; wrap shim's token cascade exhausted; not retrying)"
+      break
+    fi
+    if [ "$_attempt" -lt "$_max" ]; then
+      log_err "  retry ${_attempt}/${_max} for: op read $ref (rc=$rc; sleeping ${_delay}s)"
+      sleep "$_delay"
+      _delay=$((_delay * 2))
+    fi
+  done
   end_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
   pref_after="$(cat "${XDG_RUNTIME_DIR:-/tmp}/coo-op-wrap/active" 2>/dev/null || echo "?")"
   elapsed_ms=$((end_ms - start_ms))
-  # Preserve prior stderr behavior — retry already wrote its diagnostic
-  # lines to err_file; replay them so existing log consumers see them.
+  # Preserve prior stderr behavior — replay the last attempt's stderr
+  # (op-coo-wrap.sh's trace, the actual op-real error) to the operator
+  # for log consumers that grep for the underlying failure shape.
   cat "$err_file" >&2 2>/dev/null || true
   # Observability: record when the call failed or took non-trivial time
   # (>1s strongly suggests at least one retry attempt; a clean cold cache


### PR DESCRIPTION
Implements both Tier-1 reductions from briefing-40 after the Layer 1 + Layer 2 instrumentation merged in #540/#542 produced 7 sessions of data on 2026-06-07 (746 events total). Both T1.x decisions met their acceptance thresholds in coo-harness#545; nothing else gates them.

## Data summary

```
L1 — _resolve_pat decisions (170 events):
  cache-hit            : 107  (63%)
  env-passthrough      :  45  (26%)
  cache-miss-op-read   :  18  (11%)

L1 cache_age_sec across cache-hit + cache-miss-op-read (n=125):
  p50=36s  p75=104s  p95=260s  max=261s

L2 — op-coo-wrap.sh per-call events (576 events):
  steady-state: 362 (43 fail, 13 rate-limited)
  bootstrap  : 204 (47 fail, 39 rate-limited)
  monitor    :  10 (  0 fail,  0 rate-limited)

L2 rate_limited:true with retry_attempt_index > 0 (n=10):
  retry_attempt_index=1 : 9
  retry_attempt_index=2 : 1
```

## T1.1 — PAT-cache TTL 300s → 3600s

`gh-coo-wrap.sh::_resolve_pat`'s `local ttl=300` becomes `local ttl=3600`. The acceptance threshold from coo-harness#545 was "75th percentile well under 1800s"; measured p75 is 104s — 6% of the threshold, with headroom to spare. 1 hr matches the documented rationale ("amortize op-read latency + rate-limit pressure; PAT rotation is daily") and gives a 24× safety margin to rotation cadence. Tmpfs cache stays container-ephemeral; stale-PAT-after-rotation risk bounded to one session.

Memo: MEMO-2026-06-07-ax4s (per plan §3 Tier-1 "Memo-worthy — changes a documented constant"). Memo PR: coo-labs/coo-memory#1314 (branch `claude/magical-newton-Vl6ER`).

## T1.2 — `_op_to_file` fast-fails on rate-limit

`common.sh::_op_to_file`'s `retry 5 op read` is replaced with an inline retry loop that distinguishes transient (5xx, network, timeout — full 5-attempt budget retained for SA cold-start tolerance per coo-harness#451) from rate-limit (matches the same `rate.?limit|too many requests` regex as `op-coo-wrap.sh::_is_rate_limit`; fail-fast, bypass remaining attempts). The generic `retry` helper and other callers (curl fetchers, `op whoami` bootstrap probes) are unchanged.

Acceptance threshold: "rate_limited:true events with retry_attempt_index > 0 observed → ship." 10 such events seen in the data, all in the wrap shim's post-cascade tail. Each one burned 1–2 extra `op read` attempts for no chance of success — pure wall-time + quota waste.

Per plan §3 Tier-1, T1.2 is "not memo-worthy if shape stays compatible." The 5-attempt budget, 1+2+4+8s backoff, jsonl observability, and external `retry()` helper all stay; the only behavior change is the early break on rate-limit.

## Test changes

`scripts/ci/test-op-retry-recovery.sh` is updated:
- Tests 1 and 2 swap their mock-`op` stderr from `Too many requests` → `HTTP 503/502` so the transient-recovery and full-budget-exhaustion paths still exercise the 5-attempt loop (the rate-limit string would now short-circuit them by design).
- New Test 3 asserts exactly 1 op-read attempt is consumed when stderr matches rate-limit, target file is not written, and rc is non-zero.

`bash scripts/ci/test-op-retry-recovery.sh` → 11/11 PASS.

## Followups

Both T1.x land per the issue's acceptance. The remaining briefing-40 close-out step (`/briefing done 040 --via ...` citing #540/#541/#542 plus these PRs) waits for this merge.

Closes #545

Closes #545

https://claude.ai/code/session_014Y9jnCvMxUyQCoLcyw8M4G