### PR TITLE
trace: extract CLAUDE_SESSION_ID for per-event /logs link (L3b)

### DIFF
--- a/.claude/skills/trace-timeline/SKILL.md
+++ b/.claude/skills/trace-timeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trace-timeline
-description: "Render an interactive timeline from a bootstrap-trace run. Use when the user wants to view, visualize, or \"see\" what happened during a traced boot — process spans, write/read interleavings, snapshot states, D-group invariant decisions. Triggers: \"show me the trace\", \"visualize the boot\", \"timeline of the trace\", \"render the trace\", or when investigating a `~/.vade/traces/<run-id>/` directory and a chart beats raw text. Default: uploads the parsed trace to the VADE Console and prints `console.vade-app.dev/trace/?run-id=<id>`. Legacy mode (user asks for an offline file, or Console is unreachable): writes a self-contained HTML via `SendUserFile`. Reads `xtrace.log` + `snapshots/*/content/settings.json` + `meta.json`; read-only. Don't invoke for: running a fresh trace (use `bootstrap-trace-init.sh`) or proposing boot-pipeline fixes (audit pause forbids it)."
+description: "Render an interactive timeline from a bootstrap-trace run. Use when the user wants to view, visualize, or \"see\" what happened during a traced boot — process spans, write/read interleavings, snapshot states, D-group invariant decisions. Triggers: \"show me the trace\", \"visualize the boot\", \"timeline of the trace\", \"render the trace\", or when investigating a `~/.vade/traces/<run-id>/` directory and a chart beats raw text. Default: uploads the parsed trace to the VADE Console and prints `console.vade-app.dev/trace/?run-id=<id>`. Legacy mode (user asks for an offline file, or Console is unreachable): writes a self-contained HTML via `SendUserFile`. Reads `xtrace.log` + `snapshots/*/content/settings.json` + `snapshots/*/metadata/{env.txt,processes.txt}` + `meta.json`; read-only. Don't invoke for: running a fresh trace (use `bootstrap-trace-init.sh`) or proposing boot-pipeline fixes (audit pause forbids it)."
 allowed-tools: Bash, Read, SendUserFile
 metadata:
   type: procedural
@@ -96,6 +96,15 @@ The renderer (invoked by both paths):
   chain + tracked children) per PID. Prefers `ps`-side identity over
   xtrace identity when walking the ancestor chain (handles PID reuse
   cleanly).
+- Reads `snapshots/*/metadata/env.txt` for `CLAUDE_SESSION_ID` and
+  attributes each tracked PID's events with the matching session_id
+  (primary: snapshot subprocess PPID == bash PID; fallback: nearest
+  snapshot by time + script name). Emits the value as `session_id` on
+  each affected event; the Console renders it as a `/logs/<session_id>`
+  link (coo-labs/coo-console#46). Cloud-setup build-time PIDs have no
+  session yet and stay un-attributed by design — the field is omitted
+  from events whose env didn't carry a session id, so legacy traces and
+  no-session-context events render unchanged.
 - Captures these event kinds (one marker each on the timeline):
     - `_write_claude_settings_*` — file writes (orange)
     - `merge_coo_settings_*` — wrapper merge calls (blue)

--- a/.claude/skills/trace-timeline/scripts/render-trace-timeline.py
+++ b/.claude/skills/trace-timeline/scripts/render-trace-timeline.py
@@ -168,6 +168,15 @@ with open(xtrace_path) as f:
 
 # Parse snapshots
 SNAPSHOTS = []
+# Coordinated additive contract with coo-labs/coo-console#46 / PR #50:
+# events optionally carry a Claude Code session_id, which the Console
+# renders as a /logs/<session_id> link. CLAUDE_SESSION_ID is the canonical
+# env var (set by Claude Code in hook processes); CLAUDE_CODE_SESSION_ID
+# is a legacy fallback some older surfaces emit. Per-PID attribution is
+# done below from snapshots' env.txt; never invented or guessed.
+SESSION_ID_LINE_RE = re.compile(
+    r"^CLAUDE(?:_CODE)?_SESSION_ID=([A-Za-z0-9._-]{8,128})\s*$"
+)
 snapshots_dir = os.path.join(TRACE_DIR, "snapshots")
 if os.path.isdir(snapshots_dir):
     snap_re = re.compile(
@@ -198,8 +207,34 @@ if os.path.isdir(snapshots_dir):
         except Exception:
             pass
 
+        # CLAUDE_SESSION_ID lives in the snapshot's metadata/env.txt — the
+        # `env | sort` dump captured at this bash invocation's entry. Strip
+        # rule in bootstrap-trace-snapshot.sh excludes TOKEN/API_KEY/SECRET/
+        # PASSWORD/PAT/CLOUDFLARE_API but not session ids. Absent during
+        # container build-time bash invocations (no session yet); present
+        # for session-start hook processes.
+        snap_sid = None
+        try:
+            with open(os.path.join(snapshots_dir, d, "metadata", "env.txt")) as ef:
+                for ln in ef:
+                    sm = SESSION_ID_LINE_RE.match(ln)
+                    if sm:
+                        snap_sid = sm.group(1)
+                        break
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
+
         SNAPSHOTS.append(
-            {"ts": ts, "script": m["script"], "pid": int(m["pid"]), "env": env_state, "dir": d}
+            {
+                "ts": ts,
+                "script": m["script"],
+                "pid": int(m["pid"]),
+                "env": env_state,
+                "dir": d,
+                "session_id": snap_sid,
+            }
         )
 
 # strip sentinel keys we used internally
@@ -289,6 +324,57 @@ def to_ms(ts):
     return (ts - boot_start) * 1000
 
 
+# ── Per-PID session_id attribution ────────────────────────────────────
+# Snapshots record CLAUDE_SESSION_ID at bash invocation entry. For each
+# tracked bash PID we want the session_id that was in its env when it
+# was running. Two signals, primary then fallback:
+#
+#   1. Process-tree match. The snapshot subprocess (whose pid is in the
+#      snapshot dir name) is spawned by bootstrap-trace-init.sh inside
+#      the bash being entered, so its PPID is the bash PID. PID_ALL_PPID
+#      (built from processes.txt across snapshots) gives that linkage.
+#      When (1) hits, the snapshot's env *is* the bash's env at entry.
+#
+#   2. Time + script match. When (1) misses (snapshot subprocess never
+#      caught by any later processes.txt; race), fall back to snapshots
+#      whose tag-script matches PID_SCRIPT[p] and whose ts lies inside
+#      [first_ms - 1s, last_ms + 1s] for that PID. Closest-by-time wins.
+#
+# Conservative on uncertainty: a PID with no matching snapshot session_id
+# stays un-attributed (the field is omitted from its events), satisfying
+# the backward-compat clause of the issue.
+PID_SESSION_ID = {}  # tracked pid -> session_id (str)
+_TIME_TOL_SEC = 1.0
+for p in PIDS:
+    # Primary: snapshot subprocess whose PPID == p, with a session_id.
+    primary = [
+        s for s in SNAPSHOTS
+        if s.get("session_id") and PID_ALL_PPID.get(s["pid"]) == p
+    ]
+    if primary:
+        # Most recent wins (latest snapshot env is the most current
+        # attribution; PID_ALL_PPID is first-seen-wins for the snapshot
+        # pid, so each candidate here is a distinct snapshot subprocess).
+        best = max(primary, key=lambda s: s["ts"])
+        PID_SESSION_ID[p] = best["session_id"]
+        continue
+    # Fallback: time + script match. Tag-script in the snapshot dir name
+    # is the bash invocation's $0##*/ value, same domain as PID_SCRIPT[p].
+    script = PID_SCRIPT.get(p)
+    first = PID_FIRST[p]
+    last = PID_LAST[p]
+    nearby = [
+        s for s in SNAPSHOTS
+        if s.get("session_id")
+        and s["script"] == script
+        and first - _TIME_TOL_SEC <= s["ts"] <= last + _TIME_TOL_SEC
+    ]
+    if not nearby:
+        continue
+    best = min(nearby, key=lambda s: abs(s["ts"] - first))
+    PID_SESSION_ID[p] = best["session_id"]
+
+
 data = {
     "meta": meta,
     "boot_start_epoch": boot_start,
@@ -335,6 +421,16 @@ data = {
             "fn": e["fn"],
             "cmd": e["cmd"],
             "detail": e.get("detail", ""),
+            # Additive per coo-labs/coo-console#46. Field is omitted when
+            # the PID's bash invocation had no resolvable CLAUDE_SESSION_ID
+            # in its env at entry-time. Console renders this as a link to
+            # /logs/<session_id> when present and falls back to no link
+            # when absent (backward-compatible).
+            **(
+                {"session_id": PID_SESSION_ID[e["pid"]]}
+                if e["pid"] in PID_SESSION_ID
+                else {}
+            ),
         }
         for e in EVENTS
     ],
@@ -350,9 +446,14 @@ data = {
     ],
 }
 
+_events_with_sid = sum(1 for e in data["events"] if "session_id" in e)
+_unique_sids = len({s["session_id"] for s in SNAPSHOTS if s.get("session_id")})
 print(
     f"PIDs={len(PIDS)}  events={len(EVENTS)}  snapshots={len(SNAPSHOTS)}  "
-    f"duration={data['duration_ms']:.0f}ms",
+    f"duration={data['duration_ms']:.0f}ms  "
+    f"session_id: pids_attributed={len(PID_SESSION_ID)}/{len(PIDS)}  "
+    f"events_with_session_id={_events_with_sid}/{len(EVENTS)}  "
+    f"unique={_unique_sids}",
     file=sys.stderr,
 )
 

--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -163,6 +163,18 @@ read and write. Pass `--dry-run` to parse + validate without uploading.
 `--data-json <path>` skips parsing and uploads a pre-rendered blob —
 useful for re-uploading a saved bundle.
 
+Pass `--session-id <id>` to stamp every event with a known session id,
+overriding whatever the renderer attributed from snapshot env.txt. Use
+when the trace was captured outside a real session (e.g. manual run
+where `CLAUDE_SESSION_ID` was not exported) but you want the Console
+events cross-linked to a specific `/logs/<session_id>` page. The
+renderer's automatic attribution is per-PID and uses the
+`CLAUDE_SESSION_ID` value present in the bash invocation's env at
+entry-time (captured in `snapshots/*/metadata/env.txt`); cloud-setup
+build-time PIDs have no session yet and stay un-attributed by design.
+Contract is additive — events without `session_id` render unchanged in
+the Console (`coo-labs/coo-console#46`).
+
 ## How to stop the trace
 
 Three options, descending order of operational simplicity:

--- a/scripts/debug/upload-trace-bundle.py
+++ b/scripts/debug/upload-trace-bundle.py
@@ -29,6 +29,11 @@ import urllib.request
 
 DEFAULT_CONSOLE = "https://console.vade-app.dev"
 RUN_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+# Coordinated with the trace-timeline renderer and coo-labs/coo-console#46
+# (Console-side accepts whatever shape the harness sends and renders it
+# as /logs/<session_id>). Permissive: matches both Claude Code UUID-shape
+# session ids and ULID-shape cloud session ids.
+SESSION_ID_RE = re.compile(r"^[A-Za-z0-9._-]{8,128}$")
 
 
 def find_default_trace_dir() -> str:
@@ -107,11 +112,31 @@ def main() -> int:
         help="upload a pre-rendered data.json (skips renderer invocation)",
     )
     ap.add_argument(
+        "--session-id",
+        default=None,
+        help=(
+            "stamp every event with this session_id, overriding whatever "
+            "the renderer attributed from snapshot env.txt. Use when the "
+            "trace was captured outside a session (CLAUDE_SESSION_ID "
+            "unset) but the operator knows the session the trace belongs "
+            "to. Console renders the value as a /logs/<session_id> link "
+            "(coo-labs/coo-console#46)."
+        ),
+    )
+    ap.add_argument(
         "--dry-run",
         action="store_true",
         help="parse + validate but do not POST",
     )
     args = ap.parse_args()
+
+    if args.session_id is not None and not SESSION_ID_RE.match(args.session_id):
+        print(
+            f"--session-id {args.session_id!r} fails sanitization "
+            "(allowed: A-Z a-z 0-9 . _ -, length 8-128)",
+            file=sys.stderr,
+        )
+        return 1
 
     if args.data_json:
         with open(args.data_json) as f:
@@ -139,12 +164,23 @@ def main() -> int:
         )
         return 1
 
+    events = data.get("events", []) or []
+    if args.session_id is not None:
+        # Operator override: stamp every event. Mutates the data blob
+        # in place; the POST body below picks up the new values.
+        for ev in events:
+            ev["session_id"] = args.session_id
+
     body = json.dumps(data).encode("utf-8")
     target = f"{args.console_url}/trace/data?run-id={run_id}"
+    events_with_sid = sum(1 for ev in events if ev.get("session_id"))
+    unique_sids = len({ev.get("session_id") for ev in events if ev.get("session_id")})
     print(
         f"PIDs={len(data.get('pids', []))}  "
-        f"events={len(data.get('events', []))}  "
+        f"events={len(events)}  "
         f"snapshots={len(data.get('snapshots', []))}  "
+        f"events_with_session_id={events_with_sid}/{len(events)}  "
+        f"unique_session_ids={unique_sids}  "
         f"bytes={len(body)}",
         file=sys.stderr,
     )


### PR DESCRIPTION
L3b — harness-side completion of [coo-labs/coo-console#46](https://github.com/coo-labs/coo-console/issues/46). The Console-side L3a shipped in [coo-labs/coo-console#50](https://github.com/coo-labs/coo-console/pull/50) (additive `TraceEvent.session_id?: string` + `EventDetail` renders the `/logs/<session_id>` link). This PR is the renderer + uploader half that emits the field.

## Scope

Harness-side only — additive contract end-to-end. The Console worker validator only checks `duration_ms` and `pids`; additive event fields pass through unchanged (per L3a review).

## Changes

**`.claude/skills/trace-timeline/scripts/render-trace-timeline.py`**

- Parses `CLAUDE(_CODE)?_SESSION_ID` from each `snapshots/*/metadata/env.txt` (the `env | sort` dump captured at every bash invocation entry by `bootstrap-trace-snapshot.sh`). The existing strip rule excludes `TOKEN/API_KEY/SECRET/PASSWORD/PAT/CLOUDFLARE_API` but not session ids, so the value lands on disk during session-start hook execution.
- Per-PID attribution uses two signals, primary then fallback:
  1. **Process-tree match** — snapshot subprocess PPID == bash PID via `PID_ALL_PPID` (built from `snapshots/*/metadata/processes.txt`). When the snapshot subprocess was caught in any later `ps` dump, this is exact: the snapshot's env *is* the bash's env at entry.
  2. **Time + script match** — snapshots whose tag-script matches `PID_SCRIPT[p]` and whose ts lies within `[first_ms - 1s, last_ms + 1s]` for `p`. Closest-by-time wins. Catches the race where the snapshot subprocess never made it into any `processes.txt` dump.
- `session_id` is emitted conditionally: a PID with no resolvable session_id stays un-attributed and the field is omitted from its events — satisfies the backward-compat clause of #46 ("traces without session_id annotations render unchanged"). Cloud-setup build-time PIDs naturally lack `CLAUDE_SESSION_ID` (no session yet); session-start hook PIDs get it.
- Coverage surfaced on stderr: `pids_attributed=N/M events_with_session_id=K/L unique=U`.

**`scripts/debug/upload-trace-bundle.py`**

- New `--session-id <id>` operator flag stamps every event with the given value, overriding renderer attribution. Use when the trace was captured outside a real session (`CLAUDE_SESSION_ID` unset) but the operator knows the session the trace belongs to.
- `SESSION_ID_RE` sanitizes the flag's input the same way `RUN_ID_RE` guards run-id (alphanumeric + `. _ -`, length 8-128). Permissive enough for both Claude Code UUID-shape and ULID-shape ids.
- Coverage echoed on stderr: `events_with_session_id=N/M unique_session_ids=U`.

**Docs**

- `.claude/skills/trace-timeline/SKILL.md` — adds `env.txt` to the read-source list in the description (one-word addition) and a body bullet documenting the attribution model.
- `scripts/debug/README.md` — adds a paragraph on the `--session-id` override and the additive contract.

## Verification

End-to-end against three synthetic trace fixtures (full fixture under `/tmp/fake-trace*` during the session; not committed):

| Fixture | Expectation | Result |
|---|---|---|
| primary path (full `processes.txt`) | 6/8 events attributed (cloud-setup PID 100 unattributed; PIDs 200, 300 attributed via PPID match) | pass: `pids_attributed=2/3 events_with_session_id=6/8` |
| fallback path (`processes.txt` deleted, primary always misses) | 6/8 events attributed via time+script match | pass: same coverage |
| no `CLAUDE_SESSION_ID` anywhere | 0/8 events attributed; field omitted from every event | pass: `'session_id' in e` is `False` for all events |
| `--session-id` override on dry-run | 8/8 events stamped with the override value | pass: `events_with_session_id=8/8` |
| bad `--session-id` input (`evil; rm -rf /`) | sanitization rejects with exit 1 | pass |

`render-trace-timeline.py --json` output structure unchanged on legacy traces (no new top-level keys; `session_id` only ever appears as a per-event additive field).

## L3 acceptance criteria status

- [x] `render-trace-timeline.py --json` emits `session_id` per event in the trace data blob.
- [x] `upload-trace-bundle.py` records `session_id` provenance per event (via renderer pass-through + `--session-id` override path).
- [x] Console `/trace/data` ingest accepts session_id provenance fields additively (verified in [#50](https://github.com/coo-labs/coo-console/pull/50) review).
- [x] Console `/trace/` React route renders events with session_id as links to `/logs/<session_id>` (shipped via [#50](https://github.com/coo-labs/coo-console/pull/50)).
- [x] A trace whose events reference session_ids renders with clickable links — will work end-to-end on the next real bootstrap-trace captured during an active session, once this PR lands and re-renders.
- [x] Backward-compatible: traces without session_id annotations render unchanged.

## Notes

No CI test added — `render-trace-timeline.py` and `upload-trace-bundle.py` are operator/debug tools, not part of the boot-pipeline regression suite. `bootstrap-regression.yml` doesn't trigger on changes here, and the existing pattern is unit-tested only for the lifecycle and lib paths. Manual verification table above is the evidence.

Closes coo-labs/coo-console#46

https://claude.ai/code/session_013rcKAtJj5qHgZMQY2aoZXe