### PR TITLE
boot-brake: silence identity_predicate_unmatched in benign no-overflow case (coo-memory#1175)

### DIFF
--- a/scripts/ci/test-boot-brake-guard.sh
+++ b/scripts/ci/test-boot-brake-guard.sh
@@ -360,18 +360,75 @@ else
   _fail "PENDING under block-on-FAIL emitted output: $out"
 fi
 
-# ─── Test 13 (NEW): identity_consumed predicate-unmatched event ─
-echo "Test 13 — identity_consumed predicate-unmatched emits diagnostic (SRE F5)"
+# ─── Test 13 (NEW): identity_consumed predicate behavior ────────
+#
+# coo-memory#1175 split this into three cases. The earlier version
+# asserted the diagnostic fires on empty tool-results/; that case is
+# now suppressed (the digest-fit-inline shape was producing constant
+# noise that trained operators to ignore the signal). The three
+# sub-tests cover the post-fix behavior:
+#
+#   13   — tool-results/ absent OR empty: diagnostic suppressed.
+#   13b  — hook-*-stdout.txt present (>1KB): predicate matches; no
+#          diagnostic; identity_consumed FAILs because the agent
+#          hasn't Read the file.
+#   13c  — hook-* file present but no -stdout suffix: convention
+#          drift; diagnostic fires.
+
+echo "Test 13 — identity_consumed predicate suppressed when tool-results/ empty (#1175)"
 set -- $(echo "$(_setup_session_dirs "t13")" | tr '|' ' ')
 state_dir="$1"; home_dir="$2"
 _make_all_deliverables_present "$state_dir" "$home_dir"
 # No persisted-output files exist for session t13. The predicate glob
-# expands to a path under home_dir that has nothing → predicate unmatched.
+# expands to a path under home_dir that has nothing → predicate unmatched
+# AND no hook-* file present → diagnostic suppressed.
 _invoke_guard t13 Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
 if grep -q '"cause":"identity_predicate_unmatched"' "$state_dir/brake-events.jsonl" 2>/dev/null; then
-  _pass "predicate-unmatched event emitted in brake-events.jsonl"
+  _fail "predicate-unmatched event emitted with empty tool-results/ (#1175 regression)"
 else
-  _fail "predicate-unmatched event NOT emitted (events.jsonl content: $(cat "$state_dir/brake-events.jsonl" 2>/dev/null | tail -3))"
+  _pass "predicate-unmatched event suppressed in benign no-overflow case"
+fi
+
+echo "Test 13b — predicate matches when hook-*-stdout.txt fixture present (#1175)"
+set -- $(echo "$(_setup_session_dirs "t13b")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+# Stage a tool-results/ dir with a hook-*-stdout.txt file matching the
+# predicate. Use a 2KB body so it clears the substantive (>1KB) bar.
+tool_results_dir="$home_dir/.claude/projects/-home-user/t13b/tool-results"
+mkdir -p "$tool_results_dir"
+python3 -c "open('$tool_results_dir/hook-SessionStart-stdout.txt','w').write('x'*2048)"
+_invoke_guard t13b Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+# Predicate matched → identity_consumed evaluated. Agent hasn't Read the
+# file → check returns FAIL with the "overflowed but not Read" reason.
+if grep -q '"deliverable":"identity_consumed"' "$state_dir/boot-brake.t13b.json" 2>/dev/null; then
+  _pass "predicate matched the hook-*-stdout.txt fixture and gated identity_consumed"
+else
+  _fail "predicate did NOT match a hook-*-stdout.txt fixture (sentinel: $(cat "$state_dir/boot-brake.t13b.json" 2>/dev/null | tail -3))"
+fi
+# AND the diagnostic should be suppressed when the predicate cleanly
+# matched (we got substantive matches, no drift to surface).
+if grep -q '"cause":"identity_predicate_unmatched"' "$state_dir/brake-events.jsonl" 2>/dev/null; then
+  _fail "predicate-unmatched event emitted despite substantive match"
+else
+  _pass "no spurious predicate-unmatched event when match succeeds"
+fi
+
+echo "Test 13c — diagnostic fires when hook-* present but no -stdout suffix (drift) (#1175)"
+set -- $(echo "$(_setup_session_dirs "t13c")" | tr '|' ' ')
+state_dir="$1"; home_dir="$2"
+_make_all_deliverables_present "$state_dir" "$home_dir"
+# Stage a hook-prefixed file whose name does NOT match the predicate
+# suffix. Models the "Claude Code persisted-output naming has drifted"
+# case the diagnostic is supposed to catch.
+tool_results_dir="$home_dir/.claude/projects/-home-user/t13c/tool-results"
+mkdir -p "$tool_results_dir"
+python3 -c "open('$tool_results_dir/hook-SessionStart-1780823625482.txt','w').write('x'*2048)"
+_invoke_guard t13c Bash block-on-FAIL "$state_dir" "$home_dir" "ls" > /dev/null
+if grep -q '"cause":"identity_predicate_unmatched"' "$state_dir/brake-events.jsonl" 2>/dev/null; then
+  _pass "predicate-unmatched event emitted on convention drift (hook-* without -stdout)"
+else
+  _fail "drift case NOT surfaced (events.jsonl: $(cat "$state_dir/brake-events.jsonl" 2>/dev/null | tail -3))"
 fi
 
 # ─── Test 14 (NEW): override tamper resistance ──────────────────

--- a/scripts/hooks/boot-brake-guard.py
+++ b/scripts/hooks/boot-brake-guard.py
@@ -510,6 +510,14 @@ def check_deliverable(entry, env, home, session_id, cwd):
             expanded_glob = predicate_glob
             for var in ("VADE_CLOUD_STATE_DIR", "VADE_COO_MEMORY_DIR", "VADE_RUNTIME_DIR", "HOME"):
                 expanded_glob = expanded_glob.replace(f"${var}", env.get(var, ""))
+            # Resolve the parent directory before glob-escape so the
+            # convention-drift heuristic below can iterdir() the literal
+            # filesystem path (coo-memory#1175). The glob-escaped form
+            # is for matching only.
+            literal_parent = os.path.dirname(expanded_glob)
+            literal_parent = literal_parent.replace(
+                "$CWD_DASHIFIED", cwd.replace("/", "-")
+            ).replace("$SESSION_ID", session_id)
             # Polish P2 (coo-memory#1167): escape glob metacharacters in
             # substituted values so a malicious cwd / session_id can't
             # reshape the glob (e.g. inject `*` or `[` into the literal
@@ -533,18 +541,30 @@ def check_deliverable(entry, env, home, session_id, cwd):
                 except OSError:
                     continue
             if not substantive:
-                # Loud-fail on the surface that "no overflow detected"
-                # could mean either (a) digest fit inline (correct skip)
-                # OR (b) the path convention drifted and the §11
-                # invariant is now silently disabled. SRE F5: surface
-                # this as a diagnostic event so a Phase 1 aggregator
-                # can detect convention drift in the wild.
-                signals.append({
-                    "type": "predicate_unmatched",
-                    "deliverable": entry.get("id", "unknown"),
-                    "expanded_glob": sanitize(expanded_glob),
-                    "matches_total": len(matches),
-                })
+                # Two cases collapse here (coo-memory#1175):
+                #   (a) parent dir absent OR contains no hook-prefixed
+                #       files — digest fit inline, nothing persisted,
+                #       gate is correctly no-op. Suppress diagnostic.
+                #   (b) parent dir contains hook-prefixed files but none
+                #       match the predicate suffix — Claude Code
+                #       file-naming may have drifted; fire diagnostic.
+                # Pre-#1175 the diagnostic fired in (a) too, polluting
+                # the signal so case (b) became hard to spot.
+                has_hook_files = False
+                try:
+                    for f in Path(literal_parent).iterdir():
+                        if f.name.startswith("hook-"):
+                            has_hook_files = True
+                            break
+                except OSError:
+                    pass
+                if has_hook_files:
+                    signals.append({
+                        "type": "predicate_unmatched",
+                        "deliverable": entry.get("id", "unknown"),
+                        "expanded_glob": sanitize(expanded_glob),
+                        "matches_total": len(matches),
+                    })
                 return True, "predicate not present; check skipped", None, signals
         pattern = entry.get("check_arg", "")
         try:


### PR DESCRIPTION
Addresses [coo-memory#1175](https://github.com/coo-labs/coo-memory/issues/1175).

## What

Silence the `identity_predicate_unmatched` diagnostic when there's no signal to surface.

Pre-fix: the diagnostic fired on every guard call in every session where the SessionStart digest fit inline (i.e. almost every session). Live evidence — my own session today fired 17+ of these events between 09:01Z and 09:04Z, all benign. The constant noise trained operators to ignore the signal, which defeats its design purpose of catching convention drift in Claude Code's persisted-output naming.

## How

Split the predicate-zero-matches case in `boot-brake-guard.py:check_deliverable` (`read_observed` branch):

- Parent `tool-results/` absent OR contains no `hook-*` files → digest fit inline, gate is correctly no-op, **suppress diagnostic**.
- Parent `tool-results/` contains `hook-*` files but none match the predicate suffix → suspected convention drift, **fire diagnostic**.

Gate-correctness semantics unchanged: still returns `True` (no-op) when predicate matches zero substantive files. Only the diagnostic event is gated by the new heuristic.

## Tests

- **Test 13** (was: asserts diagnostic fires on empty `tool-results/`) → inverted to assert suppression in the benign case.
- **Test 13b** (new) — predicate matches a >1KB `hook-SessionStart-stdout.txt` fixture; `identity_consumed` correctly FAILs (no Read observed); no spurious diagnostic. Closes the gap the issue body flagged: there was no test asserting the match path actually worked.
- **Test 13c** (new) — drift case: `hook-SessionStart-<ts>.txt` fixture (no `-stdout` suffix) triggers the diagnostic.

Pre-PR CI: `72 passed, 2 failed`. Post-PR CI: `75 passed, 2 failed`. The 2 pre-existing failures (Test 8 prompt-injection sanitization, Test 29 has_jq_path syntax rejection) both fail on a manifest-SHA-pin mismatch — they're unrelated to this change and existed on `main`. Filing as a separate issue.

## Residual uncertainty (parked, NOT this PR)

The predicate filename pattern (`hook-*-stdout.txt`) was never independently verified against Claude Code's actual persisted-output naming. The original issue's 2026-06-03 observation reported a 14.9KB file at that path, but I can't reproduce because the historical session's `tool-results/` and `brake-events.jsonl` are wiped (per-container ephemeral, not in R2). Reproduction requires a controlled SessionStart-overflow test. Doc updated to flag this as unverified.

Closes coo-labs/coo-memory#1175

Closes coo-labs/coo-memory#1175

https://claude.ai/code/session_017DjEWfwd9vXX8cs5xX8ehH