### PR TITLE
transcripts: env-first bucket resolution for CI workflows

### DIFF
--- a/lib/transcripts/r2.py
+++ b/lib/transcripts/r2.py
@@ -149,10 +149,18 @@ def _bucket_from_env_or_op() -> str:
 
     A caller that brings its own boto3 client still needs to tell us which
     bucket; we re-resolve it rather than threading it through every call site.
+    Env-first because CI populates R2_TRANSCRIPTS_BUCKET via
+    1password/load-secrets-action but the `op` CLI is gone from PATH after the
+    action's tempdir is torn down.
     """
+    bucket = os.environ.get("R2_TRANSCRIPTS_BUCKET", "").strip()
+    if bucket:
+        return bucket
     bucket = _op_read("op://COO/r2-transcripts/bucket")
     if not bucket:
-        raise R2Error("bucket name unresolvable via 1Password")
+        raise R2Error(
+            "bucket name unresolvable via env (R2_TRANSCRIPTS_BUCKET) or 1Password"
+        )
     return bucket
 
 

--- a/lib/transcripts/r2.py
+++ b/lib/transcripts/r2.py
@@ -158,9 +158,7 @@ def _bucket_from_env_or_op() -> str:
         return bucket
     bucket = _op_read("op://COO/r2-transcripts/bucket")
     if not bucket:
-        raise R2Error(
-            "bucket name unresolvable via env (R2_TRANSCRIPTS_BUCKET) or 1Password"
-        )
+        raise R2Error("bucket name unresolvable via env (R2_TRANSCRIPTS_BUCKET) or 1Password")
     return bucket
 
 

--- a/lib/transcripts/tests/test_r2.py
+++ b/lib/transcripts/tests/test_r2.py
@@ -16,6 +16,7 @@ import pytest
 from transcripts.r2 import (
     R2Coordinates,
     R2Error,
+    _bucket_from_env_or_op,
     list_keys,
     r2_coordinates,
     read_sidecar,
@@ -158,6 +159,27 @@ class TestR2Coordinates:
         assert "sk-LEAK" not in rep
         assert "https://r2.example" in rep
         assert "bkt" in rep
+
+
+class TestBucketFromEnvOrOp:
+    def test_env_first_skips_op_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("R2_TRANSCRIPTS_BUCKET", "bkt-from-env")
+        with patch("transcripts.r2._op_read") as op_read:
+            assert _bucket_from_env_or_op() == "bkt-from-env"
+        op_read.assert_not_called()
+
+    def test_falls_back_to_op_when_env_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("R2_TRANSCRIPTS_BUCKET", raising=False)
+        with patch("transcripts.r2._op_read", return_value="bkt-from-op"):
+            assert _bucket_from_env_or_op() == "bkt-from-op"
+
+    def test_raises_when_both_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("R2_TRANSCRIPTS_BUCKET", raising=False)
+        with (
+            patch("transcripts.r2._op_read", return_value=""),
+            pytest.raises(R2Error, match="R2_TRANSCRIPTS_BUCKET"),
+        ):
+            _bucket_from_env_or_op()
 
 
 class TestReadSidecar:


### PR DESCRIPTION
The `corpus-index` nightly Action in `coo-labs/coo-logs` was failing with:

```
transcripts.r2.R2Error: bucket name unresolvable via 1Password
```

even though the workflow loads `R2_TRANSCRIPTS_BUCKET` into the job env via `1password/load-secrets-action@v2`. Failing run: [coo-labs/coo-logs/actions/runs/27125283714](https://github.com/coo-labs/coo-logs/actions/runs/27125283714/job/80052160488).

## Root cause

The path through `corpus-index.py` builds R2 coordinates from env via the CI-only `_r2_coords_from_env()` helper, creates the boto3 client with those coords, then calls `enum_sidecar_keys(s3)` — passing only the client, not the coords. Inside `r2.list_keys`, when `s3` is provided and `coords` is None, it falls through to `_bucket_from_env_or_op()`. That helper was misnamed: it only did `_op_read(\"op://COO/r2-transcripts/bucket\")` with no env fallback.

In CI, `1password/load-secrets-action@v2` extracts `op` to a tempdir, populates the env vars, and the tempdir is gone by the time the next step runs — so `shutil.which(\"op\")` returns None in the python step and the op-read short-circuits to empty, raising `R2Error`.

## Fix

`_bucket_from_env_or_op` now checks `R2_TRANSCRIPTS_BUCKET` from env first, falling back to op-read for interactive sessions that have the `op` CLI on PATH but no env var pre-populated. This aligns with the function name and with `r2_coordinates()`, which already reads access/secret keys env-first.

Covers all four call sites that use this helper:
- `list_keys` (the failing path)
- `read_sidecar`
- `write_sidecar`
- `write_html`

Any CI caller that brings its own boto3 client and relies on internal bucket re-resolution gets the same fix.

## Tests

Adds `TestBucketFromEnvOrOp` with three cases:
- env-first skips op-read entirely
- falls back to op when env empty
- raises with both surfaces mentioned in the message when both empty

`lib/transcripts/tests/` — 295 passed locally.

Closes: n/a

Closes: n/a

https://claude.ai/code/session_01HHWFuYxhDLQmpR676XeUD3