### PR TITLE
integrity-check: allowlist 8354ca0d6f (F4) + 6542a1be51 (F1)

### DIFF
--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -1055,6 +1055,22 @@ F1_ALLOWLIST_SHA=(
   # in body context but the F1 regex matches neither MEMO-... nor #N
   # forms. Clear linkage to #871 Track close-out; F1 regex miss only.
   "aa645c5315"
+  # 6542a1be51 — "funding/billing: file 1Password credit invoice in_1Tfpth
+  # (Jun 7 2026)" by Coo on 2026-06-08, merged via coo-memory#1329. First
+  # agent-authored receipt filing under funding/billing/ (precedent: BDFL
+  # uploads receipts directly per funding/billing/README.md "Who writes
+  # here"). Vendor receipts are pure archive — vendor-issued PDFs with the
+  # vendor's own identifier in the filename — and carry no decision content
+  # that would warrant a memo or issue citation. The vendor invoice ID
+  # `in_1TfpthHBax7L5HDfdwcnBTMX` is present in the body but doesn't match
+  # the F1 regex (MEMO-YYYY-MM-DD-suffix or #NNN). Already pushed to
+  # origin/main — rewriting public history is the wrong tradeoff.
+  # Systemic gap: any agent-filed vendor receipt under funding/billing/
+  # will hit this same shape; consider excluding `^funding/billing/` from
+  # the F1 scope regex (structurally similar to the existing _archive/
+  # carve-out — receipts are archive, not decision content). Surfaced in
+  # the PR that adds this entry.
+  "6542a1be51"
 )
 if [ -d "$F_REPO/.git" ] && check_cmd git; then
   f1_total=0
@@ -1215,6 +1231,28 @@ F4_ALLOWLIST_SHA=(
   # origin/main — rewriting public history is the wrong tradeoff.
   # Allowlisted with full causal record above; no policy gap.
   "d3479467e8"
+  # 8354ca0d6f — coo-memory commit "coo-on-assign: flip thin trigger
+  # from assigned to field_added (PR3/4)" on 2026-06-07, merged via
+  # coo-memory#1327. Author leaked as vade-coo-app[bot] <286614649+
+  # vade-coo-app[bot]@users.noreply.github.com>; committer correctly
+  # set to Coo <coo@vade-app.dev>. Root cause: the diff touches
+  # `.github/workflows/coo-on-assign.yml`, which requires the
+  # `vade-coo-app` GitHub App install-token write authority (the
+  # OAuth that authenticates `git push` lacks the `workflow` scope —
+  # see coo-memory/CLAUDE.md "To commit a file the session's OAuth
+  # lacks scope for ..."). The pr-ven-human-action-marker workflow
+  # correctly skipped marker injection because the PR author was
+  # `vade-coo` (the COO opens own PRs); on rebase-merge the original
+  # commit SHA was preserved, carrying the App author email forward.
+  # F4's PR-body fallback can't reach PR #1327 either because the
+  # subject ends in "(PR3/4)" rather than "(#1327)". Already pushed
+  # to origin/main — rewriting public history is the wrong tradeoff.
+  # Systemic gap: any workflow-file commit made via App install-token
+  # in a `vade-coo`-authored PR will hit this same shape; consider a
+  # follow-on that accepts the App-bot author email as COO attribution
+  # outright, rather than per-commit allowlisting. Surfaced in the PR
+  # that adds this entry.
+  "8354ca0d6f"
 )
 if [ -d "$F_REPO/.git" ] && check_cmd git; then
   f4_total=0


### PR DESCRIPTION
Both commits already on `origin/main`; rewriting public history is the wrong tradeoff. Allowlist entries carry full causal record per the existing pattern (matches the 7cb8a86da4 / d3479467e8 / 16cb6fb81d shape).

## What this fixes

After this session's boot, F4 was degraded with `1/50 attribution mismatches: 8354ca0d6f(286614649+vade-coo-app[bot]@users.noreply.github.com)`. While investigating + filing the immediate cause, the session's own follow-on commit (a vendor receipt under `funding/billing/`) tripped F1 with `1/39 commits missing memo-or-issue citation: 6542a1be51`. Both are allowlisted in the same patch; verified locally — 34/34 OK after.

## F4 — `8354ca0d6f`

Commit [`8354ca0`](https://github.com/coo-labs/coo-memory/commit/8354ca0d6fec2fdb51c664fae39b4e7877b36e9d), merged via coo-labs/coo-memory#1327. Author leaked as `vade-coo-app[bot]`; committer correctly set to Coo. Root cause: the diff touches `.github/workflows/coo-on-assign.yml`, requiring the `vade-coo-app` App install-token write authority (the OAuth that authenticates `git push` lacks the `workflow` scope). The `pr-ven-human-action-marker` workflow correctly skipped marker injection because the PR author was `vade-coo` (COO opens own PRs). On rebase-merge the original SHA was preserved, carrying the App author email forward. F4's PR-body fallback can't reach #1327 either because the subject ends in `(PR3/4)` rather than `(#1327)`.

**Systemic gap surfaced:** any workflow-file commit made via App install-token in a `vade-coo`-authored PR hits this same shape. A principled follow-on would accept the `vade-coo-app[bot]` author email as COO attribution outright (it IS COO, just routed through the App because of the OAuth scope wall), rather than per-commit allowlisting.

## F1 — `6542a1be51`

Commit [`6542a1b`](https://github.com/coo-labs/coo-memory/commit/6542a1be515166da24209a71eed47aba6177c83b), merged via coo-labs/coo-memory#1329. First agent-authored receipt filing under `funding/billing/` (precedent: BDFL uploads receipts directly per `funding/billing/README.md` "Who writes here"). Vendor receipts are pure archive — vendor-issued PDFs with the vendor's own identifier in the filename — and carry no decision content that would warrant a memo or issue citation. The vendor invoice ID is in the body but doesn't match the F1 regex.

**Systemic gap surfaced:** any agent-filed vendor receipt under `funding/billing/` hits this same shape. A principled follow-on would exclude `^funding/billing/` from the F1 scope regex (structurally similar to the existing `_archive/` carve-out — receipts are archive, not decision content).

## Verification

```
$ VADE_INTEGRITY_PHASE=fast bash scripts/boot/integrity-check.sh
VADE integrity: 34/34 OK
```

Both systemic gaps are noted in-line in the allowlist entries so a future reader can find the decision point without re-deriving it.

Closes n/a

Closes: n/a

https://claude.ai/code/session_01DehLL5ZAB9hghQUm85VZap