### PR TITLE
settings.json: purge stale one-shot allowlist entries

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -292,23 +292,11 @@
       "Read(//root/.claude/plans/**)",
       "Bash(gh project:*)",
       "Bash(flyctl secrets *)",
-      "Bash(cp /home/user/coo-harness/.claude/settings.json /home/user/.claude/settings.json && diff /home/user/.claude/settings.json /home/user/coo-harness/.claude/settings.json && echo \"sync OK\")",
       "Edit(/tmp/**)",
       "Write(/tmp/**)",
       "Read(/tmp/**)",
       "Edit(/home/user/coo-memory/.claude/_lib/**)",
-      "Write(/home/user/coo-memory/.claude/_lib/**)",
-      "Bash(jq '.permissions.allow |= map\\(select\\(\\(. | contains\\(\"vade-canvas\"\\) | not\\) and \\(. | contains\\(\"canvas-\"\\) | not\\)\\)\\)' .claude/settings.json)",
-      "Bash(mv .claude/settings.json.tmp .claude/settings.json)",
-      "Bash(echo \"=== count Mac-local path refs in settings.json ===\" && grep -c \"GitHub/coo-labs/vade-\\\\|/coo-harness/\\\\|/coo-memory/\\\\|/coo-logs/\\\\|/vade-canvas/\" .claude/settings.json && echo \"\" && echo \"=== apply bulk replacement ===\" && sed -i \\\\ *)",
-      "Bash(sed -i \\\\ *)",
-      "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/brake-test-2 VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/brake-test-home2 bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)",
-      "Bash(HOME=/tmp/integ-home bash /home/user/coo-memory/.claude/skills/unbrake/scripts/unbrake.sh \"integ-session\" \"integration test of full override path\")",
-      "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/integ-state VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/integ-home bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)",
-      "Bash(mkdir -p /tmp/integ-state /tmp/integ-home/.vade /tmp/integ-home/.claude)",
-      "Bash(HOME=/tmp/integ2-home bash /home/user/coo-memory/.claude/skills/unbrake/scripts/unbrake.sh \"integ2-session\" \"verifying full override path with new HMAC scope\")",
-      "Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_BRAKE_RACE_GRACE_SECONDS=0 VADE_CLOUD_STATE_DIR=/tmp/integ2-state VADE_COO_MEMORY_DIR=/home/user/coo-memory HOME=/tmp/integ2-home bash /home/user/coo-harness/scripts/hooks/boot-brake-guard.sh)",
-      "Bash(mkdir -p /tmp/integ2-state /tmp/integ2-home/.vade /tmp/integ2-home/.claude)"
+      "Write(/home/user/coo-memory/.claude/_lib/**)"
     ],
     "additionalDirectories": [
       "/tmp"


### PR DESCRIPTION
## Summary

Removes twelve stale one-shot test entries from `.claude/settings.json`'s `permissions.allow`, per [coo-harness#552](https://github.com/coo-labs/coo-harness/issues/552). The candidates were dead state from completed work — five from a prior settings-sync / vade-canvas / Mac-path cleanup session, seven from boot-brake integration testing — and no automated path uses any of them now.

## Targets removed (12)

**One-shot session-end / sweep partials (5):**

- `Bash(cp /home/user/coo-harness/.claude/settings.json /home/user/.claude/settings.json && diff … && echo "sync OK")` — session-end sync-verify one-shot.
- `Bash(jq '.permissions.allow |= map(select(… vade-canvas | not …)' .claude/settings.json)` — vade-canvas reference cleanup.
- `Bash(mv .claude/settings.json.tmp .claude/settings.json)` — partial of the same one-shot.
- `Bash(echo "=== count Mac-local path refs… && sed -i \\ *)` — Mac-path count + bulk-replace diagnostic.
- `Bash(sed -i \\ *)` — partial of the same one-shot.

**Boot-brake harness integration test scenarios (7):**

- `Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/brake-test-2 … bash …/boot-brake-guard.sh)`
- `Bash(HOME=/tmp/integ-home bash …/unbrake.sh "integ-session" …)`
- `Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_CLOUD_STATE_DIR=/tmp/integ-state … bash …/boot-brake-guard.sh)`
- `Bash(mkdir -p /tmp/integ-state /tmp/integ-home/.vade /tmp/integ-home/.claude)`
- `Bash(HOME=/tmp/integ2-home bash …/unbrake.sh "integ2-session" …)`
- `Bash(VADE_BRAKE_ENFORCE=block-on-FAIL VADE_BRAKE_RACE_GRACE_SECONDS=0 VADE_CLOUD_STATE_DIR=/tmp/integ2-state … bash …/boot-brake-guard.sh)`
- `Bash(mkdir -p /tmp/integ2-state /tmp/integ2-home/.vade /tmp/integ2-home/.claude)`

The boot-brake harness has shipped ([MEMO-2026-06-06-bvqe](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-06-bvqe.md)). Its live test at `scripts/ci/test-boot-brake-guard.sh` uses `/tmp/boot-brake-test-$$` (PID-suffixed) and never matched the hardcoded `/tmp/integ*-state` / `/tmp/integ*-home` paths — confirmed these entries only ever served the ad-hoc interactive runs that built the harness, not any automated path.

## What was deliberately kept (out of issue scope)

- `Edit(/tmp/**)`, `Write(/tmp/**)`, `Read(/tmp/**)` — operational scratch-space, used routinely by skills.
- `Edit(/home/user/coo-memory/.claude/_lib/**)`, `Write(…/_lib/**)` — substrate-library edit surface, operational.
- Broad patterns `Bash(bash *coo-harness/scripts/*:*)`, `Bash(bash *.claude/_lib/*:*)`, `Bash(bash *.claude/skills/*/scripts/*:*)` — kept per issue body.
- The `claude/*` force-push family, `Bash(gh:*)` / `Bash(gh api *)` / `Bash(gh pr *)` family, and the `mcp__github__*` read tools — kept per issue body.

## Verification

- `jq -e . .claude/settings.json` → JSON OK.
- `.permissions.allow | length`: 141 → 129 (12 removed, exactly matching the enumeration).
- `bash scripts/boot/integrity-check.sh` → `34/34 OK`.
- No hook commands changed; the `.claude/CLAUDE.md` rule about coordinated `scripts/ci/test-<script>.sh` updates does not apply (permissions-only edit).

## Notes

- `settings.json` is strict JSON; no inline-comment surface to "explain why it stays." Retention rationales live in the section above instead.
- Bootstrap-regression CI triggers on `.claude/` paths and will run on this PR.

Closes #552

Closes #552

https://claude.ai/code/session_016igdRVA1x3iRJ8oL5sAdZi