### PR TITLE
issue-pr hygiene: catch naked `<reponame>#N` form (Pattern-C extension)

### DIFF
--- a/.github/workflows/issue-pr-hygiene-reusable.yml
+++ b/.github/workflows/issue-pr-hygiene-reusable.yml
@@ -378,6 +378,39 @@ jobs:
               );
             }
 
+            // Naked-reponame sub-check — `<slug>#N` (no `coo-labs/` prefix, no space).
+            // Pattern B's broken-form regex catches this only in closing-keyword
+            // position (Closes/Fixes/Resolves <slug>#N); this fires anywhere in
+            // title or body. Classify by host: same-repo (slug == host) wants bare
+            // `#N`; cross-repo wants `coo-labs/<slug>#N`. Lookbehind `(?<![\w/])`
+            // excludes the valid `coo-labs/<slug>#N` form and wordy false
+            // positives like `xcoo-memory#1`. Discussion carve-out applied for
+            // parity. Closes coo-memory#930 (recurring ref-format hygiene failure).
+            const nakedSlugRe = new RegExp(`(?<![\\w/])(${slugAlt})#(\\d+)`, 'g');
+            const nakedMatches = [...cleanBody.matchAll(nakedSlugRe), ...cleanTitle.matchAll(nakedSlugRe)]
+              .filter(m => !/discussion/i.test(m[0]));
+            if (nakedMatches.length > 0) {
+              const sameRepo = nakedMatches.filter(m => m[1] === repo);
+              const crossRepo = nakedMatches.filter(m => m[1] !== repo);
+              let msg =
+                `**Pattern C — naked reponame form**\n\n` +
+                `Detected ${nakedMatches.length} reference(s) using \`<reponame>#N\` form ` +
+                `(no \`coo-labs/\` prefix). Autolinks but doesn't satisfy closing-keyword ` +
+                `semantics; reads as a broken form to skim readers expecting either ` +
+                `bare \`#N\` (same-repo) or \`coo-labs/<repo>#N\` (cross-repo).`;
+              if (sameRepo.length > 0) {
+                const ex = sameRepo.slice(0, 5)
+                  .map(m => `  - \`${m[0]}\` → \`#${m[2]}\``).join('\n');
+                msg += `\n\nSame-repo (${sameRepo.length}) — use bare \`#N\`:\n\n${ex}`;
+              }
+              if (crossRepo.length > 0) {
+                const ex = crossRepo.slice(0, 5)
+                  .map(m => `  - \`${m[0]}\` → \`coo-labs/${m[1]}#${m[2]}\``).join('\n');
+                msg += `\n\nCross-repo (${crossRepo.length}) — use \`coo-labs/<repo>#N\`:\n\n${ex}`;
+              }
+              advisories.push(msg);
+            }
+
             // List-inheritance: `coo-labs/<repo>#N, #M, ...` — only first gets prefix.
             // Detect prefix followed by comma-separated #N where subsequent #N lack the prefix.
             const listInheritanceRe = /coo-labs\/[a-z0-9-]+#\d+\s*,\s*#\d+/g;

--- a/scripts/ci/test-gh-pr-create.sh
+++ b/scripts/ci/test-gh-pr-create.sh
@@ -170,6 +170,44 @@ assert_pass_with_body_contains \
   --title "session: log" --body "no closes"
 
 echo
+echo "test-gh-pr-create: Pattern-C naked-reponame lint (coo-memory#930)"
+
+# Test origin is coo-labs/coo-harness, so "coo-harness#N" is same-repo,
+# "coo-memory#N" is cross-repo.
+assert_fail_with_exit_and_contains \
+  "naked same-repo ref (coo-harness#42) trips Pattern-C lint" \
+  2 \
+  "naked reponame form" \
+  --title "test" --body $'see coo-harness#42 for context\nCloses #1'
+
+assert_fail_with_exit_and_contains \
+  "naked cross-repo ref (coo-memory#42) trips Pattern-C lint" \
+  2 \
+  "naked reponame form" \
+  --title "test" --body $'see coo-memory#42 for context\nCloses #1'
+
+assert_pass_with_body_contains \
+  "canonical cross-repo form coo-labs/coo-memory#42 passes" \
+  "ARG[1]=pr" \
+  --title "test" --body $'see coo-labs/coo-memory#42 for context\nCloses #1'
+
+assert_pass_with_body_contains \
+  "bare same-repo #42 passes (no slug prefix)" \
+  "ARG[1]=pr" \
+  --title "test" --body $'see #42 for context\nCloses #1'
+
+assert_pass_with_body_contains \
+  "discussion carve-out: coo-memory discussion #42 passes" \
+  "ARG[1]=pr" \
+  --title "test" --body $'see coo-memory discussion #42 for context\nCloses #1'
+
+assert_fail_with_exit_and_contains \
+  "naked-reponame advisory cites both same-repo and cross-repo" \
+  2 \
+  "→ \`#42\`" \
+  --title "test" --body $'see coo-harness#42 + coo-memory#99\nCloses #1'
+
+echo
 if [ "$FAIL" -eq 0 ]; then
   printf 'test-gh-pr-create: %d passed\n' "$PASS"
   exit 0

--- a/scripts/gh-pr-create.sh
+++ b/scripts/gh-pr-create.sh
@@ -267,7 +267,20 @@ fi
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 helper="$script_dir/lib/pr-hygiene-patterns.py"
 if [ -x "$helper" ]; then
-  if ! printf '%s' "$(jq -n --arg t "$title" --arg b "$resolved_body" '{title:$t,body:$b}')" \
+  # Derive bare host-repo name (e.g. "coo-memory") from origin/--repo so the
+  # helper can classify naked-reponame hits as same-repo (suggest bare `#N`)
+  # vs cross-repo (suggest `coo-labs/<repo>#N`). Falls back to empty if we
+  # can't tell; the helper then treats every hit as cross-repo.
+  host_repo_name=""
+  if [ -n "$proxy_url" ]; then
+    host_repo_name="${proxy_repo##*/}"
+  else
+    origin_for_host="${origin_url:-$(git remote get-url origin 2>/dev/null || true)}"
+    if [[ "$origin_for_host" =~ github\.com[:/][^/]+/([^/.]+)(\.git)?/?$ ]]; then
+      host_repo_name="${BASH_REMATCH[1]}"
+    fi
+  fi
+  if ! printf '%s' "$(jq -n --arg t "$title" --arg b "$resolved_body" --arg h "$host_repo_name" '{title:$t,body:$b,host:$h}')" \
       | python3 "$helper"; then
     exit 2
   fi

--- a/scripts/lib/pr-hygiene-patterns.py
+++ b/scripts/lib/pr-hygiene-patterns.py
@@ -40,7 +40,7 @@ def strip_links_and_code(s: str) -> str:
     return s
 
 
-def check_pattern_c(title: str, body: str) -> list[str]:
+def check_pattern_c(title: str, body: str, host_repo: str | None = None) -> list[str]:
     findings: list[str] = []
 
     slug_alt = "|".join(re.escape(s) for s in ACTIVE_SLUGS)
@@ -66,6 +66,40 @@ def check_pattern_c(title: str, body: str) -> list[str]:
             "Examples:\n"
             f"{examples}"
         )
+
+    # Naked-reponame sub-check — `<slug>#N` (no `coo-labs/` prefix, no space).
+    # Pattern B's broken-form regex catches this only in closing-keyword position
+    # (Closes/Fixes/Resolves <slug>#N); this fires anywhere in title or body.
+    # Lookbehind `(?<![\w/])` excludes the valid `coo-labs/<slug>#N` form and
+    # wordy false positives like `xcoo-memory#1`. Discussion carve-out applied
+    # for parity with the cross-repo subcheck.
+    naked_slug_re = re.compile(rf"(?<![\w/])({slug_alt})#(\d+)")
+    naked_matches = [
+        m for m in list(naked_slug_re.finditer(clean_body)) + list(naked_slug_re.finditer(clean_title))
+        if not re.search(r"discussion", m.group(0), re.IGNORECASE)
+    ]
+    if naked_matches:
+        same_repo = [m for m in naked_matches if host_repo and m.group(1) == host_repo]
+        cross_repo = [m for m in naked_matches if not host_repo or m.group(1) != host_repo]
+        msg = (
+            "Pattern C — naked reponame form\n"
+            f"Detected {len(naked_matches)} reference(s) using `<reponame>#N` form "
+            "(no `coo-labs/` prefix). Autolinks but doesn't satisfy closing-keyword "
+            "semantics; reads as a broken form to skim readers expecting either bare "
+            "`#N` (same-repo) or `coo-labs/<repo>#N` (cross-repo)."
+        )
+        if same_repo:
+            ex = "\n".join(
+                f"  - `{m.group(0)}` → `#{m.group(2)}`" for m in same_repo[:5]
+            )
+            msg += f"\n\nSame-repo ({len(same_repo)}) — use bare `#N`:\n{ex}"
+        if cross_repo:
+            ex = "\n".join(
+                f"  - `{m.group(0)}` → `coo-labs/{m.group(1)}#{m.group(2)}`"
+                for m in cross_repo[:5]
+            )
+            msg += f"\n\nCross-repo ({len(cross_repo)}) — use `coo-labs/<repo>#N`:\n{ex}"
+        findings.append(msg)
 
     list_inheritance = re.compile(r"coo-labs/[a-z0-9-]+#\d+\s*,\s*#\d+")
     list_matches = [
@@ -121,8 +155,9 @@ def main() -> int:
     payload = json.load(sys.stdin)
     title = payload.get("title", "") or ""
     body = payload.get("body", "") or ""
+    host_repo = payload.get("host", "") or None
 
-    findings = check_pattern_c(title, body) + check_pattern_d(title, body)
+    findings = check_pattern_c(title, body, host_repo) + check_pattern_d(title, body)
 
     if not findings:
         return 0

--- a/scripts/lifecycle/session-end-transcript-export.py
+++ b/scripts/lifecycle/session-end-transcript-export.py
@@ -71,7 +71,7 @@ Optional:
                                        network or PAT)
   GITHUB_MCP_PAT                     — required for auto-PR-on-meta;
                                        absence is a soft skip, not an
-                                       error (per coo-harness#148 A)
+                                       error (per coo-labs/coo-harness#148 A)
 """
 
 from __future__ import annotations
@@ -582,7 +582,7 @@ def _open_meta_pr(
 
         commit_msg = (
             f"meta: auto-commit sidecar for {session_id}\n\n"
-            "Stop hook auto-commit per coo-harness#148 Part A.\n"
+            "Stop hook auto-commit per coo-labs/coo-harness#148 Part A.\n"
             "Pure-add (single file) — eligible for the Night's Watch\n"
             "§4 pure-add merge gate (MEMO-2026-04-26-04 §4)."
         )
@@ -613,7 +613,7 @@ def _open_meta_pr(
             "## Summary\n\n"
             f"Auto-commit of `{rel_sidecar}` for session `{session_id}`.\n"
             "Written by `coo-harness/scripts/lifecycle/session-end-transcript-export.py`\n"
-            "per coo-harness#148 Part A. The encrypted ciphertext is\n"
+            "per coo-labs/coo-harness#148 Part A. The encrypted ciphertext is\n"
             "already in R2; this PR makes the sidecar visible to the\n"
             "transcript-analyzer pipeline.\n\n"
             "## Test plan\n\n"
@@ -863,7 +863,7 @@ def main() -> int:
             _stderr(f"wrote sidecar: {sidecar_path}")
 
         # Best-effort: open a single-file pure-add PR carrying just the
-        # sidecar. Per coo-harness#148 Part A — closes the structural
+        # sidecar. Per coo-labs/coo-harness#148 Part A — closes the structural
         # gap where 78% of sessions skipped committing meta.json.
         # Failures here are logged via export-error, never raised.
         try:


### PR DESCRIPTION
## Summary

Closes the recurring-failure question in coo-labs/coo-memory#930: agents keep emitting `<reponame>#N` (no `coo-labs/` prefix, no space) in PR and issue bodies. Pattern B's broken-form regex catches this in the closing-keyword position only; body-text refs were uncaught until now.

7-day data scan (2026-05-31 → 2026-06-07, 697 issues+PRs across the 9 active `coo-labs/*` repos):

| date | total | items | same-repo | cross-repo |
|---|---:|---:|---:|---:|
| 2026-05-31 | 9 | 7 | 2 | 7 |
| 2026-06-01 | 4 | 3 | 2 | 2 |
| 2026-06-02 | 0 | 0 | 0 | 0 |
| 2026-06-03 | 5 | 3 | 4 | 1 |
| 2026-06-04 | 5 | 4 | 3 | 2 |
| 2026-06-05 | 44 | 19 | 11 | 33 |
| 2026-06-06 | 27 | 17 | 9 | 18 |
| 2026-06-07 | 11 | 8 | 8 | 3 |
| **total** | **105** | **61** | **39** | **66** |

(Auto-meta-sidecar PRs added another 118 templated hits in the same window — addressed below.) The 2026-06-05/06 spike concentrates in audit/sweep PRs that discuss many repos in prose — exactly the shape the existing Pattern-C heuristic (active-repo name within 80 chars of bare `#N`) was meant for, except its `(?!#)` lookahead lets the naked-reponame form (no space between slug and `#`) escape.

## Changes

**`.github/workflows/issue-pr-hygiene-reusable.yml`** — Pattern-C step gets a new sub-check that fires on `<slug>#N` anywhere in title or body. Classifies by host: same-repo suggests bare `#N`; cross-repo suggests `coo-labs/<slug>#N`. Reuses the existing `stripLinksAndCode` helper, discussion carve-out, and `slugAlt` loaded from the canonical registry. Same advisory comment marker as C+D (idempotent update).

**`scripts/lib/pr-hygiene-patterns.py`** — mirrors the new subcheck. Adds an optional `host` field to the JSON payload (back-compat: absent host treats every hit as cross-repo).

**`scripts/gh-pr-create.sh`** — plumbs the host bare-name into the helper's JSON payload (proxy URL → `proxy_repo##*/`; origin URL → BASH_REMATCH on `github.com[:/]<owner>/<repo>`).

**`scripts/lifecycle/session-end-transcript-export.py`** — auto-meta-sidecar template now uses `coo-labs/coo-harness#148` instead of `coo-harness#148` in the commit message, PR body, docstring, and one inline comment. These PRs are already exempt from Pattern B via headRef regex, but they accounted for ~118 hits/week in the corpus scan. Eliminates the largest template-source noise.

**`scripts/ci/test-gh-pr-create.sh`** — 6 new cases covering same-repo / cross-repo / valid `coo-labs/` form / bare `#N` / discussion carve-out / mixed. Full suite: 19/19 passing.

## Test plan

- [x] `bash scripts/ci/test-gh-pr-create.sh` — 19/19 pass (13 prior + 6 new).
- [x] Smoke-test helper directly on real samples from the data scan — naked-reponame hits trigger exit 2 with correct same-repo / cross-repo classification; canonical forms exit 0.
- [x] Helper back-compat — payload without `host` still parses; all hits treated as cross-repo (preserves prior behavior for any existing callers).
- [x] Workflow Pattern-C subcheck dogfood — the first version of this PR body deliberately included naked `coo-memory#930` refs; the workflow's idempotent advisory comment fired and surfaced the violation. Body now amended to the canonical `coo-labs/coo-memory#930` form.

## Companion PR

A small follow-on in `coo-labs/coo-memory` extends the same lint to `gh-issue-create.sh` and notes the Pattern-C extension in `operations/issue-pr-hygiene.md`. The two PRs are independent; this one is the substrate-layer fix.

Closes coo-labs/coo-memory#930

https://claude.ai/code/session_01BY4d4N42ecc2cpZWrzBZZa