### PR TITLE
briefing-40 T3.1: session-scope op-read cache (74.4% identical-path repeats → ~0%)

### DIFF
--- a/bin/op-read-rollup.py
+++ b/bin/op-read-rollup.py
@@ -54,7 +54,7 @@ def parse_args():
     )
     p.add_argument(
         "--by",
-        choices=("script", "path", "phase", "layer", "decision"),
+        choices=("script", "path", "phase", "layer", "decision", "cache_decision"),
         default="script",
         help="Aggregation dimension",
     )
@@ -166,6 +166,8 @@ def aggregate(rows, by):
             return ev.get("layer") or "<unknown>"
         if by == "decision":
             return ev.get("decision") or "<n/a>"
+        if by == "cache_decision":
+            return ev.get("cache_decision") or "<bypass>"
         return "<unknown>"
 
     groups = defaultdict(list)

--- a/scripts/ci/test-op-coo-wrap-cache.sh
+++ b/scripts/ci/test-op-coo-wrap-cache.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# test-op-coo-wrap-cache: exercise the T3.1 session-scope op-read cache
+# in scripts/op-coo-wrap.sh (briefing-40 plan §3, coo-harness#562).
+#
+# Strategy: stand up a mock op-real binary that echoes a deterministic
+# value per (path, scenario) and tracks invocation count via a counter
+# file, then drive op-coo-wrap.sh against it through scenarios that
+# exercise each cache_decision branch:
+#
+#   1. cache-miss-new — first read of a path; rc=0, value flows to
+#      stdout, cache file is written, invocation count = 1.
+#   2. cache-hit — second read of the same path; rc=0, value matches
+#      the cached value, mock's counter does NOT advance (op-real never
+#      invoked), event carries cache_decision=cache-hit.
+#   3. TTL expiry — backdate the cache mtime past COO_OP_CACHE_TTL, read
+#      again; op-real is re-invoked, cache file is refreshed, event is
+#      cache-miss-new.
+#   4. cache-miss-stale-fallback — every token rate-limited AND a stale
+#      cache file exists; the cached value is served, event is
+#      cache-miss-stale-fallback, exit code is 0 (not the rate-limit rc).
+#   5. cache bypass (non-`read` subcommand) — `op whoami` passes through
+#      to the real binary; no cache file is created; event carries
+#      empty cache_decision.
+#   6. COO_OP_CACHE=0 opt-out — read with the env var set; no cache file
+#      is created; event carries empty cache_decision.
+#
+# Run: bash scripts/ci/test-op-coo-wrap-cache.sh
+# Exit: 0 if all assertions pass, non-zero otherwise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WRAP="$REPO_ROOT/scripts/op-coo-wrap.sh"
+
+[ -f "$WRAP" ] || { echo "FAIL: op-coo-wrap.sh not found at $WRAP" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Isolated runtime dir so the cache and L2 jsonl don't touch /dev/shm or
+# the operator's $XDG_RUNTIME_DIR.
+export XDG_RUNTIME_DIR="$WORK/xdg"
+mkdir -p "$XDG_RUNTIME_DIR"
+
+# Mock op-real. Behavior:
+#   - SCENARIO=success    → echo "value-for-<path>", rc=0
+#   - SCENARIO=rate-limit → echo nothing on stdout, "Too many requests" on stderr, rc=1
+#   - SCENARIO=signin     → echo "you are 'tester'", rc=0 (whoami passthrough)
+MOCK_OP="$WORK/op-real-mock"
+COUNTER="$WORK/mock-counter"
+echo 0 > "$COUNTER"
+cat > "$MOCK_OP" <<'MOCK_EOF'
+#!/usr/bin/env bash
+# Track every invocation in the counter so the test can assert the
+# wrap shim called us exactly N times (cache hits should NOT advance).
+COUNTER="${MOCK_COUNTER:-/tmp/mock-counter}"
+cur="$(cat "$COUNTER" 2>/dev/null || echo 0)"
+echo $((cur + 1)) > "$COUNTER"
+
+case "${SCENARIO:-success}" in
+  rate-limit)
+    printf '[ERROR] could not read secret: Too many requests. Your client has been rate-limited.\n' >&2
+    exit 1
+    ;;
+  signin)
+    # Treat `whoami` as a special success
+    echo "you are 'tester'"
+    exit 0
+    ;;
+  success|*)
+    # Echo a value derived from argv (skip "read" itself, use the path).
+    for arg in "$@"; do
+      case "$arg" in
+        op://*) echo "value-for-${arg}"; exit 0 ;;
+      esac
+    done
+    echo "value-for-default"
+    exit 0
+    ;;
+esac
+MOCK_EOF
+chmod +x "$MOCK_OP"
+
+export COO_OP_REAL="$MOCK_OP"
+export MOCK_COUNTER="$COUNTER"
+
+# Set both SA token slots so the cascade has tokens to iterate. They
+# don't need to be real values; op-real is mocked.
+export OP_SERVICE_ACCOUNT_TOKEN="fake-token-A"
+export OP_SERVICE_ACCOUNT_TOKEN_BACKUP="fake-token-B"
+export OP_SERVICE_ACCOUNT_TOKEN_BACKUP2="fake-token-C"
+
+# Bootstrap-done marker so phase classification doesn't keep flipping
+# to bootstrap and writing extra events.
+mkdir -p "$HOME/.vade" 2>/dev/null || true
+touch "$HOME/.vade/.coo-bootstrap-done"
+
+# L2 log path is /dev/shm/coo-op-reads-L2.<session>.jsonl — redirect via
+# CLAUDE_CODE_SESSION_ID to a session-id under our isolated runtime dir,
+# then symlink /dev/shm to it.
+SESSION_ID="cache-test-$$"
+export CLAUDE_CODE_SESSION_ID="$SESSION_ID"
+
+# We can't easily reroute /dev/shm; instead, sample by reading the path
+# the wrap shim writes to. The default path is /dev/shm/coo-op-reads-L2.<sid>.jsonl.
+LOG_PATH="/dev/shm/coo-op-reads-L2.${SESSION_ID}.jsonl"
+rm -f "$LOG_PATH" 2>/dev/null || true
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+_pass() { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+_fail() { FAIL=$((FAIL+1)); FAILURES+=("$1"); printf '  FAIL  %s\n' "$1"; }
+
+run_op() {
+  # Wrap-shim subprocess; bash explicitly to honor shebang on systems
+  # where the test bit isn't preserved.
+  SCENARIO="${SCENARIO:-success}" bash "$WRAP" "$@"
+}
+
+last_event() {
+  tail -n 1 "$LOG_PATH" 2>/dev/null
+}
+
+# ── Test 1: cache-miss-new ───────────────────────────────────────
+printf '\nTest 1: cache-miss-new (first read writes cache)\n'
+echo 0 > "$COUNTER"
+RC1=0
+OUT1="$(SCENARIO=success run_op read op://COO/foo/bar 2>/dev/null)" || RC1=$?
+
+if [ "$RC1" -eq 0 ]; then _pass "rc=0"; else _fail "rc=$RC1 (expected 0)"; fi
+if [ "$OUT1" = "value-for-op://COO/foo/bar" ]; then _pass "stdout matches mock value"; else _fail "stdout='$OUT1' (expected 'value-for-op://COO/foo/bar')"; fi
+COUNT1="$(cat "$COUNTER")"
+if [ "$COUNT1" = "1" ]; then _pass "mock invoked exactly 1 time"; else _fail "mock counter=$COUNT1 (expected 1)"; fi
+CACHE_DIR="$XDG_RUNTIME_DIR/coo-op-cache"
+N_CACHE_FILES="$(find "$CACHE_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l)"
+if [ "$N_CACHE_FILES" = "1" ]; then _pass "1 cache file written"; else _fail "$N_CACHE_FILES cache files (expected 1)"; fi
+EV1="$(last_event)"
+if echo "$EV1" | grep -q '"cache_decision":"cache-miss-new"'; then _pass "event: cache_decision=cache-miss-new"; else _fail "event cache_decision wrong: $EV1"; fi
+
+# ── Test 2: cache-hit ────────────────────────────────────────────
+printf '\nTest 2: cache-hit (second read of same path skips op-real)\n'
+RC2=0
+OUT2="$(SCENARIO=success run_op read op://COO/foo/bar 2>/dev/null)" || RC2=$?
+
+if [ "$RC2" -eq 0 ]; then _pass "rc=0"; else _fail "rc=$RC2 (expected 0)"; fi
+if [ "$OUT2" = "value-for-op://COO/foo/bar" ]; then _pass "stdout matches cached value"; else _fail "stdout='$OUT2'"; fi
+COUNT2="$(cat "$COUNTER")"
+if [ "$COUNT2" = "1" ]; then _pass "mock counter still 1 (op-real not invoked)"; else _fail "mock counter=$COUNT2 (expected 1)"; fi
+EV2="$(last_event)"
+if echo "$EV2" | grep -q '"cache_decision":"cache-hit"'; then _pass "event: cache_decision=cache-hit"; else _fail "event cache_decision wrong: $EV2"; fi
+
+# ── Test 3: TTL expiry → fresh cache-miss-new ────────────────────
+printf '\nTest 3: TTL expiry forces re-fetch\n'
+# Find the cache file (only one entry) and backdate its mtime past 1hr.
+CACHE_FILE="$(find "$CACHE_DIR" -maxdepth 1 -type f | head -1)"
+if [ -n "$CACHE_FILE" ] && [ -f "$CACHE_FILE" ]; then
+  # Use a deliberately tiny TTL so we don't need to actually wait. Combine
+  # with `touch -d` to set mtime two seconds in the past.
+  touch -d "2 seconds ago" "$CACHE_FILE"
+  _pass "cache mtime backdated"
+else
+  _fail "no cache file found to backdate"
+fi
+
+RC3=0
+OUT3="$(COO_OP_CACHE_TTL=1 SCENARIO=success run_op read op://COO/foo/bar 2>/dev/null)" || RC3=$?
+if [ "$RC3" -eq 0 ]; then _pass "rc=0"; else _fail "rc=$RC3"; fi
+COUNT3="$(cat "$COUNTER")"
+if [ "$COUNT3" = "2" ]; then _pass "mock counter advanced to 2 (cache expired → re-fetched)"; else _fail "mock counter=$COUNT3 (expected 2)"; fi
+EV3="$(last_event)"
+if echo "$EV3" | grep -q '"cache_decision":"cache-miss-new"'; then _pass "event: cache_decision=cache-miss-new on expiry"; else _fail "event cache_decision wrong: $EV3"; fi
+
+# ── Test 4: cache-miss-stale-fallback on all-tokens-rate-limited ─
+printf '\nTest 4: stale-fallback when every token rate-limited\n'
+# Cache file from Test 3 is still present. Backdate it again so it's
+# definitely past the TTL we'll use for this read.
+CACHE_FILE="$(find "$CACHE_DIR" -maxdepth 1 -type f | head -1)"
+touch -d "2 seconds ago" "$CACHE_FILE"
+COUNT_BEFORE="$(cat "$COUNTER")"
+RC4=0
+OUT4="$(COO_OP_CACHE_TTL=1 SCENARIO=rate-limit run_op read op://COO/foo/bar 2>/dev/null)" || RC4=$?
+
+if [ "$RC4" -eq 0 ]; then _pass "rc=0 (stale cache served, rate-limit absorbed)"; else _fail "rc=$RC4 (expected 0; fall-back to cache should succeed)"; fi
+if [ "$OUT4" = "value-for-op://COO/foo/bar" ]; then _pass "stdout = cached stale value"; else _fail "stdout='$OUT4'"; fi
+COUNT_AFTER="$(cat "$COUNTER")"
+EXPECTED_DELTA=3  # All three tokens cascaded
+ACTUAL_DELTA=$((COUNT_AFTER - COUNT_BEFORE))
+if [ "$ACTUAL_DELTA" -eq "$EXPECTED_DELTA" ]; then _pass "all 3 tokens probed before fallback (delta=$ACTUAL_DELTA)"; else _fail "token cascade delta=$ACTUAL_DELTA (expected $EXPECTED_DELTA)"; fi
+EV4="$(last_event)"
+if echo "$EV4" | grep -q '"cache_decision":"cache-miss-stale-fallback"'; then _pass "event: cache_decision=cache-miss-stale-fallback"; else _fail "event cache_decision wrong: $EV4"; fi
+
+# ── Test 5: cache bypass for non-read subcommand ─────────────────
+printf '\nTest 5: op whoami passes through, no cache file written\n'
+# Clear the cache dir so we can verify nothing new is written.
+rm -rf "$CACHE_DIR"
+N_BEFORE="$(find "$XDG_RUNTIME_DIR" -name 'coo-op-cache' -maxdepth 1 2>/dev/null | wc -l)"
+
+RC5=0
+OUT5="$(SCENARIO=signin run_op whoami 2>/dev/null)" || RC5=$?
+if [ "$RC5" -eq 0 ]; then _pass "rc=0"; else _fail "rc=$RC5"; fi
+if [ "$OUT5" = "you are 'tester'" ]; then _pass "stdout matches mock whoami output"; else _fail "stdout='$OUT5'"; fi
+N_AFTER_FILES="$(find "$XDG_RUNTIME_DIR/coo-op-cache" -maxdepth 1 -type f 2>/dev/null | wc -l)"
+if [ "$N_AFTER_FILES" = "0" ]; then _pass "no cache file written for whoami"; else _fail "$N_AFTER_FILES cache files (expected 0)"; fi
+EV5="$(last_event)"
+if echo "$EV5" | grep -q '"op_subcommand":"whoami"' && echo "$EV5" | grep -q '"cache_decision":""'; then
+  _pass "event: op_subcommand=whoami, cache_decision empty (bypass)"
+else
+  _fail "event shape wrong for whoami: $EV5"
+fi
+
+# ── Test 6: COO_OP_CACHE=0 opt-out ───────────────────────────────
+printf '\nTest 6: COO_OP_CACHE=0 disables caching even for read\n'
+echo 0 > "$COUNTER"
+rm -rf "$CACHE_DIR"
+RC6=0
+OUT6="$(COO_OP_CACHE=0 SCENARIO=success run_op read op://COO/foo/baz 2>/dev/null)" || RC6=$?
+if [ "$RC6" -eq 0 ]; then _pass "rc=0"; else _fail "rc=$RC6"; fi
+if [ "$OUT6" = "value-for-op://COO/foo/baz" ]; then _pass "stdout matches"; else _fail "stdout='$OUT6'"; fi
+N_OPTOUT_FILES="$(find "$XDG_RUNTIME_DIR/coo-op-cache" -maxdepth 1 -type f 2>/dev/null | wc -l)"
+if [ "$N_OPTOUT_FILES" = "0" ]; then _pass "no cache file written when COO_OP_CACHE=0"; else _fail "$N_OPTOUT_FILES cache files (expected 0)"; fi
+EV6="$(last_event)"
+if echo "$EV6" | grep -q '"cache_decision":""'; then _pass "event cache_decision empty under opt-out"; else _fail "event wrong: $EV6"; fi
+
+# ── Summary ──────────────────────────────────────────────────────
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+rm -f "$LOG_PATH" 2>/dev/null || true
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failures:\n'
+  for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f"; done
+  exit 1
+fi
+exit 0

--- a/scripts/op-coo-wrap.sh
+++ b/scripts/op-coo-wrap.sh
@@ -49,6 +49,12 @@
 #   COO_OP_REAL=/path/to/op-real   — alternate real-binary path
 #   COO_OP_WRAP_DISABLE=1          — bypass the shim entirely (exec op-real)
 #   COO_OP_WRAP_TRACE=1            — write decisions to /dev/shm/coo-op-wrap.trace
+#   COO_OP_CACHE=0                 — disable the read-side cache (T3.1)
+#   COO_OP_CACHE_TTL=<seconds>     — cache TTL (default 3600, matches the
+#                                    1-hour identical-path-repeat window
+#                                    measured in briefing-40 day-of-record
+#                                    data; 74.4% of L2 reads were repeats
+#                                    within this window — coo-harness#562)
 #
 # Marker (DO NOT REMOVE): COO-OP-COO-WRAP-MARKER-v1
 
@@ -223,8 +229,9 @@ _log_setup() {
 }
 
 # Emit one Layer 2 jsonl event. Arguments: rc, token_slot, latency_ms,
-# attempt_index (1-based), stderr_tail (truncated). No-op when logging
-# disabled, log_path unresolvable, or cap reached.
+# attempt_index (1-based), stderr_tail (truncated), cache_decision
+# (T3.1 — empty string for non-cacheable subcommands or cache-disabled).
+# No-op when logging disabled, log_path unresolvable, or cap reached.
 _emit_event() {
   [ "$COO_OP_WRAP_LOG_READS" = "1" ] || return 0
   [ -n "$_log_path" ] || return 0
@@ -235,7 +242,7 @@ _emit_event() {
     [ "$_count" -ge "$_log_max" ] 2>/dev/null && return 0
   fi
 
-  local rc="$1" token="$2" latency_ms="$3" attempt="$4" stderr_tail="${5:-}"
+  local rc="$1" token="$2" latency_ms="$3" attempt="$4" stderr_tail="${5:-}" cache_decision="${6:-}"
   local ts rate_limited=false
   ts="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
   _is_rate_limit "$stderr_tail" && rate_limited=true
@@ -243,7 +250,7 @@ _emit_event() {
   # Truncate stderr_tail to 240 chars before escaping.
   stderr_tail="${stderr_tail:0:240}"
 
-  printf '{"ts":"%s","layer":"L2","session_id":"%s","container_id":"%s","phase":"%s","caller_pid":%d,"caller_cmd":"%s","op_subcommand":"%s","op_path":"%s","token_slot":"%s","latency_ms":%d,"rc":%d,"rate_limited":%s,"retry_attempt_index":%d,"stderr_tail":"%s"}\n' \
+  printf '{"ts":"%s","layer":"L2","session_id":"%s","container_id":"%s","phase":"%s","caller_pid":%d,"caller_cmd":"%s","op_subcommand":"%s","op_path":"%s","token_slot":"%s","latency_ms":%d,"rc":%d,"rate_limited":%s,"retry_attempt_index":%d,"stderr_tail":"%s","cache_decision":"%s"}\n' \
     "$ts" \
     "$(_je "$_session_id")" \
     "$(_je "$_container_id")" \
@@ -258,21 +265,76 @@ _emit_event() {
     "$rate_limited" \
     "$((attempt - 1))" \
     "$(_je "$stderr_tail")" \
+    "$(_je "$cache_decision")" \
     >> "$_log_path" 2>/dev/null || true
 }
 
 # One-shot setup (resolves session, phase, caller info, op-sub/path).
 _log_setup "$@"
 
+# ── T3.1 — Session-scope op-read cache (briefing-40 plan §3, coo-harness#562) ──
+# Eliminates redundant op-reads of the same op:// path within a 1-hour
+# window. Day-of-record data (2026-06-07) showed 74.4% of L2 reads were
+# identical-path repeats; cache short-circuits those before the cascade.
+#
+# Key shape: sha256(argv-after-`op`). Argv-based rather than path-only
+# so flag differences (`--no-newline`, `--field`, etc.) don't return the
+# wrong-shape output from the same op:// path. Filenames are path-
+# anonymous in the filesystem (the original op:// path is not derivable
+# from the hex digest).
+#
+# Cached only for `read` — the subcommand whose output is deterministic
+# for a given (path, flags) tuple within the TTL. All other subcommands
+# (whoami / signin / item / vault / etc.) pass through untouched.
+#
+# Container-ephemeral (tmpfs); cache is forgotten on reboot. Mid-session
+# credential rotation should clear the cache (rotate-credential follow-up).
+COO_OP_CACHE="${COO_OP_CACHE:-1}"
+COO_OP_CACHE_TTL="${COO_OP_CACHE_TTL:-3600}"
+_cache_dir="${XDG_RUNTIME_DIR:-/tmp}/coo-op-cache"
+_cache_file=""
+_cache_key=""
+_can_cache=0
+if [ "$COO_OP_CACHE" = "1" ] && [ "$_op_sub" = "read" ] && [ -n "$_op_path" ]; then
+  _cache_key="$(printf '%s\n' "$@" | sha256sum 2>/dev/null | head -c 64)"
+  if [ -n "$_cache_key" ]; then
+    _cache_file="$_cache_dir/$_cache_key"
+    _can_cache=1
+  fi
+fi
+
+# Cache hit — serve from tmpfs, skip the cascade entirely. Latency
+# captures the cat-and-read overhead so the rollup can distinguish
+# warm-cache (<1ms) from cold-fetch (~100ms+).
+if [ "$_can_cache" -eq 1 ] && [ -f "$_cache_file" ]; then
+  _now="$(date +%s 2>/dev/null || echo 0)"
+  _mtime="$(stat -c %Y "$_cache_file" 2>/dev/null || stat -f %m "$_cache_file" 2>/dev/null || echo 0)"
+  _age=$((_now - _mtime))
+  if [ "$_age" -lt "$COO_OP_CACHE_TTL" ]; then
+    _trace "cache-hit: argv-sha=$_cache_key age=${_age}s path=$_op_path"
+    _start_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
+    cat "$_cache_file"
+    _end_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
+    _emit_event 0 "$_pref" "$((_end_ms - _start_ms))" 1 "" "cache-hit"
+    exit 0
+  fi
+fi
+
 # Buffer stderr so we can inspect for rate-limit while still replaying
-# verbatim. Stdout flows through directly — op's interesting payload is
-# on stdout, and capturing it would risk truncating large reads.
+# verbatim. Stdout flows through directly for non-cacheable subcommands
+# (capturing it would risk truncating large reads from `op item get`).
+# For cacheable `op read` calls, stdout is captured to a tmpfile so we
+# can both write it to the cache and stream it through unchanged.
 _err_tmp=""
-_cleanup() { [ -n "$_err_tmp" ] && rm -f "$_err_tmp" || true; }
+_cleanup() {
+  [ -n "$_err_tmp" ] && rm -f "$_err_tmp" || true
+  [ -n "${_out_tmp:-}" ] && rm -f "$_out_tmp" || true
+}
 trap _cleanup EXIT
 
 _err_tmp="$(mktemp 2>/dev/null || echo "/tmp/op-coo-wrap.$$.err")"
 : > "$_err_tmp"
+_out_tmp=""
 
 # Iterate through configured tokens. Each attempt:
 #   - rc=0 OR non-rate-limit error → stop (don't keep probing on legitimate failures)
@@ -285,14 +347,60 @@ _stopped_name=""
 _attempt=0
 _n_tokens=${#_toks[@]}
 
+# T3.1: when caching is in play, capture stdout to a tmpfile so we can
+# write it to the cache before streaming it on; otherwise stdout flows
+# through op-real directly.
+if [ "$_can_cache" -eq 1 ]; then
+  _out_tmp="$(mktemp 2>/dev/null || echo "/tmp/op-coo-wrap.$$.out")"
+fi
+
+# _run_real <token-or-empty> <token-name-for-event> -- <script-argv...>
+#   - Honors $_can_cache for stdout capture.
+#   - On rc=0 with cache enabled: populates the cache file (0600).
+#   - Emits the L2 event with the appropriate cache_decision.
+#   - Sets caller-visible: _rc, _err_tmp populated.
+_run_real() {
+  local _t="$1" _n="$2"
+  shift 2
+  local _start_ms _end_ms _decision=""
+  _start_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
+  if [ "$_can_cache" -eq 1 ]; then
+    : > "$_out_tmp"
+    if [ -n "$_t" ]; then
+      OP_SERVICE_ACCOUNT_TOKEN="$_t" "$REAL_OP" "$@" >"$_out_tmp" 2>"$_err_tmp"
+    else
+      "$REAL_OP" "$@" >"$_out_tmp" 2>"$_err_tmp"
+    fi
+    _rc=$?
+    _end_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
+    if [ "$_rc" -eq 0 ]; then
+      mkdir -p "$_cache_dir" 2>/dev/null || true
+      chmod 0700 "$_cache_dir" 2>/dev/null || true
+      local _save_umask; _save_umask="$(umask)"
+      umask 0177
+      cp "$_out_tmp" "$_cache_file" 2>/dev/null || true
+      umask "$_save_umask"
+      _decision="cache-miss-new"
+      _trace "cache-miss-new: argv-sha=$_cache_key path=$_op_path slot=$_n"
+    fi
+    cat "$_out_tmp"
+  else
+    if [ -n "$_t" ]; then
+      OP_SERVICE_ACCOUNT_TOKEN="$_t" "$REAL_OP" "$@" 2>"$_err_tmp"
+    else
+      "$REAL_OP" "$@" 2>"$_err_tmp"
+    fi
+    _rc=$?
+    _end_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
+  fi
+  _emit_event "$_rc" "$_n" "$((_end_ms - _start_ms))" "$_attempt" "$(head -c 240 "$_err_tmp" 2>/dev/null || true)" "$_decision"
+}
+
 if [ "$_n_tokens" -eq 0 ]; then
   # No tokens at all — let op surface its own auth error.
+  _attempt=1
   _trace "attempt 1: no tokens configured; running real op without OP_SERVICE_ACCOUNT_TOKEN"
-  _start_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
-  "$REAL_OP" "$@" 2>"$_err_tmp"
-  _rc=$?
-  _end_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
-  _emit_event "$_rc" "?" "$((_end_ms - _start_ms))" 1 "$(head -c 240 "$_err_tmp" 2>/dev/null || true)"
+  _run_real "" "?" "$@"
 else
   for _i in "${!_toks[@]}"; do
     _attempt=$((_attempt + 1))
@@ -300,11 +408,7 @@ else
     _t="${_toks[$_i]}"
     [ "$_attempt" -gt 1 ] && : > "$_err_tmp"
     _trace "attempt $_attempt: token=$_n argv=$*"
-    _start_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
-    OP_SERVICE_ACCOUNT_TOKEN="$_t" "$REAL_OP" "$@" 2>"$_err_tmp"
-    _rc=$?
-    _end_ms="$(date -u +%s%3N 2>/dev/null || echo 0)"
-    _emit_event "$_rc" "$_n" "$((_end_ms - _start_ms))" "$_attempt" "$(head -c 240 "$_err_tmp" 2>/dev/null || true)"
+    _run_real "$_t" "$_n" "$@"
     if [ "$_rc" -eq 0 ] || ! _is_rate_limit "$(cat "$_err_tmp" 2>/dev/null)"; then
       _stopped_name="$_n"
       break
@@ -324,6 +428,20 @@ else
     printf '%s' "$_stopped_name" > "$PREF_FILE" 2>/dev/null || true
     _trace "marker -> $_stopped_name (was $_pref)"
   fi
+fi
+
+# T3.1: stale-on-rate-limit fallback. If every token ended in a rate-limit
+# (_stopped_name is empty AND last err is rate-limit) AND a cache file
+# exists (even past TTL), surface the cached value rather than fail the
+# call — same posture as gh-coo-wrap's _resolve_pat stale-fallback. The
+# fallback emits one extra event with cache_decision=cache-miss-stale-fallback
+# so the rollup can quantify how often the cache absorbs throttle storms.
+if [ "$_can_cache" -eq 1 ] && [ "$_rc" -ne 0 ] && [ -z "$_stopped_name" ] \
+   && [ -f "$_cache_file" ] && _is_rate_limit "$(cat "$_err_tmp" 2>/dev/null)"; then
+  _trace "stale-fallback: all tokens rate-limited; serving cached value for $_op_path"
+  cat "$_cache_file"
+  _emit_event 0 "?" 0 "$_attempt" "" "cache-miss-stale-fallback"
+  exit 0
 fi
 
 # Replay stderr verbatim.


### PR DESCRIPTION
Ships briefing-40 T3.1 — the session-scope op-read cache — after the day-of-record data (746 events, 7 sessions, 2026-06-07) cleared the plan's >50% identical-path-repeat-within-1hr threshold by a wide margin (74.4%).

## Mechanism

`op-coo-wrap.sh` intercepts `op read <op://...>` calls and consults a per-(argv-sha256) tmpfs cache under `${XDG_RUNTIME_DIR}/coo-op-cache/` before the 3-token cascade fires.

- **Key** = `sha256(argv-after-op)`. Argv-based so `--no-newline` / `--field` etc. don't collide on the same op:// path. Cache filenames are path-anonymous (the op:// path can't be reversed from the hex digest).
- **Gated on `_op_sub == "read"`.** `whoami` / `signin` / `item` / `vault` / etc. pass through to op-real untouched (the schema in `_op_to_file`'s output isn't deterministic for these subcommands within a TTL window).
- **Populated on rc=0 only.** rc!=0 (rate-limit, transient, not-found) never writes the cache.
- **Stale-on-rate-limit fallback.** When every token rate-limits AND a cache file exists (even past TTL), surface the cached value and emit `cache_decision=cache-miss-stale-fallback`. Same posture as `gh-coo-wrap`'s `_resolve_pat` stale-fallback (#558).
- **Container-ephemeral tmpfs.** 0700 directory, 0600 files. Forgotten on container reboot. Stale-after-rotation risk bounded to one session × TTL.

## Configurability

| Env | Default | Effect |
|---|---|---|
| `COO_OP_CACHE` | `1` | Set to `0` to disable caching (read-through unchanged). |
| `COO_OP_CACHE_TTL` | `3600` | Cache TTL in seconds. Matches the 1-hour gate window from briefing-40's day-of-record analysis. |

## Observability

L2 jsonl events gain a `cache_decision` field carrying one of:

- `cache-hit` — value served from tmpfs; op-real never invoked.
- `cache-miss-new` — first read of (argv-sha) post-cache-write; cache populated.
- `cache-miss-stale-fallback` — every token rate-limited; served stale cached value.
- `""` (empty) — bypass case (non-read subcommand OR `COO_OP_CACHE=0`).

`bin/op-read-rollup.py` grows `--by cache_decision` so the next post-merge data answers "how much did we actually save." Legacy events (pre-T3.1) and bypass-case events both bin to `<bypass>` — backwards-compatible.

## Tests

`scripts/ci/test-op-coo-wrap-cache.sh` (new) drives op-coo-wrap.sh against a mock op-real binary, asserting every cache_decision branch:

```
Test 1: cache-miss-new (first read writes cache)               5/5
Test 2: cache-hit (second read of same path skips op-real)     4/4
Test 3: TTL expiry forces re-fetch                             4/4
Test 4: stale-fallback when every token rate-limited           4/4
Test 5: op whoami passes through, no cache file written        4/4
Test 6: COO_OP_CACHE=0 disables caching even for read          4/4

25 passed, 0 failed
```

`scripts/ci/test-op-retry-recovery.sh` (T1.2) re-runs clean — its mock-`op`-as-bash-function never reaches the wrap shim. 11/11 pass.

## Expected reduction

From the 2026-06-07 jsonl:

```
session                                  events  repeats  pct
coo-s7-alt-fields-loader                    250     215   86.0%
coo-op-bootstrap-allowlist-sync             108      75   69.4%
coo-dynamic-workflows-smoketest             102      70   68.6%
coo-briefing-040-instrumentation              6       4   66.7%
coo-console-v0-trace-viewer-shipped          10       6   60.0%
coo-epic-917-cleanup                         30       7   23.3%
coo-ci-epic-wrap-1219-design                  1       0    0.0%
                                            ---     ---
aggregate                                   507     377   74.4%
```

Target on next post-merge sample: identical-path-repeat rate drops to near 0%; total L2 op-reads drop ~70-75% on a 2026-06-07-shaped workload.

## Out of scope / followups

- **Rotation-aware invalidation.** When `rotate-credential` runs, the cache should be cleared (`rm -rf $XDG_RUNTIME_DIR/coo-op-cache/`). This PR doesn't change the rotation skill; follow-up is a small one-line addition to that flow.
- **Per-process opt-out.** `COO_OP_CACHE=0` is per-invocation. No global kill-switch beyond removing the cache directory.
- **Issue criteria deviation.** The acceptance body said `Key = sha256(op_path + token_slot)`. The implementation uses `sha256(argv)` because argv covers flag differences AND because all 3 SA tokens have identical vault access on the current setup — keying on slot would 3× the cache entries without changing serving behavior. Captured here for review.

Closes #562

Closes #562

https://claude.ai/code/session_014Y9jnCvMxUyQCoLcyw8M4G