### PR TITLE
coo-on-assign-reusable: strip legacy assignee clause (PR4/4)

### DIFF
--- a/.github/workflows/coo-on-assign-reusable.yml
+++ b/.github/workflows/coo-on-assign-reusable.yml
@@ -1,15 +1,9 @@
 name: COO on issue assign (reusable)
 
 # Reusable workflow: posts a pre-fill claude.ai/code launch URL on an
-# issue when one of two trigger conditions matches:
-#   (a) assignee.login == 'vade-coo' on an issues.assigned event (legacy path)
-#   (b) issue_field.name == 'Readiness' && issue_field_value.option.name == 'Assigned'
-#       on an issues.field_added event (new path)
-# Called from per-repo thin trigger workflows at `.github/workflows/coo-on-assign.yml`.
-#
-# Dual gate exists during the trigger-rewire rollout: coo-harness is canary
-# (field_added), the other 8 consumer repos still fire on assigned. PR4 of
-# the series strips clause (a) once every thin trigger is on field_added.
+# issue when the Readiness field flips to Assigned. Called from per-repo
+# thin trigger workflows at `.github/workflows/coo-on-assign.yml`, which
+# fire on `issues.field_added` and delegate the gate logic here.
 #
 # Canonical home: coo-labs/coo-harness/.github/workflows/coo-on-assign-reusable.yml
 # Centralization design: coo-memory#939 (F7); moved to coo-harness
@@ -26,11 +20,9 @@ name: COO on issue assign (reusable)
 # scope because coo-on-assign-reusable.yml itself reads repos.yaml from
 # there at job time, and the COO needs write access to keep it current.
 #
-# Trigger contract for callers (either path is valid during rollout):
+# Trigger contract for callers:
 #   on: issues
-#     types: [assigned]              # legacy
-#   on: issues
-#     types: [field_added]           # new — gated by Readiness=Assigned
+#     types: [field_added]
 #   permissions:
 #     issues: write
 #     contents: read
@@ -56,16 +48,12 @@ concurrency:
 
 jobs:
   post-launch-link:
-    # Dual gate (rollout window): either an assignment of vade-coo via the
-    # legacy `issues.assigned` path, OR a Readiness=Assigned transition via
-    # the new `issues.field_added` path. Field_added events fire for ANY
-    # issue-level field value being set/updated, so the field+option pair
-    # match is required to filter to the intended trigger. PR4 of the
-    # rewire series strips the assignee clause.
+    # Gate: field_added events fire for ANY issue-level field value being
+    # set/updated, so the field+option pair match is required to filter to
+    # the intended trigger (Readiness flipping to Assigned).
     if: |
-      github.event.assignee.login == 'vade-coo'
-      || (github.event.issue_field.name == 'Readiness'
-          && github.event.issue_field_value.option.name == 'Assigned')
+      github.event.issue_field.name == 'Readiness'
+      && github.event.issue_field_value.option.name == 'Assigned'
     runs-on: ubuntu-latest
     steps:
       - name: Load active repos from canonical registry
@@ -181,7 +169,7 @@ jobs:
               ``,
               `[**Launch COO session →**](${launchUrl})`,
               ``,
-              `The session opens when you click — claude.ai/code needs a signed-in human (you) to spawn the container. Re-trigger by re-setting \`Readiness: Assigned\` (or re-assigning vade-coo) to post a fresh link (e.g. after a session ends or gets stuck).`,
+              `The session opens when you click — claude.ai/code needs a signed-in human (you) to spawn the container. Re-trigger by re-setting \`Readiness: Assigned\` to post a fresh link (e.g. after a session ends or gets stuck).`,
               ``,
               `---`,
               `<sub>posted by \`coo-on-assign\` workflow · design: coo-labs/coo-memory#801 · [operations doc](https://github.com/coo-labs/coo-memory/blob/main/operations/coo-on-assign.md)</sub>`,


### PR DESCRIPTION
PR4/4 — strips the legacy assignee clause from the reusable now that all 8 PR3 PRs are merged and every thin trigger fires on `issues.field_added`. Closes the trigger-rewire series.

## What changed

`coo-on-assign-reusable.yml`:

- **Gate simplified** to the single field+option match:
  ```yaml
  if: |
    github.event.issue_field.name == 'Readiness'
    && github.event.issue_field_value.option.name == 'Assigned'
  ```
  Drops the `github.event.assignee.login == 'vade-coo'` clause.
- **Header comment** rewritten — drops the dual-gate / rollout-window block; states the steady-state behavior (Readiness=Assigned trigger only).
- **Trigger contract for callers** simplified to one stanza (`types: [field_added]`).
- **Comment-body wording** drops the `(or re-assigning vade-coo)` parenthetical from the "Re-trigger by re-setting `Readiness: Assigned`" line — the assignee path no longer fires.

Concurrency group was already simplified in PR2 — no further change here.

## Why safe to merge

- All 9 thin triggers (coo-harness + 8 others) are on `field_added` after PR3. Assignment of vade-coo to any coo-labs issue no longer triggers the reusable via any thin trigger.
- The reusable's old assignee clause was dead code under the new wiring; removing it eliminates the only remaining reference to the legacy contract.
- No behavior change for the new path — gate logic for `Readiness=Assigned` is byte-identical to PR2.

## Series outline (recap)

- ✅ PR1 coo-labs/coo-memory#1326 — Add `Assigned` option to Readiness field.
- ✅ PR2 #570 — Reusable dual gate + coo-harness canary flip.
- ✅ PR3 (8 PRs, all merged) — Flip remaining 8 consumer thin triggers to `field_added`.
- 🟢 PR4 (this PR) — Strip the legacy assignee clause from the reusable.

After this merges, the assignee field on every coo-labs/* issue is fully decoupled from the launch-link workflow. UX is: set Readiness=Assigned → link appears.

Closes: n/a

https://claude.ai/code/session_015io8MjjJ2eF2i3GiZz6MnM