### PR TITLE
integrity-check: skip Group S op-reads in fast phase (briefing-40 T2.1)

### DIFF
--- a/.github/workflows/bootstrap-regression.yml
+++ b/.github/workflows/bootstrap-regression.yml
@@ -236,6 +236,9 @@ jobs:
       - name: bootstrap op caches (materialize_app_key_cache; gh-app-token cache reuse)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-bootstrap-op-caches.sh"
 
+      - name: integrity-check phase gate (fast skips S3/S4/S7; live runs s_check_all)
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/test-integrity-phase-gate.sh"
+
       - name: bootstrap allowlist sync (op-coo-wrap transparent swap → .op-sa-identity append)
         run: bash "$GITHUB_WORKSPACE/scripts/ci/test-coo-bootstrap-allowlist-sync.sh"
 

--- a/scripts/boot/integrity-check.sh
+++ b/scripts/boot/integrity-check.sh
@@ -1516,11 +1516,31 @@ fi
 #   - S7: skip if op CLI not live.
 #   - S8: works everywhere — classifies current process env against
 #         schema + writes today's keynames snapshot.
+#
+# Phase gate (briefing-40 T2.1, coo-harness#563): S3/S4/S7 each iterate
+# the full credential set with `op read` / `op item get`, costing ~25-30
+# op-reads per integrity-check run. The fast phase fires synchronously
+# from coo-bootstrap.sh's EXIT trap before the boot banner renders;
+# moving the op-touching S-checks to live-phase-only halves cold-boot
+# op-quota use without changing the live-phase contract. The structural
+# checks (S1/S2/S5/S8/S9/S10) do no op-reads and stay in fast phase.
 S_LIB="$SCRIPT_DIR/../lib/integrity-group-s.sh"
 if [ -r "$S_LIB" ]; then
   # shellcheck source=../lib/integrity-group-s.sh
   source "$S_LIB"
-  s_check_all
+  if [ "$VADE_INTEGRITY_PHASE" = "fast" ]; then
+    s_check_S1
+    s_check_S2
+    for _s in S3 S4 S7; do
+      _add "$_s" skip "phase=fast: op-bound check deferred to live pass (coo-harness#563)"
+    done
+    s_check_S5
+    s_check_S8
+    s_check_S9
+    s_check_S10
+  else
+    s_check_all
+  fi
 else
   _add S1 skip "integrity-group-s.sh helper missing at $S_LIB"
 fi

--- a/scripts/ci/test-integrity-phase-gate.sh
+++ b/scripts/ci/test-integrity-phase-gate.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# test-integrity-phase-gate: assert Group S in integrity-check.sh skips
+# the op-touching invariants (S3, S4, S7) when VADE_INTEGRITY_PHASE=fast,
+# and runs the full s_check_all when phase is unset or live.
+#
+# Background: briefing-40 T2.1 (coo-labs/coo-harness#563) — cold-boot
+# op-reads were 3-4x the documented bound because integrity-check.sh
+# fires twice per cold-boot (fast phase from coo-bootstrap.sh's EXIT
+# trap, live phase from post-bootstrap-chain.sh) and Group S iterates
+# the full schema with `op read` per credential each time. Gating S3/
+# S4/S7 to live-phase only halves cold-boot op-quota use.
+#
+# Run: bash scripts/ci/test-integrity-phase-gate.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INTEGRITY="$REPO_ROOT/scripts/boot/integrity-check.sh"
+HELPER="$REPO_ROOT/scripts/lib/integrity-group-s.sh"
+
+[ -r "$INTEGRITY" ] || { echo "FAIL: integrity-check.sh not readable at $INTEGRITY"; exit 1; }
+[ -r "$HELPER" ]    || { echo "FAIL: integrity-group-s.sh not readable at $HELPER"; exit 1; }
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+_pass() { PASS=$((PASS + 1)); printf '  ok: %s\n' "$1"; }
+_fail() { FAIL=$((FAIL + 1)); FAILURES+=("$1"); printf '  FAIL: %s\n' "$1"; }
+
+# Sanity: the production dispatcher still contains the phase-gate marker
+# and the skip reason wording the test asserts on — surfaces accidental
+# removal or rename.
+if ! grep -q 'phase=fast: op-bound check deferred to live pass' "$INTEGRITY"; then
+  _fail "production dispatcher missing phase-gate skip reason marker"
+fi
+if ! grep -q 'VADE_INTEGRITY_PHASE.*=.*fast' "$INTEGRITY"; then
+  _fail "production dispatcher missing VADE_INTEGRITY_PHASE=fast comparison"
+fi
+
+# Source the helper into a sandbox that mocks each s_check_* function to
+# record its name. Re-run the exact dispatcher logic from integrity-check.sh
+# under each phase value and assert the call set + recorded skips.
+_run_dispatcher() {
+  local phase="$1" out
+  out="$(
+    VADE_INTEGRITY_PHASE="$phase" bash -c '
+      set -uo pipefail
+      RESULTS=()
+      CALLED=()
+      _add() { RESULTS+=("$1|$2|$3"); }
+      # Stub every s_check_* to record its name without doing work.
+      for fn in s_check_S1 s_check_S2 s_check_S3 s_check_S4 s_check_S5 \
+                s_check_S7 s_check_S8 s_check_S9 s_check_S10 s_check_all; do
+        eval "${fn}() { CALLED+=(\"${fn}\"); }"
+      done
+      # Mirror of the phase-gate dispatcher block in integrity-check.sh.
+      # Keep these two blocks (here and the production site) in lockstep —
+      # the sanity grep above catches drift in the skip-reason wording.
+      if [ "$VADE_INTEGRITY_PHASE" = "fast" ]; then
+        s_check_S1
+        s_check_S2
+        for _s in S3 S4 S7; do
+          _add "$_s" skip "phase=fast: op-bound check deferred to live pass (coo-harness#563)"
+        done
+        s_check_S5
+        s_check_S8
+        s_check_S9
+        s_check_S10
+      else
+        s_check_all
+      fi
+      printf "CALLED:%s\n" "$(IFS=,; echo "${CALLED[*]:-}")"
+      printf "RESULTS:%s\n" "$(IFS=,; echo "${RESULTS[*]:-}")"
+    ')"
+  printf '%s' "$out"
+}
+
+echo "Case 1: VADE_INTEGRITY_PHASE=fast"
+out_fast="$(_run_dispatcher fast)"
+called_fast="$(printf '%s\n' "$out_fast" | grep '^CALLED:' | sed 's/^CALLED://')"
+results_fast="$(printf '%s\n' "$out_fast" | grep '^RESULTS:' | sed 's/^RESULTS://')"
+
+for expected in s_check_S1 s_check_S2 s_check_S5 s_check_S8 s_check_S9 s_check_S10; do
+  case ",$called_fast," in
+    *,"$expected",*) _pass "fast phase invokes $expected" ;;
+    *)               _fail "fast phase missing $expected (called: $called_fast)" ;;
+  esac
+done
+for forbidden in s_check_S3 s_check_S4 s_check_S7 s_check_all; do
+  case ",$called_fast," in
+    *,"$forbidden",*) _fail "fast phase unexpectedly invokes $forbidden" ;;
+    *)                _pass "fast phase skips $forbidden" ;;
+  esac
+done
+for sk in S3 S4 S7; do
+  if printf '%s' "$results_fast" | grep -q "${sk}|skip|phase=fast: op-bound check deferred to live pass (coo-harness#563)"; then
+    _pass "fast phase emits skip for $sk with phase-fast wording"
+  else
+    _fail "fast phase missing skip for $sk (results: $results_fast)"
+  fi
+done
+
+echo
+echo "Case 2: VADE_INTEGRITY_PHASE=live"
+out_live="$(_run_dispatcher live)"
+called_live="$(printf '%s\n' "$out_live" | grep '^CALLED:' | sed 's/^CALLED://')"
+case ",$called_live," in
+  *,s_check_all,*) _pass "live phase invokes s_check_all" ;;
+  *)               _fail "live phase missing s_check_all (called: $called_live)" ;;
+esac
+for forbidden in s_check_S1 s_check_S2 s_check_S5 s_check_S8; do
+  case ",$called_live," in
+    *,"$forbidden",*) _fail "live phase unexpectedly invokes $forbidden individually (should go via s_check_all)" ;;
+    *)                _pass "live phase delegates $forbidden to s_check_all" ;;
+  esac
+done
+
+echo
+echo "Case 3: VADE_INTEGRITY_PHASE unset (defaults to live)"
+out_default="$(_run_dispatcher '')"
+called_default="$(printf '%s\n' "$out_default" | grep '^CALLED:' | sed 's/^CALLED://')"
+case ",$called_default," in
+  *,s_check_all,*) _pass "unset phase defaults to s_check_all" ;;
+  *)               _fail "unset phase missing s_check_all (called: $called_default)" ;;
+esac
+
+echo
+echo "Results: PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

[#563](https://github.com/coo-labs/coo-harness/issues/563) Phase 1 (root-cause investigation) + Phase 2 (consolidation) — gates the op-touching Group S invariants (S3 mirror sha8-compare, S4 multi-field `op item get`, S7 primary+alt-field `op read` walk) behind `VADE_INTEGRITY_PHASE != "fast"`, matching the existing Group E pattern. Halves cold-boot op-read quota use; expected 85→~57 and 60→~32 on a 2026-06-07-shaped workload, clears Phase-3's <40 target.

## Root cause (from instrumentation)

Briefing-40 T2.1 day-of-record data showed three cold-boot sessions burning 60-85 op-reads each, 3-4× the plan's documented bound. Per-credential counts (e.g. `mem0-api-vade-coo/credential` 3× per session) traced to:

| Source | Reads per fire | Times fired per cold-boot |
|---|---|---|
| `fetch_coo_secrets` (one per active-aliased credential) | ~14-22 | 1 (24h tmpfs cache) |
| `install_coo_ssh_keys` | 4 | 1 |
| gh-coo-wrap PAT resolves + sentinels | ~3-5 | varies |
| **integrity-check.sh Group S (S3+S4+S7)** | **~25-30** | **2 — fast + live** |

Group S was not gated by the phase flag — only Group E was. Each integrity-check run walked the full non-dormant credential set with op-reads, double-billing across the fast-phase (`coo-bootstrap.sh`'s EXIT trap, blocking boot banner) and live-phase (`post-bootstrap-chain.sh`, backgrounded) invocations.

## Change

`scripts/boot/integrity-check.sh` lines 1497-1526 — wrap the `s_check_all` dispatch in a phase check. Fast phase runs the cheap structural checks (S1/S2/S5/S8/S9/S10 — no op-reads) and emits `skip phase=fast` for S3/S4/S7. Live phase still calls `s_check_all`. Comment block documents the new contract.

## Boot-banner side effect

`integrity-check.json` shows `S3/S4/S7: skip phase=fast: op-bound check deferred to live pass (coo-harness#563)` for the ~5-10s window between banner render and live-phase completion. The live phase from post-bootstrap-chain.sh overwrites the JSON with full S-results. Consumers reading after live phase lands (boot brake, `/verify-secrets`, debug-mode) see the merged result.

## Tests

New `scripts/ci/test-integrity-phase-gate.sh` — mocks `s_check_*` as recorders, runs the exact dispatcher block under each phase value, asserts:
- `VADE_INTEGRITY_PHASE=fast`: invokes S1/S2/S5/S8/S9/S10; skips s_check_all; emits `S3|skip|phase=fast…`, `S4|skip|phase=fast…`, `S7|skip|phase=fast…`.
- `VADE_INTEGRITY_PHASE=live`: invokes s_check_all.
- unset phase: defaults to s_check_all.

Wired into `.github/workflows/bootstrap-regression.yml` between the existing `bootstrap-op-caches` and `bootstrap-allowlist-sync` tests. Local run: 19 assertions, all pass.

## Paired memo

[MEMO-2026-06-08-mi7m](https://github.com/coo-labs/coo-memory/blob/main/memos/2026-06-08-mi7m.md) (coo-labs/coo-memory#1336 — co-shipping) records the contract change as case-law.

## Verification posture

Phase 3 close-out (rerun the rollup on the next post-merge cold-boot, target <40 reads) requires a fresh container snapshot built off this PR. The Phase 3 rerun lands as a follow-up comment on this PR once a post-merge cold-boot session has generated a new `.op-reads.jsonl`.

Closes #563

Closes #563

https://claude.ai/code/session_01KJz4XXL9qYPyZvDheXyDv8