### PR TITLE
coo-on-assign: dual gate + canary flip to issues.field_added (PR2/4)

### DIFF
--- a/.github/workflows/coo-on-assign-reusable.yml
+++ b/.github/workflows/coo-on-assign-reusable.yml
@@ -1,8 +1,15 @@
 name: COO on issue assign (reusable)
 
-# Reusable workflow: posts a pre-fill claude.ai/code launch URL on the
-# assigned issue when the new assignee is vade-coo. Called from per-repo
-# thin trigger workflows at `.github/workflows/coo-on-assign.yml`.
+# Reusable workflow: posts a pre-fill claude.ai/code launch URL on an
+# issue when one of two trigger conditions matches:
+#   (a) assignee.login == 'vade-coo' on an issues.assigned event (legacy path)
+#   (b) issue_field.name == 'Readiness' && issue_field_value.option.name == 'Assigned'
+#       on an issues.field_added event (new path)
+# Called from per-repo thin trigger workflows at `.github/workflows/coo-on-assign.yml`.
+#
+# Dual gate exists during the trigger-rewire rollout: coo-harness is canary
+# (field_added), the other 8 consumer repos still fire on assigned. PR4 of
+# the series strips clause (a) once every thin trigger is on field_added.
 #
 # Canonical home: coo-labs/coo-harness/.github/workflows/coo-on-assign-reusable.yml
 # Centralization design: coo-memory#939 (F7); moved to coo-harness
@@ -19,9 +26,11 @@ name: COO on issue assign (reusable)
 # scope because coo-on-assign-reusable.yml itself reads repos.yaml from
 # there at job time, and the COO needs write access to keep it current.
 #
-# Trigger contract for callers:
+# Trigger contract for callers (either path is valid during rollout):
 #   on: issues
-#     types: [assigned]
+#     types: [assigned]              # legacy
+#   on: issues
+#     types: [field_added]           # new — gated by Readiness=Assigned
 #   permissions:
 #     issues: write
 #     contents: read
@@ -38,19 +47,25 @@ permissions:
   contents: read
 
 concurrency:
-  # Scope per (repo, issue, assignee). The repo prefix prevents cross-repo
-  # collisions on issue numbers; concurrent assigns of different users to
-  # the same issue don't serialize (the assignee gate filters anyway), but
-  # rapid re-assigns of vade-coo to the same issue queue.
-  group: coo-on-assign-${{ github.repository }}-${{ github.event.issue.number }}-${{ github.event.assignee.login }}
+  # Scope per (repo, issue). The repo prefix prevents cross-repo collisions
+  # on issue numbers; rapid re-fires on the same issue queue. The assignee
+  # suffix was dropped because field_added events don't carry it — the gate
+  # filters out everything that isn't the intended trigger anyway.
+  group: coo-on-assign-${{ github.repository }}-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
   post-launch-link:
-    # Gate: only fire when the user that was just assigned is vade-coo.
-    # `github.event.assignee` is the user added by THIS event (distinct
-    # from `github.event.issue.assignees`, the full current list).
-    if: ${{ github.event.assignee.login == 'vade-coo' }}
+    # Dual gate (rollout window): either an assignment of vade-coo via the
+    # legacy `issues.assigned` path, OR a Readiness=Assigned transition via
+    # the new `issues.field_added` path. Field_added events fire for ANY
+    # issue-level field value being set/updated, so the field+option pair
+    # match is required to filter to the intended trigger. PR4 of the
+    # rewire series strips the assignee clause.
+    if: |
+      github.event.assignee.login == 'vade-coo'
+      || (github.event.issue_field.name == 'Readiness'
+          && github.event.issue_field_value.option.name == 'Assigned')
     runs-on: ubuntu-latest
     steps:
       - name: Load active repos from canonical registry
@@ -162,11 +177,11 @@ jobs:
 
             // --- Comment body ---------------------------------------
             const body = [
-              `I've been assigned this issue. To launch a cloud COO session with the boot prompt + issue context pre-loaded:`,
+              `This issue is up. To launch a cloud COO session with the boot prompt + issue context pre-loaded:`,
               ``,
               `[**Launch COO session →**](${launchUrl})`,
               ``,
-              `The session opens when you click — claude.ai/code needs a signed-in human (you) to spawn the container. Re-assign me to post a fresh link (e.g. after a session ends or gets stuck).`,
+              `The session opens when you click — claude.ai/code needs a signed-in human (you) to spawn the container. Re-trigger by re-setting \`Readiness: Assigned\` (or re-assigning vade-coo) to post a fresh link (e.g. after a session ends or gets stuck).`,
               ``,
               `---`,
               `<sub>posted by \`coo-on-assign\` workflow · design: coo-labs/coo-memory#801 · [operations doc](https://github.com/coo-labs/coo-memory/blob/main/operations/coo-on-assign.md)</sub>`,

--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -1,22 +1,30 @@
 name: COO on issue assign
 
-# Thin trigger: fires on `issues.assigned` and delegates to the canonical
+# Thin trigger: fires on `issues.field_added` and delegates to the canonical
 # reusable workflow at coo-labs/coo-memory/.github/workflows/coo-on-assign-reusable.yml.
+# The reusable's gate filters down to the Readiness=Assigned transition;
+# field_added itself fires on ANY field value being set, so the wide trigger
+# is correct and the narrow filtering happens reusable-side.
+#
+# Canary repo (this file): coo-harness is the first to flip from the legacy
+# `issues.assigned` trigger to `issues.field_added` (PR2 of the rewire
+# series). The other 8 consumer repos still fire on assigned; PR3 flips
+# them; PR4 strips the legacy clause from the reusable.
 #
 # Centralization: coo-memory#939 (F7). Logic + COO_SCOPE_REPOS list
 # lives in the reusable; this file only carries the event trigger and
 # the per-repo opt-in. To opt OUT, delete this file.
 #
-# Trigger:   gh issue edit <n> --add-assignee vade-coo
-# Suppress:  gh issue edit <n> --remove-assignee vade-coo
+# Trigger:   gh api -X POST repos/<o>/<r>/issues/<n>/issue-field-values
+#            with [{"field_id":42387399,"value":"Assigned"}]  (Readiness)
+# Suppress:  set the field back to Ready (or any other value)
 #
-# Idempotency: none by design — every assigned event posts a fresh
-# comment. Re-assignment (remove + add) is the explicit re-launch
-# primitive (e.g. after a session ended or got stuck).
+# Idempotency: none by design — every Readiness=Assigned transition posts
+# a fresh comment. Re-setting the field is the explicit re-launch primitive.
 
 on:
   issues:
-    types: [assigned]
+    types: [field_added]
 
 permissions:
   issues: write


### PR DESCRIPTION
PR2 of the 4-PR series rewiring the `coo-on-assign` workflow trigger from `issues.assigned` (assignee picker) to `issues.field_added` (Readiness field). PR1 — [coo-labs/coo-memory#1326](https://github.com/coo-labs/coo-memory/pull/1326), merged — added the `Assigned` option to the Readiness field. This PR is the canary: rewires the canonical reusable + flips coo-harness's own thin trigger. The other 8 consumer repos stay on the legacy path until PR3, with the reusable's dual gate keeping them functional during the rollout.

## What changed

**`coo-on-assign-reusable.yml`** — canonical reusable in this repo:

- **Dual gate.** Job-level `if:` now matches either `assignee.login == 'vade-coo'` (legacy path) OR `(issue_field.name == 'Readiness' && issue_field_value.option.name == 'Assigned')` (new path). The field_added event fires for ANY issue-level field value being set, so the field+option pair match is required to filter to the intended trigger. PR4 strips the legacy clause.
- **Concurrency group** drops the `${{ github.event.assignee.login }}` suffix — field_added events don't carry it. Remaining group: `coo-on-assign-<repo>-<issue>`.
- **Comment-body wording** updated to cover both trigger paths: "This issue is up" instead of "I've been assigned this issue"; "Re-trigger by re-setting `Readiness: Assigned` (or re-assigning vade-coo)" instead of "Re-assign me".
- **Header comment** documents the dual-trigger contract and the rollout window explicitly.

**`coo-on-assign.yml`** — coo-harness's thin trigger (canary):

- `on: issues: types: [assigned]` → `on: issues: types: [field_added]`.
- Header comment updates to reflect canary role + new trigger semantics (Trigger/Suppress recipes now reference the issue-field-values endpoint instead of `gh issue edit --add-assignee`).

## Why a dual gate during the rollout

If the reusable only matched field_added during PR2, the 8 consumer repos still firing on `issues.assigned` (PR3 hasn't shipped) would call the reusable, hit the gate, and silently no-op. Vade-coo would be assignable without the launch link appearing — silent regression for a week. The dual gate keeps both paths working until PR3 flips the 8 thin triggers and PR4 simplifies the reusable.

If coo-harness ALSO still fired on assigned during PR2, every assignment of vade-coo (old habit) would double-fire the reusable — once via assigned, once via field_added (assuming Readiness was also flipped). Hence flipping coo-harness's thin trigger to field_added only.

## Verification

Once merged: on any coo-harness issue, set Readiness to `Assigned` via the GitHub UI (Readiness field pill in the sidebar) or via `gh api`:

```bash
echo '[{"field_id":42387399,"value":"Assigned"}]' | \
  gh api -X POST repos/coo-labs/coo-harness/issues/<n>/issue-field-values --input -
```

Workflow run should fire under "Actions → COO on issue assign". A new comment with `[**Launch COO session →**]` should appear on the issue within ~30s.

Counter-test: assigning vade-coo to a coo-harness issue (legacy path) should now NOT fire the workflow on coo-harness (the thin trigger no longer listens for `assigned`). The other 8 repos still post the link on assignment until PR3.

## Series outline (recap)

- ✅ **PR1** ([coo-memory#1326](https://github.com/coo-labs/coo-memory/pull/1326)) — Add `Assigned` to Readiness field.
- 🟢 **PR2 (this one)** — Reusable dual gate + coo-harness canary flip.
- ⏳ **PR3** — Flip the other 8 consumer repos' thin triggers (mechanical).
- ⏳ **PR4** — Strip the legacy assignee clause from the reusable once PR3 is stable for ~a week.

Closes n/a (in-flight design from this session; no separate tracker filed).

Closes: n/a

https://claude.ai/code/session_015io8MjjJ2eF2i3GiZz6MnM