### PR TITLE
ci(boot-brake): inject fixture SHA into manifest-SHA pin override for tests 8/29

### DIFF
--- a/scripts/ci/test-boot-brake-guard.sh
+++ b/scripts/ci/test-boot-brake-guard.sh
@@ -994,7 +994,12 @@ deliverables:
     producer: coo-harness/scripts/boot/integrity-check.sh
     severity: critical
 EOF
+# Compute and inject the fixture's SHA so the brake's manifest-SHA pin
+# check (SH1, coo-memory#1167) doesn't self-fault before the actual
+# has_jq_path syntax check runs.
+t29_sha=$(sha256sum "$malformed_manifest/operations/boot-deliverables.yml" | cut -d' ' -f1)
 out="$(VADE_COO_MEMORY_DIR_OVERRIDE="$malformed_manifest" \
+  VADE_BRAKE_MANIFEST_SHA256="$t29_sha" \
   _invoke_guard t29 Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
 if printf '%s' "$out" | grep -q 'unsupported jq path syntax'; then
   _pass "malformed has_jq_path → deny reason names 'unsupported jq path syntax'"
@@ -1017,7 +1022,10 @@ state_dir="$1"; home_dir="$2"
 # integrity-check.json with summary.ok=true satisfies the check.
 mkdir -p "$state_dir" "$home_dir/.vade" "$home_dir/.claude"
 printf '{"summary":{"ok":true}}' > "$state_dir/integrity-check.json"
+# Recompute SHA — the fixture was rewritten with the well-formed entry.
+t29b_sha=$(sha256sum "$malformed_manifest/operations/boot-deliverables.yml" | cut -d' ' -f1)
 out="$(VADE_COO_MEMORY_DIR_OVERRIDE="$malformed_manifest" \
+  VADE_BRAKE_MANIFEST_SHA256="$t29b_sha" \
   _invoke_guard t29b Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
 if [ -z "$out" ]; then
   _pass "well-formed has_jq_path resolves to OK (no deny output)"
@@ -1373,7 +1381,11 @@ deliverables:
     producer: "producer;`$(rm)<inject>"
     severity: critical
 EOF
+# Pin the fixture's SHA so the brake's manifest-SHA pin check
+# (SH1, coo-memory#1167) doesn't self-fault before sanitization runs.
+t8_sha=$(sha256sum "$t8_manifest_dir/operations/boot-deliverables.yml" | cut -d' ' -f1)
 out8="$(VADE_COO_MEMORY_DIR_OVERRIDE="$t8_manifest_dir" \
+  VADE_BRAKE_MANIFEST_SHA256="$t8_sha" \
   _invoke_guard t8 Bash block-on-FAIL "$state_dir" "$home_dir" "ls")"
 # Extract permissionDecisionReason — the actual string the agent sees in
 # its tool-feedback context. Sanitization is asserted on THIS value, not


### PR DESCRIPTION
Fixes two pre-existing CI failures in `scripts/ci/test-boot-brake-guard.sh` that surfaced while verifying coo-harness#560:

- **Test 8** (prompt-injection sanitization)
- **Test 29** (`has_jq_path` rejects unsupported syntax, two sub-cases)

Both stage a custom `boot-deliverables.yml` fixture via `VADE_COO_MEMORY_DIR_OVERRIDE`. The brake's manifest-SHA pin (SH1 from coo-labs/coo-memory#1167) reads `VADE_BRAKE_MANIFEST_SHA256` from env — which the test runner inherits from `coo-harness/.claude/settings.json` and pins the **real** manifest's hash. Against the fixture, that hash mismatches, the brake fires a `manifest_sha_mismatch` validator self-fault, and the tests' expected deliverable-specific deny reasons never appear.

Fix: at each fixture-staging call site, compute the fixture's SHA-256 and pass it alongside `VADE_COO_MEMORY_DIR_OVERRIDE` so the pin check passes and the actual assertion can run.

Three call sites patched:
- Test 8 (`t8_manifest_dir`)
- Test 29 part 1 (`malformed_manifest`, malformed jq syntax)
- Test 29 part 2 (same dir, rewritten with well-formed entry — SHA recomputed)

Test 11 (`validator_self_fault` on a missing manifest dir) stays untouched — it correctly wants the manifest to be unreadable, never reaching the pin check.

Pre-fix CI: `75 passed, 2 failed`.
Post-fix CI: `77 passed, 0 failed`.

Closes: n/a

Closes: n/a

https://claude.ai/code/session_017DjEWfwd9vXX8cs5xX8ehH