### PR TITLE
CLAUDE.md: signpost lib/transcripts/ primitives at boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,31 +135,13 @@ and its followup plan §4 (`briefings/_followups/040-op-request-volume-plan-2026
 
 ## Transcript primitives — `lib/transcripts/`
 
-`lib/transcripts/` is the internal Python library for the VADE transcript
-pipeline — R2 access, schema types (Pydantic v2 `Sidecar`), JSONL parsing,
-provenance invariants, sidecar I/O. Imported by `scripts/lib/transcript-*.py`
-and `scripts/lifecycle/session-end-transcript-*.py`; consolidated out of the
-earlier copy-pasted version of those primitives.
-
-**When you touch transcripts** — JSONL walks, R2 sidecar reads/writes,
-redaction, schema validation, session-end exports, or any new sidecar
-shape (`*.cost.json`, future cost dashboard etc.) — **start with
-[`lib/transcripts/README.md`](lib/transcripts/README.md)** and import from
-`transcripts.*` rather than re-implementing in `scripts/`. The package is
-the consolidation layer; the older `scripts/lib/transcript-*.py` files are
-pre-consolidation orchestrators kept for backward-compat.
-
-Import pattern (per the README's `parents[N]` table for the script's depth):
-
-```python
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))  # scripts/lifecycle/
-from transcripts import Sidecar, read_entries, r2_client
-```
-
-CI for the package runs ruff + mypy + pytest on every PR that touches
-`lib/transcripts/` (`.github/workflows/lib-transcripts.yml`).
+Internal Python library — R2 access, Pydantic v2 `Sidecar` schemas, JSONL
+parsing, provenance invariants. **For any transcript-shape work** (JSONL
+walks, R2 sidecar reads/writes, redaction, new sidecar shapes) start with
+[`lib/transcripts/README.md`](lib/transcripts/README.md) and import from
+`transcripts.*`; the older `scripts/lib/transcript-*.py` files are
+pre-consolidation orchestrators kept for backward-compat. CI:
+`.github/workflows/lib-transcripts.yml`.
 
 ## Bootstrap CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,34 @@ same `OP_SERVICE_ACCOUNT_TOKEN` quota, so neither alone is sufficient.
 Origin: briefing-040 (`coo-memory/briefings/040-op-request-volume.md`)
 and its followup plan §4 (`briefings/_followups/040-op-request-volume-plan-2026-06-07-mrcc.md`).
 
+## Transcript primitives — `lib/transcripts/`
+
+`lib/transcripts/` is the internal Python library for the VADE transcript
+pipeline — R2 access, schema types (Pydantic v2 `Sidecar`), JSONL parsing,
+provenance invariants, sidecar I/O. Imported by `scripts/lib/transcript-*.py`
+and `scripts/lifecycle/session-end-transcript-*.py`; consolidated out of the
+earlier copy-pasted version of those primitives.
+
+**When you touch transcripts** — JSONL walks, R2 sidecar reads/writes,
+redaction, schema validation, session-end exports, or any new sidecar
+shape (`*.cost.json`, future cost dashboard etc.) — **start with
+[`lib/transcripts/README.md`](lib/transcripts/README.md)** and import from
+`transcripts.*` rather than re-implementing in `scripts/`. The package is
+the consolidation layer; the older `scripts/lib/transcript-*.py` files are
+pre-consolidation orchestrators kept for backward-compat.
+
+Import pattern (per the README's `parents[N]` table for the script's depth):
+
+```python
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))  # scripts/lifecycle/
+from transcripts import Sidecar, read_entries, r2_client
+```
+
+CI for the package runs ruff + mypy + pytest on every PR that touches
+`lib/transcripts/` (`.github/workflows/lib-transcripts.yml`).
+
 ## Bootstrap CI
 
 PRs that touch `scripts/`, `.claude/`, `.mcp.json`, or


### PR DESCRIPTION
Adds a "Transcript primitives — `lib/transcripts/`" section between the op-read telemetry block and the bootstrap-CI block in this repo's boot CLAUDE.md.

## Why

Several recent sessions have re-implemented JSONL parsing, R2 plumbing, or sidecar shapes in `scripts/lib/` or `scripts/lifecycle/` instead of importing from `lib/transcripts/`. The package is well-documented at `lib/transcripts/README.md` but the boot reading order (this CLAUDE.md → `README.md` → `coo-memory/identity/public-authority.md`) never names it — so a fresh session opening a `session-end-transcript-*.py` PR has no signal that the right primitives live elsewhere.

This signpost closes the discoverability gap at near-zero cost: every coo-harness session sees it at boot.

## Changes

- One new section in `CLAUDE.md` (+28 lines). Names the package's role (the consolidation layer for the previously copy-pasted code), points at its README, gives the import pattern with the `parents[N]` lookup table.
- Placement chosen to sit alongside other "primitives you should know about" sections (`bin/coo-search`, `bin/op-read-rollup.py`).

## Companion changes (separate PRs)

- coo-console — cross-repo mention in this repo's CLAUDE.md (for Console routes that consume sidecar shapes).
- coo-logs — cross-repo mention in this repo's CLAUDE.md (for the sidecar writers/readers under `transcripts/`).
- coo-memory — new `transcripts-lib` skill that fires on transcript-keyword triggers across all four repos.

Together the four edits cover boot-time discovery (this PR + cross-repo CLAUDE.md), keyword-triggered skill activation (skill), and the canonical reference (existing `lib/transcripts/README.md`, unchanged).

Closes: n/a

Closes: n/a

https://claude.ai/code/session_013rcKAtJj5qHgZMQY2aoZXe